### PR TITLE
Fix non-compiling ImPolygonTest

### DIFF
--- a/bundle/edu.gemini.shared.util/src/test/scala/edu/gemini/shared/util/immutable/ImPolygonTest.scala
+++ b/bundle/edu.gemini.shared.util/src/test/scala/edu/gemini/shared/util/immutable/ImPolygonTest.scala
@@ -185,14 +185,14 @@ class ImPolygonTest {
         case Nil           => (0.0, 0.0)
         case (x0, y0) :: _ => (x0,  y0)
       }
-      assertEquals(point, (PathIterator.SEG_MOVETO, transform(initX, initY)))
+      assertEquals(point, (PathIterator.SEG_MOVETO, transform((initX, initY))))
       iter.next()
 
       // Each intermediate point.
       points.drop(1).foreach {
         case (x, y) =>
           assertFalse(iter.isDone)
-          assertEquals(point, (PathIterator.SEG_LINETO, transform(x, y)))
+          assertEquals(point, (PathIterator.SEG_LINETO, transform((x, y))))
           iter.next()
       }
 


### PR DESCRIPTION
@sraaphorst Hey, the generated IDEA project doesn't inherit all the compile flags that we use in the sbt build, so please be sure to run your tests from sbt. This test didn't compile because we disable auto-tupling in the sbt build. There may be a way to turn this on in IDEA but I don't know how.
