### PR TITLE
REL-643 Fix for removal of shortcuts on uninstall in Windows

### DIFF
--- a/project/src/main/resources/edu/gemini/osgi/tools/app/template.nsis
+++ b/project/src/main/resources/edu/gemini/osgi/tools/app/template.nsis
@@ -23,7 +23,8 @@ Section "-pre"
 SectionEnd
 
 Section "Default Installation"
-    CreateShortCut "$SMPROGRAMS\Gemini\${NAME}\${NAME} ${VERSION}.lnk" "$INSTDIR\jre\bin\javaw.exe" "${APP_VM_ARGS} -jar ${APP_JAR} ${APP_ARGS}" "$INSTDIR\${ICON}"
+	SetShellVarContext all
+	CreateShortCut "$SMPROGRAMS\Gemini\${NAME}\${NAME} ${VERSION}.lnk" "$INSTDIR\jre\bin\javaw.exe" "${APP_VM_ARGS} -jar ${APP_JAR} ${APP_ARGS}" "$INSTDIR\${ICON}"
 SectionEnd
 
 Section "-post"
@@ -40,11 +41,12 @@ UninstallText "This will uninstall ${NAME} ${VERSION}."
 
 Section Uninstall
 
+	SetShellVarContext all
 	DeleteRegKey HKEY_LOCAL_MACHINE "SOFTWARE\Gemini 8.1m HLPG\${NAME} ${VERSION}"
 	DeleteRegKey HKEY_LOCAL_MACHINE "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${NAME} ${VERSION}"
 	RMDIR /r "$INSTDIR"
 
-	RMDIR /r "$SMPROGRAMS\Gemini\${NAME}\${NAME} ${VERSION}.lnk"
+	DELETE "$SMPROGRAMS\Gemini\${NAME}\${NAME} ${VERSION}.lnk"
 
 SectionEnd
 


### PR DESCRIPTION
Make the installer use the Start Menu area for all users as recommended by nsis on Windows Vista and 7

See
http://nsis.sourceforge.net/Shortcuts_removal_fails_on_Windows_Vista

It was tested on a Windows 7 VM
