### PR TITLE
REL-2081: Spurious NPE in drag and drop operations.

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/PlotViewer.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/PlotViewer.java
@@ -326,11 +326,11 @@ public class PlotViewer extends GViewer<Variant, Alloc> {
 		public void dragOver(final DropTargetDragEvent dtde) {
 			final Option<GSelection<Alloc>> obj = getDraggedObject(dtde.getTransferable());
 			if (obj.isDefined()) {
-                final boolean snap = BooleanToolPreference.TOOL_SNAP.get();
-                // Get the offset. This will be in ms between 0 and the obs/alloc length (or null).
-                getControl().setDrag(dtde.getLocation(), obj.get(), snap, (Long) obj.get().getProperty("offset"));
+				final boolean snap = BooleanToolPreference.TOOL_SNAP.get();
+				// Get the offset. This will be in ms between 0 and the obs/alloc length (or null).
+				getControl().setDrag(dtde.getLocation(), obj.get(), snap, (Long) obj.get().getProperty("offset"));
 			} else {
-                dtde.rejectDrag();
+				dtde.rejectDrag();
 			}
 		}
 
@@ -341,16 +341,16 @@ public class PlotViewer extends GViewer<Variant, Alloc> {
 			// from the model. We can just go ahead and remove anything from the model that's
 			// in the drag.
 			final Option<GSelection<Alloc>> obj = getDraggedObject(dtde.getTransferable());
-            if (obj.isDefined()) {
- 			    for (Alloc a: getModel().getAllocs()) {
-			    	if (obj.get().contains(a)) {
-                        a.forceRemove();
-                    }
-                }
-                dragOver(dtde);
-            } else {
-                dtde.rejectDrag();
-            }
+			if (obj.isDefined()) {
+				for (Alloc a: getModel().getAllocs()) {
+					if (obj.get().contains(a)) {
+						a.forceRemove();
+					}
+				}
+				dragOver(dtde);
+			} else {
+				dtde.rejectDrag();
+			}
 
 			getControl().setIgnoreRepaint(false); // [QPT-185]; see dragGestureRecognized() above
 		}


### PR DESCRIPTION
Andy experienced spurious NPEs when removing observations from a plan. I was not able to reproduce this however it seemed that introducing an option for the result of `getDraggedObject()` might be a good idea anyway; there were already null checks in place for two of the three calls of this method, now empty results are checked for in all three usages. Manual testing seemed to work as expected, Andy will have to retest this with his data set.
