### PR TITLE
REL-2148: make hamamatsu default GMOS-S option

### DIFF
--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Inst.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Inst.java
@@ -89,7 +89,7 @@ public enum Inst {
                     new Enum[]{GmosOiwfsGuideProbe.instance}),
             join(new Enum[] { FPUnitSouth.FPU_NONE, FPUnitSouth.CUSTOM_MASK, DisperserSouth.MIRROR },
                     FilterSouth.values(),
-                    new Enum[]{GmosCommonType.DetectorManufacturer.E2V},
+                    new Enum[]{GmosCommonType.DetectorManufacturer.HAMAMATSU},
                     new Enum[]{GmosOiwfsGuideProbe.instance}),
              join(GmosCommonType.UseNS.values(), PreImagingType.values())),
 


### PR DESCRIPTION
Tracking update to release branch.
