### PR TITLE
REL-1308: Made requisite changes to allow for e-offsetting for GMOS N&S ...

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -1949,8 +1949,6 @@ public abstract class InstGmosCommon<
      * more than 2 arcsec from any other. If doing a square dither pattern, for example,
      * the diagonal of the square should be <=2 arcsec.
      * The default should be for no electronic offsets.
-     *
-     * @param inst the instrument corresponding to this list
      * @return a string explaining why electronic offsets are not allowed, or null if they are allowed
      */
     public static UseElectronicOffsettingRuling checkUseElectronicOffsetting(InstGmosCommon inst, OffsetPosList<OffsetPos> p) {


### PR DESCRIPTION
...with no guide star if offsets sufficiently small.

Essentially, for GMOS N&S templates, we want to allow for electronic offsetting if there is no guide star but the offsets are sufficiently small (sqrt(p^2 + q^2) <= 1).

I think that the electronic offsetting checkbox behaviour - independent of these changes - needs work, but I'm not going to touch that for now and until it can be discussed in more detail with science staff.
