### PR TITLE
OCSADV-154 removed failing/obsolete test

### DIFF
--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -74,18 +74,6 @@ public final class SPTargetSkyObjectTest {
             CoordinateTypes.Epoch spEpoch = hmsDeg.getEpoch();
             assertEquals(e.getYear(), spEpoch.getValue(), 0.000001);
 
-
-            HmsDegTarget.SystemType st = (HmsDegTarget.SystemType) hmsDeg.getSystemOption();
-            switch (st.getTypeCode()) {
-                case HmsDegTarget.SystemType._B1950:
-                    assertEquals(Epoch.B1950, e);
-                    break;
-                case HmsDegTarget.SystemType._J2000:
-                    assertEquals(Epoch.J2000, e);
-                    break;
-                default:
-                    fail();
-            }
         }
     }
 


### PR DESCRIPTION
Missed this in the earlier PR #172. This logic doesn't apply anymore.
