### PR TITLE
REL-1063: Fix OT nonsidereal Solar System Object Horizons name resolution

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1895,7 +1895,13 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             SPTarget base = env.getBase();
             base.setTargetWithJ2000(basePos.getRaDeg(), basePos.getDecDeg());
         } else if (w == _w.resolveButton) {
-            _resolveName(HorizonsAction.Type.GET_ORBITAL_ELEMENTS, null);
+            // REL-1063 Fix OT nonsidereal Solar System Object Horizons name resolution
+            if (_curPos.getTarget() instanceof NamedTarget) {
+                // For named objects like Moon, Saturn, etc don't get the orbital elements, just the position
+                _resolveName(HorizonsAction.Type.UPDATE_POSITION, null);
+            } else {
+                _resolveName(HorizonsAction.Type.GET_ORBITAL_ELEMENTS, null);
+            }
         } else if (w == _w.timeRangePlotButton) {
             _resolveName(HorizonsAction.Type.PLOT_EPHEMERIS, null);
         } else if (w == _w.updateRaDecButton) {


### PR DESCRIPTION
Added extra change to the existing fix. It will do the same resolution when the search button is pressed

The relevant commit is:
https://github.com/cquiroz/ocs/commit/11cbba9abaeed5b8099cba68c3233456b7ae0f17
