### PR TITLE
REL-2091: Memoize decryption attempts

### DIFF
--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/Sealed.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/Sealed.scala
@@ -13,7 +13,7 @@ case class Sealed[+A](so: SealedObject) {
   import Sealed._
 
   /** Attempts to retrieve the sealed object. */
-  def get(passPhrase: String): Exception \/ A = {
+  lazy val get: String => Exception \/ A = Memo.weakHashMapMemo { passPhrase =>
     val oldLoader = Thread.currentThread.getContextClassLoader
     try {
       Thread.currentThread.setContextClassLoader(getClass.getClassLoader) // TODO: may not be necessary


### PR DESCRIPTION
Now that we no longer rely on the sandbox's shared `Subject`, the security policy consults the `KeyChain` directly, which was causing its kernel to be decrypted on demand rather than once on startup and again when replaced due to a keychain modification. This is an expensive operation and was slowing the OT down. So I added a memo to cache decryption attempts, which speeds things up quite a bit.
