### PR TITLE
REL-2175: NPE bugfix

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/html/HTMLViewer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/html/HTMLViewer.java
@@ -90,7 +90,7 @@ public class HTMLViewer extends JPanel implements GenericToolBarTarget {
     /**
      * List of HTMLViewerHistoryItem, for previously viewed catalogs or query results.
      */
-    protected LinkedList historyList;
+    protected LinkedList historyList = new LinkedList();
 
     /**
      * Base filename for serialization of the history list


### PR DESCRIPTION
This is a fix for a `NullPointerException` that sometimes occurs in the TPE.  There exists the concept of a history list of image and catalog query results.  In the past this history list would be initialized upon creation of the `HTMLViewer` class in the constructor by loading serialized data from a file.  At some point this was turned off but the history list was unfortunately left altogether uninitialized.

This change simply initializes the history list to an empty list upon creation of the class.  There are many opportunities for improvement in this class, starting with parameterizing the `LinkedList` correctly.  I'm bypassing those opportunities though since I want to touch this code as little as possible for the patch release.

