### PR TITLE
REL-1914: Added flip transformation to GMOS OIWFS when using Altair.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -10,6 +10,7 @@ import edu.gemini.skycalc.Offset;
 import edu.gemini.shared.skyobject.SkyObject;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.spModel.gemini.altair.InstAltair;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -117,11 +118,18 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     public PatrolField getCorrectedPatrolField(ObsContext ctx, PatrolField patrolField) {
         final AffineTransform sideLooking = transformForPort(ctx.getIssPort());
+        final AffineTransform altairTransform = AffineTransform.getScaleInstance(1.0, -1.0);
 
         // calculate and apply GMOS specific IFU offsets and flip coordinates
         double ifuXOffset = ((GmosCommonType.FPUnit) ((InstGmosCommon) ctx.getInstrument()).getFPUnit()).getWFSOffset();
         AffineTransform offsetAndFlipTransform = AffineTransform.getTranslateInstance(ifuXOffset, 0.0);
         offsetAndFlipTransform.concatenate(sideLooking);
+
+        // REL-1914 flip the field if using Altair.
+        if(!ctx.getAOComponent().isEmpty()
+                && ctx.getAOComponent().getValue().getType().equals(InstAltair.SP_TYPE)) {
+            offsetAndFlipTransform.concatenate(altairTransform);
+        }
 
         // now get corrected patrol field
         return patrolField.getTransformed(offsetAndFlipTransform);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
@@ -2,6 +2,7 @@ package edu.gemini.spModel.gemini.gmos;
 
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Coordinates;
+import edu.gemini.spModel.gemini.altair.InstAltair;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.guide.BoundaryPosition;
 import edu.gemini.spModel.obs.context.ObsContext;
@@ -14,6 +15,8 @@ import org.junit.Test;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.spModel.core.Site;
 
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 
 import static edu.gemini.skycalc.Angle.Unit.ARCSECS;
@@ -216,6 +219,26 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
                         GmosOiwfsGuideProbe.instance.checkBoundaries(guideTarget,baseContext));
             }
         }
+    }
+
+
+    /**
+     * Tests that the patrol field calculation considers the flip introduced by Altair
+     */
+    @Test
+    public void testAOFlip() {
+
+        final ObsContext ctx = baseContext.withAOComponent(new InstAltair());
+        final Area aoArea = GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx).getArea();
+
+        final AffineTransform altairTransform = AffineTransform.getScaleInstance(1.0, -1.0);
+        final Area expectedArea = GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(baseContext)
+                .getTransformed(altairTransform).getArea();
+
+        // Had to use assertTrue() instead of assertEquals() because
+        // Area.equals() doesn't override Object.equals()
+        assertTrue("Patrol field not adjusted for AO.", aoArea.equals(expectedArea));
+
     }
 
     /**


### PR DESCRIPTION
My first pull request!
The task was to flip the GMOS OIWFS FOV when using Altair. There is one part of my solution that leaves me a bit unsatisfied. That is that I created a AffineTransform (called altairTransform) to apply the flip. If the LGS+OIWFS mode is used for other instruments in the future, they will also need this transformation. I thought of making altairTransform accessible to other instruments OIWFS classes, but I didn't know where to put it.
