### PR TITLE
REL-2155: fix bug in gpi guiding sequence

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -1419,13 +1419,20 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         }
     }
 
+    private static double offsetVal(final Config c, final ItemKey key, double cur) {
+        // of course the p and q are stored as strings in the sequence ....
+        return c.containsItem(key) ? Double.parseDouble(c.getItemValue(key).toString()) : cur;
+    }
+
     public ConfigSequence postProcessSequence(ConfigSequence in) {
         final Config[] steps = in.getAllSteps();
         double p = 0;
         double q = 0;
-        ItemKey obsClassKey = new ItemKey(CalDictionary.OBS_KEY, InstConstants.OBS_CLASS_PROP);
-        ItemKey obsTypeKey = new ItemKey(CalDictionary.OBS_KEY, InstConstants.OBSERVE_TYPE_PROP);
+        final ItemKey obsClassKey = new ItemKey(CalDictionary.OBS_KEY, InstConstants.OBS_CLASS_PROP);
+        final ItemKey obsTypeKey  = new ItemKey(CalDictionary.OBS_KEY, InstConstants.OBSERVE_TYPE_PROP);
         for (Config c:steps) {
+            p = offsetVal(c, OffsetPosBase.TEL_P_KEY, p);
+            q = offsetVal(c, OffsetPosBase.TEL_Q_KEY, q);
             if (p == 0  && q == 0) {
                 c.putItem(new ItemKey(GUIDING_PATH), StandardGuideOptions.instance.getDefaultActive());
             } else {
@@ -1456,13 +1463,6 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
                     // REL-1743 Set guiding to off if it is a calibration sequence
                     c.putItem(new ItemKey(GUIDING_PATH), StandardGuideOptions.instance.getDefaultOff());
                 }
-            }
-
-            if (c.containsItem(OffsetPosBase.TEL_P_KEY)) {
-                p = Double.parseDouble(c.getItemValue(OffsetPosBase.TEL_P_KEY).toString());
-            }
-            if (c.containsItem(OffsetPosBase.TEL_Q_KEY)) {
-                q = Double.parseDouble(c.getItemValue(OffsetPosBase.TEL_Q_KEY).toString());
             }
         }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gpi/OffsetTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gpi/OffsetTest.scala
@@ -1,0 +1,120 @@
+package edu.gemini.spModel.gemini.gpi
+
+
+import edu.gemini.pot.sp.{ISPSeqComponent, SPComponentType, SPNodeKey}
+import edu.gemini.pot.spdb.DBLocalDatabase
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances
+import edu.gemini.spModel.config2.{Config, ItemKey}
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.gemini.seqcomp.SeqRepeatOffset
+import edu.gemini.spModel.guide.StandardGuideOptions
+import edu.gemini.spModel.guide.StandardGuideOptions.Value._
+import edu.gemini.spModel.obsclass.ObsClass
+import edu.gemini.spModel.obsclass.ObsClass._
+import edu.gemini.spModel.seqcomp.SeqRepeatObserve
+import edu.gemini.spModel.target.obsComp.TargetObsCompConstants
+import org.junit.Assert._
+import org.junit.Test
+
+object OffsetTest {
+  val GuideKey = new ItemKey(TargetObsCompConstants.CONFIG_NAME + ":" + TargetObsCompConstants.GUIDE_WITH_OIWFS_PROP)
+
+  case class Row(p: Int, q: Int) {
+    val expect: StandardGuideOptions.Value =
+      if ((p == 0) && (q == 0)) guide else freeze
+  }
+
+  class Env {
+    val odb  = DBLocalDatabase.createTransient()
+    val pid  = SPProgramID.toProgramID("GS-2015A-Q-1")
+    val prog = odb.getFactory.createProgram(new SPNodeKey(), pid)
+    odb.put(prog)
+
+    val obs = odb.getFactory.createObservation(prog, null)
+
+    val gpi = odb.getFactory.createObsComponent(prog, Gpi.SP_TYPE, null)
+    obs.addObsComponent(gpi)
+
+    def addOffsets(c: ObsClass, rows: Seq[Row]): Unit = {
+      val off = odb.getFactory.createSeqComponent(prog, SPComponentType.ITERATOR_OFFSET, null)
+      val dob = off.getDataObject.asInstanceOf[SeqRepeatOffset]
+
+      val posList = dob.getPosList
+      rows.foreach { case Row(p, q) =>  posList.addPosition(p.toDouble, q.toDouble) }
+
+      off.setDataObject(dob)
+
+      obs.getSeqComponent.addSeqComponent(off)
+
+      off.addSeqComponent(makeObserve(c))
+    }
+
+    def makeObserve(c: ObsClass): ISPSeqComponent = {
+      val observe = odb.getFactory.createSeqComponent(prog, SPComponentType.OBSERVER_OBSERVE, null)
+      val dob     = observe.getDataObject.asInstanceOf[SeqRepeatObserve]
+      dob.setObsClass(c)
+      observe.setDataObject(dob)
+      observe
+    }
+
+    private val options = new java.util.HashMap[Object, Object]()
+
+    def steps: Array[Config] =
+      ConfigBridge.extractSequence(obs, options, ConfigValMapInstances.IDENTITY_MAP).getAllSteps
+
+    def shutdown(): Unit = {
+      odb.getDBAdmin.shutdown()
+    }
+  }
+
+  private def doTest(rows: Row*): Unit = doTest(ObsClass.SCIENCE, rows: _*)
+
+  private def doTest(c: ObsClass, rows: Row*): Unit = {
+    val env = new Env
+    try {
+      if (rows.nonEmpty) env.addOffsets(c, rows)
+      else env.obs.getSeqComponent.addSeqComponent(env.makeObserve(c))
+
+      val seq = ConfigBridge.extractSequence(env.obs, new java.util.HashMap[Object, Object](), ConfigValMapInstances.IDENTITY_MAP)
+      val steps = seq.getAllSteps
+
+      // calibration should park
+      def mapExpected(normal: StandardGuideOptions.Value): StandardGuideOptions.Value =
+        c match {
+          case SCIENCE => normal
+          case ACQ     => normal
+          case _       => park
+        }
+
+      if (rows.isEmpty) {
+        // Handle the empty sequence differently since there is always one step.
+        assertEquals(1, steps.size)
+        assertEquals(mapExpected(guide), steps(0).getItemValue(GuideKey))
+      } else {
+        assertEquals(rows.size, steps.size)
+        rows.zip(steps).zipWithIndex.foreach { case ((row, step), index) =>
+          val msg = s"$index) p=${row.p}, q=${row.q}"
+          assertEquals(msg, mapExpected(row.expect), step.getItemValue(GuideKey))
+        }
+      }
+    } finally {
+      env.shutdown()
+    }
+  }
+}
+
+import OffsetTest._
+
+class OffsetTest {
+  @Test def noOffsets(): Unit       = doTest()
+  @Test def guideOne(): Unit        = doTest(Row(0, 0))
+  @Test def freezeOne(): Unit       = doTest(Row(1, 0))
+  @Test def guideThenFreeze(): Unit = doTest(Row(0,0), Row(1,0))
+  @Test def freezeThenGuide(): Unit = doTest(Row(1,0), Row(0,0))
+  @Test def guideMany(): Unit       = doTest(Row(0,0), Row(0,0), Row(0,0))
+  @Test def freezeMany(): Unit      = doTest(Row(1,0), Row(0,1), Row(2,2))
+  @Test def freezeMiddle(): Unit    = doTest(Row(0,0), Row(1,1), Row(0,0))
+  @Test def parkAcqCal(): Unit      = doTest(ObsClass.ACQ_CAL, Row(0, 0))
+  @Test def parkAcqCals(): Unit     = doTest(ObsClass.ACQ_CAL, Row(0, 0), Row(1,0))
+}


### PR DESCRIPTION
A bug was introduced in the implementation of REL-1743 in that the (p,q) values in the sequence didn't match the step being evaluated.  This change makes one substantive change in Gpi to get the correct (p,q) value for the step, and adds one sketchy test case.
