### PR TITLE
REL-2158: change private package declaration

### DIFF
--- a/bundle/edu.gemini.oodb.too.window/build.sbt
+++ b/bundle/edu.gemini.oodb.too.window/build.sbt
@@ -23,6 +23,6 @@ OsgiKeys.dynamicImportPackage := Seq("")
 OsgiKeys.exportPackage := Seq(
   "edu.gemini.too.window",
   "edu.gemini.too.email")
-        
-OsgiKeys.privatePackage := Seq("edu.gemini.too.*")
+
+OsgiKeys.privatePackage := Seq("edu.gemini.too.email.*", "edu.gemini.too.window.*")
 


### PR DESCRIPTION
ToO emails were not being sent because the ToO emailer was not registered with `TooPublisher` as a subscriber of ToO events.  It wasn't registered because `TooPublisher` wasn't picked up by the service tracker in `edu.gemini.too.email.osgi.Activator`.  The bundle containing the ToO email code, `edu.gemini.oodb.too.window`, declared the package containing `TooPublisher` as a "private package" yet the bundle didn't actually contain the class.

Note, the updated private package declaration overlaps with the export package declaration so the net effect is that the `edu.gemini.too.email.osgi` and `edu.gemini.too.window.osgi` sub-packages are marked private since export takes precedence.
