### PR TITLE
OCSADV-165: add smartgcal servlet to spdb app

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -106,6 +106,7 @@ def common(version: Version) = AppConfig(
     BundleSpec("edu.gemini.qpt.shared",                  version),
     BundleSpec("edu.gemini.services.server",             version),
     BundleSpec("edu.gemini.smartgcal.odbinit",           version),
+    BundleSpec("edu.gemini.smartgcal.servlet",           version),
     BundleSpec("edu.gemini.sp.vcs.tui",                  version),
     BundleSpec("edu.gemini.spdb.rollover.servlet",       version),
     BundleSpec("edu.gemini.spdb.shell",                  version),

--- a/bundle/edu.gemini.smartgcal.servlet/build.sbt
+++ b/bundle/edu.gemini.smartgcal.servlet/build.sbt
@@ -9,7 +9,8 @@ name := "edu.gemini.smartgcal.servlet"
 unmanagedJars in Compile ++= Seq(
   new File(baseDirectory.value, "../../lib/bundle/javax-servlet_2.10-2.5.0.jar"),
   new File(baseDirectory.value, "../../lib/bundle/osgi.cmpn-4.3.1.jar"),
-  new File(baseDirectory.value, "../../lib/bundle/au-com-bytecode-opencsv_2.10-2.1.0.jar")
+  new File(baseDirectory.value, "../../lib/bundle/au-com-bytecode-opencsv_2.10-2.1.0.jar"),
+  new File(baseDirectory.value, "lib/svnClientAdapter-1.3.0.jar")
   // new File(baseDirectory.value, "../../lib/bundle/org.apache.felix-4.2.1.jar"),
   // new File(baseDirectory.value, "../../lib/bundle/org.apache.felix.http.jetty-2.2.0.jar"),
   // new File(baseDirectory.value, "../../lib/bundle/pax-web-jetty-bundle-1.1.13.jar")
@@ -28,4 +29,8 @@ OsgiKeys.dynamicImportPackage := Seq("")
 OsgiKeys.exportPackage := Seq(
   )
 
-        
+OsgiKeys.importPackage := Seq(
+  "!javax.portlet.*",
+  "!org.tigris.subversion.*",
+  "!org.tmatesoft.svn.core.*",
+  "*")

--- a/project/OcsApp.scala
+++ b/project/OcsApp.scala
@@ -59,7 +59,8 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_wdba_session_client,
     bundle_edu_gemini_wdba_xmlrpc_server,
     bundle_edu_gemini_obslog,
-    bundle_edu_gemini_services_server
+    bundle_edu_gemini_services_server,
+    bundle_edu_gemini_smartgcal_servlet
   )
 
   lazy val app_weather = project.in(file("app/weather")).dependsOn(


### PR DESCRIPTION
The smartgcal servlet was mistakenly left out of the spdb app.  This at least makes it show up and I tested it enough to see that I could download a smartgcal definition file.  There may be additional configuration or jars necessary?
