### PR TITLE
REL-2114: Fixed typo in base position parameter sent to Seqexec.

### DIFF
--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/SequenceOutputService.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/SequenceOutputService.java
@@ -78,7 +78,7 @@ public enum SequenceOutputService {
     // telescope:Base:name has to be called telescope:position(Base):name when
     // sent to the seqexec.
     private static final ItemKey REAL_BASE_KEY = new ItemKey("telescope:Base:name");
-    private static final ItemKey SEXQ_BASE_KEY = new ItemKey("telescope:postion(Base):name");
+    private static final ItemKey SEXQ_BASE_KEY = new ItemKey("telescope:position(Base):name");
     private void renameTargetBase(Config c) {
         Object val = c.remove(REAL_BASE_KEY);
         if (val != null) c.putItem(SEXQ_BASE_KEY, val);


### PR DESCRIPTION
Not much to say about this one. I found use for a parameter sent to Seqexec that was not used before, only to discover that it was sent with the wrong name. So, I fixed it.
