### PR TITLE
OCSADV-170: fix the comma splice

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -80,7 +80,7 @@ object AgsAnalysis {
   case class NoMagnitudeForBand(guideProbe: GuideProbe, target: SPTarget, band: Magnitude.Band) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"${guideProbe.getKey} g" else "G"
-      s"${p}uide star ${band.name}-band magnitude is missing, cannot determine guiding performance."
+      s"${p}uide star ${band.name}-band magnitude is missing. Cannot determine guiding performance."
     }
     override val quality = AgsGuideQuality.PossiblyUnusable
   }


### PR DESCRIPTION
It was brought to my attention that the update to the message (while matching the spec) introduced a comma splice.
