### PR TITLE
REL-2158: added missing javamail providers

### DIFF
--- a/bundle/edu.gemini.util.javax.mail/src/main/resources/META-INF/javamail.providers
+++ b/bundle/edu.gemini.util.javax.mail/src/main/resources/META-INF/javamail.providers
@@ -1,0 +1,1 @@
+protocol=smtp; type=transport; class=edu.gemini.mail.RetrySMTPTransport; vendor=Gemini 8.1m HLPG;


### PR DESCRIPTION
Same as #158 but for `develop`.
