### PR TITLE
REL-2115: make titles black so they stand out

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/edu/gemini/mask/MaskEdit.java
+++ b/bundle/jsky.app.ot/src/main/java/edu/gemini/mask/MaskEdit.java
@@ -193,7 +193,7 @@ public class MaskEdit extends JFrame {
         TileCache cache = JAI.getDefaultInstance().getTileCache();
         cache.setMemoryCapacity(tilecache * 1024 * 1024);
 
-        Theme.installGreenTheme();
+        Theme.install();
 
         // Set the default catalog config file URL
         SkycatConfigFile.setConfigFile(Resources.getResource("conf/skycat.cfg"));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/jskycat/JSkyCat.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/jskycat/JSkyCat.java
@@ -453,7 +453,7 @@ public class JSkyCat extends JFrame {
         // For testing
         // new tilecachetool.TCTool();
 
-        Theme.installGreenTheme();
+        Theme.install();
 
         new JSkyCat(imageFileOrUrl, internalFrames, showNavigator, portNum);
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OT.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OT.java
@@ -162,7 +162,7 @@ public final class OT {
 //        }
 
 
-        Theme.installGreenTheme();
+        Theme.install();
 
         // [OT-642] Poke around with the keybindings for text fields on the Mac so
         // they respond to Cmd rather than Ctrl. Copied from QPT (Platform.java)

--- a/bundle/jsky.util.gui/src/main/java/jsky/util/gui/Theme.java
+++ b/bundle/jsky.util.gui/src/main/java/jsky/util/gui/Theme.java
@@ -12,14 +12,14 @@ import javax.swing.*;
 import javax.swing.plaf.ColorUIResource;
 
 /**
- * Modifies the JGoodies SkyGreen theme to have greenish labels
+ * Provides a utility for installing the OT look and feel and color theme.
  */
 public final class Theme {
 
     /**
-      * Install the green theme and JGoodies Plastic3DLookAndFeel.
+      * Install the OT theme and look and feel.
       */
-     public static void installGreenTheme() {
+     public static void install() {
          PlasticLookAndFeel.setPlasticTheme(new SkyBlue() {
              private final ColorUIResource darkGray = new ColorUIResource(90, 90, 90);
              @Override public ColorUIResource getPrimary1() {


### PR DESCRIPTION
This PR updates the OT color theme slightly in order to make node editor window titles, titled separators etc. black instead of dark gray.  Keeps the menu selection background the same color of dark gray that it was before.
