### PR TITLE
REL-1394: Uploaded files are now always explicitly marked as unchecked

### DIFF
--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/client/AuxFileClient.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/client/AuxFileClient.java
@@ -14,7 +14,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 
 /**
  * An {@link AuxFileSystem} implementation that may be used by a client


### PR DESCRIPTION
(with respect to the NGO flag) so that re-uploaded files have the flag reset to unchecked as required.

(Tested with some files and verified to be correct.)
