### PR TITLE
REL-1535: Display effective NIFS OIWFS FOV corrected for offsets.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/nifs/NIFS_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/nifs/NIFS_OIWFS_Feature.java
@@ -31,7 +31,7 @@ import java.util.Set;
 /**
  * Draws the OIWFS overlay for NIFS.
  */
-public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
+public final class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
 
     // Composite used for drawing items that partially block the view
     private static final Composite PARTIAL = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.4F);
@@ -50,7 +50,7 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
     }
 
     /** Return true if the display needs to be updated because values changed. */
-    protected boolean _needsUpdate(SPInstObsComp inst, TpeImageInfo tii) {
+    protected boolean _needsUpdate(final SPInstObsComp inst, final TpeImageInfo tii) {
         // Needs to take into account offset position list updates to work
         // as intended.  Unclear whether it is worth the effort to maintain
         // the old offset lists when the calculation isn't that slow anyway.
@@ -71,11 +71,11 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
      * @param oiwfsDefined set to true if an OIWFS position is defined (otherwise
      *                     the xg and yg parameters are ignored)
      */
-    protected void _updateFigureList(double guidePosX, double guidePosY, double offsetPosX, double offsetPosY,
-                                     double translateX, double translateY, double basePosX, double basePosY, boolean oiwfsDefined) {
+    protected void _updateFigureList(final double guidePosX, final double guidePosY, final double offsetPosX, final double offsetPosY,
+                                     final double translateX, final double translateY, final double basePosX, final double basePosY, final boolean oiwfsDefined) {
         _figureList.clear();
 
-        InstNIFS inst = _iw.getContext().instrument().orNull(InstNIFS.SP_TYPE);
+        final InstNIFS inst = _iw.getContext().instrument().orNull(InstNIFS.SP_TYPE);
         if (inst == null) return;
 
         addOffsetConstrainedPatrolField(basePosX, basePosY);
@@ -84,7 +84,7 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
         _posAngleTrans.setToIdentity();
         _posAngleTrans.rotate(-_posAngle+Math.toRadians(90.), offsetPosX + translateX, offsetPosY + translateY);
 
-        Point2D.Double p = new Point2D.Double(offsetPosX + translateX, offsetPosY + translateY);
+        final Point2D.Double p = new Point2D.Double(offsetPosX + translateX, offsetPosY + translateY);
         _addGuideFields(p);
         _addPickoffProbe(p);
     }
@@ -93,17 +93,17 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
     /**
      * Add the OIWFS patrol field to the list of figures to display.
      */
-    protected void addPatrolField(double xc, double yc) {
+    protected void addPatrolField(final double xc, final double yc) {
         for (ObsContext ctx : _iw.getMinimalObsContext()) {
             // get scaled and offset f2 oiwfs patrol field
-            PatrolField patrolField = NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx);
+            final PatrolField patrolField = NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx);
             // rotation, scaling and transformation to match screen coordinates
-            Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-            Point2D.Double translation = new Point2D.Double(xc, yc);
+            final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+            final Point2D.Double translation = new Point2D.Double(xc, yc);
             setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
 
             // set patrol field for in Range check (this should probably be done using the inRange check provided by the guide probe)
-            Area _patrolField = patrolField.getArea();
+            final Area _patrolField = patrolField.getArea();
             transformToScreen(_patrolField);
 
             // draw patrol field
@@ -118,17 +118,17 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
      * @param xc the X screen coordinate for the base position to use
      * @param yc the Y screen coordinate for the base position to use
      */
-    protected void addOffsetConstrainedPatrolField(double xc, double yc) {
+    protected void addOffsetConstrainedPatrolField(final double xc, final double yc) {
 
         if (_iw.getMinimalObsContext().isEmpty()) return;
 
-        PatrolField patrolField = NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(_iw.getMinimalObsContext().getValue());
+        final PatrolField patrolField = NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(_iw.getMinimalObsContext().getValue());
         // rotation, scaling and transformation to match screen coordinates
-        Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-        Point2D.Double translation = new Point2D.Double(xc, yc);
+        final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+        final Point2D.Double translation = new Point2D.Double(xc, yc);
         setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
 
-        Set<Offset> offsets = _iw.getContext().offsets().scienceOffsetsJava();
+        final Set<Offset> offsets = _iw.getContext().offsets().scienceOffsetsJava();
         addOffsetConstrainedPatrolField(patrolField, offsets);
     }
 
@@ -142,11 +142,10 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
     }
 
     // draw a guide field at the given location, with the given diameter in arcsec and color
-    private void _addGuideFields(Point2D.Double p, double d, Color c) {
-        Composite composite = null;
-        d *= _pixelsPerArcsec;
-        Ellipse2D.Double oval = new Ellipse2D.Double(p.x - d / 2, p.y - d / 2, d, d);
-        _figureList.add(new Figure(oval, c, composite, OIWFS_STROKE));
+    private void _addGuideFields(final Point2D.Double p, final double dd, final Color c) {
+        final double d = dd * _pixelsPerArcsec;
+        final Ellipse2D.Double oval = new Ellipse2D.Double(p.x - d / 2, p.y - d / 2, d, d);
+        _figureList.add(new Figure(oval, c, null, OIWFS_STROKE));
     }
 
     private InstAltair extractAltair() {
@@ -159,28 +158,28 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
     }
 
     // draw the NIFS pickoff probe at the given location
-    private void _addPickoffProbe(Point2D.Double p) {
-        boolean fill = getFillObscuredArea();
+    private void _addPickoffProbe(final Point2D.Double p) {
+        final boolean fill = getFillObscuredArea();
         _addPickoffProbeBlocked(p, fill);
         _addPickoffProbePartial(p, fill);
     }
 
 
     // draw the fully vignetted part of the NIFS pickoff probe at the given location
-    private void _addPickoffProbeBlocked(Point2D.Double p, boolean fill) {
-        Composite composite = fill ? BLOCKED : null;
+    private void _addPickoffProbeBlocked(final Point2D.Double p, final boolean fill) {
+        final Composite composite = fill ? BLOCKED : null;
 
-        double h = 100 * _pixelsPerArcsec;
-        double w = 16.1 * _pixelsPerArcsec;
-        Rectangle2D.Double rect = new Rectangle2D.Double(p.x - w / 2, p.y, w, h);
+        final double h = 100 * _pixelsPerArcsec;
+        final double w = 16.1 * _pixelsPerArcsec;
+        final Rectangle2D.Double rect = new Rectangle2D.Double(p.x - w / 2, p.y, w, h);
 
         // draw an arc at top
-        double radius = w/2;
-        Arc2D.Double arc = new Arc2D.Double();
+        final double radius = w/2;
+        final Arc2D.Double arc = new Arc2D.Double();
         arc.setArcByCenter(p.x, p.y, radius, -180, -180, Arc2D.OPEN);
 
         // Only display the outline, and rotate by the position angle
-        Area area = new Area(rect);
+        final Area area = new Area(rect);
         area.add(new Area(arc));
         area.transform(_posAngleTrans);
         _figureList.add(new Figure(area, OIWFS_COLOR, composite, OIWFS_STROKE));
@@ -188,31 +187,31 @@ public class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
 
 
     // draw the partially vignetted part of the NIFS pickoff probe at the given location
-    private void _addPickoffProbePartial(Point2D.Double p, boolean fill) {
+    private void _addPickoffProbePartial(final Point2D.Double p, final boolean fill) {
         final Composite composite = fill ? PARTIAL : null;
 
         // the outer shadow is no longer rectangular (Its wider at the outside)
-        double h = 100 * _pixelsPerArcsec;
-        double w1 = 26 * _pixelsPerArcsec;
-        double w2 = 30 * _pixelsPerArcsec;
-        double x0 = p.x - w1 / 2;
-        double y0 = p.y;
-        double x1 = p.x + w1 / 2;
-        double y1 = y0;
-        double x2 = p.x + w2 / 2;
-        double y2 = p.y + h;
-        double x3 = p.x - w2 / 2;
-        double y3 = y2;
-        double[] coords = new double[] {x0, y0, x1, y1, x2, y2, x3, y3};
-        Polygon2D.Double polygon = new Polygon2D.Double(coords);
+        final double h = 100 * _pixelsPerArcsec;
+        final double w1 = 26 * _pixelsPerArcsec;
+        final double w2 = 30 * _pixelsPerArcsec;
+        final double x0 = p.x - w1 / 2;
+        final double y0 = p.y;
+        final double x1 = p.x + w1 / 2;
+        final double y1 = y0;
+        final double x2 = p.x + w2 / 2;
+        final double y2 = p.y + h;
+        final double x3 = p.x - w2 / 2;
+        final double y3 = y2;
+        final double[] coords = new double[] {x0, y0, x1, y1, x2, y2, x3, y3};
+        final Polygon2D.Double polygon = new Polygon2D.Double(coords);
 
         // draw an arc at top
-        double radius = w1/2;
-        Arc2D.Double arc = new Arc2D.Double();
+        final double radius = w1/2;
+        final Arc2D.Double arc = new Arc2D.Double();
         arc.setArcByCenter(p.x, p.y, radius, -180, -180, Arc2D.OPEN);
 
         // Only display the outline, and rotate by the position angle
-        Area area = new Area(polygon);
+        final Area area = new Area(polygon);
         area.add(new Area(arc));
         area.transform(_posAngleTrans);
         _figureList.add(new Figure(area, OIWFS_COLOR, composite, OIWFS_STROKE));


### PR DESCRIPTION
Trying to reintegrate a change from September 2012 that was somehow lost in space and time at some point. Seems simple enough but I am a bit lost at the point where originally an array of OffsetPosLists was taken from the program. I assume this has to be replaced with information taken from _iw.getContext().offsets() but I am not sure which one to use in this context. Before spending more time  digging through old/new code I hoped maybe @swalker2m could shed some light on this; see TODO comments in code.
