### PR TITLE
Ignore the jres.sbt build file which will differ across developer environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+jres.sbt
 
 # Scala-IDE specific
 .scala_dependencies


### PR DESCRIPTION
It seems like we don't want `jres.sbt`, which is needed to tell the build where to find the various JREs, to count as a difference?
