### PR TITLE
REL-1301

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -24,6 +24,7 @@ import edu.gemini.ui.workspace.IShell;
 import edu.gemini.ui.workspace.IViewAdvisor;
 import edu.gemini.ui.workspace.IViewContext;
 import edu.gemini.ui.workspace.util.ElementFactory;
+import scalaz.Alpha;
 
 public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
 
@@ -62,7 +63,7 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
         });
 
         // Scroll pane
-        JScrollPane scroll = new JScrollPane(tree);
+        final JScrollPane scroll = new JScrollPane(tree);
         scroll.getViewport().setPreferredSize(new Dimension(tree.getPreferredSize().width, tree.getRowHeight() * 8));
         scroll.getViewport().setMinimumSize(new Dimension(tree.getPreferredSize().width,  tree.getRowHeight() * 8));
         scroll.setBorder(BorderFactory.createEmptyBorder());
@@ -87,28 +88,31 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
     @SuppressWarnings("unchecked")
     private OutlineNode getRoot(Schedule sched) {
         if (sched == null) return new OutlineNode();
-        OutlineNode root = new OutlineNode();
+        final OutlineNode root = new OutlineNode();
         for (final Inst i: Inst.values()) {
             if (!i.existsAtSite(sched.getSite())) continue;
 
-            OutlineNode inode = new OutlineNode(i);
+            final OutlineNode inode = new OutlineNode(i);
             inode.setSelected(sched.hasFacility(i.getValue()));
             root.add(inode);
 
-            Map<String, OutlineNode> categoryNodes = new TreeMap<String, OutlineNode>();
-            for (Enum option: i.getOptions()) {
-                OutlineNode optionNode = new OutlineNode(option);
+            final Map<String, OutlineNode> categoryNodes = new TreeMap<>();
+            for (final Enum option: i.getOptions()) {
+                final OutlineNode optionNode = new OutlineNode(option);
 
-                String category = Inst.getCategory(option);
+                final String category = Inst.getCategory(option);
                 if (category == null)
                     inode.add(optionNode);
                 else {
-                    OutlineNode categoryNode = categoryNodes.get(category);
-                    if (categoryNode == null) {
+                    final OutlineNode categoryNodeLookup = categoryNodes.get(category);
+					final OutlineNode categoryNode;
+                    if (categoryNodeLookup == null) {
                         categoryNode = new OutlineNode(category);
                         categoryNodes.put(category, categoryNode);
                         inode.add(categoryNode);
-                    }
+                    } else {
+						categoryNode = categoryNodeLookup;
+					}
                     categoryNode.add(optionNode);
                 }
                 optionNode.setSelected(sched.hasFacility(option));
@@ -120,7 +124,12 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
     public void propertyChange(PropertyChangeEvent evt) {
         if (IShell.PROP_MODEL.equals(evt.getPropertyName())) {
             synchronized (this) {
-                Schedule newModel = (Schedule) evt.getNewValue();
+				// There is a hack in RefreshAction that calls shell.setModel(null) and then sets it back to the
+				// original model to force certain components to reupdate. We wish to ignore the null as this will
+				// otherwise trigger a call to setRoot(null), and then when the model is set back, a call to
+				// setRoot(old model), which causes tree node settings to be lost.
+                final Schedule newModel = (Schedule) evt.getNewValue();
+				if (newModel == null) return;
 
                 // REL-1301: Only rebuild the entire tree when the model has just been instantiated.
                 // Note that if a new plan is created, this will happen as well automatically.
@@ -138,12 +147,12 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
             synchronized (this) {
                 // This is inefficient but it's cleaner than figuring out all the
                 // corner cases for various kinds of modifications.
-                Set<Enum> facilities = new HashSet<Enum>();
-                Enumeration e = ((OutlineNode) tree.getModel().getRoot()).breadthFirstEnumeration();
+                final Set<Enum> facilities = new HashSet<>();
+                final Enumeration e = ((OutlineNode) tree.getModel().getRoot()).breadthFirstEnumeration();
                 while (e.hasMoreElements()) {
-                    OutlineNode n = (OutlineNode) e.nextElement();
+                    final OutlineNode n = (OutlineNode) e.nextElement();
                     if (n.getSelected() != TriState.UNSELECTED) {
-                        Object o = n.getUserObject();
+                        final Object o = n.getUserObject();
                         if (o != null && o instanceof Enum) {
                             if (o instanceof Inst)
                                 facilities.add(((Inst)o).getValue());

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -124,12 +124,12 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
     public void propertyChange(PropertyChangeEvent evt) {
         if (IShell.PROP_MODEL.equals(evt.getPropertyName())) {
             synchronized (this) {
-				// There is a hack in RefreshAction that calls shell.setModel(null) and then sets it back to the
-				// original model to force certain components to reupdate. We wish to ignore the null as this will
-				// otherwise trigger a call to setRoot(null), and then when the model is set back, a call to
-				// setRoot(old model), which causes tree node settings to be lost.
+                // There is a hack in RefreshAction that calls shell.setModel(null) and then sets it back to the
+                // original model to force certain components to reupdate. We wish to ignore the null as this will
+                // otherwise trigger a call to setRoot(null), and then when the model is set back, a call to
+                // setRoot(old model), which causes tree node settings to be lost.
                 final Schedule newModel = (Schedule) evt.getNewValue();
-				if (newModel == null) return;
+                if (newModel == null) return;
 
                 // REL-1301: Only rebuild the entire tree when the model has just been instantiated.
                 // Note that if a new plan is created, this will happen as well automatically.

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -24,7 +24,6 @@ import edu.gemini.ui.workspace.IShell;
 import edu.gemini.ui.workspace.IViewAdvisor;
 import edu.gemini.ui.workspace.IViewContext;
 import edu.gemini.ui.workspace.util.ElementFactory;
-import scalaz.Alpha;
 
 public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
 
@@ -105,14 +104,14 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
                     inode.add(optionNode);
                 else {
                     final OutlineNode categoryNodeLookup = categoryNodes.get(category);
-					final OutlineNode categoryNode;
+                    final OutlineNode categoryNode;
                     if (categoryNodeLookup == null) {
                         categoryNode = new OutlineNode(category);
                         categoryNodes.put(category, categoryNode);
                         inode.add(categoryNode);
                     } else {
-						categoryNode = categoryNodeLookup;
-					}
+                        categoryNode = categoryNodeLookup;
+                    }
                     categoryNode.add(optionNode);
                 }
                 optionNode.setSelected(sched.hasFacility(option));

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -27,100 +27,100 @@ import edu.gemini.ui.workspace.util.ElementFactory;
 
 public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
 
-	private final JTree tree = ElementFactory.createTree();
-	private Schedule model;
+    private final JTree tree = ElementFactory.createTree();
+    private Schedule model;
     private IViewContext context;
-	
-	public void open(final IViewContext context) {
+
+    public void open(final IViewContext context) {
         this.context = context;
 
-		// Set up the tree control.
-		tree.setModel(new DefaultTreeModel(getRoot(null)));
-		tree.setRootVisible(false);		
-		tree.setShowsRootHandles(true);
-		tree.setCellRenderer(new OutlineNodeRenderer());
-		tree.setSelectionModel(null);
-		tree.addMouseListener(new OutlineNodeMouseListener());
-		tree.setToggleClickCount(Integer.MAX_VALUE); // don't expand on multi-clicks
-		
-		tree.getModel().addTreeModelListener(new TreeModelListener() {
-			public void treeStructureChanged(TreeModelEvent e) {
-				updateSchedule();
-			}
-		
-			public void treeNodesRemoved(TreeModelEvent e) {
-				updateSchedule();
-			}
-		
-			public void treeNodesInserted(TreeModelEvent e) {
-				updateSchedule();
-			}
-		
-			public void treeNodesChanged(TreeModelEvent e) {
-				updateSchedule();
-			}
-		});
-		
-		// Scroll pane
-		JScrollPane scroll = new JScrollPane(tree);
-		scroll.getViewport().setPreferredSize(new Dimension(tree.getPreferredSize().width, tree.getRowHeight() * 8));	
-		scroll.getViewport().setMinimumSize(new Dimension(tree.getPreferredSize().width,  tree.getRowHeight() * 8));
-		scroll.setBorder(BorderFactory.createEmptyBorder());
-		
-		// And the context.
-		context.setTitle("Instruments");
-		context.setContent(scroll);		
-		
-		// Listen for model changes
-		context.getShell().addPropertyChangeListener(this);
-	}
+        // Set up the tree control.
+        tree.setModel(new DefaultTreeModel(getRoot(null)));
+        tree.setRootVisible(false);
+        tree.setShowsRootHandles(true);
+        tree.setCellRenderer(new OutlineNodeRenderer());
+        tree.setSelectionModel(null);
+        tree.addMouseListener(new OutlineNodeMouseListener());
+        tree.setToggleClickCount(Integer.MAX_VALUE); // don't expand on multi-clicks
 
-	public void close(IViewContext context) {
-		
-	}
+        tree.getModel().addTreeModelListener(new TreeModelListener() {
+            public void treeStructureChanged(TreeModelEvent e) {
+                updateSchedule();
+            }
 
-	public void setFocus() {
-		tree.requestFocus();
-	}
+            public void treeNodesRemoved(TreeModelEvent e) {
+                updateSchedule();
+            }
+
+            public void treeNodesInserted(TreeModelEvent e) {
+                updateSchedule();
+            }
+
+            public void treeNodesChanged(TreeModelEvent e) {
+                updateSchedule();
+            }
+        });
+
+        // Scroll pane
+        JScrollPane scroll = new JScrollPane(tree);
+        scroll.getViewport().setPreferredSize(new Dimension(tree.getPreferredSize().width, tree.getRowHeight() * 8));
+        scroll.getViewport().setMinimumSize(new Dimension(tree.getPreferredSize().width,  tree.getRowHeight() * 8));
+        scroll.setBorder(BorderFactory.createEmptyBorder());
+
+        // And the context.
+        context.setTitle("Instruments");
+        context.setContent(scroll);
+
+        // Listen for model changes
+        context.getShell().addPropertyChangeListener(this);
+    }
+
+    public void close(IViewContext context) {
+
+    }
+
+    public void setFocus() {
+        tree.requestFocus();
+    }
 
     // Rebuild the entire tree for the specified schedule.
-	@SuppressWarnings("unchecked")
-	private OutlineNode getRoot(Schedule sched) {
-		if (sched == null) return new OutlineNode();
-		OutlineNode root = new OutlineNode();
-		for (final Inst i: Inst.values()) {
-			if (!i.existsAtSite(sched.getSite())) continue;
+    @SuppressWarnings("unchecked")
+    private OutlineNode getRoot(Schedule sched) {
+        if (sched == null) return new OutlineNode();
+        OutlineNode root = new OutlineNode();
+        for (final Inst i: Inst.values()) {
+            if (!i.existsAtSite(sched.getSite())) continue;
 
-			OutlineNode inode = new OutlineNode(i);
-			inode.setSelected(sched.hasFacility(i.getValue()));
-			root.add(inode);
+            OutlineNode inode = new OutlineNode(i);
+            inode.setSelected(sched.hasFacility(i.getValue()));
+            root.add(inode);
 
-			Map<String, OutlineNode> categoryNodes = new TreeMap<String, OutlineNode>();			
-			for (Enum option: i.getOptions()) {
-				OutlineNode optionNode = new OutlineNode(option);
+            Map<String, OutlineNode> categoryNodes = new TreeMap<String, OutlineNode>();
+            for (Enum option: i.getOptions()) {
+                OutlineNode optionNode = new OutlineNode(option);
 
-				String category = Inst.getCategory(option);
-				if (category == null)
-					inode.add(optionNode);
-				else {
-					OutlineNode categoryNode = categoryNodes.get(category);
-					if (categoryNode == null) {
-						categoryNode = new OutlineNode(category);
-						categoryNodes.put(category, categoryNode);
-						inode.add(categoryNode);
-					}
-					categoryNode.add(optionNode);
-				}
-				optionNode.setSelected(sched.hasFacility(option));
-			}
-		}
-		return root;
-	}
+                String category = Inst.getCategory(option);
+                if (category == null)
+                    inode.add(optionNode);
+                else {
+                    OutlineNode categoryNode = categoryNodes.get(category);
+                    if (categoryNode == null) {
+                        categoryNode = new OutlineNode(category);
+                        categoryNodes.put(category, categoryNode);
+                        inode.add(categoryNode);
+                    }
+                    categoryNode.add(optionNode);
+                }
+                optionNode.setSelected(sched.hasFacility(option));
+            }
+        }
+        return root;
+    }
 
-	public void propertyChange(PropertyChangeEvent evt) {
-		if (IShell.PROP_MODEL.equals(evt.getPropertyName())) {
-			synchronized (this) {
-				Schedule newModel = (Schedule) evt.getNewValue();
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (IShell.PROP_MODEL.equals(evt.getPropertyName())) {
+            synchronized (this) {
+                Schedule newModel = (Schedule) evt.getNewValue();
 
                 // REL-1301: Only rebuild the entire tree when the model has just been instantiated.
                 // Note that if a new plan is created, this will happen as well automatically.
@@ -129,9 +129,9 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
                     ((DefaultTreeModel) tree.getModel()).setRoot(getRoot(newModel));
                 model = newModel;
                 updateSchedule();
-			}
-		}
-	}
+            }
+        }
+    }
 
     private void updateSchedule() {
         if (model != null) {


### PR DESCRIPTION
This PR was originally proposed for develop, but it falls under the OCS patch release, so I have closed the previous PR and opened a new one as appropriate.

The issue being addressed here is in the QPT and involves the instrument filters. The filter choices were not preserved when a reset was done on the plan.

The original issue is that a refresh was trigger an entire (and completely unnecessary) rebuild of the Swing tree that holds the filter choices, which resulted in resetting all of the filter choices to their original default values. I originally prevented the rebuilding of the tree once it had already been built for the plan, but it was reported that there were still problems with filter choices being reset.

An investigation revealed that the issue was some ugly hackery in `RefreshAction`, where in order to force-trigger certain updates, two property change events were fired: one with `null` and then one with the original model. This caused the code in `InstViewAdvisor` to think that the model had changed and thus the tree needed to be rebuilt. In order to avoid this, I now check in the property change listener whether or not the new value is `null`, and if it is, I ignore it and wait for the second property change event, which is what we actually care about.