### PR TITLE
REL-2063: QPT cannot open existing queue plans.

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Alloc.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Alloc.java
@@ -75,11 +75,11 @@ public final class Alloc implements Comparable<Alloc>, Commentable, PioSerializa
 	private Map<Circumstance, Double[]> circV, circS;
 
 	// Package-protected constructor called by Variant#addAlloc()
-	Alloc(Variant variant, Obs obs, Long low, int firstStep, int lastStep, SetupType setup, String comment) {
+	Alloc(final Variant variant, final Obs obs, final long low, final int firstStep, final int lastStep, final SetupType setup, final String comment) {
 		this(variant, obs, low, firstStep, lastStep, setup, comment, span(obs, firstStep, lastStep, setup));
 	}
 
-    Alloc(Variant variant, Obs obs, Long low, int firstStep, int lastStep, SetupType setup, String comment, long span) {
+    Alloc(final Variant variant, final Obs obs, final long low, final int firstStep, final int lastStep, final SetupType setup, final String comment, final long span) {
         this.interval = new Interval(low, addLchOverlap(obs, low, low + span));
         this.shutterTime = getEnd() - (low + span);
         this.variant = variant;
@@ -90,7 +90,7 @@ public final class Alloc implements Comparable<Alloc>, Commentable, PioSerializa
         setComment(comment);
     }
 
-    Alloc(Variant variant, Obs obs, ParamSet params) {
+    Alloc(final Variant variant, final Obs obs, final ParamSet params) {
 		this.interval = new Interval(params);
         this.shutterTime = 0;
 		this.variant = variant;
@@ -393,9 +393,7 @@ public final class Alloc implements Comparable<Alloc>, Commentable, PioSerializa
 	/// TRIVIAL ACCESSORS
 	///
 
-	public Obs getObs() {
-		return obs;
-	}
+	public Obs getObs() { return obs; }
 
 	public int getLastStep() {
 		return lastStep;
@@ -470,25 +468,6 @@ public final class Alloc implements Comparable<Alloc>, Commentable, PioSerializa
 			return Grouping.NONE;
 		}
 
-//
-//		Group group = getObs().getGroup();
-//		if (group != null) {
-//			Alloc prev = getPrevious();
-//			Alloc next = getNext();
-//			boolean gup = prev != null && group == prev.getObs().getGroup();
-//			boolean gdn = next != null && group == next.getObs().getGroup();
-//			if (gup && gdn) {
-//				return Grouping.MIDDLE;
-//			} else if (gup) {
-//				return Grouping.LAST;
-//			} else if (gdn) {
-//				return Grouping.FIRST;
-//			} else {
-//				return Grouping.SOLO;
-//			}
-//		} else {
-//			return Grouping.NONE;
-//		}
 	}
 
 	public int getGroupIndex() {

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
@@ -650,7 +650,7 @@ public final class Variant extends BaseMutableBean implements PioSerializable, C
 				}
 
 				// Insufficient facilities (option - grating, filter, etc)
-				for (Enum option: obs.getOptions()) {
+				for (Enum<?> option: obs.getOptions()) {
 					if (!owner.hasFacility(option)) {
 						facilitiesFlags.add(Flag.CONFIG_UNAVAILABLE);
 						break;
@@ -996,7 +996,7 @@ public final class Variant extends BaseMutableBean implements PioSerializable, C
 	}
 
 	@SuppressWarnings("unchecked")
-	private boolean containsAny(Collection a, Collection b) {
+	private boolean containsAny(Collection<?> a, Collection<?> b) {
 		for (Object o: a)
 			if (b.contains(o))
 				return true;
@@ -1025,16 +1025,15 @@ public final class Variant extends BaseMutableBean implements PioSerializable, C
 
 
 @SuppressWarnings("serial")
-class AllocSet extends TreeSet<Alloc> implements PioSerializable {
+final class AllocSet extends TreeSet<Alloc> implements PioSerializable {
 
     private static final Logger LOGGER = Logger.getLogger(AllocSet.class.getName());
 
     public static final String PROP_MEMBER = "visit";
 
-	public AllocSet() {
-	}
+    public AllocSet() {}
 
-	public AllocSet(Variant variant, ParamSet paramSet) {
+	public AllocSet(final Variant variant, final ParamSet paramSet) {
 		for (ParamSet allocParams: paramSet.getParamSets(PROP_MEMBER)) {
             final String obsId = Pio.getValue(allocParams, "obs");
             final Obs obs = variant.getSchedule().getMiniModel().getObs(obsId);
@@ -1048,8 +1047,8 @@ class AllocSet extends TreeSet<Alloc> implements PioSerializable {
         }
 	}
 
-	public ParamSet getParamSet(PioFactory factory, String name) {
-		ParamSet params = factory.createParamSet(name);
+	public ParamSet getParamSet(final PioFactory factory, final String name) {
+		final ParamSet params = factory.createParamSet(name);
 		for (Alloc a: this) {
 			params.addParamSet(a.getParamSet(factory, PROP_MEMBER));
 		}


### PR DESCRIPTION
Don't create Alloc objects for observations that can not be found in the ODB data provided by the mini model. This can for example happen if an observation is deleted or its state is changed from Prepared to Inactive (or in many other cases). This case was silently tolerated in earlier QPT versions where the obs object was not part of the hashCode, compareTo and equals methods which changed with PR-8 https://github.com/gemini-hlsw/ocs/pull/8. What happened was that Alloc objects were created but (I think) never really showed up anywhere and probably were lost / filtered out at some point. Now Alloc objects are only created if a corresponding obs is found in the mini model data. All other observations are ignored and will (as previously) not show up on the plan. I spoke with a QC here and this is the expected behavior, so I think we're good with this.
