### PR TITLE
REL-2062: Fixed width of percentage labels in Program Admin dialog box.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
@@ -37,6 +37,8 @@ final class TimeAcctUI extends JPanel {
 
             JLabel lab = new JLabel();
             lab.setHorizontalAlignment(JLabel.TRAILING);
+            lab.setPreferredSize(new Dimension(lab.getFontMetrics(lab.getFont()).stringWidth("100%"),
+                    lab.getFontMetrics(lab.getFont()).getHeight()));
             percentLabelMap.put(cat, lab);
         }
 
@@ -124,7 +126,7 @@ final class TimeAcctUI extends JPanel {
             gbc.anchor    = GridBagConstraints.EAST;
             gbc.gridx     = col+2;
             gbc.gridy     = row;
-            gbc.insets    = new Insets(10, 0, 0, (col == 0) ? 15 : 0);
+            gbc.insets    = new Insets(10, 0, 0, (col == 0) ? 30 : 0);
             pan.add(percentLabelMap.get(cat), gbc);
         }
 


### PR DESCRIPTION
The problem: In CentOS 6 (and probably other Linux distributions) all the text input fields in the Time Accounting section of the Program Admin dialog box shrink to a width of a few pixels when a number is input on any of the time fields.

The root cause is a layout problem. When a number is input, the percentage labels are updated and resized, making all the section wider. In CentOS, the Time Accounting section is the widest, defining the wide of the whole dialog box. Because there is no extra space, the layout manager decides to ignore the size suggested by the text fields.
This does not happen in OSX, because there the width of the Time Accounting section is smaller. The total width of the dialog box is defined by a HorizontalStrut of 520 pixels, which gives enough space for the percentage labels to grow.

Solution: The easiest solution would have been to increase the width of the HorizontalStrut. I decided against it, because it may not work for all OS. Instead, I chose to fix the width of the percentage labels, and increased the separation between the two columns to make clear the percentage label was associated with the text field at its left.
The one drawback is that, when the percentage value is "0%", it looks too distant from the  text field at its left. On a positive note, the columns don't move around anymore when the user inputs values.
This is how the dialog box looks after the changes:
![progadmin01](https://cloud.githubusercontent.com/assets/7621164/4831302/7d4d3c7a-5f93-11e4-9486-30c4350067c8.png)

And this is how it look when the user puts some numbers on it:
![progadmin02](https://cloud.githubusercontent.com/assets/7621164/4831316/99dbee04-5f93-11e4-97c4-78a05cb36d8f.png)
