### PR TITLE
OCSADV-154 Target editor cleanup

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1178,21 +1178,21 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                     switch (reply.getObjectType()) {
                         case COMET: {
                             final ConicTarget target = newOrExistingTarget(ITarget.Tag.JPL_MINOR_BODY);
-                            _nonSiderealTargetSup.showNonSiderealTarget(target, ITarget.Tag.JPL_MINOR_BODY);
+                            _nonSiderealTargetSup.showNonSiderealTarget(target);
                             _w.orbitalElementFormat.setValue(_nonSiderealTargetSup.getNonSiderealSystems()[NonSiderealTargetSupport.JPL_COMET]);
                             _curPos.setTarget(target);
                             }
                             break;
                         case MINOR_BODY: {
                             final ConicTarget target = newOrExistingTarget(ITarget.Tag.MPC_MINOR_PLANET);
-                            _nonSiderealTargetSup.showNonSiderealTarget(target, ITarget.Tag.MPC_MINOR_PLANET);
+                            _nonSiderealTargetSup.showNonSiderealTarget(target);
                             _w.orbitalElementFormat.setValue(_nonSiderealTargetSup.getNonSiderealSystems()[NonSiderealTargetSupport.JPL_MINOR_PLANET]);
                             _curPos.setTarget(target);
                             }
                             break;
                         case MAJOR_BODY: {
                             final NamedTarget target = (oldTarget instanceof NamedTarget) ? (NamedTarget) oldTarget : new NamedTarget();
-                            _nonSiderealTargetSup.showNonSiderealTarget(target,ITarget.Tag.NAMED);
+                            _nonSiderealTargetSup.showNonSiderealTarget(target);
                             _w.orbitalElementFormat.setValue(_nonSiderealTargetSup.getNonSiderealSystems()[NonSiderealTargetSupport.MAJOR_PLANET]);
                             _curPos.setTarget(target);
                             }
@@ -1657,9 +1657,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         // update the display in the tabs
         if (_curPos.getTarget() instanceof NonSiderealTarget) {
-            ITarget.Tag system = _curPos.getTarget().getTag();
             NonSiderealTarget nst = (NonSiderealTarget) _curPos.getTarget();
-            _nonSiderealTargetSup.showNonSiderealTarget(nst, system);
+            _nonSiderealTargetSup.showNonSiderealTarget(nst);
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1031,9 +1031,9 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
                 ITarget.Tag tag = (ITarget.Tag) _w.orbitalElementFormat.getSelectedItem();
                 switch (tag) {
-                    case JPL_MINOR_BODY:   service.setObjectType(HorizonsQuery.ObjectType.COMET);
-                    case MPC_MINOR_PLANET: service.setObjectType(HorizonsQuery.ObjectType.MINOR_BODY);
-                    case NAMED:            service.setObjectType(HorizonsQuery.ObjectType.MAJOR_BODY);
+                    case JPL_MINOR_BODY:   service.setObjectType(HorizonsQuery.ObjectType.COMET);      break;
+                    case MPC_MINOR_PLANET: service.setObjectType(HorizonsQuery.ObjectType.MINOR_BODY); break;
+                    case NAMED:            service.setObjectType(HorizonsQuery.ObjectType.MAJOR_BODY); break;
                 }
                 _nonSiderealTargetSup.ignoreResetCacheEvents(false);
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -60,7 +60,6 @@ import javax.swing.event.MenuListener;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import java.awt.*;
 import java.awt.event.*;
-import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.DateFormat;
@@ -81,14 +80,13 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         implements TelescopePosWatcher, ActionListener {
 
     private static final Logger LOG = Logger.getLogger(EdCompTargetList.class.getName());
-
     private static final String NON_SIDEREAL_TARGET = "Nonsidereal";
     private static final String EXTRA_URL_INFO = "/mimetype=full-rec";
     private static final String PROPER_MOTION_COL_ID = "pm1";
     private static final String SIMBAD_CATALOG_SHORTNAME = "simbad";
-    public static final DateFormat timeFormatter = new SimpleDateFormat("HH:mm:ss");
     private static final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
+    private static final DateFormat timeFormatter = new SimpleDateFormat("HH:mm:ss");
     static {
         timeFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
@@ -111,7 +109,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     private GuideGroup _curGroup;
 
     // Helper class for dealing with NonSidereal targets.
-    private NonSiderealTargetSupport _nonSiderealTargetSup;
+    private final NonSiderealTargetSupport _nonSiderealTargetSup;
 
     // If true, ignore change events for the current position
     private boolean _ignorePosUpdate = false;
@@ -123,12 +121,14 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     // which contains the time (HH:MM:SS) for when an Horizons query should be made
     private TimeDocument _timeDocument;
 
-    private AgsContextPublisher _agsPub = new AgsContextPublisher();
+    private final AgsContextPublisher _agsPub = new AgsContextPublisher();
     /**
      * The constructor initializes the user interface.
      */
     public EdCompTargetList() {
+
         _w = new TelescopeForm(this);
+
         //Callback for AGS visibiity
         _w.addComponentListener(new ComponentAdapter() {
             @Override
@@ -140,6 +140,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         _siderealEditor = new SiderealEditor();
         _trackingEditor = new TrackingEditor();
+
         // Tracking Editor use My Doggy style to match the p2 checker
         _trackingButton = new JToggleButton("Tracking Details") {{
             setUI(new RotatedButtonUI(RotatedButtonUI.Orientation.topToBottom));
@@ -554,21 +555,13 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     }
 
     private interface PositionType {
-        String getName();
-
         boolean isAvailable();
-
         void morphTarget(TargetObsComp obsComp, SPTarget target);
-
         boolean isMember(TargetEnvironment env, SPTarget target);
     }
 
     private enum BasePositionType implements PositionType {
         instance;
-
-        public String getName() {
-            return TargetEnvironment.BASE_NAME;
-        }
 
         public boolean isAvailable() {
             return true;
@@ -593,7 +586,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         }
 
         public String toString() {
-            return getName();
+            return TargetEnvironment.BASE_NAME;
         }
     }
 
@@ -604,10 +597,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         GuidePositionType(GuideProbe guider, boolean available) {
             this.guider = guider;
             this.available = available;
-        }
-
-        public String getName() {
-            return guider.getKey();
         }
 
         public boolean isAvailable() {
@@ -642,16 +631,12 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         }
 
         public String toString() {
-            return getName();
+            return guider.getKey();
         }
     }
 
     private enum UserPositionType implements PositionType {
         instance;
-
-        public String getName() {
-            return TargetEnvironment.USER_NAME;
-        }
 
         public boolean isAvailable() {
             return true;
@@ -671,7 +656,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         }
 
         public String toString() {
-            return getName();
+            return TargetEnvironment.USER_NAME;
         }
     }
 
@@ -910,14 +895,13 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
     private static TargetClipboard clipboard;
 
-    static boolean copySelectedPosition(ISPObsComponent obsComponent, TargetObsComp dataObject) {
+    private static void copySelectedPosition(ISPObsComponent obsComponent, TargetObsComp dataObject) {
         Option<TargetClipboard> opt = TargetClipboard.copy(dataObject.getTargetEnvironment(), obsComponent);
-        if (opt.isEmpty()) return false;
+        if (opt.isEmpty()) return;
         clipboard = opt.getValue();
-        return true;
     }
 
-    static void pasteSelectedPosition(ISPObsComponent obsComponent, TargetObsComp dataObject) {
+    private static void pasteSelectedPosition(ISPObsComponent obsComponent, TargetObsComp dataObject) {
         if (clipboard == null) return;
         clipboard.paste(obsComponent, dataObject);
     }
@@ -936,8 +920,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             if (!name.isEmpty()) {
                 _resolveNonSidereal(name, operationType, listener);
             }
-        } else { //use standard catalogs.
-//            Catalog nameServer = (Catalog) _w.nameServer.getSelectedItem();
+        } else {
             if (!_selectedNameServer.isEmpty()) {
                 Catalog nameServer = _selectedNameServer.getValue();
                 if (name.length() != 0) {
@@ -948,39 +931,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             }
         }
     }
-
-
-    /**
-     * Will remove the Non Sidereal information from the current target
-     * Based on the <code>opType</code>, the data to be removed varies.
-     */
-    private void _clearNonSiderealInformation(HorizonsAction.Type opType) {
-
-        //TODO: maybe later. Currently we don't do this since it screws up
-        //TODO: the time picked up by the user.
-//        if (_curPos.getTarget() instanceof ConicTarget) {
-//            ConicTarget target = (ConicTarget)_curPos.getTarget();
-//            switch (opType) {
-//                case GET_ORBITAL_ELEMENTS:
-//                    target.getEpoch().setValue(2000.0);
-//                    target.getEpochOfPeri().setValue(2000.0);
-//                    target.getANode().setValue(0.0);
-//                    target.getPerihelion().setValue(0.0);
-//                    target.setE(0.0);
-//                    target.getInclination().setValue(0.0);
-//                    target.getLM().setValue(0.0);
-//                    target.getAQ().setValue(0.0);
-//                    //fall through
-//                case UPDATE_POSITION:
-//                    //target.setDateForPosition(null);
-//                    _curPos.setXY(0.0, 0.0);
-//                    break;
-//                case PLOT_EPHEMERIS:
-//                    break;
-//            }
-//        }
-    }
-
 
     /**
      * Retrieves a date, that's built based on the information from
@@ -1112,26 +1062,22 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 } catch (ExecutionException ex) {
                     final String message = "An error occurred fetching results for: " + name.toUpperCase();
                     LOG.log(Level.WARNING, message, ex);
-                    _clearNonSiderealInformation(operationType);
                     DialogUtil.message(message);
                     return;
                 }
 
                 if ((reply == null) || (reply.getReplyType() == HorizonsReply.ReplyType.NO_RESULTS)) {
-                    _clearNonSiderealInformation(operationType);
                     DialogUtil.message("No results were found for: " + name.toUpperCase());
                     return;
                 }
 
                 if (reply.getReplyType() == HorizonsReply.ReplyType.MAJOR_PLANET
                         && !(_curPos.getTarget() instanceof NamedTarget)) {
-                    _clearNonSiderealInformation(operationType);
                     DialogUtil.message("Can't solve the given ID to any minor body");
                     return;
                 }
 
                 if (reply.getReplyType() == HorizonsReply.ReplyType.SPACECRAFT) {
-                    _clearNonSiderealInformation(operationType);
                     DialogUtil.message("Horizons suggests this is a spacecraft. Sorry, but OT can't use spacecrafts");
                     return;
                 }
@@ -1538,7 +1484,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
     private static class AddGroupAction implements ActionListener {
         private final TargetObsComp obsComp;
-        private TelescopePosTableWidget positionTable;
+        private final TelescopePosTableWidget positionTable;
 
         AddGroupAction(TargetObsComp obsComp, TelescopePosTableWidget positionTable) {
             this.obsComp = obsComp;
@@ -1973,7 +1919,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         },;
 
         private static final int HOUR = 1000 * 60 * 60;
-        private String _displayValue;
+        private final String _displayValue;
 
         private TimeConfig(String displayValue) {
             _displayValue = displayValue;
@@ -2067,7 +2013,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                             OrbitalElements elements = reply.getOrbitalElements();
                             target.getAQ().setValue(elements.getValue(OrbitalElements.Name.A));
                         }
-                        _w.orbitalElementFormat.setSelectedItem(ITarget.Tag.JPL_MINOR_BODY.MPC_MINOR_PLANET);
+                        _w.orbitalElementFormat.setSelectedItem(ITarget.Tag.MPC_MINOR_PLANET);
                         _w.targetName.setText(name); //name is cleared if we move the element format
                         break;
 
@@ -2075,18 +2021,10 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                         return; /// ***
                 }
 
-                // If the target is capable of storing Horizons information, populate (or unpopulate) it.
-                if (target instanceof NonSiderealTarget) {
-                    NonSiderealTarget ht = (NonSiderealTarget) _curPos.getTarget();
-                    if (reply.hasObjectIdAndType()) {
-                        // Set the object id and type; both will be valid
-                        ht.setHorizonsObjectId(reply.getObjectId());
-                        ht.setHorizonsObjectTypeOrdinal(reply.getObjectType().ordinal());
-                    } else {
-                        // Clear the value out
-                        ht.setHorizonsObjectId(null);
-                        ht.setHorizonsObjectTypeOrdinal(-1);
-                    }
+                // Store horizons info, if available
+                if (reply.hasObjectIdAndType()) {
+                    target.setHorizonsObjectId(reply.getObjectId());
+                    target.setHorizonsObjectTypeOrdinal(reply.getObjectType().ordinal());
                 }
 
                 // Set the orbital elements

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1079,20 +1079,12 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
                 service.setObjectType(null);
 
-                //if the object is an Id, set the appropriate type in
-                //the query, so we can attempt to narrow it.
-                //UPDATE: why set it only for IDs? Now we'll always set it.
-                //  if (_nameIsId(name)) {
-                NonSiderealTargetSupport.NonSiderealSystem system =
-                        (NonSiderealTargetSupport.NonSiderealSystem) _w.orbitalElementFormat.getSelectedItem();
-                if (system == _nonSiderealTargetSup.getNonSiderealSystem(ITarget.Tag.JPL_MINOR_BODY)) {
-                    service.setObjectType(HorizonsQuery.ObjectType.COMET);
-                } else if (system == _nonSiderealTargetSup.getNonSiderealSystem(ITarget.Tag.MPC_MINOR_PLANET)) {
-                    service.setObjectType(HorizonsQuery.ObjectType.MINOR_BODY);
-                } else if (system == _nonSiderealTargetSup.getNonSiderealSystem(ITarget.Tag.NAMED)) {
-                    service.setObjectType(HorizonsQuery.ObjectType.MAJOR_BODY);
+                ITarget.Tag tag = (ITarget.Tag) _w.orbitalElementFormat.getSelectedItem();
+                switch (tag) {
+                    case JPL_MINOR_BODY:   service.setObjectType(HorizonsQuery.ObjectType.COMET);
+                    case MPC_MINOR_PLANET: service.setObjectType(HorizonsQuery.ObjectType.MINOR_BODY);
+                    case NAMED:            service.setObjectType(HorizonsQuery.ObjectType.MAJOR_BODY);
                 }
-                //}
                 _nonSiderealTargetSup.ignoreResetCacheEvents(false);
 
                 HorizonsReply reply = service.execute();
@@ -1100,11 +1092,9 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 if (reply == null || reply.getReplyType() == HorizonsReply.ReplyType.MAJOR_PLANET) {
                     if (service.getObjectType() == HorizonsQuery.ObjectType.COMET) {
                         service.setObjectType(HorizonsQuery.ObjectType.MINOR_BODY);
-                        //DialogUtil.message("Couldn't find JPL Comet '" + name + "', will try querying for a JPL Minor Planet");
                         reply = service.execute();
                     } else if (service.getObjectType() == HorizonsQuery.ObjectType.MINOR_BODY) {
                         service.setObjectType(HorizonsQuery.ObjectType.COMET);
-                        // DialogUtil.message("Couldn't find JPL Minor Planet '" + name + "', will try querying for a JPL Comet");
                         reply = service.execute();
                     }
                 }
@@ -1179,21 +1169,21 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                         case COMET: {
                             final ConicTarget target = newOrExistingTarget(ITarget.Tag.JPL_MINOR_BODY);
                             _nonSiderealTargetSup.showNonSiderealTarget(target);
-                            _w.orbitalElementFormat.setValue(_nonSiderealTargetSup.getNonSiderealSystems()[NonSiderealTargetSupport.JPL_COMET]);
+                            _w.orbitalElementFormat.setValue(ITarget.Tag.JPL_MINOR_BODY);
                             _curPos.setTarget(target);
                             }
                             break;
                         case MINOR_BODY: {
                             final ConicTarget target = newOrExistingTarget(ITarget.Tag.MPC_MINOR_PLANET);
                             _nonSiderealTargetSup.showNonSiderealTarget(target);
-                            _w.orbitalElementFormat.setValue(_nonSiderealTargetSup.getNonSiderealSystems()[NonSiderealTargetSupport.JPL_MINOR_PLANET]);
+                            _w.orbitalElementFormat.setValue(ITarget.Tag.MPC_MINOR_PLANET);
                             _curPos.setTarget(target);
                             }
                             break;
                         case MAJOR_BODY: {
                             final NamedTarget target = (oldTarget instanceof NamedTarget) ? (NamedTarget) oldTarget : new NamedTarget();
                             _nonSiderealTargetSup.showNonSiderealTarget(target);
-                            _w.orbitalElementFormat.setValue(_nonSiderealTargetSup.getNonSiderealSystems()[NonSiderealTargetSupport.MAJOR_PLANET]);
+                            _w.orbitalElementFormat.setValue(ITarget.Tag.NAMED);
                             _curPos.setTarget(target);
                             }
                             break;
@@ -2067,7 +2057,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                             OrbitalElements elements = reply.getOrbitalElements();
                             target.getAQ().setValue(elements.getValue(OrbitalElements.Name.QR));
                         }
-                        _w.orbitalElementFormat.setSelectedItem(_nonSiderealTargetSup.getNonSiderealSystem(ITarget.Tag.JPL_MINOR_BODY));
+                        _w.orbitalElementFormat.setSelectedItem(ITarget.Tag.JPL_MINOR_BODY);
                         _w.targetName.setText(name); //name is cleared if we move the element format
                         break;
 
@@ -2077,7 +2067,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                             OrbitalElements elements = reply.getOrbitalElements();
                             target.getAQ().setValue(elements.getValue(OrbitalElements.Name.A));
                         }
-                        _w.orbitalElementFormat.setSelectedItem(_nonSiderealTargetSup.getNonSiderealSystem(ITarget.Tag.MPC_MINOR_PLANET));
+                        _w.orbitalElementFormat.setSelectedItem(ITarget.Tag.JPL_MINOR_BODY.MPC_MINOR_PLANET);
                         _w.targetName.setText(name); //name is cleared if we move the element format
                         break;
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -96,22 +96,20 @@ class NonSiderealTargetSupport {
         }
     }
 
-    // number of possible parameters
-    private static int _paramCount = 0;
-
-    // Parameter constants: Indexes into _conicWidgets[] array.
-    private static final int EPOCHOFEL = _paramCount++;
-    private static final int ORBINC = _paramCount++;
-    private static final int LONGASCNODE = _paramCount++;
-    private static final int LONGOFPERI = _paramCount++;
-    private static final int ARGOFPERI = _paramCount++;
-    private static final int MEANDIST = _paramCount++;
-    private static final int PERIDIST = _paramCount++;
-    private static final int ECCENTRICITY = _paramCount++;
-    private static final int MEANLONG = _paramCount++;
-    private static final int MEANANOM = _paramCount++;
-    private static final int DAILYMOT = _paramCount++;
-    private static final int EPOCHOFPERI = _paramCount++;
+    enum Param {
+        EPOCHOFEL,
+        ORBINC,
+        LONGASCNODE,
+        LONGOFPERI,
+        ARGOFPERI,
+        MEANDIST,
+        PERIDIST,
+        ECCENTRICITY,
+        MEANLONG,
+        MEANANOM,
+        DAILYMOT,
+        EPOCHOFPERI
+    }
 
     // array indexed by the constants above
     private NonSiderealTargetSupport.ConicTargetParamWidgets[] _conicWidgets;
@@ -145,8 +143,8 @@ class NonSiderealTargetSupport {
 
     /** Add the given listener to all the entry widgets */
     public void initListeners(TextBoxWidgetWatcher watcher) {
-        for(int i = 0; i < _paramCount; i++) {
-            _conicWidgets[i].getEntry().addWatcher(watcher);
+        for (Param p: Param.values()) {
+            _conicWidgets[p.ordinal()].getEntry().addWatcher(watcher);
         }
     }
 
@@ -162,115 +160,94 @@ class NonSiderealTargetSupport {
         } catch (Exception ex) {
             return;
         }
-        for(int i = 0; i < _paramCount; i++) {
-            if (_conicWidgets[i].getEntry() == nbw) {
-                _setConicPos(target, i, value);
+        for (Param p: Param.values()) {
+            if (_conicWidgets[p.ordinal()].getEntry() == nbw) {
+                _setConicPos(target, p, value);
                 return;
             }
         }
     }
 
     // Set the value of the given param to the given value
-    private void _setConicPos(ConicTarget target, int paramIndex, double value) {
-        if (paramIndex == EPOCHOFEL) {
-            target.getEpoch().setValue(value);
-        }
-        if (paramIndex == ORBINC) {
-            target.getInclination().setValue(value);
-        }
-        if (paramIndex == LONGASCNODE) {
-            target.getANode().setValue(value);
-        }
-        if (paramIndex == LONGOFPERI) {
-            target.getPerihelion().setValue(value);
-        }
-        if (paramIndex == ARGOFPERI) {
-            target.getPerihelion().setValue(value);
-        }
-        if (paramIndex == MEANDIST) {
-            target.getAQ().setValue(value);
-        }
-        if (paramIndex == PERIDIST) {
-            target.getAQ().setValue(value);
-        }
-        if (paramIndex == ECCENTRICITY) {
-            target.setE(value);
-        }
-        if (paramIndex == MEANLONG) {
-            target.getLM().setValue(value);
-        }
-        if (paramIndex == MEANANOM) {
-            target.getLM().setValue(value);
-        }
-        if (paramIndex == DAILYMOT) {
-            target.getN().setValue(value);
-        }
-        if (paramIndex == EPOCHOFPERI) {
-            target.getEpochOfPeri().setValue(value);
+    private void _setConicPos(ConicTarget target, Param param, double value) {
+        switch (param) {
+            case EPOCHOFEL:    target.getEpoch().setValue(value); break;
+            case ORBINC:       target.getInclination().setValue(value); break;
+            case LONGASCNODE:  target.getANode().setValue(value); break;
+            case LONGOFPERI:   target.getPerihelion().setValue(value); break;
+            case ARGOFPERI:    target.getPerihelion().setValue(value); break;
+            case MEANDIST:     target.getAQ().setValue(value); break;
+            case PERIDIST:     target.getAQ().setValue(value); break;
+            case ECCENTRICITY: target.setE(value); break;
+            case MEANLONG:     target.getLM().setValue(value); break;
+            case MEANANOM:     target.getLM().setValue(value); break;
+            case DAILYMOT:     target.getN().setValue(value); break;
+            case EPOCHOFPERI:  target.getEpochOfPeri().setValue(value); break;
         }
     }
 
 
     // initialize the array of parameter labels for each system
     private void _initParamLabels() {
-        _paramLabels = new String[ITarget.Tag.values().length][_paramCount][2];
+        _paramLabels = new String[ITarget.Tag.values().length][Param.values().length][2];
 
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][EPOCHOFEL] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][ORBINC] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][LONGASCNODE] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][LONGOFPERI] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][ARGOFPERI] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][MEANDIST] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][PERIDIST] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][ECCENTRICITY] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][MEANLONG] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][MEANANOM] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][DAILYMOT] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][EPOCHOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.EPOCHOFEL.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.ORBINC.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.LONGASCNODE.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.LONGOFPERI.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.ARGOFPERI.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.MEANDIST.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.PERIDIST.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.ECCENTRICITY.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.MEANLONG.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.MEANANOM.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.DAILYMOT.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.EPOCHOFPERI.ordinal()] = new String[]{null, null};
 
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][EPOCHOFEL] = new String[]{"EPOCH", "Orbital Element Epoch"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][ORBINC] = new String[]{"IN", "Inclination"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][LONGASCNODE] = new String[]{"OM", "Longitude of Ascending Node"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][LONGOFPERI] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][ARGOFPERI] = new String[]{"W", "Argument of Perihelion"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][MEANDIST] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][PERIDIST] = new String[]{"QR", "Perihelion Distance"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][ECCENTRICITY] = new String[]{"EC", "Eccentricity"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][MEANLONG] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][MEANANOM] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][DAILYMOT] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][EPOCHOFPERI] = new String[]{"TP", "Time of Perihelion Passage"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.EPOCHOFEL.ordinal()] = new String[]{"EPOCH", "Orbital Element Epoch"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.ORBINC.ordinal()] = new String[]{"IN", "Inclination"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.LONGASCNODE.ordinal()] = new String[]{"OM", "Longitude of Ascending Node"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.LONGOFPERI.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.ARGOFPERI.ordinal()] = new String[]{"W", "Argument of Perihelion"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.MEANDIST.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.PERIDIST.ordinal()] = new String[]{"QR", "Perihelion Distance"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.ECCENTRICITY.ordinal()] = new String[]{"EC", "Eccentricity"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.MEANLONG.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.MEANANOM.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.DAILYMOT.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.EPOCHOFPERI.ordinal()] = new String[]{"TP", "Time of Perihelion Passage"};
 
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][EPOCHOFEL] = new String[]{"EPOCH", "Orbital Element Epoch"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][ORBINC] = new String[]{"IN", "Inclination"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][LONGASCNODE] = new String[]{"OM", "Longitude of Ascending Node"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][LONGOFPERI] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][ARGOFPERI] = new String[]{"W", "Argument of Perihelion"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][MEANDIST] = new String[]{"A", "Semi-major Axis"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][PERIDIST] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][ECCENTRICITY] = new String[]{"EC", "Eccentricity"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][MEANLONG] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][MEANANOM] = new String[]{"MA", "Mean Anomaly"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][DAILYMOT] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][EPOCHOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.EPOCHOFEL.ordinal()] = new String[]{"EPOCH", "Orbital Element Epoch"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.ORBINC.ordinal()] = new String[]{"IN", "Inclination"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.LONGASCNODE.ordinal()] = new String[]{"OM", "Longitude of Ascending Node"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.LONGOFPERI.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.ARGOFPERI.ordinal()] = new String[]{"W", "Argument of Perihelion"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.MEANDIST.ordinal()] = new String[]{"A", "Semi-major Axis"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.PERIDIST.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.ECCENTRICITY.ordinal()] = new String[]{"EC", "Eccentricity"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.MEANLONG.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.MEANANOM.ordinal()] = new String[]{"MA", "Mean Anomaly"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.DAILYMOT.ordinal()] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.EPOCHOFPERI.ordinal()] = new String[]{null, null};
+
 
     }
 
     // initialize the array of widgets for each parameter
     private void _initConicWidgets() {
-        _conicWidgets = new NonSiderealTargetSupport.ConicTargetParamWidgets[_paramCount];
-        _conicWidgets[EPOCHOFEL] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.epochofelLabel, _w.epochofel, _w.epochofelUnits);
-        _conicWidgets[ORBINC] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.orbincLabel, _w.orbinc, _w.orbincUnits);
-        _conicWidgets[LONGASCNODE] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.longascnodeLabel, _w.longascnode, _w.longascnodeUnits);
-        _conicWidgets[LONGOFPERI] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.longofperiLabel, _w.longofperi, _w.longofperiUnits);
-        _conicWidgets[ARGOFPERI] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.argofperiLabel, _w.argofperi, _w.argofperiUnits);
-        _conicWidgets[MEANDIST] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.meandistLabel, _w.meandist, _w.meandistUnits);
-        _conicWidgets[PERIDIST] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.peridistLabel, _w.peridist, _w.peridistUnits);
-        _conicWidgets[ECCENTRICITY] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.eccentricityLabel, _w.eccentricity, _w.eccentricityUnits);
-        _conicWidgets[MEANLONG] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.meanlongLabel, _w.meanlong, _w.meanlongUnits);
-        _conicWidgets[MEANANOM] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.meananomLabel, _w.meananom, _w.meananomUnits);
-        _conicWidgets[DAILYMOT] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.dailymotLabel, _w.dailymot, _w.dailymotUnits);
-        _conicWidgets[EPOCHOFPERI] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.epochofperiLabel, _w.epochofperi, _w.epochofperiUnits);
+        _conicWidgets = new NonSiderealTargetSupport.ConicTargetParamWidgets[Param.values().length];
+        _conicWidgets[Param.EPOCHOFEL.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.epochofelLabel, _w.epochofel, _w.epochofelUnits);
+        _conicWidgets[Param.ORBINC.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.orbincLabel, _w.orbinc, _w.orbincUnits);
+        _conicWidgets[Param.LONGASCNODE.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.longascnodeLabel, _w.longascnode, _w.longascnodeUnits);
+        _conicWidgets[Param.LONGOFPERI.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.longofperiLabel, _w.longofperi, _w.longofperiUnits);
+        _conicWidgets[Param.ARGOFPERI.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.argofperiLabel, _w.argofperi, _w.argofperiUnits);
+        _conicWidgets[Param.MEANDIST.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.meandistLabel, _w.meandist, _w.meandistUnits);
+        _conicWidgets[Param.PERIDIST.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.peridistLabel, _w.peridist, _w.peridistUnits);
+        _conicWidgets[Param.ECCENTRICITY.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.eccentricityLabel, _w.eccentricity, _w.eccentricityUnits);
+        _conicWidgets[Param.MEANLONG.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.meanlongLabel, _w.meanlong, _w.meanlongUnits);
+        _conicWidgets[Param.MEANANOM.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.meananomLabel, _w.meananom, _w.meananomUnits);
+        _conicWidgets[Param.DAILYMOT.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.dailymotLabel, _w.dailymot, _w.dailymotUnits);
+        _conicWidgets[Param.EPOCHOFPERI.ordinal()] = new NonSiderealTargetSupport.ConicTargetParamWidgets(_w.epochofperiLabel, _w.epochofperi, _w.epochofperiUnits);
     }
 
 
@@ -285,7 +262,8 @@ class NonSiderealTargetSupport {
                 // Update all the conic parameter widgets
                 int row = 0;
                 int col = 0;
-                for (int i1 = 0; i1 < _paramCount; i1++) {
+                for (Param p: Param.values()) {
+                    final int i1 = p.ordinal();
                     final ConicTargetParamWidgets cw = _conicWidgets[i1];
                     final String[][] labels = _paramLabels[tag.ordinal()];
                     final String label = labels[i1][0];
@@ -295,7 +273,7 @@ class NonSiderealTargetSupport {
                         cw.setText(label);
                         cw.setToolTip(toolTip);
                         if (target instanceof ConicTarget) {
-                            String s = _getTargetParamValueAsString((ConicTarget) target, i1);
+                            String s = _getTargetParamValueAsString((ConicTarget) target, p);
                             cw.setValue(s);
                         }
                         cw.setPos(row, col++);
@@ -349,50 +327,27 @@ class NonSiderealTargetSupport {
 
 
     // Return the current value of the given parameter as a string
-    private String _getTargetParamValueAsString(ConicTarget target, int paramIndex) {
-        double d = _getTargetParamvalue(target, paramIndex);
+    private String _getTargetParamValueAsString(ConicTarget target, Param param) {
+        double d = _getTargetParamvalue(target, param);
         return String.valueOf(d);
     }
     // Return the current value of the given parameter
-    private double _getTargetParamvalue(ConicTarget target, int paramIndex) {
-        if (paramIndex == EPOCHOFEL) {
-            return target.getEpoch().getValue();
+    private double _getTargetParamvalue(ConicTarget target, Param param) {
+        switch (param) {
+            case EPOCHOFEL:    return target.getEpoch().getValue();
+            case ORBINC:       return target.getInclination().getValue();
+            case LONGASCNODE:  return target.getANode().getValue();
+            case LONGOFPERI:   return target.getPerihelion().getValue();
+            case ARGOFPERI:    return target.getPerihelion().getValue();
+            case MEANDIST:     return target.getAQ().getValue();
+            case PERIDIST:     return target.getAQ().getValue();
+            case ECCENTRICITY: return target.getE();
+            case MEANLONG:     return target.getLM().getValue();
+            case MEANANOM:     return target.getLM().getValue();
+            case DAILYMOT:     return target.getN().getValue();
+            case EPOCHOFPERI:  return target.getEpochOfPeri().getValue();
+            default:           return 0;
         }
-        if (paramIndex == ORBINC) {
-            return target.getInclination().getValue();
-        }
-        if (paramIndex == LONGASCNODE) {
-            return target.getANode().getValue();
-        }
-        if (paramIndex == LONGOFPERI) {
-            return target.getPerihelion().getValue();
-        }
-        if (paramIndex == ARGOFPERI) {
-            return target.getPerihelion().getValue();
-        }
-        if (paramIndex == MEANDIST) {
-            return target.getAQ().getValue();
-        }
-        if (paramIndex == PERIDIST) {
-            return target.getAQ().getValue();
-        }
-        if (paramIndex == ECCENTRICITY) {
-            return target.getE();
-        }
-        if (paramIndex == MEANLONG) {
-            return target.getLM().getValue();
-        }
-        if (paramIndex == MEANANOM) {
-            return target.getLM().getValue();
-        }
-        if (paramIndex == DAILYMOT) {
-            return target.getN().getValue();
-        }
-        if (paramIndex == EPOCHOFPERI) {
-            return target.getEpochOfPeri().getValue();
-        }
-
-        return 0.;
     }
 
     private DropDownListBoxWidgetWatcher orbitalElementFormatWatcher = new DropDownListBoxWidgetWatcher()  {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -116,9 +116,63 @@ class NonSiderealTargetSupport {
 
     private final Map<Param, ConicTargetParamWidgets> _conicWidgets;
 
-    // parameter labels and ToolTips for each system, indexed by [system][paramIndex][0] and
-    // [system][paramIndex][1]
-    private String[][][] _paramLabels;
+    private static final Map<ITarget.Tag, Map<Param, String[]>> _paramLabels;
+    static {
+        final HashMap<ITarget.Tag, Map<Param, String[]>> map = new HashMap<>();
+        _paramLabels = Collections.unmodifiableMap(map);
+        {
+            final Map<Param, String[]> inner = new HashMap();
+            map.put(ITarget.Tag.NAMED, Collections.unmodifiableMap(inner));
+
+            inner.put(Param.EPOCHOFEL,    new String[]{null, null});
+            inner.put(Param.ORBINC,       new String[]{null, null});
+            inner.put(Param.LONGASCNODE,  new String[]{null, null});
+            inner.put(Param.LONGOFPERI,   new String[]{null, null});
+            inner.put(Param.ARGOFPERI,    new String[]{null, null});
+            inner.put(Param.MEANDIST,     new String[]{null, null});
+            inner.put(Param.PERIDIST,     new String[]{null, null});
+            inner.put(Param.ECCENTRICITY, new String[]{null, null});
+            inner.put(Param.MEANLONG,     new String[]{null, null});
+            inner.put(Param.MEANANOM,     new String[]{null, null});
+            inner.put(Param.DAILYMOT,     new String[]{null, null});
+            inner.put(Param.EPOCHOFPERI,  new String[]{null, null});
+        }
+        {
+            final Map<Param, String[]> inner = new HashMap();
+            map.put(ITarget.Tag.JPL_MINOR_BODY, Collections.unmodifiableMap(inner));
+
+            inner.put(Param.EPOCHOFEL,    new String[]{"EPOCH", "Orbital Element Epoch"});
+            inner.put(Param.ORBINC,       new String[]{"IN", "Inclination"});
+            inner.put(Param.LONGASCNODE,  new String[]{"OM", "Longitude of Ascending Node"});
+            inner.put(Param.LONGOFPERI,   new String[]{null, null});
+            inner.put(Param.ARGOFPERI,    new String[]{"W", "Argument of Perihelion"});
+            inner.put(Param.MEANDIST,     new String[]{null, null});
+            inner.put(Param.PERIDIST,     new String[]{"QR", "Perihelion Distance"});
+            inner.put(Param.ECCENTRICITY, new String[]{"EC", "Eccentricity"});
+            inner.put(Param.MEANLONG,     new String[]{null, null});
+            inner.put(Param.MEANANOM,     new String[]{null, null});
+            inner.put(Param.DAILYMOT,     new String[]{null, null});
+            inner.put(Param.EPOCHOFPERI,  new String[]{"TP", "Time of Perihelion Passage"});
+        }
+        {
+            final Map<Param, String[]> inner = new HashMap();
+            map.put(ITarget.Tag.MPC_MINOR_PLANET, Collections.unmodifiableMap(inner));
+
+            inner.put(Param.EPOCHOFEL,    new String[]{"EPOCH", "Orbital Element Epoch"});
+            inner.put(Param.ORBINC,       new String[]{"IN", "Inclination"});
+            inner.put(Param.LONGASCNODE,  new String[]{"OM", "Longitude of Ascending Node"});
+            inner.put(Param.LONGOFPERI,   new String[]{null, null});
+            inner.put(Param.ARGOFPERI,    new String[]{"W", "Argument of Perihelion"});
+            inner.put(Param.MEANDIST,     new String[]{"A", "Semi-major Axis"});
+            inner.put(Param.PERIDIST,     new String[]{null, null});
+            inner.put(Param.ECCENTRICITY, new String[]{"EC", "Eccentricity"});
+            inner.put(Param.MEANLONG,     new String[]{null, null});
+            inner.put(Param.MEANANOM,     new String[]{"MA", "Mean Anomaly"});
+            inner.put(Param.DAILYMOT,     new String[]{null, null});
+            inner.put(Param.EPOCHOFPERI,  new String[]{null, null});
+
+        }
+    }
 
 
     // The GUI layout panel
@@ -136,7 +190,6 @@ class NonSiderealTargetSupport {
     NonSiderealTargetSupport(TelescopeForm w, SPTarget curPos) {
         _w = w;
         _curPos = curPos;
-        _initParamLabels();
         _conicWidgets = mkConicWidgets(w);
     }
 
@@ -185,53 +238,6 @@ class NonSiderealTargetSupport {
         }
     }
 
-
-    // initialize the array of parameter labels for each system
-    private void _initParamLabels() {
-        _paramLabels = new String[ITarget.Tag.values().length][Param.values().length][2];
-
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.EPOCHOFEL.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.ORBINC.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.LONGASCNODE.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.LONGOFPERI.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.ARGOFPERI.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.MEANDIST.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.PERIDIST.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.ECCENTRICITY.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.MEANLONG.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.MEANANOM.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.DAILYMOT.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.NAMED.ordinal()][Param.EPOCHOFPERI.ordinal()] = new String[]{null, null};
-
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.EPOCHOFEL.ordinal()] = new String[]{"EPOCH", "Orbital Element Epoch"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.ORBINC.ordinal()] = new String[]{"IN", "Inclination"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.LONGASCNODE.ordinal()] = new String[]{"OM", "Longitude of Ascending Node"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.LONGOFPERI.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.ARGOFPERI.ordinal()] = new String[]{"W", "Argument of Perihelion"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.MEANDIST.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.PERIDIST.ordinal()] = new String[]{"QR", "Perihelion Distance"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.ECCENTRICITY.ordinal()] = new String[]{"EC", "Eccentricity"};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.MEANLONG.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.MEANANOM.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.DAILYMOT.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][Param.EPOCHOFPERI.ordinal()] = new String[]{"TP", "Time of Perihelion Passage"};
-
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.EPOCHOFEL.ordinal()] = new String[]{"EPOCH", "Orbital Element Epoch"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.ORBINC.ordinal()] = new String[]{"IN", "Inclination"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.LONGASCNODE.ordinal()] = new String[]{"OM", "Longitude of Ascending Node"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.LONGOFPERI.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.ARGOFPERI.ordinal()] = new String[]{"W", "Argument of Perihelion"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.MEANDIST.ordinal()] = new String[]{"A", "Semi-major Axis"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.PERIDIST.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.ECCENTRICITY.ordinal()] = new String[]{"EC", "Eccentricity"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.MEANLONG.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.MEANANOM.ordinal()] = new String[]{"MA", "Mean Anomaly"};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.DAILYMOT.ordinal()] = new String[]{null, null};
-        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][Param.EPOCHOFPERI.ordinal()] = new String[]{null, null};
-
-
-    }
-
     private static Map<Param, ConicTargetParamWidgets> mkConicWidgets(TelescopeForm f) {
         final Map<Param, ConicTargetParamWidgets> map = new HashMap<>();
         map.put(Param.EPOCHOFEL,    new ConicTargetParamWidgets(f.epochofelLabel,    f.epochofel,    f.epochofelUnits));
@@ -256,16 +262,15 @@ class NonSiderealTargetSupport {
     public void showNonSiderealTarget(NonSiderealTarget target) {
         for (ITarget.Tag tag: ITarget.Tag.values()) {
             if (tag == target.getTag()) {
+                final Map<Param, String[]> labels = _paramLabels.get(tag);
 
                 // Update all the conic parameter widgets
                 int row = 0;
                 int col = 0;
                 for (Param p: Param.values()) {
-                    final int i1 = p.ordinal();
                     final ConicTargetParamWidgets cw = _conicWidgets.get(p);
-                    final String[][] labels = _paramLabels[tag.ordinal()];
-                    final String label = labels[i1][0];
-                    final String toolTip = labels[i1][1];
+                    final String label = labels.get(p)[0];
+                    final String toolTip = labels.get(p)[1];
                     if (label != null) {
                         cw.setVisible(true);
                         cw.setText(label);
@@ -329,6 +334,7 @@ class NonSiderealTargetSupport {
         double d = _getTargetParamvalue(target, param);
         return String.valueOf(d);
     }
+
     // Return the current value of the given parameter
     private double _getTargetParamvalue(ConicTarget target, Param param) {
         switch (param) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -99,7 +99,7 @@ class NonSiderealTargetSupport {
         }
     }
 
-    enum Param {
+    private enum Param {
         EPOCHOFEL,
         ORBINC,
         LONGASCNODE,
@@ -114,64 +114,50 @@ class NonSiderealTargetSupport {
         EPOCHOFPERI
     }
 
+    private static final class Labels {
+        public final String label;
+        public final String toolTip;
+        public Labels(String label, String toolTip) {
+            this.label = label;
+            this.toolTip = toolTip;
+        }
+    }
+
+
     private final Map<Param, ConicTargetParamWidgets> _conicWidgets;
 
-    private static final Map<ITarget.Tag, Map<Param, String[]>> _paramLabels;
+    private static final Map<ITarget.Tag, Map<Param, Labels>> _paramLabels;
     static {
-        final HashMap<ITarget.Tag, Map<Param, String[]>> map = new HashMap<>();
+
+        // Minor body param labels
+        final Map<Param, Labels> mbps = new HashMap<>();
+        mbps.put(Param.EPOCHOFEL,    new Labels("EPOCH", "Orbital Element Epoch"));
+        mbps.put(Param.ORBINC,       new Labels("IN", "Inclination"));
+        mbps.put(Param.LONGASCNODE,  new Labels("OM", "Longitude of Ascending Node"));
+        mbps.put(Param.ARGOFPERI,    new Labels("W", "Argument of Perihelion"));
+        mbps.put(Param.PERIDIST,     new Labels("QR", "Perihelion Distance"));
+        mbps.put(Param.ECCENTRICITY, new Labels("EC", "Eccentricity"));
+        mbps.put(Param.EPOCHOFPERI,  new Labels("TP", "Time of Perihelion Passage"));
+
+        // Minor planet param labels
+        final Map<Param, Labels> mpps = new HashMap<>();
+        mpps.put(Param.EPOCHOFEL,    new Labels("EPOCH", "Orbital Element Epoch"));
+        mpps.put(Param.ORBINC,       new Labels("IN", "Inclination"));
+        mpps.put(Param.LONGASCNODE,  new Labels("OM", "Longitude of Ascending Node"));
+        mpps.put(Param.ARGOFPERI,    new Labels("W", "Argument of Perihelion"));
+        mpps.put(Param.MEANDIST,     new Labels("A", "Semi-major Axis"));
+        mpps.put(Param.ECCENTRICITY, new Labels("EC", "Eccentricity"));
+        mpps.put(Param.MEANANOM,     new Labels("MA", "Mean Anomaly"));
+
+        // Label maps for each target type
+        final HashMap<ITarget.Tag, Map<Param, Labels>> map = new HashMap<>();
+        map.put(ITarget.Tag.NAMED,            Collections.<Param, Labels>emptyMap());
+        map.put(ITarget.Tag.MPC_MINOR_PLANET, Collections.unmodifiableMap(mpps));
+        map.put(ITarget.Tag.JPL_MINOR_BODY,   Collections.unmodifiableMap(mbps));
+
+        // Done
         _paramLabels = Collections.unmodifiableMap(map);
-        {
-            final Map<Param, String[]> inner = new HashMap();
-            map.put(ITarget.Tag.NAMED, Collections.unmodifiableMap(inner));
 
-            inner.put(Param.EPOCHOFEL,    new String[]{null, null});
-            inner.put(Param.ORBINC,       new String[]{null, null});
-            inner.put(Param.LONGASCNODE,  new String[]{null, null});
-            inner.put(Param.LONGOFPERI,   new String[]{null, null});
-            inner.put(Param.ARGOFPERI,    new String[]{null, null});
-            inner.put(Param.MEANDIST,     new String[]{null, null});
-            inner.put(Param.PERIDIST,     new String[]{null, null});
-            inner.put(Param.ECCENTRICITY, new String[]{null, null});
-            inner.put(Param.MEANLONG,     new String[]{null, null});
-            inner.put(Param.MEANANOM,     new String[]{null, null});
-            inner.put(Param.DAILYMOT,     new String[]{null, null});
-            inner.put(Param.EPOCHOFPERI,  new String[]{null, null});
-        }
-        {
-            final Map<Param, String[]> inner = new HashMap();
-            map.put(ITarget.Tag.JPL_MINOR_BODY, Collections.unmodifiableMap(inner));
-
-            inner.put(Param.EPOCHOFEL,    new String[]{"EPOCH", "Orbital Element Epoch"});
-            inner.put(Param.ORBINC,       new String[]{"IN", "Inclination"});
-            inner.put(Param.LONGASCNODE,  new String[]{"OM", "Longitude of Ascending Node"});
-            inner.put(Param.LONGOFPERI,   new String[]{null, null});
-            inner.put(Param.ARGOFPERI,    new String[]{"W", "Argument of Perihelion"});
-            inner.put(Param.MEANDIST,     new String[]{null, null});
-            inner.put(Param.PERIDIST,     new String[]{"QR", "Perihelion Distance"});
-            inner.put(Param.ECCENTRICITY, new String[]{"EC", "Eccentricity"});
-            inner.put(Param.MEANLONG,     new String[]{null, null});
-            inner.put(Param.MEANANOM,     new String[]{null, null});
-            inner.put(Param.DAILYMOT,     new String[]{null, null});
-            inner.put(Param.EPOCHOFPERI,  new String[]{"TP", "Time of Perihelion Passage"});
-        }
-        {
-            final Map<Param, String[]> inner = new HashMap();
-            map.put(ITarget.Tag.MPC_MINOR_PLANET, Collections.unmodifiableMap(inner));
-
-            inner.put(Param.EPOCHOFEL,    new String[]{"EPOCH", "Orbital Element Epoch"});
-            inner.put(Param.ORBINC,       new String[]{"IN", "Inclination"});
-            inner.put(Param.LONGASCNODE,  new String[]{"OM", "Longitude of Ascending Node"});
-            inner.put(Param.LONGOFPERI,   new String[]{null, null});
-            inner.put(Param.ARGOFPERI,    new String[]{"W", "Argument of Perihelion"});
-            inner.put(Param.MEANDIST,     new String[]{"A", "Semi-major Axis"});
-            inner.put(Param.PERIDIST,     new String[]{null, null});
-            inner.put(Param.ECCENTRICITY, new String[]{"EC", "Eccentricity"});
-            inner.put(Param.MEANLONG,     new String[]{null, null});
-            inner.put(Param.MEANANOM,     new String[]{"MA", "Mean Anomaly"});
-            inner.put(Param.DAILYMOT,     new String[]{null, null});
-            inner.put(Param.EPOCHOFPERI,  new String[]{null, null});
-
-        }
     }
 
 
@@ -262,19 +248,18 @@ class NonSiderealTargetSupport {
     public void showNonSiderealTarget(NonSiderealTarget target) {
         for (ITarget.Tag tag: ITarget.Tag.values()) {
             if (tag == target.getTag()) {
-                final Map<Param, String[]> labels = _paramLabels.get(tag);
+                final Map<Param, Labels> labels = _paramLabels.get(tag);
 
                 // Update all the conic parameter widgets
                 int row = 0;
                 int col = 0;
                 for (Param p: Param.values()) {
                     final ConicTargetParamWidgets cw = _conicWidgets.get(p);
-                    final String label = labels.get(p)[0];
-                    final String toolTip = labels.get(p)[1];
-                    if (label != null) {
+                    final Labels labs = labels.get(p);
+                    if (labs != null) {
                         cw.setVisible(true);
-                        cw.setText(label);
-                        cw.setToolTip(toolTip);
+                        cw.setText(labs.label);
+                        cw.setToolTip(labs.toolTip);
                         if (target instanceof ConicTarget) {
                             String s = _getTargetParamValueAsString((ConicTarget) target, p);
                             cw.setValue(s);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -14,9 +14,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TimeZone;
 
-//$Id: NonSiderealTargetSupport.java 7515 2006-12-28 18:04:41Z anunez $
 /**
  * Helper class for displaying and operating with non sidereal targets.
  * <p/>
@@ -26,13 +24,7 @@ import java.util.TimeZone;
  */
 class NonSiderealTargetSupport {
 
-    private static final DateFormat dateFormater = new SimpleDateFormat("dd/MMM/yyyy");
-    private static final DateFormat timeFormatter = new SimpleDateFormat("HH:mm:ss z");
-    static {
-        TimeZone tz = TimeZone.getTimeZone("UTC");
-        timeFormatter.setTimeZone(tz);
-        dateFormater.setTimeZone(tz);
-    }
+    private static final DateFormat timeFormatter = new SimpleDateFormat("HH:mm:ss");
 
     // Groups together the widgets for one parameter for conic targets
     private static class ConicTargetParamWidgets {
@@ -148,7 +140,7 @@ class NonSiderealTargetSupport {
 
     }
 
-    private static final Map<Param, ConicTargetParamWidgets> mkConicWidgets(TelescopeForm f) {
+    private static Map<Param, ConicTargetParamWidgets> mkConicWidgets(TelescopeForm f) {
         final Map<Param, ConicTargetParamWidgets> map = new HashMap<>();
         map.put(Param.EPOCHOFEL,    new ConicTargetParamWidgets(f.epochofelLabel,    f.epochofel,    f.epochofelUnits));
         map.put(Param.ORBINC,       new ConicTargetParamWidgets(f.orbincLabel,       f.orbinc,       f.orbincUnits));
@@ -261,7 +253,7 @@ class NonSiderealTargetSupport {
             date = new Date();
         }
         form.calendarDate.setDate(date);
-        td.setTime(EdCompTargetList.timeFormatter.format(date));
+        td.setTime(timeFormatter.format(date));
 
         // Update the solar system stuff
         if (target instanceof NamedTarget) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -116,40 +116,6 @@ class NonSiderealTargetSupport {
     // array indexed by the constants above
     private NonSiderealTargetSupport.ConicTargetParamWidgets[] _conicWidgets;
 
-
-    // -- systems --
-
-    // Maps the display name to the system type and the GUI labels to use.
-    // Null labels are not used or displayed.
-    public static class NonSiderealSystem {
-        ITarget.Tag tag;
-        String displayName;
-        String[][] labels; // parameter labels/tooltips, indexed by param constants
-
-        public NonSiderealSystem(ITarget.Tag tag, String[][] labels, String displayValue) {
-            this.tag = tag;
-            this.labels = labels;
-            this.displayName = displayValue;
-        }
-
-        public String toString() {
-            return displayName;
-        }
-
-    }
-
-    // number of different non sidereal systems
-    private static int _systemCount = 0;
-
-    // System constants: Indexes into _nonSiderealSystems[] array.
-    public static final int JPL_COMET = _systemCount++;
-    public static final int JPL_MINOR_PLANET = _systemCount++;
-    public static final int MAJOR_PLANET = _systemCount++;
-
-
-    // array indexed by the constants above
-    private NonSiderealTargetSupport.NonSiderealSystem[] _nonSiderealSystems;
-
     // parameter labels and ToolTips for each system, indexed by [system][paramIndex][0] and
     // [system][paramIndex][1]
     private String[][][] _paramLabels;
@@ -175,7 +141,6 @@ class NonSiderealTargetSupport {
         _curPos = curPos;
         _initParamLabels();
         _initConicWidgets();
-        _initNonSiderealSystems();
     }
 
     /** Add the given listener to all the entry widgets */
@@ -245,68 +210,49 @@ class NonSiderealTargetSupport {
         }
     }
 
-    /**
-     * Get the available Non Sidereal Systems
-     */
-    public NonSiderealTargetSupport.NonSiderealSystem[] getNonSiderealSystems() {
-        return _nonSiderealSystems;
-    }
-
-    /**
-     * Return the ConicSystem associated to the given base
-     */
-
-    public NonSiderealTargetSupport.NonSiderealSystem getNonSiderealSystem(ITarget.Tag tag) {
-        for (NonSiderealTargetSupport.NonSiderealSystem s : _nonSiderealSystems) {
-            if (s.tag == tag) {
-                return s;
-            }
-        }
-        return null;
-    }
 
     // initialize the array of parameter labels for each system
     private void _initParamLabels() {
-        _paramLabels = new String[_systemCount][_paramCount][2];
+        _paramLabels = new String[ITarget.Tag.values().length][_paramCount][2];
 
-        _paramLabels[MAJOR_PLANET][EPOCHOFEL] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][ORBINC] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][LONGASCNODE] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][LONGOFPERI] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][ARGOFPERI] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][MEANDIST] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][PERIDIST] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][ECCENTRICITY] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][MEANLONG] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][MEANANOM] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][DAILYMOT] = new String[]{null, null};
-        _paramLabels[MAJOR_PLANET][EPOCHOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][EPOCHOFEL] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][ORBINC] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][LONGASCNODE] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][LONGOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][ARGOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][MEANDIST] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][PERIDIST] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][ECCENTRICITY] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][MEANLONG] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][MEANANOM] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][DAILYMOT] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.NAMED.ordinal()][EPOCHOFPERI] = new String[]{null, null};
 
-        _paramLabels[JPL_COMET][EPOCHOFEL] = new String[]{"EPOCH", "Orbital Element Epoch"};
-        _paramLabels[JPL_COMET][ORBINC] = new String[]{"IN", "Inclination"};
-        _paramLabels[JPL_COMET][LONGASCNODE] = new String[]{"OM", "Longitude of Ascending Node"};
-        _paramLabels[JPL_COMET][LONGOFPERI] = new String[]{null, null};
-        _paramLabels[JPL_COMET][ARGOFPERI] = new String[]{"W", "Argument of Perihelion"};
-        _paramLabels[JPL_COMET][MEANDIST] = new String[]{null, null};
-        _paramLabels[JPL_COMET][PERIDIST] = new String[]{"QR", "Perihelion Distance"};
-        _paramLabels[JPL_COMET][ECCENTRICITY] = new String[]{"EC", "Eccentricity"};
-        _paramLabels[JPL_COMET][MEANLONG] = new String[]{null, null};
-        _paramLabels[JPL_COMET][MEANANOM] = new String[]{null, null};
-        _paramLabels[JPL_COMET][DAILYMOT] = new String[]{null, null};
-        _paramLabels[JPL_COMET][EPOCHOFPERI] = new String[]{"TP", "Time of Perihelion Passage"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][EPOCHOFEL] = new String[]{"EPOCH", "Orbital Element Epoch"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][ORBINC] = new String[]{"IN", "Inclination"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][LONGASCNODE] = new String[]{"OM", "Longitude of Ascending Node"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][LONGOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][ARGOFPERI] = new String[]{"W", "Argument of Perihelion"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][MEANDIST] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][PERIDIST] = new String[]{"QR", "Perihelion Distance"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][ECCENTRICITY] = new String[]{"EC", "Eccentricity"};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][MEANLONG] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][MEANANOM] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][DAILYMOT] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.JPL_MINOR_BODY.ordinal()][EPOCHOFPERI] = new String[]{"TP", "Time of Perihelion Passage"};
 
-        _paramLabels[JPL_MINOR_PLANET][EPOCHOFEL] = new String[]{"EPOCH", "Orbital Element Epoch"};
-        _paramLabels[JPL_MINOR_PLANET][ORBINC] = new String[]{"IN", "Inclination"};
-        _paramLabels[JPL_MINOR_PLANET][LONGASCNODE] = new String[]{"OM", "Longitude of Ascending Node"};
-        _paramLabels[JPL_MINOR_PLANET][LONGOFPERI] = new String[]{null, null};
-        _paramLabels[JPL_MINOR_PLANET][ARGOFPERI] = new String[]{"W", "Argument of Perihelion"};
-        _paramLabels[JPL_MINOR_PLANET][MEANDIST] = new String[]{"A", "Semi-major Axis"};
-        _paramLabels[JPL_MINOR_PLANET][PERIDIST] = new String[]{null, null};
-        _paramLabels[JPL_MINOR_PLANET][ECCENTRICITY] = new String[]{"EC", "Eccentricity"};
-        _paramLabels[JPL_MINOR_PLANET][MEANLONG] = new String[]{null, null};
-        _paramLabels[JPL_MINOR_PLANET][MEANANOM] = new String[]{"MA", "Mean Anomaly"};
-        _paramLabels[JPL_MINOR_PLANET][DAILYMOT] = new String[]{null, null};
-        _paramLabels[JPL_MINOR_PLANET][EPOCHOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][EPOCHOFEL] = new String[]{"EPOCH", "Orbital Element Epoch"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][ORBINC] = new String[]{"IN", "Inclination"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][LONGASCNODE] = new String[]{"OM", "Longitude of Ascending Node"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][LONGOFPERI] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][ARGOFPERI] = new String[]{"W", "Argument of Perihelion"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][MEANDIST] = new String[]{"A", "Semi-major Axis"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][PERIDIST] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][ECCENTRICITY] = new String[]{"EC", "Eccentricity"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][MEANLONG] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][MEANANOM] = new String[]{"MA", "Mean Anomaly"};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][DAILYMOT] = new String[]{null, null};
+        _paramLabels[ITarget.Tag.MPC_MINOR_PLANET.ordinal()][EPOCHOFPERI] = new String[]{null, null};
 
     }
 
@@ -328,37 +274,22 @@ class NonSiderealTargetSupport {
     }
 
 
-    // initialize the array of Non Sidereal system information
-    private void _initNonSiderealSystems() {
-        _nonSiderealSystems = new NonSiderealTargetSupport.NonSiderealSystem[_systemCount];
-        _nonSiderealSystems[MAJOR_PLANET] = new NonSiderealTargetSupport.NonSiderealSystem(
-                ITarget.Tag.NAMED,
-                _paramLabels[MAJOR_PLANET], "Solar System Object");
-        _nonSiderealSystems[JPL_COMET] = new NonSiderealTargetSupport.NonSiderealSystem(
-                ITarget.Tag.JPL_MINOR_BODY,
-                _paramLabels[JPL_COMET], "JPL Comet");
-        _nonSiderealSystems[JPL_MINOR_PLANET] = new NonSiderealTargetSupport.NonSiderealSystem(
-                ITarget.Tag.MPC_MINOR_PLANET,
-                _paramLabels[JPL_MINOR_PLANET], "JPL Minor Planet");
-    }
-
-
     /**
      * Display the given target in the GUI
      * @param target the target position to display
      **/
     public void showNonSiderealTarget(NonSiderealTarget target) {
-        for(int i = 0; i < _systemCount; i++) {
-            final NonSiderealSystem nss = _nonSiderealSystems[i];
-            if (nss.tag == target.getTag()) {
+        for (ITarget.Tag tag: ITarget.Tag.values()) {
+            if (tag == target.getTag()) {
 
                 // Update all the conic parameter widgets
                 int row = 0;
                 int col = 0;
                 for (int i1 = 0; i1 < _paramCount; i1++) {
                     final ConicTargetParamWidgets cw = _conicWidgets[i1];
-                    final String label = nss.labels[i1][0];
-                    final String toolTip = nss.labels[i1][1];
+                    final String[][] labels = _paramLabels[tag.ordinal()];
+                    final String label = labels[i1][0];
+                    final String toolTip = labels[i1][1];
                     if (label != null) {
                         cw.setVisible(true);
                         cw.setText(label);


### PR DESCRIPTION
This PR cleans up some of the terrible mess surrounding nonsidereal target editing in the OT. It is still terrible of course but it's substantially easier to follow now. The main culprit was `NonSiderealTargetSupport`, which had a bunch of enums encoded as arrays indexed by constants, and an amazing `String[][][]` for storing information about which fields to show and how to label them for different types of target. So this is all greatly simplified now.

The diff will be hard to follow, sorry. You might just glance at the before and after versions of `NonSiderealTargetSupport`.