### PR TITLE
REL-1988: OT Java NPE when moving Offset iterator

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/niri/NiriRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/niri/NiriRule.java
@@ -1232,6 +1232,9 @@ public final class NiriRule implements IRule {
             boolean isF32 = camera == Niri.Camera.F32 || camera == Niri.Camera.F32_PV;
             Niri.Disperser disperser = (Niri.Disperser) SequenceRule.getInstrumentItem(config, InstNIRI.DISPERSER_PROP);
             Double expTime = SequenceRule.getExposureTime(config);
+            if (expTime == null) {
+                expTime = SequenceRule.getInstrumentExposureTime(config);
+            }
             if (filter == Niri.Filter.BBF_LPRIME && isF32 && expTime != null && expTime >= 0.12) {
                 return new Problem(WARNING, PREFIX + "NIRI_L_PRIME", NIRI_L_PRIME, SequenceRule.getInstrumentOrSequenceNode(step,elems));
             } else if (filter == Niri.Filter.BBF_LPRIME && !isF32) {

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/util/SequenceRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/util/SequenceRule.java
@@ -148,6 +148,24 @@ public class SequenceRule implements IRule {
         String strVal = (String)getItem(config, String.class, EXPOSURE_TIME_KEY);
         return _getDoubleValue(strVal);
     }
+
+    private static final ItemKey INSTRUMENT_EXPOSURE_TIME_KEY = new ItemKey(INSTRUMENT_PREFIX + "exposureTime");
+    
+    /**
+     * Return the exposure time for the instrument. Will try to
+     * get it both as a Double and String. The result is always a double
+     * and will return null in case nothing can be obtained from the config.
+     */
+    public static Double getInstrumentExposureTime(Config config) {
+        Double val = (Double)getItem(config, Double.class, INSTRUMENT_EXPOSURE_TIME_KEY);
+        if (val != null) {
+            return val;
+        }
+        //attempt to read it as string
+        String strVal = (String)getItem(config, String.class, INSTRUMENT_EXPOSURE_TIME_KEY);
+        return _getDoubleValue(strVal);
+    }
+
     private static final ItemKey COADDS_KEY = new ItemKey("observe:coadds");
 
     public static Integer getCoadds(Config config) {


### PR DESCRIPTION
I'm redoing the PR after some funny rebase
This PR contains a change after discussion with Andy. For NIRI if the observe exposure time isn't found, we'll attempt to use the instrument exposure time
A null check is added anyway
