### PR TITLE
REL-2067: run dataman at frameworklevel + 1

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
@@ -29,6 +29,7 @@ case class Configuration(
       case "org" :: "scala-lang" :: _                    => 10
       case "org" :: "scalaz"     :: _                    => 15
       case "edu" :: "gemini"     :: "model" :: "p1" :: _ => 30
+      case "edu" :: "gemini"     :: "dataman" :: _       => 100
       case "edu" :: "gemini"     :: _                    => 50
       case "org" :: "jsky"       :: _                    => 50
       case _                                             => 40


### PR DESCRIPTION
The Data Manager should be explicitly started after the `spdb` process is running and verified. It generates copious output as it performs a sync with the dataflow directory and complicates basic sanity checking.
