### PR TITLE
REL-2072, OCSADV-29: updates to guiding controls

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -135,8 +135,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.addComponentListener(new ComponentAdapter() {
             @Override
             public void componentShown(ComponentEvent componentEvent) {
-                toggleAgsGuiElements(GuideStarSupport.supportsAutoGuideStarSelection(getNode())
-                        && SPObservation.needsGuideStar(getContextObservation()));
+                toggleAgsGuiElements();
             }
         });
 
@@ -1342,8 +1341,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     public void init() {
         setTargetObsComp();
         _w.manualGuideStarButton.setVisible(GuideStarSupport.supportsManualGuideStarSelection(getNode()));
-        toggleAgsGuiElements(GuideStarSupport.supportsAutoGuideStarSelection(getNode())
-                && SPObservation.needsGuideStar(getContextObservation()));
         updateGuiding();
         _agsPub.watch(getContextObservation());
     }
@@ -1358,13 +1355,14 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
     /**
      * Toggles the ags related gui elements depending on context.
-     *
-     * @param supportsAutoGuideStar
      */
-    private void toggleAgsGuiElements(boolean supportsAutoGuideStar) {
+    private void toggleAgsGuiElements() {
+        final boolean supports = GuideStarSupport.supportsAutoGuideStarSelection(getNode());
+        final boolean needs    = SPObservation.needsGuideStar(getContextObservation());
+
         // hide the ags related buttons
-        _w.guidingControls.visible_$eq(supportsAutoGuideStar);
-        _w.guidingFeedback.visible_$eq(supportsAutoGuideStar);
+        _w.guidingControls.supportsAgs_$eq(supports);
+        _w.guidingFeedback.visible_$eq(needs && supports);
     }
 
     // Guider panel property change listener to modify status and magnitude limits.
@@ -1379,6 +1377,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     }
 
     private void updateGuiding(final TargetEnvironment env) {
+        toggleAgsGuiElements();
         final Option<ObsContext> ctx = ObsContext.create(getContextObservation()).map(new Function1<ObsContext, ObsContext>() {
             @Override public ObsContext apply(ObsContext obsContext) {
                 return obsContext.withTargets(env);

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
@@ -31,19 +31,9 @@ class GuidingControls extends GridBagPanel {
     insets = new Insets(0, 5, 0, 10)
   }
 
-  val autoGuideStarButton = new Button {
-    import GuidingControls.{Search, Update}
-    text = Search
-
+  val autoGuideStarButton = new Button("Auto GS") {
     def update(analysis: List[AgsAnalysis]): Unit = {
-      def noGuideStar(a: AgsAnalysis): Boolean = a match {
-        case AgsAnalysis.NoGuideStarForGroup(_) => true
-        case AgsAnalysis.NoGuideStarForProbe(_) => true
-        case _ => false
-      }
-
       enabled = analysis.nonEmpty // if empty, no strategy so no search
-      text    = if (analysis.exists(noGuideStar)) Search else Update
     }
   }
 
@@ -52,13 +42,7 @@ class GuidingControls extends GridBagPanel {
     insets = new Insets(0, 0, 0, 5)
   }
 
-  val manualGuideStarButton = new Button {
-    text = "Plot..."
-
-    def update(analysis: List[AgsAnalysis]): Unit = {
-      enabled = analysis.nonEmpty  // only empty if there is no strategy
-    }
-  }
+  val manualGuideStarButton = new Button("Manual GS")
 
   layout(manualGuideStarButton) = new Constraints {
     gridx  = 3
@@ -70,14 +54,12 @@ class GuidingControls extends GridBagPanel {
       str <- AgsRegistrar.currentStrategy(ctx)
     } yield str.analyze(ctx, DefaultMagnitudeTable(ctx))).getOrElse(List.empty)
     autoGuideStarButton.update(analysis)
-    manualGuideStarButton.update(analysis)
     autoGuideStarGuiderSelector.setAgsOptions(AgsContext.create(ctxOpt))
   }
+
+  def supportsAgs_=(supports: Boolean): Unit = {
+    guiderLabel.visible = supports
+    autoGuideStarGuiderSelector.getUi.setVisible(supports)
+    autoGuideStarButton.visible = supports
+  }
 }
-
-object GuidingControls {
-  private val Search = "Search"
-  private val Update = "Update"
-}
-
-


### PR DESCRIPTION
These changes are mostly about REL-2072, making the guiding controls appear for ToO observations.  There is some overlap there with OCSADV-29 which requests that the guiding controls appear for empty sequence observations.  Both these situations were filtering out the guiding controls because the observation isn't considered to _need_ a guide star.  This update makes the manual guide star search button always available and the AGS controls and labels available whenever it is possible to do an AGS lookup.  Guiding feedback is still withheld unless the observation actually needs a guide star but the definition of "needs a guide star" has been adjusted for ToO observations to mean that a non-default target is available.

The first of Bryan's requests in OCSADV-29 is covered by these changes:
- The AGS buttons should always be displayed instead of only appearing when an observe is present in the sequence

In addition, the next two requests were incorporated as well since they are trivial label updates.
- The Plot... button should be labeled "Manual GS" since this button brings up the Manual Guidestar search dialog
- The Update/Search button should be labeled "Auto GS" to better distinguish the functionality from the manual search
