### PR TITLE
REL-2193: format user target numbers correctly

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -204,7 +204,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
 
         static final class UserTargetRow extends NonBaseTargetRow {
             UserTargetRow(int index, SPTarget target, WorldCoords baseCoords) {
-                super(true, String.format("%s (%d)", TargetEnvironment.USER_NAME, index), target, baseCoords);
+                super(true, String.format("%s (%d)", TargetEnvironment.USER_NAME, index+1), target, baseCoords);
             }
         }
 


### PR DESCRIPTION
The so-called "user" blind offset targets are supposed to be indexed from 1 when formatted for display.