### PR TITLE
OCSADV-154  fix stringly-typed PM methods

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -279,21 +279,21 @@ public class GeneralRule implements IRule {
 
         private boolean hasSameProperMotion(SPTarget base, SPTarget guide) {
 
-            String pmDecBase = base.getPropMotionDec();
-            String pmRaBase = base.getPropMotionRA();
+            double pmDecBase = base.getPropMotionDec();
+            double pmRaBase = base.getPropMotionRA();
 
-            String pmDecGuide = guide.getPropMotionDec();
-            String pmRaGuide = guide.getPropMotionRA();
+            double pmDecGuide = guide.getPropMotionDec();
+            double pmRaGuide = guide.getPropMotionRA();
 
-            return pmRaBase.equals(pmRaGuide) && pmDecBase.equals(pmDecGuide);
+            return pmRaBase == pmRaGuide && pmDecBase == pmDecGuide;
         }
 
         private boolean hasSameTrackingDetails(SPTarget base, SPTarget guide) {
 
             if (base.getTarget().getTag() != guide.getTarget().getTag()) return false;
-            if (!base.getTrackingEpoch().equals(guide.getTrackingEpoch())) return false;
-            if (!base.getTrackingParallax().equals(guide.getTrackingParallax())) return false;
-            if (!base.getTrackingRadialVelocity().equals(guide.getTrackingRadialVelocity())) return false;
+            if (base.getTrackingEpoch() != guide.getTrackingEpoch()) return false;
+            if (base.getTrackingParallax() !=  guide.getTrackingParallax()) return false;
+            if (base.getTrackingRadialVelocity() == guide.getTrackingRadialVelocity()) return false;
             //everything is the same
             return true;
         }
@@ -411,21 +411,16 @@ public class GeneralRule implements IRule {
 
             if (baseTarget == null) return null; //can't check;
 
-            //oh man, I hate these strings.
-            try {
-                Double pm_ra = Double.parseDouble(baseTarget.getPropMotionRA());
-                Double pm_dec = Double.parseDouble(baseTarget.getPropMotionDec());
-                Double total = pm_ra * pm_ra + pm_dec * pm_dec;
+            double pm_ra  = baseTarget.getPropMotionRA();
+            double pm_dec = baseTarget.getPropMotionDec();
+            double total = pm_ra * pm_ra + pm_dec * pm_dec;
 
-                if (total > MAX_PM * MAX_PM) { //to avoid sqrt call
-                    P2Problems problems = new P2Problems();
-                    problems.addWarning(PREFIX+"TARGET_PM_RULE", MESSAGE, elements.getTargetObsComponentNode().getValue());
-                    return problems;
-                }
-
-            }catch (NumberFormatException e) {
-               return null;
+            if (total > MAX_PM * MAX_PM) { //to avoid sqrt call
+                P2Problems problems = new P2Problems();
+                problems.addWarning(PREFIX+"TARGET_PM_RULE", MESSAGE, elements.getTargetObsComponentNode().getValue());
+                return problems;
             }
+
             return null;
         }
     };

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -293,7 +293,7 @@ public class GeneralRule implements IRule {
             if (base.getTarget().getTag() != guide.getTarget().getTag()) return false;
             if (base.getTrackingEpoch() != guide.getTrackingEpoch()) return false;
             if (base.getTrackingParallax() !=  guide.getTrackingParallax()) return false;
-            if (base.getTrackingRadialVelocity() == guide.getTrackingRadialVelocity()) return false;
+            if (base.getTrackingRadialVelocity() != guide.getTrackingRadialVelocity()) return false;
             //everything is the same
             return true;
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -270,21 +270,21 @@ public final class SPTarget extends WatchablePos {
 
     // ----- Specialized methods for an HmsDegTarget ----------
     /**
-     * Get the proper motion RA.
+     * Get the proper motion RA in mas/y
      */
-    public String getPropMotionRA() {
-        String res = "0";
+    public double getPropMotionRA() {
+        double res = 0.0;
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
-            res = t.getPM1().getStringValue();
+            res = t.getPM1().getValue();
         }
         return res;
     }
 
     /**
-     * Set the proper motion ra as a string.
+     * Set the proper motion ra in mas/y.
      */
-    public void setPropMotionRA(final String newValue) {
+    public void setPropMotionRA(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
             final PM1 pm1 = new PM1(newValue, Units.MILLI_ARCSECS_PER_YEAR);
@@ -296,21 +296,21 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Get the proper motion Dec.
+     * Get the proper motion Dec in mas/y
      */
-    public String getPropMotionDec() {
-        String res = "0";
+    public double getPropMotionDec() {
+        double res = 0.0;
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
-            res = t.getPM2().getStringValue();
+            res = t.getPM2().getValue();
         }
         return res;
     }
 
     /**
-     * Set the proper motion Dec as a string.
+     * Set the proper motion Dec in mas/y.
      */
-    public void setPropMotionDec(final String newValue) {
+    public void setPropMotionDec(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
             final PM2 pm2 = new PM2(newValue, Units.MILLI_ARCSECS_PER_YEAR);
@@ -322,35 +322,33 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Get the tracking epoch.
+     * Get the tracking epoch in julian years
      */
-    public String getTrackingEpoch() {
-        final String res = "2000";
+    public double getTrackingEpoch() {
+        final double res = 2000.0;
         final Epoch e = _target.getEpoch();
         if (e == null) return res;
 
-        return Double.toString(e.getValue());
+        return e.getValue();
     }
 
     /**
-     * Set the tracking epoch as a string.
+     * Set the tracking epoch as in julian years.
      */
-    public void setTrackingEpoch(final String trackEpoch) {
-        if (trackEpoch == null) return;
-
+    public void setTrackingEpoch(final double trackEpoch) {
         final Epoch e = new Epoch(trackEpoch);
         _target.setEpoch(e);
         _notifyOfGenericUpdate();
     }
 
     /**
-     * Get the tracking parallax.
+     * Get the tracking parallax in arcseconds
      */
-    public String getTrackingParallax() {
-        String res = "0";
+    public double getTrackingParallax() {
+        double res = 0.0;
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
-            res = t.getParallax().getStringValue();
+            res = t.getParallax().getValue();
         }
         return res;
     }
@@ -358,7 +356,7 @@ public final class SPTarget extends WatchablePos {
     /**
      * Set the tracking parallax as a string.
      */
-    public void setTrackingParallax(final String newValue) {
+    public void setTrackingParallax(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
             final Parallax p = new Parallax(newValue);
@@ -370,21 +368,21 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Get the tracking radial velocity.
+     * Get the tracking radial velocity in km/s
      */
-    public String getTrackingRadialVelocity() {
-        String res = "0";
+    public double getTrackingRadialVelocity() {
+        double res = 0.0;
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
-            res = t.getRV().getStringValue();
+            res = t.getRV().getValue();
         }
         return res;
     }
 
     /**
-     * Set the tracking radial velocity as a string.
+     * Set the tracking radial velocity in km/s.
      */
-    public void setTrackingRadialVelocity(final String newValue) {
+    public void setTrackingRadialVelocity(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
             final RV rv = new RV(newValue);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1212,13 +1212,13 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                         if (pm >= 0) {
                             Double pm1 = (Double) tqr.getValueAt(0, pm);
                             Double pm2 = (Double) tqr.getValueAt(0, pm + 1);
-                            _curPos.setPropMotionRA(Double.toString(pm1));
-                            _curPos.setPropMotionDec(Double.toString(pm2));
+                            _curPos.setPropMotionRA(pm1);
+                            _curPos.setPropMotionDec(pm2);
                         } else {
                             //SCT-301: If not found, then we reset the value
                             //to zero. I hate these strings.
-                            _curPos.setPropMotionDec("0.0");
-                            _curPos.setPropMotionRA("0.0");
+                            _curPos.setPropMotionDec(0.0);
+                            _curPos.setPropMotionRA(0.0);
                         }
                         if (tqr.getCoordinates(0) instanceof WorldCoords) {
                             WorldCoords pos = (WorldCoords) tqr.getCoordinates(0);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/ProperMotionEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/ProperMotionEditor.java
@@ -99,7 +99,7 @@ final class ProperMotionEditor implements TelescopePosEditor {
             try {
                 Number d = (Number) evt.getNewValue();
                 target.deleteWatcher(watcher);
-                target.setPropMotionRA(d == null ? "0.0" : String.valueOf(d));
+                target.setPropMotionRA(d == null ? 0.0 : d.doubleValue());
                 target.addWatcher(watcher);
             } catch (Exception ex) {
                 // do nothing
@@ -112,7 +112,7 @@ final class ProperMotionEditor implements TelescopePosEditor {
             try {
                 Number d = (Number) evt.getNewValue();
                 target.deleteWatcher(watcher);
-                target.setPropMotionDec(d == null ? "0.0" : String.valueOf(d));
+                target.setPropMotionDec(d == null ? 0 : d.doubleValue());
                 target.addWatcher(watcher);
             } catch (Exception ex) {
                 // do nothing
@@ -131,11 +131,11 @@ final class ProperMotionEditor implements TelescopePosEditor {
 
     private void reinit() {
         pmRa.removePropertyChangeListener("value", updatePmRaListener);
-        pmRa.setText(target == null ? "0.0" : target.getPropMotionRA());
+        pmRa.setText(target == null ? "0.0" : Double.toString(target.getPropMotionRA()));
         pmRa.addPropertyChangeListener("value", updatePmRaListener);
 
         pmDec.removePropertyChangeListener("value", updatePmDecListener);
-        pmDec.setText(target == null ? "0.0" : target.getPropMotionDec());
+        pmDec.setText(target == null ? "0.0" : Double.toString(target.getPropMotionDec()));
         pmDec.addPropertyChangeListener("value", updatePmDecListener);
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TrackingEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TrackingEditor.java
@@ -126,34 +126,34 @@ final class TrackingEditor implements TelescopePosEditor {
             (Row) new NumberRow("Epoch", "years",
                     new InitFunction() {
                         @Override public void apply(SPTarget target, JFormattedTextField field) {
-                            field.setText(target.getTrackingEpoch());
+                            field.setText(Double.toString(target.getTrackingEpoch()));
                         }
                     },
                     new UpdateFunction() {
                         @Override public void apply(SPTarget target, Number d) {
-                            target.setTrackingEpoch(d==null ? "2000.0" : String.valueOf(d));
+                            target.setTrackingEpoch(d == null ? 2000.0 : d.doubleValue());
                         }
                     }),
             new NumberRow("Parallax", "arcsec",
                     new InitFunction() {
                         @Override public void apply(SPTarget target, JFormattedTextField field) {
-                            field.setText(target.getTrackingParallax());
+                            field.setText(Double.toString(target.getTrackingParallax()));
                         }
                     },
                     new UpdateFunction() {
                         @Override public void apply(SPTarget target, Number d) {
-                            target.setTrackingParallax(d==null ? "0.0" : String.valueOf(d));
+                            target.setTrackingParallax(d == null ? 0.0 : d.doubleValue());
                         }
                     }),
             new NumberRow("Radial Vel", "km/sec",
                     new InitFunction() {
                         @Override public void apply(SPTarget target, JFormattedTextField field) {
-                            field.setText(target.getTrackingRadialVelocity());
+                            field.setText(Double.toString(target.getTrackingRadialVelocity()));
                         }
                     },
                     new UpdateFunction() {
                         @Override public void apply(SPTarget target, Number d) {
-                            target.setTrackingRadialVelocity(d==null ? "0.0" : String.valueOf(d));
+                            target.setTrackingRadialVelocity(d == null ? 0.0 : d.doubleValue());
                         }
                     })
         );

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -273,14 +273,14 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         set  = setTarget(_.getTarget.setC2(_))
       )
 
-      def pmField(getPM: SPTarget => String, setPM: (SPTarget, String) => Unit): BoundTextField[Double] =
+      def pmField(getPM: SPTarget => Double, setPM: (SPTarget, Double) => Unit): BoundTextField[Double] =
         new BoundTextField[Double](10)(
           read = _.toDouble,
           show = d => f"$d%.3f",
-          get  = tp => getPM(tp.getTarget).toDouble,
+          get  = tp => getPM(tp.getTarget),
           set  = (tp, pm) => {
             val newTarget = tp.getTarget
-            setPM(newTarget, pm.toString)
+            setPM(newTarget, pm)
             tp.copy(newTarget)
           }
         )


### PR DESCRIPTION
`SPTarget` has a bunch of methods for proper motion that take and return `String`, and in all cases the caller is using `double` and ends up doing string conversion. Mind-boggling. Anyway, fixed. Tests pass. OT works.