### PR TITLE
REL-2162

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/ags/AgsAnalysisRule.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/ags/AgsAnalysisRule.scala
@@ -6,7 +6,7 @@ import edu.gemini.ags.api.{AgsAnalysis, AgsRegistrar}
 import edu.gemini.p2checker.api.{P2Problems, IP2Problems, Problem, ObservationElements, IRule}
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw
-import edu.gemini.spModel.guide.{GuideProbeGroup, GuideProbe}
+import edu.gemini.spModel.guide.GuideProbeGroup
 import edu.gemini.spModel.obs.SPObservation
 import edu.gemini.spModel.rich.shared.immutable._
 

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/ags/AgsAnalysisRule.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/ags/AgsAnalysisRule.scala
@@ -4,9 +4,11 @@ import edu.gemini.ags.api.AgsGuideQuality._
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
 import edu.gemini.ags.api.{AgsAnalysis, AgsRegistrar}
 import edu.gemini.p2checker.api.{P2Problems, IP2Problems, Problem, ObservationElements, IRule}
+import edu.gemini.spModel.gemini.gems.Canopus
+import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw
+import edu.gemini.spModel.guide.{GuideProbeGroup, GuideProbe}
 import edu.gemini.spModel.obs.SPObservation
 import edu.gemini.spModel.rich.shared.immutable._
-
 
 class AgsAnalysisRule(mt: MagnitudeTable) extends IRule {
   override def check(elements: ObservationElements): IP2Problems = {
@@ -25,12 +27,17 @@ class AgsAnalysisRule(mt: MagnitudeTable) extends IRule {
           // Perform the analysis.
           val analysis = AgsRegistrar.currentStrategy(ctx).fold(List.empty[AgsAnalysis])(_.analyze(ctx, mt))
 
-          // All analyses that are not DeliversRequestedIq in quality should lead to a warning or error.
+          // Analyses that are not DeliversRequestedIq in quality should lead to a warning or error.
           // This equates to all analyses with a severity level.
+          // We also omit ODGW and Canopus errors because these are already reported with different P2 messages.
           for {
             h <- analysis
+            if (h match {
+              case AgsAnalysis.NoGuideStarForGroup(group) => !ignoredProbeGroups.contains(group)
+              case _ => true
+            })
             s <- severity(h)
-          } yield problems.append(new Problem(s, Prefix + "StrategyRule", h.message(withProbe = true), targetNode))
+          } problems.append(new Problem(s, Prefix + "StrategyRule", h.message(withProbe = true), targetNode))
         })
       })
     }
@@ -40,6 +47,9 @@ class AgsAnalysisRule(mt: MagnitudeTable) extends IRule {
 
 object AgsAnalysisRule {
   val Prefix = "AgsAnalysisRule_"
+
+  // We want to ignore AgsAnalysis problems for ODGW and Canopus.
+  val ignoredProbeGroups: Set[GuideProbeGroup] = Set(GsaoiOdgw.Group.instance, Canopus.Wfs.Group.instance)
 
   def severity(a: AgsAnalysis): Option[Problem.Type] =
     a.quality match {

--- a/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/AgsAnalysisListener.scala
+++ b/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/AgsAnalysisListener.scala
@@ -34,9 +34,7 @@ class AgsAnalysisListener extends MarkerModelListener[Variant] {
           case _ => true
         })
         s <- severity(a)
-      } yield {
-        markerManager.addMarker(false, this, s, a.message(withProbe = true), variant, alloc)
-      }
+      } markerManager.addMarker(false, this, s, a.message(withProbe = true), variant, alloc)
     }
   }
 

--- a/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/AgsAnalysisListener.scala
+++ b/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/AgsAnalysisListener.scala
@@ -8,6 +8,9 @@ import edu.gemini.ags.api.AgsAnalysis
 import edu.gemini.qpt.core.Marker.Severity
 import edu.gemini.qpt.core.Variant
 import edu.gemini.qpt.core.util.MarkerManager
+import edu.gemini.spModel.gemini.gems.Canopus
+import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw
+import edu.gemini.spModel.guide.GuideProbeGroup
 
 import scala.collection.JavaConverters._
 
@@ -23,9 +26,13 @@ class AgsAnalysisListener extends MarkerModelListener[Variant] {
     // Iterate over the observations in the variant and determine if they should generate
     // markers based on the AgsAnalysis.
     for (alloc <- variant.getAllocs.asScala if !alloc.getObs.getAgsAnalysis.isEmpty) {
-      // Only analyses with a severity level should generate a marker.
+      // Only analyses with a severity level that are not ODGW and Canopus should generate a marker.
       for {
         a <- alloc.getObs.getAgsAnalysis.asScala
+        if (a match {
+          case AgsAnalysis.NoGuideStarForGroup(group) => !ignoredProbeGroups.contains(group)
+          case _ => true
+        })
         s <- severity(a)
       } yield {
         markerManager.addMarker(false, this, s, a.message(withProbe = true), variant, alloc)
@@ -39,6 +46,9 @@ class AgsAnalysisListener extends MarkerModelListener[Variant] {
 }
 
 object AgsAnalysisListener {
+  // We want to ignore AgsAnalysis problems for ODGW and Canopus.
+  val ignoredProbeGroups: Set[GuideProbeGroup] = Set(GsaoiOdgw.Group.instance, Canopus.Wfs.Group.instance)
+
   def severity(a: AgsAnalysis): Option[Severity] =
     a.quality match {
       case DeliversRequestedIq   => None


### PR DESCRIPTION
We now suppress warnings about missing ODGW and Canopus guide stars in P2 checks and the QPT since these messages are already taken care of by other warnings.