### PR TITLE
REL-2099: policy/trpcclient fix for locked keychain

### DIFF
--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
@@ -181,7 +181,10 @@ object ImplicitPolicyForJava {
 
   // N.B. this swallows KeyFailure. May or may not be a problem.
   def hasPermission(db: IDBDatabaseService, kc: KeyChain, p: Permission): Boolean =
-    ImplicitPolicy.hasPermission(db, kc, p).run.unsafePerformIO.fold(_ => false, identity)
+    ImplicitPolicy.hasPermission(db, kc, p).run.unsafePerformIO.fold({
+      case KeyFailure.KeychainLocked => false
+      case f                         => throw f.toException
+    }, identity)
 
   def checkPermission(db: IDBDatabaseService, ps: java.util.Collection[Principal], p: Permission): Unit =
     if (hasPermission(db, ps, p)) () else fail(p)

--- a/bundle/edu.gemini.util.trpc/src/main/scala/edu/gemini/util/trpc/client/TrpcClient.scala
+++ b/bundle/edu.gemini.util.trpc/src/main/scala/edu/gemini/util/trpc/client/TrpcClient.scala
@@ -39,7 +39,10 @@ object TrpcClient {
       withKeys(Set())
 
     def withKeyChain(kc: KeyChain): TrpcClient =
-      withKeys(kc.selection.unsafeRunAndThrow.map(_._2).toSet)
+      withKeys(kc.selection.run.unsafePerformIO.fold({
+        case KeyFailure.KeychainLocked => None
+        case f                         => throw f.toException
+      }, identity).map(_._2).toSet)
 
     def withOptionalKeyChain(okc: Option[KeyChain]): TrpcClient =
       okc.map(withKeyChain).getOrElse(withoutKeys)


### PR DESCRIPTION
One of the side-effects of removing the reliance on the Java sandbox is that the keychain is consulted more often than before, and in some of these cases a locked keychain is acceptable and should be interpreted as if it were empty. In these cases `unsafeRunAndThrow` is not appropriate because it promotes `KeyFailure.KeychainLocked` to an exception. This PR addresses the two known cases: one discovered by Andy in `TrpcClient` construction, and one in `ImplicitPolicy` which was fixed in #87 but is improved here.
