### PR TITLE
REL-2064: check for mac networking issue on startup

### DIFF
--- a/bundle/edu.gemini.osgi.main/src/main/java/edu/gemini/osgi/main/FatalMessage.java
+++ b/bundle/edu.gemini.osgi.main/src/main/java/edu/gemini/osgi/main/FatalMessage.java
@@ -49,18 +49,17 @@ final class FatalMessage {
     // An awful popup so that users who aren't launching the app from the
     // command line at least know what is going on and what to do.
     private static void showPopup(final String title, final String message, final Logger log) {
-        final Dimension size = new Dimension(500, 100);
         final String wrapper = "<html><style type=\"text/css\">body { font:12pt dialog,sans-serif; }</style><body>%s</body></html>";
         final JEditorPane ed = new JEditorPane("text/html", String.format(wrapper, message)) {{
             setBackground(UIManager.getDefaults().getColor("Panel.background"));
             setHighlighter(null);
             setEditable(false);
             addHyperlinkListener(new Link(log));
-            setPreferredSize(size);
         }};
 
         final JScrollPane sp = new JScrollPane(ed) {{
             setBorder(BorderFactory.createEmptyBorder(0,0,0,0));
+            setPreferredSize(new Dimension(500, 100));
         }};
         JOptionPane.showMessageDialog(null, sp, title, JOptionPane.ERROR_MESSAGE);
     }

--- a/bundle/edu.gemini.osgi.main/src/main/java/edu/gemini/osgi/main/Main.java
+++ b/bundle/edu.gemini.osgi.main/src/main/java/edu/gemini/osgi/main/Main.java
@@ -37,9 +37,9 @@ public final class Main {
     private static final String NETWORKING_BUG_MESSAGE =
         "Your Mac's host name does not include domain information, which exposes a bug\n" +
         "in the version of Java being used by this application.  Adding <tt>.local</tt>\n" +
-        "to the host name will fix this issue.  See " +
-        "<a href=\"http://www.gemini.edu/sciops/observing-gemini/phase-ii-and-s/w-tools/observing-tool/known-bugs\">OT Known Bugs</a> "+
-        "for more information.";
+        "to the host name will fix this issue.  See our " +
+        "<a href=\"http://www.gemini.edu/node/12288\">note about Java 1.7</a> on the\n"+
+        "Gemini website for more information.";
 
     private static void checkLocalHostBug(Logger log) throws Exception {
         final String osname = System.getProperty("os.name");


### PR DESCRIPTION
Provides a warning and stops the application if we detect the Mac / JDK 1.7 [networking issue](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7180557|networking issue).  I separated out the warning popup handling into a separate `FatalMessage` class that supports html messages with links.  The idea is to refer the user to a support page, though at present I'm not sure if this is the correct URL to use.

Here is an example of the popup.  I think we'll all agree, it is stunningly beautiful.  Suggestions to improve the wording are welcome.  I expect Andy will want to make changes.

![networking](https://cloud.githubusercontent.com/assets/4906023/4883060/30726028-635e-11e4-9deb-adda99bb5411.png)
