### PR TITLE
REL-1301

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -120,13 +120,13 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
 	public void propertyChange(PropertyChangeEvent evt) {
 		if (IShell.PROP_MODEL.equals(evt.getPropertyName())) {
 			synchronized (this) {
-				Schedule newModel = (Schedule) evt.getNewValue();
-
 				// There is a hack in RefreshAction that calls shell.setModel(null) and then sets it back to the
-				// original model to force certain components to reupdate. We wish to ignore the null as this will
+				// original model to force certain components to re-update. We wish to ignore the null as this will
 				// otherwise trigger a call to setRoot(null), and then when the model is set back, a call to
 				// setRoot(old model), which causes tree node settings to be lost.
-				if (newModel == null) return;
+				Schedule newModel = (Schedule) evt.getNewValue();
+				if (newModel == null)
+					return;
 
                 // REL-1301: Only rebuild the entire tree when the model has just been instantiated.
                 // Note that if a new plan is created, this will happen as well automatically.


### PR DESCRIPTION
Now ignoring changes to temporarily set model to null and then back to the original model as per RefreshAction (to force updates based on the model), which was causing the tree recalculation code in InstViewAdvisor to rebuild the tree and thus change the state of some of the nodes.
