### PR TITLE
REL-2095: make semester option apply only if the program pid has a semester

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SpidMatcher.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SpidMatcher.java
@@ -63,8 +63,10 @@ public interface SpidMatcher extends Serializable {
         public boolean matches(scala.Option<ProgramId> pid) {
             // Sorry, this is awkward mixing Scala and Java Option and
             // worse still, using it from Java.
-            return semester.isEmpty() ||  // match anything
-                    (!pid.isEmpty() && !pid.get().semester().isEmpty() && pid.get().semester().get().equals(semester.getValue()));
+            return semester.isEmpty() ||
+                        pid.isEmpty() ||
+                        pid.get().semester().isEmpty() ||
+                        pid.get().semester().get().equals(semester.getValue());
         }
     }
 


### PR DESCRIPTION
From REL-2095:

The "Open Program" semester filtering is working well, however, it is filtering out programs with no obvious semester (i.e. Libraries, local test programs, and user work areas).  To be able to see these programs, one must now also set the Semester to "Any".  While this does clean up the program list significantly, it is requested that we display "Other" programs with no associated semester regardless of which semester is selected.
