### PR TITLE
Missing imports for qpt manifest

### DIFF
--- a/bundle/edu.gemini.qpt.client/build.sbt
+++ b/bundle/edu.gemini.qpt.client/build.sbt
@@ -31,4 +31,4 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.qpt.ui.html")
 
 OsgiKeys.additionalHeaders += 
-  ("Import-Package" -> "!javax.mail.util,*")
+  ("Import-Package" -> "!javax.mail.util,edu.gemini.spModel.gemini.altair,edu.gemini.spModel.target.obsComp,*")


### PR DESCRIPTION
So @fnussber here's the fix for the problem you reported. I created plans for both sites and tried loading them with a newly-launched QPT and got failures trying to load classes from `edu.gemini.spModel.gemini.altair` and `edu.gemini.spModel.target.obsComp` ... reflection is terrible.

So I added those packages to the `OsgiKeys.additionalHeaders` shown below. This is the way you get BND to include packages you containing stuff that you need but isn't referenced directly.
