### PR TITLE
REL-2133: Make corrected patrol field an Option[PatrolField]

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
@@ -93,7 +93,7 @@ case class PwfsParams(site: Site, guideProbe: PwfsGuideProbe) extends SingleProb
     }
 
     override def radiusLimits(ctx: ObsContext): Option[RadiusLimits] =
-      RadiusLimitCalc.getAgsQueryRadiusLimits(vignettingProofPatrolField(ctx), ctx).asScalaOpt
+      RadiusLimitCalc.getAgsQueryRadiusLimits(Some(vignettingProofPatrolField(ctx)).asGeminiOpt, ctx).asScalaOpt
 
     // We have a special validator for Pwfs.
     override def validator(ctx: ObsContext): GuideStarValidator =

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
@@ -89,7 +89,7 @@ object AgsTest {
 
 case class AgsTest(ctx: ObsContext, guideProbe: GuideProbe, usable: List[(SkyObject, GuideSpeed)], unusable: List[SkyObject],
                    calculateValidArea: (ObsContext, GuideProbe) => Area
-                    = (ctx: ObsContext, probe: GuideProbe) => probe.getCorrectedPatrolField(ctx).getArea) {
+                    = (ctx: ObsContext, probe: GuideProbe) => probe.getCorrectedPatrolField(ctx).getValue.getArea) {
   import AgsTest.{nudge, minimumDistance, magTable}
   type Point = Point2D.Double
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -1,10 +1,10 @@
 package edu.gemini.spModel.gemini.altair;
 
+import edu.gemini.shared.util.immutable.*;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
-import edu.gemini.shared.util.immutable.None;
-import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.nifs.InstNIFS;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
@@ -104,14 +104,17 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
         return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
     }
 
-    public BoundaryPosition checkBoundaries(Coordinates coords, ObsContext ctx) {
+    public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {
         final Coordinates baseCoordinates = ctx.getBaseCoordinates();
         final Angle positionAngle = ctx.getPositionAngle();
         final Set<Offset> sciencePositions = ctx.getSciencePositions();
 
         // check positions against corrected patrol field
-        final PatrolField correctedPatrolField = getCorrectedPatrolField(ctx);
-        return correctedPatrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
+        return getCorrectedPatrolField(ctx).map(new MapOp<PatrolField, BoundaryPosition>() {
+            @Override public BoundaryPosition apply(PatrolField patrolField) {
+                return patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
+            }
+        }).getOrElse(BoundaryPosition.outside);
     }
 
     @Override public boolean inRange(ObsContext ctx, Offset offset) {
@@ -119,17 +122,25 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
     }
 
     @Override public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar, getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 
-    @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        // for NIFS we must correct the patrol
-        // (this is SCT-361 related and has been moved here from Altair_WFS_Feature class)
-        if (ctx.getInstrument() instanceof InstNIFS) {
-            AffineTransform correction = AffineTransform.getTranslateInstance(-InstNIFS.ALTAIR_P_OFFSET, -InstNIFS.ALTAIR_Q_OFFSET);
-            return getPatrolField().getTransformed(correction);
-        }
-        // for all other instruments Altair does not have any correction (offsets) we need to apply to the patrol field
-        return patrolField;
+    @Override public Option<PatrolField> getCorrectedPatrolField(final ObsContext ctx) {
+        return ctx.getAOComponent().flatMap(new MapOp<AbstractDataObject, Option<PatrolField>>() {
+            @Override public Option<PatrolField> apply(final AbstractDataObject ado) {
+                if (ado instanceof InstAltair) {
+                    // for NIFS we must correct the patrol
+                    // (this is SCT-361 related and has been moved here from Altair_WFS_Feature class)
+                    if (ctx.getInstrument() instanceof InstNIFS) {
+                        AffineTransform correction = AffineTransform.getTranslateInstance(-InstNIFS.ALTAIR_P_OFFSET, -InstNIFS.ALTAIR_Q_OFFSET);
+                        return new Some<>(getPatrolField().getTransformed(correction));
+                    }
+                    // for all other instruments Altair does not have any correction (offsets) we need to apply to the patrol field
+                    return new Some<>(patrolField);
+                } else {
+                    return None.instance();
+                }
+            }
+        });
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
@@ -1,5 +1,6 @@
 package edu.gemini.spModel.gemini.flamingos2;
 
+import edu.gemini.shared.util.immutable.None;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Offset;
 import edu.gemini.shared.util.immutable.Option;
@@ -98,7 +99,7 @@ public enum Flamingos2OiwfsGuideProbe implements GuideProbe, ValidatableGuidePro
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 
     @Override
@@ -139,28 +140,32 @@ public enum Flamingos2OiwfsGuideProbe implements GuideProbe, ValidatableGuidePro
     public PatrolField getPatrolField() {
         return patrolField;
     }
-    @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        /*
-            Although normally this function only returns flips and offsets, I'm going to do the scaling to the LyotWheel plate scale here
-        */
-       Flamingos2 f2 = (Flamingos2) ctx.getInstrument();
-       final double plateScale = f2.getLyotWheel().getPlateScale();
-       AffineTransform xform = AffineTransform.getScaleInstance(plateScale, plateScale);
 
-       //Flip it for the port?
-       //Validate(ctx.getAoComponent() == null) -> getFlipConfig(false)
-       final boolean flip = f2.getFlipConfig(false);
-       if(flip){
-           //Flip in X only
-           xform.concatenate(AffineTransform.getScaleInstance(-1.0, 1.0));
-       }
+    @Override
+    public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+        if (ctx.getInstrument() instanceof Flamingos2) {
+            // Although normally this function only returns flips and offsets, I'm going to do the scaling to the LyotWheel plate scale here
+            final Flamingos2 f2 = (Flamingos2) ctx.getInstrument();
+            final double plateScale = f2.getLyotWheel().getPlateScale();
+            final AffineTransform xform = AffineTransform.getScaleInstance(plateScale, plateScale);
 
-       final int sign = flip ? -1 : 1;
-       final double rotationAngleInRadians = f2.getRotationConfig(false).toRadians().getMagnitude();
-       AffineTransform rotateForPortAndFlip = AffineTransform.getRotateInstance(rotationAngleInRadians * sign);
-       xform.concatenate(rotateForPortAndFlip);
+            // Flip it for the port?
+            // Validate(ctx.getAoComponent() == null) -> getFlipConfig(false)
+            final boolean flip = f2.getFlipConfig(false);
+            if (flip) {
+                //Flip in X only
+                xform.concatenate(AffineTransform.getScaleInstance(-1.0, 1.0));
+            }
 
-       //Apply complete transform
-        return new PatrolField(xform.createTransformedShape(getPatrolField().getArea()));
+            final int sign = flip ? -1 : 1;
+            final double rotationAngleInRadians = f2.getRotationConfig(false).toRadians().getMagnitude();
+            final AffineTransform rotateForPortAndFlip = AffineTransform.getRotateInstance(rotationAngleInRadians * sign);
+            xform.concatenate(rotateForPortAndFlip);
+
+            // Apply complete transform
+            return new Some<>(new PatrolField(xform.createTransformedShape(getPatrolField().getArea())));
+        } else {
+            return None.instance();
+        }
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -9,6 +9,7 @@ import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.CoordinateDiff;
 import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
+import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gems.GemsGuideProbeGroup;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
@@ -53,8 +54,8 @@ public enum Canopus {
             @Override public PatrolField getPatrolField() {
                 return new PatrolField(new Area());
             }
-            @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-                return getPatrolField();
+            @Override public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+                return correctedPatrolField(ctx);
             }
         },
 
@@ -81,8 +82,8 @@ public enum Canopus {
             public PatrolField getPatrolField() {
                 return new PatrolField(new Area());
             }
-            @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-                return getPatrolField();
+            @Override public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+                return correctedPatrolField(ctx);
             }
         },
 
@@ -110,10 +111,23 @@ public enum Canopus {
             public PatrolField getPatrolField() {
                 return new PatrolField(new Area());
             }
-            @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-                return getPatrolField();
+            @Override public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+                return correctedPatrolField(ctx);
             }
         };
+
+        private static Option<PatrolField> correctedPatrolField(ObsContext ctx) {
+            return ctx.getAOComponent().filter(new PredicateOp<AbstractDataObject>() {
+                @Override public Boolean apply(AbstractDataObject ado) {
+                    return ado instanceof Gems;
+                }
+            }).map(new MapOp<AbstractDataObject, PatrolField>() {
+                @Override public PatrolField apply(AbstractDataObject abstractDataObject) {
+                    // not implemented yet, return an empty area
+                    return new PatrolField(new Area());
+                }
+            });
+        }
 
         /**
          * Probe arm starting angle. PI/2 means arm comes from the right.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -4,6 +4,8 @@
 
 package edu.gemini.spModel.gemini.gmos;
 
+import edu.gemini.shared.util.immutable.MapOp;
+import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
@@ -71,14 +73,17 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
         return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
     }
 
-    public BoundaryPosition checkBoundaries(Coordinates coords, ObsContext ctx) {
+    public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {
         final Coordinates baseCoordinates = ctx.getBaseCoordinates();
         final Angle positionAngle = ctx.getPositionAngle();
         final Set<Offset> sciencePositions = ctx.getSciencePositions();
 
         // check positions against corrected patrol field
-        final PatrolField correctedPatrolField = getCorrectedPatrolField(ctx);
-        return correctedPatrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
+        return getCorrectedPatrolField(ctx).map(new MapOp<PatrolField, BoundaryPosition>() {
+            @Override public BoundaryPosition apply(PatrolField patrolField) {
+                return patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
+            }
+        }).getOrElse(BoundaryPosition.outside);
     }
 
     /**
@@ -94,15 +99,15 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 
     public boolean validate(SkyObject guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar, getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 
     public boolean validate(Coordinates guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar, getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 
     @Override
@@ -111,11 +116,15 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     @Override
-    public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        return getCorrectedPatrolField(ctx, getPatrolField());
+    public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+        if (ctx.getInstrument() instanceof InstGmosCommon) {
+            return new Some<>(getCorrectedPatrolField(ctx, getPatrolField()));
+        } else {
+            return None.instance();
+        }
     }
 
-    public PatrolField getCorrectedPatrolField(ObsContext ctx, PatrolField patrolField) {
+    private PatrolField getCorrectedPatrolField(ObsContext ctx, PatrolField patrolField) {
         final AffineTransform sideLooking = transformForPort(ctx.getIssPort());
 
         // calculate and apply GMOS specific IFU offsets and flip coordinates

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiOiwfsGuideProbe.java
@@ -1,7 +1,6 @@
 package edu.gemini.spModel.gemini.gpi;
 
-import edu.gemini.shared.util.immutable.None;
-import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 
@@ -46,7 +45,12 @@ public enum GpiOiwfsGuideProbe implements GuideProbe {
     @Override public PatrolField getPatrolField() {
         return patrolField;
     }
-    @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        return patrolField;
+
+    @Override public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+        if (ctx.getInstrument() instanceof Gpi) {
+            return new Some<>(patrolField);
+        } else {
+            return None.instance();
+        }
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -345,7 +345,8 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
     @Override public PatrolField getPatrolField() {
         return patrolField;
     }
-    @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        return patrolField;
+
+    @Override public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+        return (ctx.getInstrument() instanceof Gsaoi) ? new Some<>(patrolField) : None.<PatrolField>instance();
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
@@ -6,6 +6,7 @@ package edu.gemini.spModel.gemini.nici;
 
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -55,11 +56,12 @@ public enum NiciOiwfsGuideProbe implements ValidatableGuideProbe {
     @Override public PatrolField getPatrolField() {
         return patrolField;
     }
-    @Override public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        return getPatrolField();
+
+    @Override public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+        return (ctx.getInstrument() instanceof InstNICI) ? new Some<>(getPatrolField()) : None.<PatrolField>instance();
     }
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
@@ -4,12 +4,9 @@
 
 package edu.gemini.spModel.gemini.nifs;
 
+import edu.gemini.shared.util.immutable.*;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Offset;
-import edu.gemini.shared.util.immutable.MapOp;
-import edu.gemini.shared.util.immutable.None;
-import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.PredicateOp;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.altair.InstAltair;
 import static edu.gemini.spModel.gemini.altair.AltairParams.FieldLens.IN;
@@ -60,17 +57,21 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     @Override
-    public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        return ctx.getAOComponent().filter(new PredicateOp<AbstractDataObject>() {
-            @Override public Boolean apply(AbstractDataObject dobj) {
-                return (dobj instanceof InstAltair);
-            }
-        }).map(new MapOp<AbstractDataObject, PatrolField>() {
-            @Override public PatrolField apply(AbstractDataObject dobj) {
-                InstAltair altair = (InstAltair) dobj;
-                return (altair.getFieldLens() == IN) ? fieldLensPatrolField : noFieldLensPatrolField;
-            }
-        }).getOrElse(noFieldLensPatrolField);
+    public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+        if (ctx.getInstrument() instanceof InstNIFS) {
+            return ctx.getAOComponent().flatMap(new MapOp<AbstractDataObject, Option<PatrolField>>() {
+                @Override public Option<PatrolField> apply(AbstractDataObject ado) {
+                    if (ado instanceof InstAltair) {
+                        final InstAltair altair = (InstAltair) ado;
+                        return new Some<>((altair.getFieldLens() == IN) ? fieldLensPatrolField : noFieldLensPatrolField);
+                    } else {
+                        return None.instance();
+                    }
+                }
+            }).orElse(new Some<>(noFieldLensPatrolField));
+        } else {
+            return None.instance();
+        }
     }
 
     @Override
@@ -80,6 +81,6 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
@@ -6,6 +6,7 @@ package edu.gemini.spModel.gemini.niri;
 
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -54,12 +55,12 @@ public enum NiriOiwfsGuideProbe implements ValidatableGuideProbe {
     }
 
     @Override
-    public PatrolField getCorrectedPatrolField(ObsContext ctx) {
-        return patrolField;
+    public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
+        return (ctx.getInstrument() instanceof InstNIRI) ? new Some<>(patrolField) : None.<PatrolField>instance();
     }
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), getCorrectedPatrolField(ctx), ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbe.java
@@ -117,5 +117,5 @@ public interface GuideProbe {
      * Gets a represenation of the patrol field which is flipped and offset according to instrument
      * specifics (e.g. IFU offsets for GMOS and the port the instrument is currently mounted on).
      */
-    PatrolField getCorrectedPatrolField(ObsContext ctx);
+    Option<PatrolField> getCorrectedPatrolField(ObsContext ctx);
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/Altair_WFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/Altair_WFS_Feature.java
@@ -142,7 +142,9 @@ public class Altair_WFS_Feature extends WFS_FeatureBase {
         // If there is a context (do we ever have no context?) we need to get the corrected patrol field.
         PatrolField patrolField = AltairAowfsGuider.instance.getPatrolField();
         for (ObsContext obsCtx : _iw.getMinimalObsContext()) {
-            patrolField = AltairAowfsGuider.instance.getCorrectedPatrolField(obsCtx);
+            for (PatrolField corrected : AltairAowfsGuider.instance.getCorrectedPatrolField(obsCtx)) {
+                patrolField = corrected;
+            }
         }
         edu.gemini.skycalc.Angle angle = new edu.gemini.skycalc.Angle(-_posAngle, edu.gemini.skycalc.Angle.Unit.RADIANS);
         setTransformationToScreen(angle, pixelsPerArcsec, offsetBaseScreenPos);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_OIWFS_Feature.java
@@ -99,18 +99,19 @@ public class Flamingos2_OIWFS_Feature  extends OIWFS_FeatureBase  {
     protected void _addPatrolField(double xc, double yc, double plateScale) {
         for (ObsContext ctx : _iw.getMinimalObsContext()) {
             // get scaled and offset f2 oiwfs patrol field
-            PatrolField patrolField = Flamingos2OiwfsGuideProbe.instance.getCorrectedPatrolField(ctx);
-            // rotation, scaling and transformation to match screen coordinates
-            Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-            Point2D.Double translation = new Point2D.Double(xc, yc);
-            setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+            for (PatrolField patrolField : Flamingos2OiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
 
-            // set patrol field for in Range check (this should probably be done using the inRange check provided by the guide probe)
-            _patrolField = patrolField.getArea();
-            _patrolField = transformToScreen(_patrolField);
+                // set patrol field for in Range check (this should probably be done using the inRange check provided by the guide probe)
+                _patrolField = patrolField.getArea();
+                _patrolField = transformToScreen(_patrolField);
 
-            // draw patrol field
-            addPatrolField(patrolField);
+                // draw patrol field
+                addPatrolField(patrolField);
+            }
         }
     }
 
@@ -337,14 +338,15 @@ public class Flamingos2_OIWFS_Feature  extends OIWFS_FeatureBase  {
     private void addOffsetConstrainedPatrolField(double basePosX, double basePosY){
         for (ObsContext ctx : _iw.getMinimalObsContext()) {
             // get flipped and offset and scaled f2 oiwfs patrol field
-            PatrolField patrolField = Flamingos2OiwfsGuideProbe.instance.getCorrectedPatrolField(ctx);
-            // rotation, scaling and transformation to match screen coordinates
-            Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-            Point2D.Double translation = new Point2D.Double(basePosX, basePosY);
-            setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+            for (PatrolField patrolField : Flamingos2OiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(basePosX, basePosY);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
 
-            Set<Offset> offsets = getContext().offsets().scienceOffsetsJava();
-            addOffsetConstrainedPatrolField(patrolField, offsets);
+                final Set<Offset> offsets = getContext().offsets().scienceOffsetsJava();
+                addOffsetConstrainedPatrolField(patrolField, offsets);
+            }
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_OIWFS_Feature.java
@@ -82,13 +82,14 @@ public class GMOS_OIWFS_Feature extends OIWFS_FeatureBase {
     protected void addPatrolField(double xc, double yc) {
         // RCN: this won't work if there's no obs context
         for (ObsContext ctx : _iw.getMinimalObsContext()) {
-            PatrolField patrolField = GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx);
-            // rotation, scaling and transformation to match screen coordinates
-            Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-            Point2D.Double translation = new Point2D.Double(xc, yc);
-            setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+            for (PatrolField patrolField : GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
 
-            addPatrolField(patrolField);
+                addPatrolField(patrolField);
+            }
         }
     }
 
@@ -98,18 +99,19 @@ public class GMOS_OIWFS_Feature extends OIWFS_FeatureBase {
      * @param xc the X screen coordinate for the base position to use
      * @param yc the Y screen coordinate for the base position to use
      */
-    protected void addOffsetConstrainedPatrolField(double xc, double yc) {
-        Set<Offset> offsets = _iw.getContext().offsets().scienceOffsetsJava();
+    protected void addOffsetConstrainedPatrolField(final double xc, final double yc) {
+        final Set<Offset> offsets = _iw.getContext().offsets().scienceOffsetsJava();
 
-        if (_iw.getMinimalObsContext().isEmpty()) return;
-        PatrolField patrolField = GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(_iw.getMinimalObsContext().getValue());
-        offsetConstrainedPatrolFieldIsEmpty =  patrolField.outerLimitOffsetIntersection(offsets).isEmpty() ? true : false;
-        // rotation, scaling and transformation to match screen coordinates
-        Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-        Point2D.Double translation = new Point2D.Double(xc, yc);
-        setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
-
-        addOffsetConstrainedPatrolField(patrolField, offsets);
+        for (ObsContext ctx : _iw.getMinimalObsContext()) {
+            for (PatrolField patrolField : GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                offsetConstrainedPatrolFieldIsEmpty = patrolField.outerLimitOffsetIntersection(offsets).isEmpty() ? true : false;
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+                addOffsetConstrainedPatrolField(patrolField, offsets);
+            }
+        }
     }
 
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gnirs/GNIRS_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gnirs/GNIRS_OIWFS_Feature.java
@@ -54,19 +54,20 @@ public class GNIRS_OIWFS_Feature extends OIWFS_FeatureBase {
         if (inst == null) return;
 
         for (ObsContext ctx : _iw.getMinimalObsContext()) {
-            PatrolField range = GnirsOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx);
-            Angle angle = new Angle(-_posAngle, Angle.Unit.RADIANS);
-            Point2D.Double p1 = new Point2D.Double(offsetPosX + translateX, offsetPosY + translateY);
-            setTransformationToScreen(angle, _pixelsPerArcsec, p1);
+            for (PatrolField range : GnirsOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                final Angle angle = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double p1 = new Point2D.Double(offsetPosX + translateX, offsetPosY + translateY);
+                setTransformationToScreen(angle, _pixelsPerArcsec, p1);
 
-            // draw guide probe range
-            Composite composite = getFillObscuredArea() ? BLOCKED : null;
-            addPatrolField(range, OIWFS_COLOR, OIWFS_STROKE, composite);
+                // draw guide probe range
+                final Composite composite = getFillObscuredArea() ? BLOCKED : null;
+                addPatrolField(range, OIWFS_COLOR, OIWFS_STROKE, composite);
 
-            // draw intersection of offset patrol fields
-            Point2D.Double p2 = new Point2D.Double(basePosX, basePosY);
-            setTransformationToScreen(angle, _pixelsPerArcsec, p2);
-            addOffsetConstrainedPatrolField(range, _iw.getContext().offsets().scienceOffsetsJava());
+                // draw intersection of offset patrol fields
+                final Point2D.Double p2 = new Point2D.Double(basePosX, basePosY);
+                setTransformationToScreen(angle, _pixelsPerArcsec, p2);
+                addOffsetConstrainedPatrolField(range, _iw.getContext().offsets().scienceOffsetsJava());
+            }
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/nifs/NIFS_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/nifs/NIFS_OIWFS_Feature.java
@@ -7,8 +7,6 @@
 package jsky.app.ot.gemini.nifs;
 
 import diva.util.java2d.Polygon2D;
-import edu.gemini.shared.util.immutable.None;
-import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Offset;
 import edu.gemini.spModel.gemini.altair.AltairParams;
@@ -18,8 +16,6 @@ import edu.gemini.spModel.gemini.nifs.NifsOiwfsGuideProbe;
 import edu.gemini.spModel.guide.PatrolField;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
-import edu.gemini.spModel.target.offset.OffsetPosList;
-import edu.gemini.spModel.target.offset.OffsetUtil;
 import jsky.app.ot.gemini.inst.OIWFS_FeatureBase;
 import jsky.app.ot.tpe.TpeImageInfo;
 
@@ -96,18 +92,19 @@ public final class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
     protected void addPatrolField(final double xc, final double yc) {
         for (ObsContext ctx : _iw.getMinimalObsContext()) {
             // get scaled and offset f2 oiwfs patrol field
-            final PatrolField patrolField = NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx);
-            // rotation, scaling and transformation to match screen coordinates
-            final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-            final Point2D.Double translation = new Point2D.Double(xc, yc);
-            setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+            for (PatrolField patrolField : NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
 
-            // set patrol field for in Range check (this should probably be done using the inRange check provided by the guide probe)
-            final Area _patrolField = patrolField.getArea();
-            transformToScreen(_patrolField);
+                // set patrol field for in Range check (this should probably be done using the inRange check provided by the guide probe)
+                final Area _patrolField = patrolField.getArea();
+                transformToScreen(_patrolField);
 
-            // draw patrol field
-            addPatrolField(patrolField);
+                // draw patrol field
+                addPatrolField(patrolField);
+            }
         }
     }
 
@@ -119,17 +116,17 @@ public final class NIFS_OIWFS_Feature extends OIWFS_FeatureBase {
      * @param yc the Y screen coordinate for the base position to use
      */
     protected void addOffsetConstrainedPatrolField(final double xc, final double yc) {
+        for (ObsContext ctx : _iw.getMinimalObsContext()) {
+            for (PatrolField patrolField : NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
 
-        if (_iw.getMinimalObsContext().isEmpty()) return;
-
-        final PatrolField patrolField = NifsOiwfsGuideProbe.instance.getCorrectedPatrolField(_iw.getMinimalObsContext().getValue());
-        // rotation, scaling and transformation to match screen coordinates
-        final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
-        final Point2D.Double translation = new Point2D.Double(xc, yc);
-        setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
-
-        final Set<Offset> offsets = _iw.getContext().offsets().scienceOffsetsJava();
-        addOffsetConstrainedPatrolField(patrolField, offsets);
+                final Set<Offset> offsets = _iw.getContext().offsets().scienceOffsetsJava();
+                addOffsetConstrainedPatrolField(patrolField, offsets);
+            }
+        }
     }
 
     // draw the circles for the three guide fields at the given location


### PR DESCRIPTION
`GuideProbe` has a `getCorrectedPatrolField` method which sometimes applies transformations to take into account instrument-specific artifacts like the offset for the GMOS IFU.  The problem with the implementation of this method is that it assumes it is always called in a context that contains the associated instrument.  That's not necessarily the case since target components containing guide stars for another instrument's OIWFS can be copied and pasted around across observations in the OT, or guide stars can be added and afterwords the instrument component can be swapped out, etc.

This change makes the corrected patrol field always return an `Option` which is `None` if the context doesn't match what it is expected. That's the one substantive change.  The rest is just matching up the types.
