### PR TITLE
REL-2158: added missing javamail providers

### DIFF
--- a/bundle/edu.gemini.util.javax.mail/src/main/resources/META-INF/javamail.providers
+++ b/bundle/edu.gemini.util.javax.mail/src/main/resources/META-INF/javamail.providers
@@ -1,0 +1,1 @@
+protocol=smtp; type=transport; class=edu.gemini.mail.RetrySMTPTransport; vendor=Gemini 8.1m HLPG;


### PR DESCRIPTION
Added a missing config file that installs the retry handler for emails.

Prior to this change (from the OT bundle, just to be sure it's global)

``` scala
scala> val s = javax.mail.Session.getInstance(new java.util.Properties)
s: javax.mail.Session = javax.mail.Session@3910adea

scala> s.getProvider("smtp")
res0: javax.mail.Provider = javax.mail.Provider[TRANSPORT,smtp,com.sun.mail.smtp.SMTPTransport,Sun Microsystems, Inc]
```

After this change:

``` scala
scala> s.getProvider("smtp")
res0: javax.mail.Provider = javax.mail.Provider[TRANSPORT,smtp,edu.gemini.mail.RetrySMTPTransport,Gemini 8.1m HLPG]
```

And then, with VPN off:

``` scala
scala> val queue = new edu.gemini.mail.RetryQueue(new java.io.File("/tmp/mail"))
queue: edu.gemini.mail.RetryQueue = Thread[Thread-3,5,run-main-group-0]

scala> edu.gemini.mail.RetrySMTPTransport.setQueue(queue)

scala> queue.open()
Dec 05, 2014 1:40:17 PM edu.gemini.mail.RetryQueue open
INFO: Starting SMTP retry queue on /tmp/mail

scala> val m = edu.gemini.util.security.auth.keychain.KeyMailer(edu.gemini.spModel.core.Site.GS, "smtp.cl.gemini.edu")
Dec 05, 2014 1:40:28 PM edu.gemini.spModel.core.Site <clinit>
INFO: Current site is null
m: edu.gemini.util.security.auth.keychain.KeyMailer = edu.gemini.util.security.auth.keychain.KeyMailer$$anon$1@6de262a1

scala> m.notifyPassword(edu.gemini.util.security.principal.UserPrincipal("rnorris@gemini.edu"), "banana").unsafePerformIO

scala> Dec 05, 2014 1:40:36 PM edu.gemini.mail.RetrySMTPTransport connect
WARNING: Connect failed. Messages will be queued for retry.
Dec 05, 2014 1:40:36 PM 
```

Mail is in the queue:

```
mail$ ls /tmp/mail
<1190610655.1417815677981.JavaMail.rnorris@monad.local>.message  <1190610655.1417815677981.JavaMail.rnorris@monad.local>.session
```

Turn VPN on, wait a minute, `/tmp/mail` is empty and mail arrives. So I think we're good.
