### PR TITLE
REL-2121: NPE in TPE offset feature unload

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/tpe/EdIterOffsetFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/tpe/EdIterOffsetFeature.java
@@ -150,7 +150,7 @@ public class EdIterOffsetFeature extends TpeImageFeature
         final List<SingleOffsetListContext> iterators = ctx.offsets().allJava();
 
         // iterators map { it => new OffsetPosMap(it) }
-        posMaps = new ArrayList<OffsetPosMap>(iterators.size());
+        posMaps = new ArrayList<>(iterators.size());
         for (SingleOffsetListContext iterator : iterators) {
             posMaps.add(new OffsetPosMap(iw, iterator));
         }
@@ -158,23 +158,17 @@ public class EdIterOffsetFeature extends TpeImageFeature
 
 
     /**
-     * Unloaded, so free the position map. Also select the base position, since the
-     * offset positions are no longer visible.
+     * Unloaded, so free the position map.
      */
     public void unloaded() {
-        _iw.setViewingOffsets(false);
+        if (_iw != null) {
+            _iw.setViewingOffsets(false);
+        }
 
         super.unloaded();
 
         for (OffsetPosMap opm : posMaps) opm.free();
         posMaps = Collections.emptyList();
-
-        // select the base pos
-        // TPE REFACTOR - selection handling
-//        if (getContext().targetEnv().isDefined()) {
-//            TargetEnvironment env = getContext().targetEnv().get();
-//            obsComp.setSelectedTarget(env.getBase());
-//        }
     }
 
     // Return the SciAreaFeature, or null if none is defined yet

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeFeatureManager.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeFeatureManager.java
@@ -79,6 +79,13 @@ final class TpeFeatureManager {
         final JToggleButton btn = new JCheckBox(name);
         btn.setToolTipText(tif.getDescription());
         btn.setVisible(false);
+
+        // Load the desired value from the preferences or set to the default.
+        // Do this before adding the item listener so that the feature isn't
+        // added to the image widget as a side-effect.  Features are initialized
+        // in the image widget by updateAvailableOptions.
+        btn.setSelected(Preferences.get(prefName, tif.isEnabledByDefault()));
+
         btn.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 final boolean selected = e.getStateChange() == ItemEvent.SELECTED;
@@ -102,9 +109,6 @@ final class TpeFeatureManager {
             comp.setVisible(false);
             _tpeToolBar.addViewItem(comp, tif.getCategory());
         }
-
-        // Load the desired value from the preferences or set to the default.
-        btn.setSelected(Preferences.get(prefName, tif.isEnabledByDefault()));
     }
 
     public void updateAvailableOptions(Collection<TpeImageFeature> feats, TpeContext ctx) {


### PR DESCRIPTION
This PR addresses a `NullPointerException` in the OT TPE. It will happen when the first observation displayed in the TPE does not have offset positions.  There are two substantive changes:
- `TpeImageFeature` implementations in general do not assume that the feature has been properly initialized in their `unloaded` methods.  A quick look at all image feature implementations except `EdIterOffsetFeature` confirms this.  Unfortunately `EdIterOffsetFeature` trys to access the image widget to set a flag in its `unloaded` method:
  
  `_iw.setViewingOffsets(false);`
  
  This has been protected by a `null` check.
- Next I looked into why the `EdIterOffsetFeature` had been loaded in the first place and found that it was an unintended consequence of setting selection preferences on startup.  Setting the preference triggers an item listener which adds the feature to the image widget even though the TPE hasn't been fully initialized.  I moved the button selection before the item listener is established to avoid this issue.
