### PR TITLE
REL-2197: AGS feedback for VisitorInstrument

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -40,10 +40,6 @@ sealed trait AgsAnalysis {
 }
 
 object AgsAnalysis {
-  case object UnknownError extends AgsAnalysis {
-    override def message(withProbe: Boolean): String  = "Unknown error."
-  }
-
   case class NoGuideStarForProbe(guideProbe: GuideProbe) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"${guideProbe.getKey} " else ""
@@ -98,7 +94,6 @@ object AgsAnalysis {
   }
 
   def guideProbe(a: AgsAnalysis): Option[GuideProbe] = a match {
-    case UnknownError                => None
     case NoGuideStarForProbe(p)      => Some(p)
     case NoGuideStarForGroup(_)      => None
     case MagnitudeTooFaint(p, _)     => Some(p)
@@ -112,27 +107,33 @@ object AgsAnalysis {
   /**
    * Analysis of the selected guide star (if any) in the given context.
    */
-  def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe): AgsAnalysis = {
+  def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe): Option[AgsAnalysis] = {
     def selection(ctx: ObsContext, guideProbe: GuideProbe): Option[SPTarget] =
       for {
         gpt   <- ctx.getTargets.getPrimaryGuideProbeTargets(guideProbe).asScalaOpt
         gStar <- gpt.getPrimary.asScalaOpt
       } yield gStar
 
-    selection(ctx, guideProbe).fold(NoGuideStarForProbe(guideProbe): AgsAnalysis) { guideStar =>
+    selection(ctx, guideProbe).fold(Some(NoGuideStarForProbe(guideProbe)): Option[AgsAnalysis]) { guideStar =>
       AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar)
     }
   }
 
   /**
+   * Analysis for Java.
+   */
+  def analysisForJava(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget) =
+    analysis(ctx, mt, guideProbe, guideStar).asGeminiOpt
+
+  /**
    * Analysis of the given guide star in the given context, regardless of which
    * guide star is actually selected in the target environment.
    */
-  def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): AgsAnalysis =
-    if (!guideProbe.validate(guideStar, ctx)) NotReachable(guideProbe, guideStar)
+  def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] =
+    if (!guideProbe.validate(guideStar, ctx)) Some(NotReachable(guideProbe, guideStar))
     else magnitudeAnalysis(ctx, mt, guideProbe, guideStar)
 
-  private def magnitudeAnalysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): AgsAnalysis = {
+  private def magnitudeAnalysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] = {
     import GuideSpeed._
     import AgsGuideQuality._
 
@@ -175,7 +176,7 @@ object AgsAnalysis {
       Usable(guideProbe, guideStar, guideSpeed, quality)
     }
 
-    val magAnalysis = for {
+    for {
       mc <- mt(ctx, guideProbe)
       probeBand = band(mc)
     } yield {
@@ -183,8 +184,5 @@ object AgsAnalysis {
       val analysisOpt = magOpt.map(mag => fastestGuideSpeed(mc, mag, conds).fold(outsideLimits(mc, mag))(usable))
       analysisOpt.getOrElse(NoMagnitudeForBand(guideProbe, guideStar, probeBand))
     }
-
-    // This should theoretically never happen, but if it does, something has gone wrong with the site or magnitude table.
-    magAnalysis.getOrElse(UnknownError)
   }
 }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -101,7 +101,7 @@ object GemsStrategy extends AgsStrategy {
         case _                      => true
       }
 
-      val probeAnalysis = grp.getMembers.asScala.toList.map { analysis(ctx, mt, _) }
+      val probeAnalysis = grp.getMembers.asScala.toList.map{ analysis(ctx, mt, _) }.flatten
       probeAnalysis.filter(hasGuideStarForProbe) match {
         case Nil => List(NoGuideStarForGroup(grp))
         case lst => lst

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -19,7 +19,7 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
     Future.successful(AgsStrategy.Estimate.GuaranteedSuccess)
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
-    List(AgsAnalysis.analysis(ctx, mt, guideProbe))
+    AgsAnalysis.analysis(ctx, mt, guideProbe).toList
 
   override def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SkyObject])]] = {
     val so = skyObjectFromScienceTarget(ctx.getTargets.getBase)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -29,7 +29,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
     params.magnitudeCalc(ctx, mt).toList.map(params.guideProbe -> _)
 
   def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
-    List(AgsAnalysis.analysis(ctx, mt, params.guideProbe))
+    AgsAnalysis.analysis(ctx, mt, params.guideProbe).toList
 
   def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SkyObject])]] = {
     val empty = List((params.guideProbe: GuideProbe, List.empty[SkyObject]))

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/checker/P2Checker.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/checker/P2Checker.java
@@ -25,6 +25,7 @@ import edu.gemini.p2checker.rules.phoenix.PhoenixRule;
 import edu.gemini.p2checker.rules.pwfs.PwfsRule;
 import edu.gemini.p2checker.rules.trecs.TrecsRule;
 import edu.gemini.p2checker.rules.flamingos2.Flamingos2Rule;
+import edu.gemini.p2checker.rules.visitor.VisitorRule;
 import edu.gemini.pot.sp.*;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
@@ -38,6 +39,7 @@ import edu.gemini.spModel.gemini.niri.InstNIRI;
 import edu.gemini.spModel.gemini.phoenix.InstPhoenix;
 import edu.gemini.spModel.gemini.trecs.InstTReCS;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
+import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 
 
@@ -52,11 +54,11 @@ import java.util.Map;
 public class P2Checker {
     private static P2Checker _instance;
 
-    private Map<SPComponentType, IRule> _ruleMap;
+    private final Map<SPComponentType, IRule> _ruleMap;
 
     private class RuleComposite implements IRule {
 
-        private List<IRule> _compositeRules;
+        private final List<IRule> _compositeRules;
 
         public RuleComposite(IRule rule, AgsMagnitude.MagnitudeTable mt) {
             _compositeRules = new ArrayList<>();
@@ -65,21 +67,22 @@ public class P2Checker {
             _compositeRules.add(new SmartgcalMappingRule());
             _compositeRules.add(new PwfsRule());
             _compositeRules.add(new AgsAnalysisRule(mt));
-            _compositeRules.add(rule);
+            if (rule != null)
+                _compositeRules.add(rule);
         }
 
 
         public IP2Problems check(ObservationElements node) {
-            IP2Problems problems = new P2Problems();
+            final IP2Problems problems = new P2Problems();
 
             //first check the structure of the observation (missing instrument, missing obs.cond, etc)
-            IP2Problems structureProblems = StructureRule.INSTANCE.check(node);
+            final IP2Problems structureProblems = StructureRule.INSTANCE.check(node);
             //stop checking the rest until the structure is fixed.
             if (structureProblems.getProblemCount() > 0) {
                 return structureProblems;
             }
 
-            for (IRule rule : _compositeRules) {
+            for (final IRule rule : _compositeRules) {
                 problems.append(rule.check(node));
             }
             return problems;
@@ -97,7 +100,7 @@ public class P2Checker {
 
     private P2Checker() {
         _ruleMap = new HashMap<>();
-        IRule gmosRule = new GmosRule();
+        final IRule gmosRule = new GmosRule();
         //add the GMOS Rule to all the instruments that supports it
         _ruleMap.put(InstGmosSouth.SP_TYPE, gmosRule);
         _ruleMap.put(InstGmosNorth.SP_TYPE, gmosRule);
@@ -111,12 +114,13 @@ public class P2Checker {
         _ruleMap.put(InstNIRI.SP_TYPE, new NiriRule());
         _ruleMap.put(InstTReCS.SP_TYPE, new TrecsRule());
         _ruleMap.put(InstPhoenix.SP_TYPE, new PhoenixRule());
+        _ruleMap.put(VisitorInstrument.SP_TYPE, new VisitorRule());
     }
 
     private IRule _getRule(ObservationElements elements) {
         if (elements == null) return null;
 
-        SPInstObsComp instrument = elements.getInstrument();
+        final SPInstObsComp instrument = elements.getInstrument();
         if (instrument == null) return null;
 
         return _ruleMap.get(elements.getInstrumentNode().getType());
@@ -143,23 +147,23 @@ public class P2Checker {
             return _checkObservation((ISPObservation) node, mt);
             //groups contain observations, check them individually
         } else if (node instanceof ISPGroup) {
-            ISPGroup group = (ISPGroup) node;
-            IP2Problems problems = new P2Problems();
-            for (ISPObservation obs : group.getObservations()) {
+            final ISPGroup group = (ISPGroup) node;
+            final IP2Problems problems = new P2Problems();
+            for (final ISPObservation obs : group.getObservations()) {
                 problems.append(check(obs, mt));
             }
             return problems;
             //a program has groups and observations. Check them all.
         } else if (node instanceof ISPProgram) {
-            ISPProgram program = (ISPProgram) node;
-            IP2Problems problems = new P2Problems();
+            final ISPProgram program = (ISPProgram) node;
+            final IP2Problems problems = new P2Problems();
 
-            for (ISPObservation obs : program.getObservations()) {
+            for (final ISPObservation obs : program.getObservations()) {
                 problems.append(check(obs, mt));
             }
 
-            for (Object o : program.getGroups()) {
-                ISPGroup group = (ISPGroup) o;
+            for (final Object o : program.getGroups()) {
+                final ISPGroup group = (ISPGroup) o;
                 problems.append(check(group, mt));
             }
 
@@ -171,18 +175,18 @@ public class P2Checker {
         } else if (node instanceof ISPTemplateFolder) {
 
             // Template folder has groups in it
-            IP2Problems problems = new P2Problems();
+            final IP2Problems problems = new P2Problems();
             final ISPTemplateFolder tf = (ISPTemplateFolder) node;
-            for (ISPTemplateGroup tg : tf.getTemplateGroups())
+            for (final ISPTemplateGroup tg : tf.getTemplateGroups())
                 problems.append(check(tg, mt));
             return problems;
 
         } else if (node instanceof ISPTemplateGroup) {
 
             // Template group has obs in it
-            IP2Problems problems = new P2Problems();
+            final IP2Problems problems = new P2Problems();
             final ISPTemplateGroup tg = (ISPTemplateGroup) node;
-            for (ISPObservation o : tg.getAllObservations())
+            for (final ISPObservation o : tg.getAllObservations())
                 problems.append(check(o, mt));
             return problems;
         }
@@ -193,9 +197,9 @@ public class P2Checker {
     //Perform the checking of an observation, the small
     //unit that can be checked individually.
     private IP2Problems _checkObservation(ISPObservation node, AgsMagnitude.MagnitudeTable mt) {
-        ObservationElements elements = new ObservationElements(node);
+        final ObservationElements elements = new ObservationElements(node);
 
-        IRule rule = _getRule(elements);
+        final IRule rule = _getRule(elements);
         if (rule == null) {
             //we don't have rules for this stuff so just check the structure of
             //the observation
@@ -203,7 +207,7 @@ public class P2Checker {
         }
 
         //add the rule
-        RuleComposite rc = new RuleComposite(rule, mt);
+        final RuleComposite rc = new RuleComposite(rule, mt);
 
         //and apply the rule for the entire observation elements
         return rc.check(elements);

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/visitor/VisitorRule.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/visitor/VisitorRule.scala
@@ -1,0 +1,9 @@
+package edu.gemini.p2checker.rules.visitor
+
+import edu.gemini.p2checker.api.{IP2Problems, ObservationElements, IRule}
+
+// Empty rule set for Visitor Instrument. This is required to force the instrument to be recognized in P2Checker
+// and to perform the composite rules including the AgsAnalysisRule (as per REL-2197).
+class VisitorRule extends IRule {
+  override def check(elements: ObservationElements): IP2Problems = null
+}

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -241,8 +241,12 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 @Override public Option<AgsGuideQuality> apply(Tuple2<ObsContext, AgsMagnitude.MagnitudeTable> tup) {
                     if (guideProbe instanceof ValidatableGuideProbe) {
                         final ValidatableGuideProbe vgp = (ValidatableGuideProbe) guideProbe;
-                        final AgsGuideQuality gq = AgsAnalysis$.MODULE$.analysis(tup._1(), tup._2(), vgp, guideStar).quality();
-                        return new Some<>(gq);
+                        return AgsAnalysis$.MODULE$.analysisForJava(tup._1(), tup._2(), vgp, guideStar).map(new MapOp<AgsAnalysis, AgsGuideQuality>() {
+                            @Override
+                            public AgsGuideQuality apply(AgsAnalysis agsAnalysis) {
+                                return agsAnalysis.quality();
+                            }
+                        });
                     } else {
                         return None.instance();
                     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
@@ -156,7 +156,7 @@ object GuidingFeedback {
     val env = ctx.getTargets
     if (target == env.getBase) baseAnalysis(ctx, mt)
     else guideProbe(env, target).fold(List.empty[Row]) { vgp =>
-      List(guideStarAnalysis(ctx, mt, vgp, target))
+      guideStarAnalysis(ctx, mt, vgp, target).toList
     }
   }
 
@@ -165,7 +165,6 @@ object GuidingFeedback {
   def baseAnalysis(ctx: ObsContext, mt: MagnitudeTable): List[Row] =
     AgsRegistrar.currentStrategy(ctx).fold(List.empty[Row]) { s =>
       s.analyze(ctx, mt).filter {
-        case AgsAnalysis.UnknownError => true
         case NoGuideStarForGroup(_)   => true
         case NoGuideStarForProbe(_)   => true
         case _                        => false
@@ -173,9 +172,9 @@ object GuidingFeedback {
     }
 
   // GuidingFeedback.Row related to the given guide star itself.
-  def guideStarAnalysis(ctx: ObsContext, mt: MagnitudeTable, gp: ValidatableGuideProbe, target: SPTarget): Row = {
-    val analysis = AgsAnalysis.analysis(ctx, mt, gp, target)
-    val plo      = mt(ctx, gp).flatMap(ProbeLimits(ctx, _))
-    new Row(analysis, plo, includeProbeName = false)
-  }
+  def guideStarAnalysis(ctx: ObsContext, mt: MagnitudeTable, gp: ValidatableGuideProbe, target: SPTarget): Option[Row] =
+    AgsAnalysis.analysis(ctx, mt, gp).map { a =>
+      val plo = mt(ctx, gp).flatMap(ProbeLimits(ctx, _))
+      new Row(a, plo, includeProbeName = false)
+    }
 }


### PR DESCRIPTION
Added a `VisitorRule` to force P2 AGS checks for visitor instruments.

Also removed the `UnknownError` I previously added and returned when the `Site` couldn't be determined since we don't want an obscure message of `Unknown error.` being displayed for AGS / P2 / QPT when this happens.

Made `AgsAnalysis` methods into `Option[AgsAnalysis]` methods to compensate for the removal to allow for no analysis when the analysis does not make sense / cannot be done.