### PR TITLE
OCSADV-191: cleanup probe limits parsing

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsTable.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsTable.scala
@@ -34,7 +34,7 @@ object ProbeLimitsTable {
     try {
       for {
         s <- is.toRightDisjunction(s"Could not find $ConfFile")
-        t <- ProbeLimitsParser.read(s).map(ProbeLimitsTable(_))
+        t <- new ProbeLimitsParser().read(s).map(ProbeLimitsTable(_))
       } yield t
     } finally {
       is.foreach(_.close())

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/package.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/package.scala
@@ -3,9 +3,6 @@ package edu.gemini.ags
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{SkyBackground, ImageQuality}
 import edu.gemini.spModel.guide.GuideSpeed
 
-import scalaz._
-import Scalaz._
-
 package object conf {
 
   sealed case class MagLimitsId(name: String)
@@ -43,41 +40,15 @@ package object conf {
   case class FaintnessKey(iq: ImageQuality, sb: SkyBackground, gs: GuideSpeed) {
     override def toString: String = s"($iq, $sb, $gs)"
   }
+
   type FaintnessMap = Map[FaintnessKey, Double]
 
+  val AllFaintnessKeys =
+    (for {
+      iq <- ImageQuality.values()
+      sb <- SkyBackground.values()
+      gs <- GuideSpeed.values()
+    } yield FaintnessKey(iq, sb, gs)).toSet
+
   type CalcMap = Map[MagLimitsId, ProbeLimitsCalc]
-
-  // The parser validates most aspects of the CalcMap, but doesn't catch missing
-  // tables or duplicate faintness keys.
-  def validate(cm: CalcMap): String \/ Unit = {
-    def missingIds: String \/ Unit =
-      AllLimitsIds.filterNot(cm.contains).map(_.name) match {
-        case Nil => ().right
-        case ids => ids.mkString("Missing table for: ", ", ", "").left
-      }
-
-    // Each ProbeLimitsCalc entry should have all these keys.
-    val allKeys =
-      (for {
-        iq <- ImageQuality.values()
-        sb <- SkyBackground.values()
-        gs <- GuideSpeed.values()
-      } yield FaintnessKey(iq, sb, gs)).toSet
-
-    def incompleteTables: String \/ Unit = {
-      val errors = cm.map { case (MagLimitsId(name), ProbeLimitsCalc(_, _, fm)) =>
-        name -> (allKeys &~ fm.keySet)
-      }.filterNot(_._2.isEmpty).map { case (name, keys) =>
-        s"$name is missing entries: ${keys.mkString(", ")}"
-      }
-      if (errors.isEmpty) ().right
-      else errors.mkString(", ").left
-    }
-
-    for {
-      _ <- missingIds
-      _ <- incompleteTables
-    } yield cm
-  }
-
 }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/conf/LoadProbeLimits.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/conf/LoadProbeLimits.scala
@@ -22,7 +22,7 @@ object LoadProbeLimits {
     }
 
   def main(args: Array[String]): Unit =
-    ProbeLimitsParser.read(this.getClass.getResourceAsStream("Guide Limits - OT Config.csv")) match {
+    new ProbeLimitsParser().read(this.getClass.getResourceAsStream("Guide Limits - OT Config.csv")) match {
       case \/-(m) => dump(m)
       case -\/(m) => println(m)
     }


### PR DESCRIPTION
A few minor tweaks:
1. Make `ProbeLimitsParser` a class instead of an object to discourage use from multiple threads, since the parser isn't thread safe.
2. Make the intermediate parsers it contains `val`s since they are, well, constant values.
3. Move the additional validation to the `ProbeLimitsParser` since that's the only place it is used.
4. Switch to `Validation` to allow the two types of errors to accumulate.
