### PR TITLE
REL-2094: OT Timeline difficult to read

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/timeline/BlockTimeLineNode.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/timeline/BlockTimeLineNode.java
@@ -45,6 +45,7 @@ import jsky.science.Time;
 import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeEvent;
@@ -358,12 +359,13 @@ public class BlockTimeLineNode implements TimeLineNode {
                 graphics.setColor(Color.black);
                 float startX = fThumb.x - (float) (startBounds.getWidth() / 2.0);
                 float startY = fThumb.y + sThumbHeight + (float) (startBounds.getHeight() + TimeLineNode.DEFAULT_LABEL_SPACE);
+                AffineTransform oldTransform = graphics.getTransform();
                 if (startBounds.getWidth() > thumbWidth / 2f) {
-                    graphics.setFont(TimeLineNode.REVERSE_ROTATED_FONT);
-
+                    graphics.rotate(TimeLineNode.LABEL_REVERSE_ROTATION, startX, startY);
                 }
                 graphics.drawString(startStr, startX, startY);
                 graphics.setFont(origFont);
+                graphics.setTransform(oldTransform);
             }
 
             // draw end label
@@ -377,12 +379,13 @@ public class BlockTimeLineNode implements TimeLineNode {
                 graphics.setColor(Color.black);
                 float endX = fThumb.x + thumbWidth - (float) (endBounds.getWidth() / 2.0);
                 float endY = fThumb.y + sThumbHeight + (float) (endBounds.getHeight() + TimeLineNode.DEFAULT_LABEL_SPACE);
+                AffineTransform oldTransform = graphics.getTransform();
                 if (endBounds.getWidth() > thumbWidth / 2f) {
-                    graphics.setFont(TimeLineNode.REVERSE_ROTATED_FONT);
-
+                    graphics.rotate(TimeLineNode.LABEL_REVERSE_ROTATION, endX, endY);
                 }
                 graphics.drawString(endStr, endX, endY);
                 graphics.setFont(origFont);
+                graphics.setTransform(oldTransform);
 
             }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/timeline/DefaultTimeLineNode.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/timeline/DefaultTimeLineNode.java
@@ -45,6 +45,7 @@ import jsky.science.Time;
 import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeEvent;
@@ -582,13 +583,16 @@ public class DefaultTimeLineNode implements TimeLineNode {
 
             graphics.setFont(TimeLineNode.DEFAULT_FONT);
             NodeLabelData nlp = calc(getTimeLineNodeName(), graphics, addHandles);
-            if (nlp.rotate) graphics.setFont(TimeLineNode.ROTATED_FONT);
+            AffineTransform oldTransform = graphics.getTransform();
+            if (nlp.rotate) {
+                graphics.rotate(TimeLineNode.LABEL_ROTATION, nlp.textX, nlp.textY);
+            }
             graphics.setColor(Color.black);
             if (thumbWidth > 14.) // allan: quick fix to avoid overlapping strings
             {
                 graphics.drawString(nlp.label, nlp.textX, nlp.textY);
             }
-            graphics.setFont(origFont);
+            graphics.setTransform(oldTransform);
 
             // draw duration
             graphics.setFont(TimeLineNode.DEFAULT_FONT);
@@ -606,8 +610,8 @@ public class DefaultTimeLineNode implements TimeLineNode {
                 lengthY = fLeftHandle.y + fHandleHeight + (float) (lengthBounds.getHeight() + TimeLineNode.DEFAULT_LABEL_SPACE);
             }
             if (lengthBounds.getWidth() > thumbWidth) {
-                graphics.setFont(TimeLineNode.REVERSE_ROTATED_FONT);
                 lengthX = fThumb.x + thumbWidth / 2f;
+                graphics.rotate(TimeLineNode.LABEL_REVERSE_ROTATION, lengthX, lengthY);
 
             }
             if (thumbWidth > 14.) // allan: quick fix to avoid overlapping strings
@@ -615,6 +619,7 @@ public class DefaultTimeLineNode implements TimeLineNode {
                 graphics.drawString(lengthStr, lengthX, lengthY);
             }
             graphics.setFont(origFont);
+            graphics.setTransform(oldTransform);
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/timeline/TimeLineNode.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/timeline/TimeLineNode.java
@@ -74,9 +74,12 @@ public interface TimeLineNode extends VetoableChangeListener {
     public static final int RIGHT_HANDLE_SELECTED = 3;
 
     // fonts
+    public static final double LABEL_ROTATION = -Math.PI / 6.0;
+    public static final double LABEL_REVERSE_ROTATION = Math.PI / 6.0;
     public static final Font DEFAULT_FONT = new JLabel().getFont().deriveFont(Font.PLAIN, 10.0F);
-    public static final Font ROTATED_FONT = DEFAULT_FONT.deriveFont(AffineTransform.getRotateInstance(11.0 * Math.PI / 6.0));
-    public static final Font REVERSE_ROTATED_FONT = DEFAULT_FONT.deriveFont(AffineTransform.getRotateInstance(Math.PI / 6.0));
+    public static final Font ROTATED_FONT = DEFAULT_FONT.deriveFont(AffineTransform.getRotateInstance(LABEL_ROTATION));
+    public static final Font REVERSE_ROTATED_FONT = DEFAULT_FONT.deriveFont(AffineTransform.getRotateInstance(
+            LABEL_REVERSE_ROTATION));
 
     // cursors
     public static final Cursor MOVE_CURSOR = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);


### PR DESCRIPTION
Implemented alternate method to draw slanted text, which shows consistent results in Linux and OSX.
Instead of using a rotated font, the timeline labels are drawn using a rotate transformation on the graphics context.
