### PR TITLE
REL-2099: fixed endless stream of exceptions with locked keychain

### DIFF
--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
@@ -179,8 +179,9 @@ object ImplicitPolicyForJava {
   def hasPermission(db: IDBDatabaseService, principal: Principal, p: Permission): Boolean =
     ImplicitPolicy.hasPermission(db, Set(principal), p).unsafePerformIO
 
+  // N.B. this swallows KeyFailure. May or may not be a problem.
   def hasPermission(db: IDBDatabaseService, kc: KeyChain, p: Permission): Boolean =
-    ImplicitPolicy.hasPermission(db, kc, p).unsafeRunAndThrow
+    ImplicitPolicy.hasPermission(db, kc, p).run.unsafePerformIO.fold(_ => false, identity)
 
   def checkPermission(db: IDBDatabaseService, ps: java.util.Collection[Principal], p: Permission): Unit =
     if (hasPermission(db, ps, p)) () else fail(p)


### PR DESCRIPTION
While working on REL-2091 I noticed that if you lock the keychain with a program open, you get an endless stream of exceptions because permission checks **fail** with an exception due to the locked keychain, rather than returning `false`. All `KeyFailure` values can be interpreted as `false` in this context, so that's what this change does. 
