### PR TITLE
OCSADV-154  tidy up SPTarget

### DIFF
--- a/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
+++ b/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
@@ -181,7 +181,7 @@ public enum ToContext {
             // pick the right guider.
             case nonsidereal:
                 t = new SPTarget(new ConicTarget());
-                t.setXY(raDeg, decDeg);
+                t.setRaDecDegrees(raDeg, decDeg);
                 break;
             default:
                 t = new SPTarget(raDeg, decDeg);

--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStars.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStars.java
@@ -147,7 +147,7 @@ public class GemsGuideStars implements Comparable<GemsGuideStars> {
     // Returns the R magnitude, if known, otherwise 99.
     private double getRMag(Option<GuideProbeTargets> g) {
         if (!g.isEmpty() && !g.getValue().getPrimary().isEmpty()) {
-            Option<Magnitude> mag = g.getValue().getPrimary().getValue().getMagnitude(Magnitude.Band.R);
+            Option<Magnitude> mag = g.getValue().getPrimary().getValue().getTarget().getMagnitude(Magnitude.Band.R);
             if (!mag.isEmpty()) {
                 return mag.getValue().getBrightness();
             }

--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStars.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStars.java
@@ -170,9 +170,9 @@ public class GemsGuideStars implements Comparable<GemsGuideStars> {
             SPTarget target = guideGroup.get(guideProbe).getValue().getPrimary().getValue();
             sb.append(guideProbe);
             sb.append("[");
-            sb.append(target.getC1());
+            sb.append(target.getTarget().getC1());
             sb.append(",");
-            sb.append(target.getC2());
+            sb.append(target.getTarget().getC2());
             sb.append("] ");
         }
         return "GemsGuideStars{" +

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -69,9 +69,9 @@ object AgsStrategy {
      */
     def applyTo(env: TargetEnvironment): TargetEnvironment = {
       def findMatching(gpt: GuideProbeTargets, target: SPTarget): Option[SPTarget] =
-        Option(target.getName).flatMap { n =>
+        Option(target.getTarget.getName).flatMap { n =>
           gpt.getOptions.toList.asScala.find { t =>
-            Option(t.getName).map(_.trim).exists(_ == n.trim)
+            Option(t.getTarget.getName).map(_.trim).exists(_ == n.trim)
           }
         }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -11,6 +11,7 @@ import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.{OptionsList, GuideProbeTargets, TargetEnvironment}
+import edu.gemini.spModel.target.system.HmsDegTarget
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -76,7 +77,7 @@ object AgsStrategy {
         }
 
       (env /: assignments) { (curEnv, ass) =>
-        val target = new SPTarget(ass.guideStar.toOldModel)
+        val target = new SPTarget(HmsDegTarget.fromSkyObject(ass.guideStar.toOldModel))
         val oldGpt = curEnv.getPrimaryGuideProbeTargets(ass.guideProbe).asScalaOpt
 
         val newGpt = oldGpt.fold(GuideProbeTargets.create(ass.guideProbe, target)) { gpt =>

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
@@ -10,6 +10,7 @@ import edu.gemini.spModel.target.SPTarget
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.shared.skyobject
 import edu.gemini.skycalc
+import edu.gemini.spModel.target.system.HmsDegTarget
 import scala.math._
 import scala.collection.JavaConverters._
 
@@ -74,5 +75,5 @@ object GemsUtils4Java {
 
   def toNewAngle(angle: skycalc.Angle): Angle = angle.toNewModel
 
-  def toSPTarget(siderealTarget: SiderealTarget):SPTarget = new SPTarget(siderealTarget.toOldModel)
+  def toSPTarget(siderealTarget: SiderealTarget):SPTarget = new SPTarget(HmsDegTarget.fromSkyObject(siderealTarget.toOldModel))
 }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
@@ -180,14 +180,14 @@ object MascotGuideStar {
 
     val inst = ctx.getInstrument
     val savedPa = inst.getPosAngleDegrees
-    val savedRa = ctx.getTargets.getBase.getC1.getAs(Units.DEGREES)
-    val savedDec = ctx.getTargets.getBase.getC2.getAs(Units.DEGREES)
+    val savedRa = ctx.getTargets.getBase.getTarget.getC1.getAs(Units.DEGREES)
+    val savedDec = ctx.getTargets.getBase.getTarget.getC2.getAs(Units.DEGREES)
     val settingsList = settingsToTry(savedPa, savedRa, savedDec, posAngleTolerance, basePosTolerance)
     try {
       val result = for ((pa, ra, dec) <- settingsList) yield {
         inst.setPosAngle(pa)
-        ctx.getTargets.getBase.getC1.setAs(ra, Units.DEGREES)
-        ctx.getTargets.getBase.getC2.setAs(dec, Units.DEGREES)
+        ctx.getTargets.getBase.getTarget.getC1.setAs(ra, Units.DEGREES)
+        ctx.getTargets.getBase.getTarget.getC2.setAs(dec, Units.DEGREES)
         // XXX TODO use a cache map in the filter?
         val l = strehlList.filter(_.stars.forall(guideStarFilter))
         (l, pa, ra, dec)
@@ -197,8 +197,8 @@ object MascotGuideStar {
     finally {
       // restore settings
       inst.setPosAngleDegrees(savedPa)
-      ctx.getTargets.getBase.getC1.setAs(savedRa, Units.DEGREES)
-      ctx.getTargets.getBase.getC2.setAs(savedDec, Units.DEGREES)
+      ctx.getTargets.getBase.getTarget.getC1.setAs(savedRa, Units.DEGREES)
+      ctx.getTargets.getBase.getTarget.getC2.setAs(savedDec, Units.DEGREES)
     }
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
@@ -7,6 +7,7 @@ import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.ags.api.AgsMagnitude
 import edu.gemini.catalog.api.MagnitudeConstraints
+import edu.gemini.spModel.target.system.HmsDegTarget
 
 import scalaz._
 import Scalaz._
@@ -38,7 +39,7 @@ class CandidateValidator(params: SingleProbeStrategyParams, mt: MagnitudeTable, 
       def brightnessOk = (magLimits |@| st.magnitudeIn(params.band))(_ contains _) | false
 
       // Only keep those that are in range of the guide probe.
-      def inProbeRange = params.validator(ctx).validate(new SPTarget(st.toOldModel), ctx)
+      def inProbeRange = params.validator(ctx).validate(new SPTarget(HmsDegTarget.fromSkyObject(st.toOldModel)), ctx)
 
       farEnough && brightnessOk && inProbeRange
     }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -10,6 +10,7 @@ import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.CoordinateParam.Units
+import edu.gemini.spModel.target.system.HmsDegTarget
 import edu.gemini.spModel.telescope.PosAngleConstraint._
 
 import scala.collection.JavaConverters._
@@ -109,7 +110,7 @@ object SingleProbeStrategy {
   def calculatePositionAngle(base: Coordinates, st: SiderealTarget): Angle = {
     val ra1    = st.coordinates.ra.toAngle.toRadians
     val dec1   = st.coordinates.dec.toAngle.toRadians
-    val target = new SPTarget(st.toOldModel).getTarget
+    val target = HmsDegTarget.fromSkyObject(st.toOldModel)
     val ra2    = Angle.fromDegrees(target.getC1.getAs(Units.DEGREES)).toRadians
     val dec2   = Angle.fromDegrees(target.getC2.getAs(Units.DEGREES)).toRadians
     val raDiff = ra2 - ra1

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
@@ -129,7 +129,7 @@ package object impl {
     def toNewModel:SiderealTarget = {
       val name        = sp.getName
       val coords      = sp.getSkycalcCoordinates
-      val mags        = sp.getMagnitudes.asScalaList.map(_.toNewModel)
+      val mags        = sp.getTarget.getMagnitudes.asScalaList.map(_.toNewModel)
       val ra          = Angle.fromDegrees(coords.getRaDeg)
       val dec         = Angle.fromDegrees(coords.getDecDeg)
       val coordinates = Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
@@ -127,7 +127,7 @@ package object impl {
 
   implicit class SPTarget2SiderealTarget(val sp:SPTarget) extends AnyVal {
     def toNewModel:SiderealTarget = {
-      val name        = sp.getName
+      val name        = sp.getTarget.getName
       val coords      = sp.getSkycalcCoordinates
       val mags        = sp.getTarget.getMagnitudes.asScalaList.map(_.toNewModel)
       val ra          = Angle.fromDegrees(coords.getRaDeg)
@@ -159,7 +159,7 @@ package object impl {
     Option(targetName).map(_.trim).flatMap { tn =>
       gpt.getOptions.find(new PredicateOp[SPTarget] {
         def apply(spt: SPTarget): java.lang.Boolean =
-          Option(spt.getName).map(_.trim).exists(_ == tn)
+          Option(spt.getTarget.getName).map(_.trim).exists(_ == tn)
       }).asScalaOpt
     }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
@@ -128,7 +128,7 @@ package object impl {
   implicit class SPTarget2SiderealTarget(val sp:SPTarget) extends AnyVal {
     def toNewModel:SiderealTarget = {
       val name        = sp.getTarget.getName
-      val coords      = sp.getSkycalcCoordinates
+      val coords      = sp.getTarget.getSkycalcCoordinates
       val mags        = sp.getTarget.getMagnitudes.asScalaList.map(_.toNewModel)
       val ra          = Angle.fromDegrees(coords.getRaDeg)
       val dec         = Angle.fromDegrees(coords.getDecDeg)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/package.scala
@@ -128,7 +128,7 @@ package object impl {
   implicit class SPTarget2SiderealTarget(val sp:SPTarget) extends AnyVal {
     def toNewModel:SiderealTarget = {
       val name        = sp.getTarget.getName
-      val coords      = sp.getTarget.getSkycalcCoordinates
+      val coords      = sp.getSkycalcCoordinates
       val mags        = sp.getTarget.getMagnitudes.asScalaList.map(_.toNewModel)
       val ra          = Angle.fromDegrees(coords.getRaDeg)
       val dec         = Angle.fromDegrees(coords.getDecDeg)

--- a/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
+++ b/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
@@ -83,10 +83,26 @@ public class GemsCatalogResultsTest  implements MascotProgress {
         assertFalse(set.contains(GsaoiOdgw.odgw3));
         assertFalse(set.contains(GsaoiOdgw.odgw4));
 
-        Coordinates cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getSkycalcCoordinates();
-        Coordinates cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getSkycalcCoordinates();
-        Coordinates cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getSkycalcCoordinates();
-        Coordinates odgw1 = group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue().getSkycalcCoordinates();
+        Coordinates result4;
+        synchronized (group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue()) {
+            result4 = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
+        }
+        Coordinates cwfs1 = result4;
+        Coordinates result3;
+        synchronized (group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue()) {
+            result3 = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
+        }
+        Coordinates cwfs2 = result3;
+        Coordinates result2;
+        synchronized (group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue()) {
+            result2 = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
+        }
+        Coordinates cwfs3 = result2;
+        Coordinates result1;
+        synchronized (group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue()) {
+            result1 = group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
+        }
+        Coordinates odgw1 = result1;
 
         Coordinates cwfs1x = Coordinates.create("17:25:20.057", "-48:27:39.99");
         Coordinates cwfs2x = Coordinates.create("17:25:20.321", "-48:28:47.20");

--- a/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
+++ b/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
@@ -105,9 +105,9 @@ public class GemsCatalogResultsTest  implements MascotProgress {
         assertEquals(odgw1x.getRaDeg(), odgw1.getRaDeg(), 0.001);
         assertEquals(odgw1x.getDecDeg(), odgw1.getDecDeg(), 0.001);
 
-        double cwfs1Mag = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getMagnitude(Magnitude.Band.R).getValue().getBrightness();
-        double cwfs2Mag = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getMagnitude(Magnitude.Band.R).getValue().getBrightness();
-        double cwfs3Mag = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getMagnitude(Magnitude.Band.R).getValue().getBrightness();
+        double cwfs1Mag = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getTarget().getMagnitude(Magnitude.Band.R).getValue().getBrightness();
+        double cwfs2Mag = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getTarget().getMagnitude(Magnitude.Band.R).getValue().getBrightness();
+        double cwfs3Mag = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getTarget().getMagnitude(Magnitude.Band.R).getValue().getBrightness();
         assertTrue(cwfs3Mag < cwfs1Mag && cwfs3Mag < cwfs2Mag); // cwfs3 is brightest
 
     }

--- a/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
+++ b/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
@@ -83,26 +83,10 @@ public class GemsCatalogResultsTest  implements MascotProgress {
         assertFalse(set.contains(GsaoiOdgw.odgw3));
         assertFalse(set.contains(GsaoiOdgw.odgw4));
 
-        Coordinates result4;
-        synchronized (group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue()) {
-            result4 = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
-        }
-        Coordinates cwfs1 = result4;
-        Coordinates result3;
-        synchronized (group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue()) {
-            result3 = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
-        }
-        Coordinates cwfs2 = result3;
-        Coordinates result2;
-        synchronized (group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue()) {
-            result2 = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
-        }
-        Coordinates cwfs3 = result2;
-        Coordinates result1;
-        synchronized (group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue()) {
-            result1 = group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
-        }
-        Coordinates odgw1 = result1;
+        Coordinates cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getSkycalcCoordinates();
+        Coordinates cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getSkycalcCoordinates();
+        Coordinates cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getSkycalcCoordinates();
+        Coordinates odgw1 = group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue().getSkycalcCoordinates();
 
         Coordinates cwfs1x = Coordinates.create("17:25:20.057", "-48:27:39.99");
         Coordinates cwfs2x = Coordinates.create("17:25:20.321", "-48:28:47.20");

--- a/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
+++ b/bundle/edu.gemini.ags/src/test/java/edu/gemini/ags/gems/GemsCatalogResultsTest.java
@@ -83,10 +83,10 @@ public class GemsCatalogResultsTest  implements MascotProgress {
         assertFalse(set.contains(GsaoiOdgw.odgw3));
         assertFalse(set.contains(GsaoiOdgw.odgw4));
 
-        Coordinates cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getSkycalcCoordinates();
-        Coordinates cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getSkycalcCoordinates();
-        Coordinates cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getSkycalcCoordinates();
-        Coordinates odgw1 = group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue().getSkycalcCoordinates();
+        Coordinates cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
+        Coordinates cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
+        Coordinates cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
+        Coordinates odgw1 = group.get(GsaoiOdgw.odgw1).getValue().getPrimary().getValue().getTarget().getSkycalcCoordinates();
 
         Coordinates cwfs1x = Coordinates.create("17:25:20.057", "-48:27:39.99");
         Coordinates cwfs2x = Coordinates.create("17:25:20.321", "-48:28:47.20");

--- a/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
@@ -370,7 +370,11 @@ public class LchQueryFunctor extends DBAbstractQueryFunctor implements IDBParall
             Sidereal sidereal = new Sidereal();
             sidereal.setName(target.getTarget().getName());
             sidereal.setType(_getTargetType(target, targetEnvironment));
-            Coordinates coords = target.getSkycalcCoordinates();
+            Coordinates result;
+            synchronized (target) {
+                result = target.getTarget().getSkycalcCoordinates();
+            }
+            Coordinates coords = result;
             HmsDms hmsDms = new HmsDms();
             hmsDms.setRa(HHMMSS.valStr(coords.getRa().getMagnitude()));
             hmsDms.setDec(DDMMSS.valStr(coords.getDec().getMagnitude()));

--- a/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
@@ -359,7 +359,7 @@ public class LchQueryFunctor extends DBAbstractQueryFunctor implements IDBParall
     private Serializable _makeTargetNode(SPTarget target, TargetEnvironment targetEnvironment) {
         if (target.getTarget() instanceof NonSiderealTarget) {
             NonSidereal nonSidereal = new NonSidereal();
-            nonSidereal.setName(target.getName());
+            nonSidereal.setName(target.getTarget().getName());
             nonSidereal.setType(_getTargetType(target, targetEnvironment));
             Long id = ((NonSiderealTarget) target.getTarget()).getHorizonsObjectId();
             if (id != null) {
@@ -368,7 +368,7 @@ public class LchQueryFunctor extends DBAbstractQueryFunctor implements IDBParall
             return nonSidereal;
         } else {
             Sidereal sidereal = new Sidereal();
-            sidereal.setName(target.getName());
+            sidereal.setName(target.getTarget().getName());
             sidereal.setType(_getTargetType(target, targetEnvironment));
             Coordinates coords = target.getSkycalcCoordinates();
             HmsDms hmsDms = new HmsDms();

--- a/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
@@ -370,7 +370,7 @@ public class LchQueryFunctor extends DBAbstractQueryFunctor implements IDBParall
             Sidereal sidereal = new Sidereal();
             sidereal.setName(target.getTarget().getName());
             sidereal.setType(_getTargetType(target, targetEnvironment));
-            Coordinates coords = target.getSkycalcCoordinates();
+            Coordinates coords = target.getTarget().getSkycalcCoordinates();
             HmsDms hmsDms = new HmsDms();
             hmsDms.setRa(HHMMSS.valStr(coords.getRa().getMagnitude()));
             hmsDms.setDec(DDMMSS.valStr(coords.getDec().getMagnitude()));

--- a/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
@@ -370,11 +370,7 @@ public class LchQueryFunctor extends DBAbstractQueryFunctor implements IDBParall
             Sidereal sidereal = new Sidereal();
             sidereal.setName(target.getTarget().getName());
             sidereal.setType(_getTargetType(target, targetEnvironment));
-            Coordinates result;
-            synchronized (target) {
-                result = target.getTarget().getSkycalcCoordinates();
-            }
-            Coordinates coords = result;
+            Coordinates coords = target.getSkycalcCoordinates();
             HmsDms hmsDms = new HmsDms();
             hmsDms.setRa(HHMMSS.valStr(coords.getRa().getMagnitude()));
             hmsDms.setDec(DDMMSS.valStr(coords.getDec().getMagnitude()));

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -237,7 +237,7 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
         SPTarget base = targetEnv.getBase();
 
         base.setName(tooTarget.getName());
-        base.setXY(tooTarget.getRa(), tooTarget.getDec());
+        base.setRaDecDegrees(tooTarget.getRa(), tooTarget.getDec());
         base.setMagnitudes(tooTarget.getMagnitudes());
 
         // Set the guide star, if present.
@@ -277,7 +277,7 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
                         Option<SPTarget> targetOpt = gt.getPrimary();
                         SPTarget target = targetOpt.isEmpty() ? new SPTarget() : targetOpt.getValue();
 
-                        target.setXY(gs.getRa(), gs.getDec());
+                        target.setRaDecDegrees(gs.getRa(), gs.getDec());
                         String name = gs.getName();
                         if (name != null) target.setName(name);
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
@@ -11,7 +11,6 @@ import edu.gemini.p2checker.api.P2Problems;
 import edu.gemini.p2checker.util.PositionOffsetChecker;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.ISPProgramNode;
-import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Trio;
@@ -19,9 +18,6 @@ import edu.gemini.shared.util.immutable.Tuple3;
 import edu.gemini.spModel.gemini.altair.AltairAowfsGuider;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
-import edu.gemini.spModel.gemini.gnirs.InstGNIRS;
-import edu.gemini.spModel.gemini.nifs.InstNIFS;
-import edu.gemini.spModel.gemini.niri.InstNIRI;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
@@ -268,7 +264,7 @@ public final class AltairRule implements IRule {
             Magnitude.Band[] bands = new Magnitude.Band[]{Magnitude.Band.R, Magnitude.Band.V};
             for (SPTarget spTarget : guideGroup.getTargets()) {
                 for (Magnitude.Band band : bands) {
-                    Magnitude m = spTarget.getMagnitude(band).getOrNull();
+                    Magnitude m = spTarget.getTarget().getMagnitude(band).getOrNull();
                     if (m != null) {
                         double b = m.getBrightness();
                         if (minMag == null || b < minMag) minMag = b;

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -210,14 +210,14 @@ public class GeneralRule implements IRule {
                 Set<String> errorSet = new TreeSet<String>();
                 for (SPTarget target : guideTargets) {
                     //Check for empty name
-                    if ("".equals(target.getName().trim())) {
+                    if ("".equals(target.getTarget().getName().trim())) {
                         errorSet.add(String.format(WFS_EMPTY_NAME_TEMPLATE, guider.getKey()));
                     }
 
                     // If a WFS has the same name as the base position, make sure
                     // that it has the same position.  If they have the same
                     // position, make sure they have the same name.
-                    boolean sameName = baseTarget.getName().equals(target.getName());
+                    boolean sameName = baseTarget.getTarget().getName().equals(target.getTarget().getName());
                     boolean samePos;
                     if (baseTarget.getTarget() instanceof NonSiderealTarget) {
                         samePos = sameNonSiderealPosition(baseTarget, target);
@@ -377,7 +377,7 @@ public class GeneralRule implements IRule {
             if (scienceTarget == null) { //really unlikely
                 problems.addError(PREFIX+"NO_SCIENCE_TARGET_MSG", NO_SCIENCE_TARGET_MSG, elements.getTargetObsComponentNode().getValue());
             } else {
-                if ("".equals(scienceTarget.getName().trim())) {
+                if ("".equals(scienceTarget.getTarget().getName().trim())) {
                     problems.addError(PREFIX+"EMPTY_TARGET_NAME_MSG", EMPTY_TARGET_NAME_MSG, elements.getTargetObsComponentNode().getValue());
                 }
             }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -427,11 +427,11 @@ public class GeneralRule implements IRule {
 
     private static boolean _areTargetsEquals(SPTarget p1Target, SPTarget target, ObservationElements elems) {
 
-        double spRA = target.getC1().getAs(CoordinateParam.Units.HMS);
-        double spDec = target.getC2().getAs(CoordinateParam.Units.DEGREES);
+        double spRA = target.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
+        double spDec = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
 
-        double p1RA = p1Target.getC1().getAs(CoordinateParam.Units.HMS);
-        double p1Dec = p1Target.getC2().getAs(CoordinateParam.Units.DEGREES);
+        double p1RA = p1Target.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
+        double p1Dec = p1Target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
 
         return _closeEnough(elems, spRA, spDec, p1RA, p1Dec);
     }
@@ -444,8 +444,8 @@ public class GeneralRule implements IRule {
         final ISPObservation obs = elems.getObservationNode();
         if (obs == null || !Too.isToo(obs)) return false;
 
-        double p1RA = p1Target.getC1().getAs(CoordinateParam.Units.HMS);
-        double p1Dec = p1Target.getC2().getAs(CoordinateParam.Units.DEGREES);
+        double p1RA = p1Target.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
+        double p1Dec = p1Target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
         return (p1RA == 0.0) && (p1Dec == 0.0);
     }
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gpi/GpiRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gpi/GpiRule.java
@@ -174,8 +174,8 @@ public class GpiRule implements IRule {
                 P2Problems problems = new P2Problems();
                 TargetEnvironment env = obsComp.getTargetEnvironment();
                 SPTarget base = env.getBase();
-                Option<Magnitude> imag = base.getMagnitude(Magnitude.Band.I);
-                Option<Magnitude> hmag = base.getMagnitude(Magnitude.Band.H);
+                Option<Magnitude> imag = base.getTarget().getMagnitude(Magnitude.Band.I);
+                Option<Magnitude> hmag = base.getTarget().getMagnitude(Magnitude.Band.H);
                 // OT-74
                 if (imag.isEmpty() || imag.getValue().getBrightness() == Magnitude.UNDEFINED_MAG) {
                     problems.addError(PREFIX + "MAG_BAND_MESSAGE", MAG_BAND_MESSAGE + "I-band.", elements.getTargetObsComponentNode().getValue());
@@ -190,7 +190,7 @@ public class GpiRule implements IRule {
                     if (!inst.getObservingMode().isEmpty()) {
                         Gpi.ObservingMode obsMode = inst.getObservingMode().getValue();
                         Magnitude.Band band = inst.getFilter().getBand(); // OT-102: obsMode could be NONSTANDARD
-                        Option<Magnitude> mag = base.getMagnitude(band);
+                        Option<Magnitude> mag = base.getTarget().getMagnitude(band);
                         if (mag.isEmpty() || mag.getValue().getBrightness() == Magnitude.UNDEFINED_MAG) {
                             // OT-99
                             problems.addError(PREFIX + "MAG_BAND_MESSAGE", MAG_BAND_MESSAGE + band + "-band",

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
@@ -8,9 +8,7 @@ import edu.gemini.pot.sp.ISPProgramNode;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.config2.Config;
-import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.altair.AltairAowfsGuider;
-import edu.gemini.spModel.gemini.altair.InstAltair;
 import edu.gemini.spModel.gemini.nifs.InstNIFS;
 import edu.gemini.spModel.gemini.nifs.NIFSParams;
 import edu.gemini.spModel.gemini.nifs.NifsOiwfsGuideProbe;
@@ -193,14 +191,14 @@ public final class NifsRule implements IRule {
                 if (baseTarget == null || oiTarget.isEmpty() || aoTarget.isEmpty()) return null;
                 //now, let's compare coordinates. If they are the same, raise an error
 
-                double baseC1 = baseTarget.getC1().getAs(CoordinateParam.Units.HMS);
-                double baseC2 = baseTarget.getC2().getAs(CoordinateParam.Units.DEGREES);
+                double baseC1 = baseTarget.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
+                double baseC2 = baseTarget.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
 
-                double oiC1 = oiTarget.getValue().getC1().getAs(CoordinateParam.Units.HMS);
-                double oiC2 = oiTarget.getValue().getC2().getAs(CoordinateParam.Units.DEGREES);
+                double oiC1 = oiTarget.getValue().getTarget().getC1().getAs(CoordinateParam.Units.HMS);
+                double oiC2 = oiTarget.getValue().getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
 
-                double aoC1 = aoTarget.getValue().getC1().getAs(CoordinateParam.Units.HMS);
-                double aoC2 = aoTarget.getValue().getC2().getAs(CoordinateParam.Units.DEGREES);
+                double aoC1 = aoTarget.getValue().getTarget().getC1().getAs(CoordinateParam.Units.HMS);
+                double aoC2 = aoTarget.getValue().getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
 
 
                 if (Double.compare(baseC1, oiC1) == 0

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -119,7 +119,7 @@ trait Partitioner {
 
 object GnirsSpectroscopyPartitioner extends Partitioner {
   import edu.gemini.shared.skyobject.Magnitude.Band.H
-  def bucket(t:SPTarget):Int = Option(t.getMagnitude(H).getOrNull).map(_.getBrightness).map {H =>
+  def bucket(t:SPTarget):Int = Option(t.getTarget.getMagnitude(H).getOrNull).map(_.getBrightness).map {H =>
     if (H < 11.5) 1
     else if (H < 16) 2
     else if (H < 20) 3
@@ -136,7 +136,7 @@ object GnirsSpectroscopyPartitioner extends Partitioner {
 
 object NifsAoPartitioner extends Partitioner {
   import edu.gemini.shared.skyobject.Magnitude.Band.H
-  def bucket(t:SPTarget):Int = Option(t.getMagnitude(H).getOrNull).map(_.getBrightness).map {H =>
+  def bucket(t:SPTarget):Int = Option(t.getTarget.getMagnitude(H).getOrNull).map(_.getBrightness).map {H =>
     if (H <= 9) 1
     else if (H <= 12) 2
     else if (H <= 20) 3
@@ -150,7 +150,7 @@ object NifsAoPartitioner extends Partitioner {
 
 object F2LongslitPartitioner extends Partitioner {
   import edu.gemini.shared.skyobject.Magnitude.Band.H
-  def bucket(t: SPTarget): Int = (Option(t.getMagnitude(H).getOrNull).map(_.getBrightness) map { h =>
+  def bucket(t: SPTarget): Int = (Option(t.getTarget.getMagnitude(H).getOrNull).map(_.getBrightness) map { h =>
     if (h <= 12.0) 1 else 2
   }).getOrElse(3)
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
@@ -33,7 +33,7 @@ case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTa
 //              Put FILTERS from PI into F2 ITERATOR
 //
 
-  val acq = exampleTarget.flatMap(t => Option(t.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
+  val acq = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
     case Some(h) if h <= 12 => Seq(13)
     case Some(h) if h >  12 => Seq(14)
     case _                  => Seq(13, 14)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsSpectroscopy.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsSpectroscopy.scala
@@ -98,7 +98,7 @@ case class GnirsSpectroscopy(blueprint:SpGnirsBlueprintSpectroscopy, exampleTarg
   // IF TARGET H-MAGNITUDE >= 20 INCLUDE {10}        #Blind offset target
   // ELSE INCLUDE {7} - {11}, {22}   # No H-magnitude provided for target, so put all of them
 
-  val otherAcq = exampleTarget.flatMap(t => Option(t.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
+  val otherAcq = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
     case Some(h) =>
       if (h < 7) Seq(22)
       else if (h < 11.5) Seq(7)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/Nifs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/Nifs.scala
@@ -12,7 +12,7 @@ case class Nifs(blueprint:SpNifsBlueprint, exampleTarget: Option[SPTarget]) exte
 
   // N.B. This is the same as NifsAo but without altair or occulting disk
 
-  val tb = exampleTarget.flatMap(t => Option(t.getMagnitude(Band.H).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
+  val tb = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(Band.H).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
 
   // # Select acquisition and science observation
   //    IF target information contains a H magnitude

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/NifsAo.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/NifsAo.scala
@@ -16,7 +16,7 @@ import edu.gemini.spModel.rich.pot.sp._
 case class NifsAo(blueprint: SpNifsBlueprintAo, exampleTarget: Option[SPTarget]) extends NifsBase[SpNifsBlueprintAo] {
   import blueprint._
 
-  val tb = exampleTarget.flatMap(t => Option(t.getMagnitude(Band.H).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
+  val tb = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(Band.H).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
 
   // # Select acquisition and science observation
   // IF OCCULTING DISK == None

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -101,7 +101,11 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx) {
-        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return checkBoundaries(result, ctx);
     }
 
     public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -101,11 +101,7 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return checkBoundaries(result, ctx);
+        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
     }
 
     public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -101,7 +101,7 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx) {
-        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
+        return checkBoundaries(guideStar.getTarget().getSkycalcCoordinates(), ctx);
     }
 
     public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
@@ -99,7 +99,7 @@ public enum Flamingos2OiwfsGuideProbe implements GuideProbe, ValidatableGuidePro
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
@@ -2,7 +2,6 @@ package edu.gemini.spModel.gemini.flamingos2;
 
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.skycalc.Angle;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
@@ -100,11 +99,7 @@ public enum Flamingos2OiwfsGuideProbe implements GuideProbe, ValidatableGuidePro
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return GuideProbeUtil.instance.validate(result, this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
@@ -2,6 +2,7 @@ package edu.gemini.spModel.gemini.flamingos2;
 
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.skycalc.Angle;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
@@ -99,7 +100,11 @@ public enum Flamingos2OiwfsGuideProbe implements GuideProbe, ValidatableGuidePro
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return GuideProbeUtil.instance.validate(result, this, ctx);
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -223,7 +223,7 @@ public enum Canopus {
         public abstract Area probeArm(ObsContext ctx, boolean validate);
 
         public boolean validate(SPTarget guideStar, ObsContext ctx) {
-            Coordinates coords = guideStar.getSkycalcCoordinates();
+            Coordinates coords = guideStar.getTarget().getSkycalcCoordinates();
             return Canopus.instance.getProbesInRange(coords, ctx).contains(this);
         }
 
@@ -234,7 +234,7 @@ public enum Canopus {
             Area a = wfs.probeArm(ctx, false);
             if (a == null) return false;
 
-            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getSkycalcCoordinates());
+            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getTarget().getSkycalcCoordinates());
             Offset dis = diff.getOffset();
             double p = -dis.p().toArcsecs().getMagnitude();
             double q = -dis.q().toArcsecs().getMagnitude();
@@ -258,7 +258,7 @@ public enum Canopus {
             SPTarget guideStar = guideStarOpt.getValue();
 
             // Calculate the difference between the coordinate and the observation's base position.
-            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getSkycalcCoordinates());
+            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getTarget().getSkycalcCoordinates());
             // Get offset and switch it to be defined in the same coordinate
             // system as the shape.
             Offset dis = diff.getOffset();
@@ -340,7 +340,7 @@ public enum Canopus {
         SPTarget target = spTargetOpt.getValue();
 
         CoordinateDiff diff;
-        diff = new CoordinateDiff(base.getSkycalcCoordinates(), target.getSkycalcCoordinates());
+        diff = new CoordinateDiff(base.getTarget().getSkycalcCoordinates(), target.getTarget().getSkycalcCoordinates());
         Offset o = diff.getOffset();
         double p = -o.p().toArcsecs().getMagnitude();
         double q = -o.q().toArcsecs().getMagnitude();
@@ -486,7 +486,7 @@ public enum Canopus {
             SPTarget target = targets.getPrimary().getOrElse(null);
             if (target != null && (!validate || cwfs.validate(target, ctx))) {
                 // Get offset from base position to cwfs in arcsecs
-                CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), target.getSkycalcCoordinates());
+                CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), target.getTarget().getSkycalcCoordinates());
                 Offset dis = diff.getOffset();
                 double p = -dis.p().toArcsecs().getMagnitude();
                 double q = -dis.q().toArcsecs().getMagnitude();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -223,11 +223,7 @@ public enum Canopus {
         public abstract Area probeArm(ObsContext ctx, boolean validate);
 
         public boolean validate(SPTarget guideStar, ObsContext ctx) {
-            Coordinates result;
-            synchronized (guideStar) {
-                result = guideStar.getTarget().getSkycalcCoordinates();
-            }
-            Coordinates coords = result;
+            Coordinates coords = guideStar.getSkycalcCoordinates();
             return Canopus.instance.getProbesInRange(coords, ctx).contains(this);
         }
 
@@ -238,11 +234,7 @@ public enum Canopus {
             Area a = wfs.probeArm(ctx, false);
             if (a == null) return false;
 
-            Coordinates result;
-            synchronized (guideStar) {
-                result = guideStar.getTarget().getSkycalcCoordinates();
-            }
-            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), result);
+            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getSkycalcCoordinates());
             Offset dis = diff.getOffset();
             double p = -dis.p().toArcsecs().getMagnitude();
             double q = -dis.q().toArcsecs().getMagnitude();
@@ -266,11 +258,7 @@ public enum Canopus {
             SPTarget guideStar = guideStarOpt.getValue();
 
             // Calculate the difference between the coordinate and the observation's base position.
-            Coordinates result;
-            synchronized (guideStar) {
-                result = guideStar.getTarget().getSkycalcCoordinates();
-            }
-            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), result);
+            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getSkycalcCoordinates());
             // Get offset and switch it to be defined in the same coordinate
             // system as the shape.
             Offset dis = diff.getOffset();
@@ -352,15 +340,7 @@ public enum Canopus {
         SPTarget target = spTargetOpt.getValue();
 
         CoordinateDiff diff;
-        Coordinates result;
-        synchronized (target) {
-            result = target.getTarget().getSkycalcCoordinates();
-        }
-        Coordinates result1;
-        synchronized (base) {
-            result1 = base.getTarget().getSkycalcCoordinates();
-        }
-        diff = new CoordinateDiff(result1, result);
+        diff = new CoordinateDiff(base.getSkycalcCoordinates(), target.getSkycalcCoordinates());
         Offset o = diff.getOffset();
         double p = -o.p().toArcsecs().getMagnitude();
         double q = -o.q().toArcsecs().getMagnitude();
@@ -506,11 +486,7 @@ public enum Canopus {
             SPTarget target = targets.getPrimary().getOrElse(null);
             if (target != null && (!validate || cwfs.validate(target, ctx))) {
                 // Get offset from base position to cwfs in arcsecs
-                Coordinates result;
-                synchronized (target) {
-                    result = target.getTarget().getSkycalcCoordinates();
-                }
-                CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), result);
+                CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), target.getSkycalcCoordinates());
                 Offset dis = diff.getOffset();
                 double p = -dis.p().toArcsecs().getMagnitude();
                 double q = -dis.q().toArcsecs().getMagnitude();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -223,7 +223,11 @@ public enum Canopus {
         public abstract Area probeArm(ObsContext ctx, boolean validate);
 
         public boolean validate(SPTarget guideStar, ObsContext ctx) {
-            Coordinates coords = guideStar.getSkycalcCoordinates();
+            Coordinates result;
+            synchronized (guideStar) {
+                result = guideStar.getTarget().getSkycalcCoordinates();
+            }
+            Coordinates coords = result;
             return Canopus.instance.getProbesInRange(coords, ctx).contains(this);
         }
 
@@ -234,7 +238,11 @@ public enum Canopus {
             Area a = wfs.probeArm(ctx, false);
             if (a == null) return false;
 
-            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getSkycalcCoordinates());
+            Coordinates result;
+            synchronized (guideStar) {
+                result = guideStar.getTarget().getSkycalcCoordinates();
+            }
+            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), result);
             Offset dis = diff.getOffset();
             double p = -dis.p().toArcsecs().getMagnitude();
             double q = -dis.q().toArcsecs().getMagnitude();
@@ -258,7 +266,11 @@ public enum Canopus {
             SPTarget guideStar = guideStarOpt.getValue();
 
             // Calculate the difference between the coordinate and the observation's base position.
-            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getSkycalcCoordinates());
+            Coordinates result;
+            synchronized (guideStar) {
+                result = guideStar.getTarget().getSkycalcCoordinates();
+            }
+            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), result);
             // Get offset and switch it to be defined in the same coordinate
             // system as the shape.
             Offset dis = diff.getOffset();
@@ -340,7 +352,15 @@ public enum Canopus {
         SPTarget target = spTargetOpt.getValue();
 
         CoordinateDiff diff;
-        diff = new CoordinateDiff(base.getSkycalcCoordinates(), target.getSkycalcCoordinates());
+        Coordinates result;
+        synchronized (target) {
+            result = target.getTarget().getSkycalcCoordinates();
+        }
+        Coordinates result1;
+        synchronized (base) {
+            result1 = base.getTarget().getSkycalcCoordinates();
+        }
+        diff = new CoordinateDiff(result1, result);
         Offset o = diff.getOffset();
         double p = -o.p().toArcsecs().getMagnitude();
         double q = -o.q().toArcsecs().getMagnitude();
@@ -486,7 +506,11 @@ public enum Canopus {
             SPTarget target = targets.getPrimary().getOrElse(null);
             if (target != null && (!validate || cwfs.validate(target, ctx))) {
                 // Get offset from base position to cwfs in arcsecs
-                CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), target.getSkycalcCoordinates());
+                Coordinates result;
+                synchronized (target) {
+                    result = target.getTarget().getSkycalcCoordinates();
+                }
+                CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), result);
                 Offset dis = diff.getOffset();
                 double p = -dis.p().toArcsecs().getMagnitude();
                 double q = -dis.q().toArcsecs().getMagnitude();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -70,7 +70,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx) {
-        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
+        return checkBoundaries(guideStar.getTarget().getSkycalcCoordinates(), ctx);
     }
 
     public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {
@@ -99,7 +99,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 
     public boolean validate(SkyObject guideStar, ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -70,7 +70,11 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx) {
-        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return checkBoundaries(result, ctx);
     }
 
     public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {
@@ -99,7 +103,11 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return GuideProbeUtil.instance.validate(result, this, ctx);
     }
 
     public boolean validate(SkyObject guideStar, ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -70,11 +70,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return checkBoundaries(result, ctx);
+        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
     }
 
     public BoundaryPosition checkBoundaries(final Coordinates coords, final ObsContext ctx) {
@@ -103,11 +99,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return GuideProbeUtil.instance.validate(result, this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 
     public boolean validate(SkyObject guideStar, ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
@@ -7,6 +7,7 @@ package edu.gemini.spModel.gemini.gnirs;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -96,6 +97,10 @@ public enum GnirsOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return GuideProbeUtil.instance.validate(result, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
@@ -96,6 +96,6 @@ public enum GnirsOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
@@ -7,7 +7,6 @@ package edu.gemini.spModel.gemini.gnirs;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -97,10 +96,6 @@ public enum GnirsOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return GuideProbeUtil.instance.validate(result, this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
@@ -91,7 +91,7 @@ public class GpiCB extends AbstractObsComponentCB {
             final TargetObsComp toc = (TargetObsComp) targetcomp.getDataObject();
             if (toc != null) {
                 if (toc.getTargetEnvironment().getBase() != null) {
-                    ImList<Magnitude> magnitudes = toc.getTargetEnvironment().getBase().getMagnitudes();
+                    ImList<Magnitude> magnitudes = toc.getTargetEnvironment().getBase().getTarget().getMagnitudes();
                     magnitudes.filter(new MagnitudeFilter(Magnitude.Band.H)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_H_PROP));
                     magnitudes.filter(new MagnitudeFilter(Magnitude.Band.I)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_I_PROP));
                 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -81,11 +81,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
         public TargetEnvironment add(SPTarget guideStar, ObsContext ctx) {
             // Select the appropriate guider, if any.
             TargetEnvironment env = ctx.getTargets();
-            Coordinates result;
-            synchronized (guideStar) {
-                result = guideStar.getTarget().getSkycalcCoordinates();
-            }
-            Option<GuideProbe> probeOpt = select(result, ctx);
+            Option<GuideProbe> probeOpt = select(guideStar.getSkycalcCoordinates(), ctx);
             GuideProbe probe;
             if (probeOpt.isEmpty()) {
                 // Just use ODGW1 since we're adding a target that is off the
@@ -137,11 +133,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
                 if (gtOpt.isEmpty()) continue;
 
                 for (SPTarget target : gtOpt.getValue().getOptions()) {
-                    Coordinates result;
-                    synchronized (target) {
-                        result = target.getTarget().getSkycalcCoordinates();
-                    }
-                    Option<GuideProbe> opt = select(result, ctx);
+                    Option<GuideProbe> opt = select(target.getSkycalcCoordinates(), ctx);
                     if (opt.isEmpty()) {
                         // Doesn't fall on the detector, so keep it with
                         // whichever ODGW it was associated with.
@@ -341,11 +333,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
     }
 
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        Coordinates coords = result;
+        Coordinates coords = guideStar.getSkycalcCoordinates();
         // Get the id of the detector in which the guide star lands, if any
         Option<GsaoiDetectorArray.Id> idOpt = GsaoiDetectorArray.instance.getId(coords, ctx);
         if (idOpt.isEmpty()) return false;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -81,7 +81,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
         public TargetEnvironment add(SPTarget guideStar, ObsContext ctx) {
             // Select the appropriate guider, if any.
             TargetEnvironment env = ctx.getTargets();
-            Option<GuideProbe> probeOpt = select(guideStar.getSkycalcCoordinates(), ctx);
+            Option<GuideProbe> probeOpt = select(guideStar.getTarget().getSkycalcCoordinates(), ctx);
             GuideProbe probe;
             if (probeOpt.isEmpty()) {
                 // Just use ODGW1 since we're adding a target that is off the
@@ -133,7 +133,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
                 if (gtOpt.isEmpty()) continue;
 
                 for (SPTarget target : gtOpt.getValue().getOptions()) {
-                    Option<GuideProbe> opt = select(target.getSkycalcCoordinates(), ctx);
+                    Option<GuideProbe> opt = select(target.getTarget().getSkycalcCoordinates(), ctx);
                     if (opt.isEmpty()) {
                         // Doesn't fall on the detector, so keep it with
                         // whichever ODGW it was associated with.
@@ -333,7 +333,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
     }
 
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates coords = guideStar.getSkycalcCoordinates();
+        Coordinates coords = guideStar.getTarget().getSkycalcCoordinates();
         // Get the id of the detector in which the guide star lands, if any
         Option<GsaoiDetectorArray.Id> idOpt = GsaoiDetectorArray.instance.getId(coords, ctx);
         if (idOpt.isEmpty()) return false;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
@@ -7,6 +7,7 @@ package edu.gemini.spModel.gemini.nici;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -62,6 +63,10 @@ public enum NiciOiwfsGuideProbe implements ValidatableGuideProbe {
     }
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return GuideProbeUtil.instance.validate(result, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
@@ -62,6 +62,6 @@ public enum NiciOiwfsGuideProbe implements ValidatableGuideProbe {
     }
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
@@ -7,7 +7,6 @@ package edu.gemini.spModel.gemini.nici;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -63,10 +62,6 @@ public enum NiciOiwfsGuideProbe implements ValidatableGuideProbe {
     }
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return GuideProbeUtil.instance.validate(result, this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
@@ -6,7 +6,6 @@ package edu.gemini.spModel.gemini.nifs;
 
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.skycalc.Angle;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.altair.InstAltair;
@@ -82,10 +81,6 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return GuideProbeUtil.instance.validate(result, this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
@@ -6,6 +6,7 @@ package edu.gemini.spModel.gemini.nifs;
 
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.skycalc.Angle;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.altair.InstAltair;
@@ -81,6 +82,10 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return GuideProbeUtil.instance.validate(result, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
@@ -81,6 +81,6 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
@@ -7,6 +7,7 @@ package edu.gemini.spModel.gemini.niri;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -61,6 +62,10 @@ public enum NiriOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return GuideProbeUtil.instance.validate(result, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
@@ -7,7 +7,6 @@ package edu.gemini.spModel.gemini.niri;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
@@ -62,10 +61,6 @@ public enum NiriOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return GuideProbeUtil.instance.validate(result, this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
@@ -61,6 +61,6 @@ public enum NiriOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
@@ -80,7 +80,7 @@ public enum GuideProbeUtil {
     }
 
     public boolean validate(final SPTarget guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
-        return validate(guideStar.getSkycalcCoordinates(), guideProbe, ctx);
+        return validate(guideStar.getTarget().getSkycalcCoordinates(), guideProbe, ctx);
     }
 
     public boolean validate(final SkyObject guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
@@ -126,7 +126,7 @@ public enum GuideProbeUtil {
                 final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians().getMagnitude()));
                 // find distance of base position to the guide star
                 final Coordinates baseCoordinates = ctx.getBaseCoordinates();
-                final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, guideStar.getSkycalcCoordinates());
+                final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, guideStar.getTarget().getSkycalcCoordinates());
                 final Offset dis = diff.getOffset();
                 final double p = -dis.p().toArcsecs().getMagnitude();
                 final double q = -dis.q().toArcsecs().getMagnitude();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
@@ -80,7 +80,11 @@ public enum GuideProbeUtil {
     }
 
     public boolean validate(final SPTarget guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
-        return validate(guideStar.getSkycalcCoordinates(), guideProbe, ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return validate(result, guideProbe, ctx);
     }
 
     public boolean validate(final SkyObject guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
@@ -126,7 +130,11 @@ public enum GuideProbeUtil {
                 final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians().getMagnitude()));
                 // find distance of base position to the guide star
                 final Coordinates baseCoordinates = ctx.getBaseCoordinates();
-                final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, guideStar.getSkycalcCoordinates());
+                Coordinates result;
+                synchronized (guideStar) {
+                    result = guideStar.getTarget().getSkycalcCoordinates();
+                }
+                final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, result);
                 final Offset dis = diff.getOffset();
                 final double p = -dis.p().toArcsecs().getMagnitude();
                 final double q = -dis.q().toArcsecs().getMagnitude();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
@@ -80,11 +80,7 @@ public enum GuideProbeUtil {
     }
 
     public boolean validate(final SPTarget guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return validate(result, guideProbe, ctx);
+        return validate(guideStar.getSkycalcCoordinates(), guideProbe, ctx);
     }
 
     public boolean validate(final SkyObject guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
@@ -130,11 +126,7 @@ public enum GuideProbeUtil {
                 final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians().getMagnitude()));
                 // find distance of base position to the guide star
                 final Coordinates baseCoordinates = ctx.getBaseCoordinates();
-                Coordinates result;
-                synchronized (guideStar) {
-                    result = guideStar.getTarget().getSkycalcCoordinates();
-                }
-                final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, result);
+                final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, guideStar.getSkycalcCoordinates());
                 final Offset dis = diff.getOffset();
                 final double p = -dis.p().toArcsecs().getMagnitude();
                 final double q = -dis.q().toArcsecs().getMagnitude();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
@@ -1,7 +1,5 @@
 package edu.gemini.spModel.guide;
 
-import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.CoordinateDiff;
 import edu.gemini.skycalc.Coordinates;
@@ -13,7 +11,6 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
-import java.awt.geom.Rectangle2D;
 import java.util.Collection;
 import java.util.Set;
 
@@ -270,7 +267,11 @@ public class PatrolField {
 
         @Override public boolean validate(SPTarget guideStar, ObsContext ctx) {
             final Coordinates baseCoordinates  = ctx.getBaseCoordinates();
-            final Coordinates guideCoordinates = guideStar.getSkycalcCoordinates();
+            Coordinates result;
+            synchronized (guideStar) {
+                result = guideStar.getTarget().getSkycalcCoordinates();
+            }
+            final Coordinates guideCoordinates = result;
             // Calculate the difference between the coordinate and the observation's
             // base position.
             CoordinateDiff diff;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.guide;
 
+import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.CoordinateDiff;
 import edu.gemini.skycalc.Coordinates;
@@ -11,6 +13,7 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
+import java.awt.geom.Rectangle2D;
 import java.util.Collection;
 import java.util.Set;
 
@@ -267,11 +270,7 @@ public class PatrolField {
 
         @Override public boolean validate(SPTarget guideStar, ObsContext ctx) {
             final Coordinates baseCoordinates  = ctx.getBaseCoordinates();
-            Coordinates result;
-            synchronized (guideStar) {
-                result = guideStar.getTarget().getSkycalcCoordinates();
-            }
-            final Coordinates guideCoordinates = result;
+            final Coordinates guideCoordinates = guideStar.getSkycalcCoordinates();
             // Calculate the difference between the coordinate and the observation's
             // base position.
             CoordinateDiff diff;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
@@ -1,7 +1,5 @@
 package edu.gemini.spModel.guide;
 
-import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.CoordinateDiff;
 import edu.gemini.skycalc.Coordinates;
@@ -13,7 +11,6 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
-import java.awt.geom.Rectangle2D;
 import java.util.Collection;
 import java.util.Set;
 
@@ -270,7 +267,7 @@ public class PatrolField {
 
         @Override public boolean validate(SPTarget guideStar, ObsContext ctx) {
             final Coordinates baseCoordinates  = ctx.getBaseCoordinates();
-            final Coordinates guideCoordinates = guideStar.getSkycalcCoordinates();
+            final Coordinates guideCoordinates = guideStar.getTarget().getSkycalcCoordinates();
             // Calculate the difference between the coordinate and the observation's
             // base position.
             CoordinateDiff diff;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
@@ -14,6 +14,7 @@ import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummaryService;
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummary;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import edu.gemini.spModel.too.Too;
 import jsky.coords.WorldCoords;
 
@@ -130,8 +131,8 @@ public final class ObsSchedulingReport implements Serializable {
         SPTarget target = env.getBase();
         if (target == null) return null;
 
-        double ra  = target.getXaxis();
-        double dec = target.getYaxis();
+        double ra  = target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES);
+        double dec = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
         return new WorldCoords(ra, dec);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -18,6 +18,7 @@ import edu.gemini.spModel.pio.PioParseException;
 import edu.gemini.spModel.seqcomp.IObserveSeqComponent;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import edu.gemini.spModel.time.ChargeClass;
 import edu.gemini.spModel.time.ObsTimeCharges;
 import edu.gemini.spModel.time.ObsTimeCorrection;
@@ -444,7 +445,7 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
         } else {
             final TargetObsComp toc = (TargetObsComp) targetComp.getDataObject();
             final SPTarget target = toc.getBase();
-            return (target.getXaxis() != 0.0) || (target.getYaxis() != 0.0);
+            return (target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES) != 0.0) || (target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES) != 0.0);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -264,8 +264,8 @@ public final class ObsContext {
 
     public Coordinates getBaseCoordinates() {
         SPTarget target = targets.getBase();
-        double raDeg = target.getC1().getAs(CoordinateParam.Units.DEGREES);
-        double decDeg = target.getC2().getAs(CoordinateParam.Units.DEGREES);
+        double raDeg = target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES);
+        double decDeg = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
         return new Coordinates(raDeg, decDeg);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
@@ -16,7 +16,6 @@ import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummaryService;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.system.CoordinateParam.Units;
-import edu.gemini.spModel.target.system.HmsDegTarget;
 import edu.gemini.spModel.target.system.ICoordinate;
 import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.time.TimeAmountFormatter;
@@ -69,7 +68,7 @@ public class ObsTargetDesc extends TargetDesc {
         double x = c1.getAs(Units.DEGREES);
         double y = c2.getAs(Units.DEGREES);
         WorldCoords pos = new WorldCoords(x, y, 2000.);
-        String targetName = basePos.getName();
+                 String targetName = basePos.getTarget().getName();
 
         String obsId = "";
         SPObservationID spObsId = obs.getObservationID();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -165,16 +165,6 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Gets the set of magnitude bands that have been recorded in this target.
-     *
-     * @returns a Set of {@link Magnitude.Band magnitude bands} for which
-     * we have information in this target
-     */
-    public Set<Magnitude.Band> getMagnitudeBands() {
-        return _target.getMagnitudeBands();
-    }
-
-    /**
      * Adds the given magnitude to the collection of magnitudes associated with
      * this target, replacing any other magnitude of the same band if any.
      *

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -567,25 +567,11 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Returns the ICoordinateValue for c1
-     */
-    public final ICoordinate getC1() {
-        return _target.getC1();
-    }
-
-    /**
      * Get the xaxis.
      */
     public final double getXaxis() {
         final ICoordinate c1 = _target.getC1();
         return c1.getAs(Units.DEGREES);
-    }
-
-    /**
-     * Returns the ICoordinate for c2
-     */
-    public final ICoordinate getC2() {
-        return _target.getC2();
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -152,17 +152,6 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Gets all the {@link Magnitude} information associated with this target,
-     * if any.
-     *
-     * @return (possibly empty) immutable list of {@link Magnitude} values
-     * associated with this target
-     */
-    public ImList<Magnitude> getMagnitudes() {
-        return getTarget().getMagnitudes();
-    }
-
-    /**
      * Assigns the list of magnitudes to associate with this target.  If there
      * are multiple magnitudes associated with the same bandpass, only one will
      * be kept.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -9,6 +9,7 @@ package edu.gemini.spModel.target;
 
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.system.*;
@@ -231,11 +232,6 @@ public final class SPTarget extends WatchablePos {
     /** @deprecated */
     public void notifyOfGenericUpdate() {
     	super._notifyOfUpdate();
-    }
-
-    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
-    public synchronized Coordinates getSkycalcCoordinates() {
-        return new Coordinates(getTarget().getC1().getAs(Units.DEGREES), getTarget().getC2().getAs(Units.DEGREES));
     }
 
     /** Set the contained target RA/Dec in degrees and notify observers. */

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -234,11 +234,6 @@ public final class SPTarget extends WatchablePos {
     	super._notifyOfUpdate();
     }
 
-    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
-    public synchronized Coordinates getSkycalcCoordinates() {
-        return new Coordinates(getTarget().getC1().getAs(Units.DEGREES), getTarget().getC2().getAs(Units.DEGREES));
-    }
-
     /** Set the contained target RA/Dec in degrees and notify observers. */
     public void setXY(final double raDeg, final double decDeg) {
         synchronized (this) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -8,23 +8,13 @@
 package edu.gemini.spModel.target;
 
 import edu.gemini.shared.skyobject.Magnitude;
-import edu.gemini.shared.skyobject.SkyObject;
-import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.pio.ParamSet;
-import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.system.*;
 import edu.gemini.spModel.target.system.CoordinateParam.Units;
 import edu.gemini.spModel.target.system.CoordinateTypes.*;
-
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.util.Date;
-import java.util.TimeZone;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * A data object that describes a telescope position and includes methods
@@ -34,72 +24,6 @@ public final class SPTarget extends WatchablePos {
 
 
     private static final String COORDINATE_ZERO = "00:00:00.0";
-    private static final Logger LOGGER = Logger.getLogger(SPTarget.class.getName());
-
-    ///
-    /// DATE HANDLING
-    ///
-
-    private static final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.FULL);
-    static {
-        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
-
-    private static synchronized String formatDate(final Date d) {
-        return formatter.format(d);
-    }
-
-    private static synchronized Date parseDate(final String dateStr) {
-        if (dateStr == null) return null;
-
-        DateFormat format = formatter;
-        if (!dateStr.contains("UTC")) {
-            // OT-755: we didn't used to store the time zone, which
-            // led to bugs when exporting in one time zone and importing
-            // in another -- say when the program is stored.
-            // If the date doesn't include "UTC", then assume it is in
-            // the old style and import in the local time zone so that
-            // at least the behavior when reading in existing programs for
-            // the first time won't change.
-            format = DateFormat.getInstance();
-        }
-
-        try {
-            return format.parse(dateStr);
-        } catch (final ParseException e) {
-            LOGGER.log(Level.WARNING, " Invalid date found " + dateStr);
-            return null;
-        }
-    }
-
-    ///
-    /// PARAMSET
-    ///
-
-    public static final String PARAM_SET_NAME = "spTarget";
-
-    private static final String _NAME = "name";
-    private static final String _OBJECT = "object";
-    private static final String _SYSTEM = "system";
-    private static final String _EPOCH = "epoch";
-    private static final String _BRIGHTNESS = "brightness";
-    private static final String _C1 = "c1";
-    private static final String _C2 = "c2";
-    private static final String _VALID_DATE = "validAt";
-    private static final String _PM1 = "pm1";
-    private static final String _PM2 = "pm2";
-    private static final String _PARALLAX = "parallax";
-    private static final String _RV = "rv";
-    private static final String _WAVELENGTH = "wavelength";
-    private static final String _ANODE = "anode";
-    private static final String _AQ = "aq";
-    private static final String _E = "e";
-    private static final String _INCLINATION = "inclination";
-    private static final String _LM = "lm";
-    private static final String _N = "n";
-    private static final String _PERIHELION = "perihelion";
-    private static final String _EPOCH_OF_PERIHELION = "epochOfPeri";
-
 
     ///
     /// FIELDS
@@ -320,212 +244,18 @@ public final class SPTarget extends WatchablePos {
      * Return a paramset describing this object
      */
     public ParamSet getParamSet(final PioFactory factory) {
-        final ParamSet paramSet = factory.createParamSet(PARAM_SET_NAME);
-
-        // Based on instance create the right target
-        final ITarget target = getTarget();
-        Pio.addParam(factory, paramSet, _NAME, getTarget().getName());
-
-        if (target instanceof HmsDegTarget) {
-            final HmsDegTarget t = (HmsDegTarget) target;
-            Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
-            paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
-            Pio.addParam(factory, paramSet, _BRIGHTNESS, t.getBrightness());
-            Pio.addParam(factory, paramSet, _C1, t.c1ToString());
-            Pio.addParam(factory, paramSet, _C2, t.c2ToString());
-            paramSet.addParam(t.getPM1().getParam(factory, _PM1));
-            paramSet.addParam(t.getPM2().getParam(factory, _PM2));
-            paramSet.addParam(t.getParallax().getParam(factory, _PARALLAX));
-            paramSet.addParam(t.getRV().getParam(factory, _RV));
-        } else if (target instanceof NonSiderealTarget) {
-            final NonSiderealTarget nst = (NonSiderealTarget) target;
-
-            // Horizons data, if any
-            if (nst.isHorizonsDataPopulated()) {
-                Pio.addLongParam(factory, paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_ID, nst.getHorizonsObjectId());
-                Pio.addLongParam(factory, paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_TYPE_ORDINAL, nst.getHorizonsObjectTypeOrdinal());
-            }
-
-            // OT-495: save and restore RA/Dec for conic targets
-            // XXX FIXME: Temporary, until nonsidereal support is implemented
-            Pio.addParam(factory, paramSet, _C1, nst.c1ToString());
-            Pio.addParam(factory, paramSet, _C2, nst.c2ToString());
-            if (nst.getDateForPosition() != null) {
-                Pio.addParam(factory, paramSet, _VALID_DATE, formatDate(nst.getDateForPosition()));
-            }
-
-            if (target instanceof ConicTarget) {
-                final ConicTarget t = (ConicTarget) target;
-                Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
-                paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
-                Pio.addParam(factory, paramSet, _BRIGHTNESS, t.getBrightness());
-
-                paramSet.addParam(t.getANode().getParam(factory, _ANODE));
-                paramSet.addParam(t.getAQ().getParam(factory, _AQ));
-                Pio.addParam(factory, paramSet, _E, Double.toString(t.getE()));
-                paramSet.addParam(t.getInclination().getParam(factory, _INCLINATION));
-                paramSet.addParam(t.getLM().getParam(factory, _LM));
-                paramSet.addParam(t.getN().getParam(factory, _N));
-                paramSet.addParam(t.getPerihelion().getParam(factory, _PERIHELION));
-                paramSet.addParam(t.getEpochOfPeri().getParam(factory, _EPOCH_OF_PERIHELION));
-            } else if (target instanceof NamedTarget) {
-                final NamedTarget t = (NamedTarget) target;
-                Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
-                Pio.addParam(factory, paramSet, _OBJECT, t.getSolarObject().name());
-            }
-        }
-
-        // Add magnitude information to the paramset.
-        final ImList<Magnitude> magnitudes = target.getMagnitudes();
-        if (magnitudes.size() > 0) {
-            paramSet.addParamSet(MagnitudePio.instance.toParamSet(factory, magnitudes));
-        }
-
-        return paramSet;
+        return SPTargetPio.getParamSet(this, factory);
     }
 
     /**
      * Initialize this object from the given paramset
      */
     public void setParamSet(final ParamSet paramSet) {
-        if (paramSet == null) return;
-
-        final String name = Pio.getValue(paramSet, _NAME);
-        final String system = Pio.getValue(paramSet, _SYSTEM);
-        final String brightness = Pio.getValue(paramSet, _BRIGHTNESS);
-
-        // The system is the tccName, so we need to find it.
-        ITarget itarget = null;
-        for (ITarget.Tag t: ITarget.Tag.values()) {
-            if (t.tccName.equals(system)) {
-                itarget = ITarget.forTag(t);
-                break;
-            }
-        }
-        if (itarget == null)
-            throw new IllegalArgumentException("No target tag with tccName " + system);
-
-        itarget.setName(name);
-
-        if (itarget instanceof HmsDegTarget) {
-            final HmsDegTarget t = (HmsDegTarget)itarget;
-
-            final String c1 = Pio.getValue(paramSet, _C1);
-            final String c2 = Pio.getValue(paramSet, _C2);
-            t.setC1C2(c1, c2);
-
-            final Epoch e = new Epoch();
-            e.setParam(paramSet.getParam(_EPOCH));
-            t.setEpoch(e);
-
-            t.setBrightness(brightness);
-
-            final PM1 pm1 = new PM1();
-            pm1.setParam(paramSet.getParam(_PM1));
-            t.setPM1(pm1);
-
-            final PM2 pm2 = new PM2();
-            pm2.setParam(paramSet.getParam(_PM2));
-            t.setPM2(pm2);
-
-            final Parallax p = new Parallax();
-            p.setParam(paramSet.getParam(_PARALLAX));
-            t.setParallax(p);
-
-            final RV rv = new RV();
-            rv.setParam(paramSet.getParam(_RV));
-            t.setRV(rv);
-
-        } else if (itarget instanceof NonSiderealTarget) {
-
-            final NonSiderealTarget nst = (NonSiderealTarget)itarget;
-
-            // Horizons Info
-            nst.setHorizonsObjectId(Pio.getLongValue(paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_ID, null));
-            nst.setHorizonsObjectTypeOrdinal(Pio.getIntValue(paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_TYPE_ORDINAL, -1));
-
-            // OT-495: save and restore RA/Dec for conic targets
-            // XXX FIXME: Temporary, until nonsidereal support is implemented
-            final String c1 = Pio.getValue(paramSet, _C1);
-            final String c2 = Pio.getValue(paramSet, _C2);
-            if (c1 != null && c2 != null) {
-                nst.setC1C2(c1, c2);
-            }
-
-            final String dateStr = Pio.getValue(paramSet, _VALID_DATE);
-            final Date validDate = parseDate(dateStr);
-            nst.setDateForPosition(validDate);
-
-
-            if (itarget instanceof ConicTarget) {
-                final ConicTarget t = (ConicTarget) itarget;
-
-
-                final Epoch e = new Epoch();
-                e.setParam(paramSet.getParam(_EPOCH));
-                t.setEpoch(e);
-
-                t.setBrightness(brightness);
-
-                final ANode anode = new ANode();
-                anode.setParam(paramSet.getParam(_ANODE));
-                t.setANode(anode);
-
-                final AQ aq = new AQ();
-                aq.setParam(paramSet.getParam(_AQ));
-                t.setAQ(aq);
-
-                final Double de = Double.valueOf(Pio.getValue(paramSet, _E));
-                t.setE(de);
-
-                final Inclination i = new Inclination();
-                i.setParam(paramSet.getParam(_INCLINATION));
-                t.setInclination(i);
-
-                final LM lm = new LM();
-                lm.setParam(paramSet.getParam(_LM));
-                t.setLM(lm);
-
-                final N n = new N();
-                n.setParam(paramSet.getParam(_N));
-                t.setN(n);
-
-                final Perihelion p = new Perihelion();
-                p.setParam(paramSet.getParam(_PERIHELION));
-                t.setPerihelion(p);
-
-                final Epoch epochOfperi = new Epoch();
-                epochOfperi.setParam(paramSet.getParam(_EPOCH_OF_PERIHELION));
-                t.setEpochOfPeri(epochOfperi);
-            } else if (itarget instanceof NamedTarget) {
-                final NamedTarget t = (NamedTarget) itarget;
-                final String planet = Pio.getValue(paramSet, _OBJECT);
-                try {
-                    t.setSolarObject(NamedTarget.SolarObject.valueOf(planet));
-                } catch (final IllegalArgumentException ex) {
-                    //this shouldn't happen, unless corrupted data
-                    LOGGER.log(Level.WARNING, "Invalid Planet found : " + planet);
-                }
-            }
-        }
-        _target = itarget;
-
-
-        // Add magnitude information to the target.
-        final ParamSet magCollectionPset = paramSet.getParamSet(MagnitudePio.MAG_LIST);
-        if (magCollectionPset != null) {
-            try {
-                _target.setMagnitudes(MagnitudePio.instance.toList(magCollectionPset));
-            } catch (final ParseException ex) {
-                LOGGER.log(Level.WARNING, "Could not parse target magnitudes", ex);
-            }
-        }
+        SPTargetPio.setParamSet(paramSet, this);
     }
 
     public static SPTarget fromParamSet(final ParamSet pset) {
-        final SPTarget res = new SPTarget();
-        res.setParamSet(pset);
-        return res;
+        return SPTargetPio.fromParamSet(pset);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -22,7 +22,6 @@ import edu.gemini.spModel.target.system.CoordinateTypes.*;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -183,13 +182,6 @@ public final class SPTarget extends WatchablePos {
     public void setName(final String name) {
         _target.setName(name);
         _notifyOfUpdate();
-    }
-
-    /**
-     * Get the name.
-     */
-    public String getName() {
-        return _target.getName();
     }
 
 
@@ -355,7 +347,7 @@ public final class SPTarget extends WatchablePos {
 
         // Based on instance create the right target
         final ITarget target = getTarget();
-        Pio.addParam(factory, paramSet, _NAME, getName());
+        Pio.addParam(factory, paramSet, _NAME, getTarget().getName());
 
         if (target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget) target;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -9,7 +9,6 @@ package edu.gemini.spModel.target;
 
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.system.*;
@@ -50,6 +49,15 @@ public final class SPTarget extends WatchablePos {
     public void setTarget(final ITarget target) {
         _target = target;
         _notifyOfUpdate();
+    }
+
+    /**
+     * Replace the contained target with a new, empty target of the specified type, or do nothing
+     * if the contained target is of the specified type.
+     */
+    public void setTargetType(final ITarget.Tag tag) {
+        if (tag != _target.getTag())
+            setTarget(ITarget.forTag(tag));
     }
 
     /** Return a paramset describing this SPTarget. */
@@ -114,15 +122,6 @@ public final class SPTarget extends WatchablePos {
             }
         }
         _notifyOfUpdate();
-    }
-
-    /**
-     * Replace the contained target with a new, empty target of the specified type, or do nothing
-     * if the contained target is of the specified type.
-     */
-    public void setCoordSys(final ITarget.Tag tag) {
-        if (tag != _target.getTag())
-            setTarget(ITarget.forTag(tag));
     }
 
     /** Get the PM RA in mas/y if the contained target is sidereal, otherwise zero. */

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -22,18 +22,7 @@ import edu.gemini.spModel.target.system.CoordinateTypes.*;
  */
 public final class SPTarget extends WatchablePos {
 
-
-    private static final String COORDINATE_ZERO = "00:00:00.0";
-
-    ///
-    /// FIELDS
-    ///
-
     private ITarget _target;
-
-    ///
-    /// CONSTRUCTORS
-    ///
 
     /** SPTarget with default empty target. */
     public SPTarget() {
@@ -51,74 +40,54 @@ public final class SPTarget extends WatchablePos {
         _target.getC2().setAs(yaxis, Units.DEGREES);
     }
 
-    /**
-     * Assigns the list of magnitudes to associate with this target.  If there
-     * are multiple magnitudes associated with the same bandpass, only one will
-     * be kept.
-     *
-     * @param magnitudes new collection of magnitude information to store with
-     * the target
-     */
+    /** Set contained target magnitudes and notify listeners. */
     public void setMagnitudes(final ImList<Magnitude> magnitudes) {
         _target.setMagnitudes(magnitudes);
-        notifyOfGenericUpdate();
+        _notifyOfUpdate();
     }
 
-    /**
-     * Adds the given magnitude to the collection of magnitudes associated with
-     * this target, replacing any other magnitude of the same band if any.
-     *
-     * @param mag magnitude information to add to the collection of magnitudes
-     */
+    /** Set a magnitude on the contained target and notify listeners. */
     public void putMagnitude(final Magnitude mag) {
         _target.putMagnitude(mag);
-        notifyOfGenericUpdate();
+        _notifyOfUpdate();
     }
 
-
-
-    /**
-     * Set the name.
-     */
+    /** Set the contained target's name and notify listeners. */
     public void setName(final String name) {
         _target.setName(name);
         _notifyOfUpdate();
     }
 
-
     /**
-     * Set the xaxis and the yaxis.
+     * Set the contained target's RA and Dec from Strings in HMS/DMS format and notify listeners.
+     * Invalid values are replaced with 00:00:00.
      */
     public void setXYFromString(final String xaxisStr, final String yaxisStr) {
         synchronized (this) {
             try {
                 _target.setC1(xaxisStr);
             } catch (final IllegalArgumentException ex) {
-                //a problem found, set it to 00:00:00
-                _target.setC1(COORDINATE_ZERO);
+                _target.setC1("00:00:00.0");
             }
             try {
                 _target.setC2(yaxisStr);
             } catch( final IllegalArgumentException ex) {
-                //a problem found, set it to 00:00:00
-                _target.setC2(COORDINATE_ZERO);
+                _target.setC2("00:00:00.0");
             }
         }
         _notifyOfUpdate();
     }
 
     /**
-     * Set the Coordinate System with a string.
+     * Replace the contained target with a new, empty target of the specified type, or do nothing
+     * if the contained target is of the specified type.
      */
     public void setCoordSys(final ITarget.Tag tag) {
         if (tag != _target.getTag())
             setTarget(ITarget.forTag(tag));
     }
 
-    // ----- Specialized methods for an HmsDegTarget ----------
-    /**
-     * Get the proper motion RA in mas/y
-     */
+    /** Get the PM RA in mas/y if the contained target is sidereal, otherwise zero. */
     public double getPropMotionRA() {
         double res = 0.0;
         if (_target instanceof HmsDegTarget) {
@@ -128,9 +97,7 @@ public final class SPTarget extends WatchablePos {
         return res;
     }
 
-    /**
-     * Set the proper motion ra in mas/y.
-     */
+    /** Set the PM RA in mas/y if the contained target is sidereal, otherwise throw. */
     public void setPropMotionRA(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
@@ -142,9 +109,7 @@ public final class SPTarget extends WatchablePos {
         }
     }
 
-    /**
-     * Get the proper motion Dec in mas/y
-     */
+    /** Get the PM Dec in mas/y if the contained target is sidereal, otherwise zero. */
     public double getPropMotionDec() {
         double res = 0.0;
         if (_target instanceof HmsDegTarget) {
@@ -154,9 +119,7 @@ public final class SPTarget extends WatchablePos {
         return res;
     }
 
-    /**
-     * Set the proper motion Dec in mas/y.
-     */
+    /** Set the PM Dec in mas/y if the contained target is sidereal, otherwise throw. */
     public void setPropMotionDec(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
@@ -168,29 +131,19 @@ public final class SPTarget extends WatchablePos {
         }
     }
 
-    /**
-     * Get the tracking epoch in julian years
-     */
+    /** Get the contained target epoch in Julian years. */
     public double getTrackingEpoch() {
-        final double res = 2000.0;
-        final Epoch e = _target.getEpoch();
-        if (e == null) return res;
-
-        return e.getValue();
+        return getTarget().getEpoch().getValue();
     }
 
-    /**
-     * Set the tracking epoch as in julian years.
-     */
+    /** Set the contained target epoch as in Julian years and notify listeners. */
     public void setTrackingEpoch(final double trackEpoch) {
         final Epoch e = new Epoch(trackEpoch);
         _target.setEpoch(e);
         _notifyOfUpdate();
     }
 
-    /**
-     * Get the tracking parallax in arcseconds
-     */
+    /** Get the PM parallax in arcsec if the contained target is sidereal, otherwise zero. */
     public double getTrackingParallax() {
         double res = 0.0;
         if (_target instanceof HmsDegTarget) {
@@ -200,9 +153,7 @@ public final class SPTarget extends WatchablePos {
         return res;
     }
 
-    /**
-     * Set the tracking parallax as a string.
-     */
+    /** Set the PM parallax in arcsec if the contained target is sidereal, otherwise throw. */
     public void setTrackingParallax(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
@@ -214,9 +165,7 @@ public final class SPTarget extends WatchablePos {
         }
     }
 
-    /**
-     * Get the tracking radial velocity in km/s
-     */
+    /** Get the PM radial velocity in km/s if the contained target is sidereal, otherwise zero. */
     public double getTrackingRadialVelocity() {
         double res = 0.0;
         if (_target instanceof HmsDegTarget) {
@@ -226,9 +175,7 @@ public final class SPTarget extends WatchablePos {
         return res;
     }
 
-    /**
-     * Set the tracking radial velocity in km/s.
-     */
+    /** Set the PM radial velocity in km/s if the contained target is sidereal, otherwise throw. */
     public void setTrackingRadialVelocity(final double newValue) {
         if (_target instanceof HmsDegTarget) {
             final HmsDegTarget t = (HmsDegTarget)_target;
@@ -240,27 +187,21 @@ public final class SPTarget extends WatchablePos {
         }
     }
 
-    /**
-     * Return a paramset describing this object
-     */
+    /** Return a paramset describing this SPTarget. */
     public ParamSet getParamSet(final PioFactory factory) {
         return SPTargetPio.getParamSet(this, factory);
     }
 
-    /**
-     * Initialize this object from the given paramset
-     */
+    /** Re-initialize this SPTarget from the given paramset */
     public void setParamSet(final ParamSet paramSet) {
         SPTargetPio.setParamSet(paramSet, this);
     }
 
+    /** Construct a new SPTarget from the given paramset */
     public static SPTarget fromParamSet(final ParamSet pset) {
         return SPTargetPio.fromParamSet(pset);
     }
 
-    /**
-     * Standard debugging method.
-     */
     public String toString() {
         return _target.toString();
     }
@@ -269,24 +210,21 @@ public final class SPTarget extends WatchablePos {
     // a change to the contained target, rather than publishing all the
     // target members through this idiotic class. All of this crap needs
     // to be rewritten.
+    /** @deprecated */
     public void notifyOfGenericUpdate() {
     	super._notifyOfUpdate();
     }
 
-    /**
-     * Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation.
-     */
+    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
     public synchronized Coordinates getSkycalcCoordinates() {
         return new Coordinates(getTarget().getC1().getAs(Units.DEGREES), getTarget().getC2().getAs(Units.DEGREES));
     }
 
-    /**
-     * Set the x/y position and notify observers
-     */
-    public void setXY(final double x, final double y) {
+    /** Set the contained target RA/Dec in degrees and notify observers. */
+    public void setXY(final double raDeg, final double decDeg) {
         synchronized (this) {
-            _target.getC1().setAs(x, Units.DEGREES);
-            _target.getC2().setAs(y, Units.DEGREES);
+            _target.getC1().setAs(raDeg, Units.DEGREES);
+            _target.getC2().setAs(decDeg, Units.DEGREES);
         }
         _notifyOfUpdate();
     }
@@ -303,11 +241,6 @@ public final class SPTarget extends WatchablePos {
     public ITarget getTarget() {
         return _target;
     }
-
-
-    ///
-    /// CLONING
-    ///
 
     /** A function wrapper for cloning SPTargets. */
     public static Function1<SPTarget, SPTarget> CLONE_FUNCTION = new Function1<SPTarget, SPTarget>() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -127,29 +127,6 @@ public final class SPTarget extends WatchablePos {
         _target.getC2().setAs(yaxis, Units.DEGREES);
     }
 
-    /** Constructs with a {@link SkyObject}, extracting its coordinate and magnitude information. */
-    public SPTarget(final SkyObject obj) {
-        final HmsDegCoordinates  coords = obj.getHmsDegCoordinates();
-        final HmsDegCoordinates.Epoch e = coords.getEpoch();
-
-        // Epoch, RA, Dec
-        final HmsDegTarget target = new HmsDegTarget();
-        target.setEpoch(new Epoch(e.getYear()));
-        target.setC1(new HMS(coords.getRa().toDegrees().getMagnitude()));
-        target.setC2(new DMS(coords.getDec().toDegrees().getMagnitude()));
-
-        // Proper Motion
-        final Units mas = Units.MILLI_ARCSECS_PER_YEAR;
-        final double pmRa  = coords.getPmRa().toMilliarcsecs().getMagnitude();
-        final double pmDec = coords.getPmDec().toMilliarcsecs().getMagnitude();
-        target.setPM1(new PM1(pmRa, mas));
-        target.setPM2(new PM2(pmDec, mas));
-
-        _target = target;
-        setName(obj.getName());
-        setMagnitudes(obj.getMagnitudes());
-    }
-
     /**
      * Assigns the list of magnitudes to associate with this target.  If there
      * are multiple magnitudes associated with the same bandpass, only one will

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -34,11 +34,49 @@ public final class SPTarget extends WatchablePos {
         _target = target;
     }
 
-    public SPTarget(final double xaxis, final double yaxis) {
+    /** SPTarget with the given RA/Dec in degrees. */
+    public SPTarget(final double raDeg, final double degDec) {
         this();
-        _target.getC1().setAs(xaxis, Units.DEGREES);
-        _target.getC2().setAs(yaxis, Units.DEGREES);
+        _target.getC1().setAs(raDeg, Units.DEGREES);
+        _target.getC2().setAs(degDec, Units.DEGREES);
     }
+
+    /** Return the contained target. */
+    public ITarget getTarget() {
+        return _target;
+    }
+
+    /** Replace the contained target and notify listeners. */
+    public void setTarget(final ITarget target) {
+        _target = target;
+        _notifyOfUpdate();
+    }
+
+    /** Return a paramset describing this SPTarget. */
+    public ParamSet getParamSet(final PioFactory factory) {
+        return SPTargetPio.getParamSet(this, factory);
+    }
+
+    /** Re-initialize this SPTarget from the given paramset */
+    public void setParamSet(final ParamSet paramSet) {
+        SPTargetPio.setParamSet(paramSet, this);
+    }
+
+    /** Construct a new SPTarget from the given paramset */
+    public static SPTarget fromParamSet(final ParamSet pset) {
+        return SPTargetPio.fromParamSet(pset);
+    }
+
+    /** Clone this SPTarget. */
+    public SPTarget clone() {
+        return new SPTarget((ITarget) _target.clone());
+    }
+
+
+    ///
+    /// END OF PUBLIC API ... EVERYTHING FROM HERE DOWN GOES AWAY
+    ///
+
 
     /** Set contained target magnitudes and notify listeners. */
     public void setMagnitudes(final ImList<Magnitude> magnitudes) {
@@ -187,25 +225,6 @@ public final class SPTarget extends WatchablePos {
         }
     }
 
-    /** Return a paramset describing this SPTarget. */
-    public ParamSet getParamSet(final PioFactory factory) {
-        return SPTargetPio.getParamSet(this, factory);
-    }
-
-    /** Re-initialize this SPTarget from the given paramset */
-    public void setParamSet(final ParamSet paramSet) {
-        SPTargetPio.setParamSet(paramSet, this);
-    }
-
-    /** Construct a new SPTarget from the given paramset */
-    public static SPTarget fromParamSet(final ParamSet pset) {
-        return SPTargetPio.fromParamSet(pset);
-    }
-
-    public String toString() {
-        return _target.toString();
-    }
-
     // I'm making this public so I can call it from an editor when I make
     // a change to the contained target, rather than publishing all the
     // target members through this idiotic class. All of this crap needs
@@ -229,32 +248,4 @@ public final class SPTarget extends WatchablePos {
         _notifyOfUpdate();
     }
 
-    /** Set a new ITarget for this position and notify watchers */
-    public void setTarget(final ITarget target) {
-        _target = target;
-        _notifyOfUpdate();
-    }
-
-    /**
-     * Returns the position's current target.
-     */
-    public ITarget getTarget() {
-        return _target;
-    }
-
-    public SPTarget clone() {
-        final SPTarget ntarget;
-        try {
-            ntarget = (SPTarget) super.clone();
-
-            // We also have to clone the inner target object because it is
-            // mutable. We don't need to clone the magnitudes list because it
-            // is an immutable list holding immutable objects.
-            ntarget._target = (ITarget) _target.clone();
-        } catch (final CloneNotSupportedException ex) {
-            // Should not happen
-            throw new UnsupportedOperationException();
-        }
-        return ntarget;
-    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -233,6 +233,11 @@ public final class SPTarget extends WatchablePos {
     	super._notifyOfUpdate();
     }
 
+    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
+    public synchronized Coordinates getSkycalcCoordinates() {
+        return new Coordinates(getTarget().getC1().getAs(Units.DEGREES), getTarget().getC2().getAs(Units.DEGREES));
+    }
+
     /** Set the contained target RA/Dec in degrees and notify observers. */
     public void setRaDecDegrees(final double raDeg, final double decDeg) {
         synchronized (this) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -220,9 +220,7 @@ public final class SPTarget extends WatchablePos {
      * Set the name.
      */
     public void setName(final String name) {
-        synchronized (this) {
-            _target.setName(name);
-        }
+        _target.setName(name);
         _notifyOfUpdate();
     }
 
@@ -239,22 +237,17 @@ public final class SPTarget extends WatchablePos {
      */
     public void setXYFromString(final String xaxisStr, final String yaxisStr) {
         synchronized (this) {
-            //set the first coordinate in the target.
-
-            //repeat operation for C2
-            synchronized (this) {
-                try {
-                    _target.setC1(xaxisStr);
-                } catch (final IllegalArgumentException ex) {
-                    //a problem found, set it to 00:00:00
-                    _target.setC1(COORDINATE_ZERO);
-                }
-                try {
-                    _target.setC2(yaxisStr);
-                } catch( final IllegalArgumentException ex) {
-                    //a problem found, set it to 00:00:00
-                    _target.setC2(COORDINATE_ZERO);
-                }
+            try {
+                _target.setC1(xaxisStr);
+            } catch (final IllegalArgumentException ex) {
+                //a problem found, set it to 00:00:00
+                _target.setC1(COORDINATE_ZERO);
+            }
+            try {
+                _target.setC2(yaxisStr);
+            } catch( final IllegalArgumentException ex) {
+                //a problem found, set it to 00:00:00
+                _target.setC2(COORDINATE_ZERO);
             }
         }
         _notifyOfUpdate();
@@ -608,7 +601,7 @@ public final class SPTarget extends WatchablePos {
     /**
      * Standard debugging method.
      */
-    public synchronized String toString() {
+    public String toString() {
         return _target.toString();
     }
 
@@ -623,14 +616,14 @@ public final class SPTarget extends WatchablePos {
     /**
      * Returns the ICoordinateValue for c1
      */
-    public final synchronized ICoordinate getC1() {
+    public final ICoordinate getC1() {
         return _target.getC1();
     }
 
     /**
      * Get the xaxis.
      */
-    public final synchronized double getXaxis() {
+    public final double getXaxis() {
         final ICoordinate c1 = _target.getC1();
         return c1.getAs(Units.DEGREES);
     }
@@ -638,14 +631,14 @@ public final class SPTarget extends WatchablePos {
     /**
      * Returns the ICoordinate for c2
      */
-    public final synchronized ICoordinate getC2() {
+    public final ICoordinate getC2() {
         return _target.getC2();
     }
 
     /**
      * Get the yaxis.
      */
-    public final synchronized double getYaxis() {
+    public final double getYaxis() {
         final ICoordinate c2 = _target.getC2();
         return c2.getAs(Units.DEGREES);
     }
@@ -653,14 +646,14 @@ public final class SPTarget extends WatchablePos {
     /**
      * Get the xaxis as a String.
      */
-    public synchronized String getXaxisAsString() {
+    public String getXaxisAsString() {
         return _target.c1ToString();
     }
 
     /**
      * Get the yaxis as a String.
      */
-    public synchronized String getYaxisAsString() {
+    public String getYaxisAsString() {
         return _target.c2ToString();
     }
 
@@ -684,9 +677,7 @@ public final class SPTarget extends WatchablePos {
 
     /** Set a new ITarget for this position and notify watchers */
     public void setTarget(final ITarget target) {
-        synchronized (this) {
-            _target = target;
-        }
+        _target = target;
         _notifyOfUpdate();
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -165,19 +165,6 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Gets the {@link Magnitude} value associated with the given magnitude
-     * passband.
-     *
-     * @param band passband of the {@link Magnitude} value to retrieve
-     *
-     * @return {@link Magnitude} value associated with the given passband,
-     * wrapped in a {@link Some} object; {@link None} if none
-     */
-    public Option<Magnitude> getMagnitude(final Magnitude.Band band) {
-        return _target.getMagnitude(band);
-    }
-
-    /**
      * Gets the set of magnitude bands that have been recorded in this target.
      *
      * @returns a Set of {@link Magnitude.Band magnitude bands} for which

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -151,11 +151,6 @@ public final class SPTarget extends WatchablePos {
         setMagnitudes(obj.getMagnitudes());
     }
 
-    /** Create a default base position using the HmsDegTarget. */
-    public static SPTarget createDefaultBasePosition() {
-        return new SPTarget();
-    }
-
     /**
      * Gets all the {@link Magnitude} information associated with this target,
      * if any.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -242,14 +242,7 @@ public final class SPTarget extends WatchablePos {
         return _target;
     }
 
-    /** A function wrapper for cloning SPTargets. */
-    public static Function1<SPTarget, SPTarget> CLONE_FUNCTION = new Function1<SPTarget, SPTarget>() {
-        @Override public SPTarget apply(final SPTarget target) {
-            return (SPTarget) target.clone();
-        }
-    };
-
-    public Object clone() {
+    public SPTarget clone() {
         final SPTarget ntarget;
         try {
             ntarget = (SPTarget) super.clone();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -100,15 +100,15 @@ public final class SPTarget extends WatchablePos {
      * Set the contained target's RA and Dec from Strings in HMS/DMS format and notify listeners.
      * Invalid values are replaced with 00:00:00.
      */
-    public void setXYFromString(final String xaxisStr, final String yaxisStr) {
+    public void setHmsDms(final String hms, final String dms) {
         synchronized (this) {
             try {
-                _target.setC1(xaxisStr);
+                _target.setC1(hms);
             } catch (final IllegalArgumentException ex) {
                 _target.setC1("00:00:00.0");
             }
             try {
-                _target.setC2(yaxisStr);
+                _target.setC2(dms);
             } catch( final IllegalArgumentException ex) {
                 _target.setC2("00:00:00.0");
             }
@@ -235,7 +235,7 @@ public final class SPTarget extends WatchablePos {
     }
 
     /** Set the contained target RA/Dec in degrees and notify observers. */
-    public void setXY(final double raDeg, final double decDeg) {
+    public void setRaDecDegrees(final double raDeg, final double decDeg) {
         synchronized (this) {
             _target.getC1().setAs(raDeg, Units.DEGREES);
             _target.getC2().setAs(decDeg, Units.DEGREES);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -567,40 +567,10 @@ public final class SPTarget extends WatchablePos {
     }
 
     /**
-     * Get the xaxis.
-     */
-    public final double getXaxis() {
-        final ICoordinate c1 = _target.getC1();
-        return c1.getAs(Units.DEGREES);
-    }
-
-    /**
-     * Get the yaxis.
-     */
-    public final double getYaxis() {
-        final ICoordinate c2 = _target.getC2();
-        return c2.getAs(Units.DEGREES);
-    }
-
-    /**
-     * Get the xaxis as a String.
-     */
-    public String getXaxisAsString() {
-        return _target.c1ToString();
-    }
-
-    /**
-     * Get the yaxis as a String.
-     */
-    public String getYaxisAsString() {
-        return _target.c2ToString();
-    }
-
-    /**
      * Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation.
      */
     public synchronized Coordinates getSkycalcCoordinates() {
-        return new Coordinates(getXaxis(), getYaxis());
+        return new Coordinates(getTarget().getC1().getAs(Units.DEGREES), getTarget().getC2().getAs(Units.DEGREES));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -1,0 +1,287 @@
+package edu.gemini.spModel.target;
+
+import edu.gemini.shared.skyobject.Magnitude;
+import edu.gemini.shared.util.immutable.ImList;
+import edu.gemini.spModel.pio.ParamSet;
+import edu.gemini.spModel.pio.Pio;
+import edu.gemini.spModel.pio.PioFactory;
+import edu.gemini.spModel.target.system.ConicTarget;
+import edu.gemini.spModel.target.system.CoordinateTypes;
+import edu.gemini.spModel.target.system.HmsDegTarget;
+import edu.gemini.spModel.target.system.ITarget;
+import edu.gemini.spModel.target.system.NamedTarget;
+import edu.gemini.spModel.target.system.NonSiderealTarget;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class SPTargetPio {
+
+    private static final Logger LOGGER = Logger.getLogger(SPTarget.class.getName());
+
+    public static final String PARAM_SET_NAME = "spTarget";
+
+    private static final String _NAME = "name";
+    private static final String _OBJECT = "object";
+    private static final String _SYSTEM = "system";
+    private static final String _EPOCH = "epoch";
+    private static final String _BRIGHTNESS = "brightness";
+    private static final String _C1 = "c1";
+    private static final String _C2 = "c2";
+    private static final String _VALID_DATE = "validAt";
+    private static final String _PM1 = "pm1";
+    private static final String _PM2 = "pm2";
+    private static final String _PARALLAX = "parallax";
+    private static final String _RV = "rv";
+    private static final String _ANODE = "anode";
+    private static final String _AQ = "aq";
+    private static final String _E = "e";
+    private static final String _INCLINATION = "inclination";
+    private static final String _LM = "lm";
+    private static final String _N = "n";
+    private static final String _PERIHELION = "perihelion";
+    private static final String _EPOCH_OF_PERIHELION = "epochOfPeri";
+
+    private static final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.FULL);
+    static {
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    private static synchronized String formatDate(final Date d) {
+        return formatter.format(d);
+    }
+
+    private static synchronized Date parseDate(final String dateStr) {
+        if (dateStr == null) return null;
+
+        DateFormat format = formatter;
+        if (!dateStr.contains("UTC")) {
+            // OT-755: we didn't used to store the time zone, which
+            // led to bugs when exporting in one time zone and importing
+            // in another -- say when the program is stored.
+            // If the date doesn't include "UTC", then assume it is in
+            // the old style and import in the local time zone so that
+            // at least the behavior when reading in existing programs for
+            // the first time won't change.
+            format = DateFormat.getInstance();
+        }
+
+        try {
+            return format.parse(dateStr);
+        } catch (final ParseException e) {
+            LOGGER.log(Level.WARNING, " Invalid date found " + dateStr);
+            return null;
+        }
+    }
+
+    public static ParamSet getParamSet(final SPTarget spt, final PioFactory factory) {
+        final ParamSet paramSet = factory.createParamSet(PARAM_SET_NAME);
+
+        // Based on instance create the right target
+        final ITarget target = spt.getTarget();
+        Pio.addParam(factory, paramSet, _NAME, target.getName());
+
+        if (target instanceof HmsDegTarget) {
+            final HmsDegTarget t = (HmsDegTarget) target;
+            Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
+            paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
+            Pio.addParam(factory, paramSet, _BRIGHTNESS, t.getBrightness());
+            Pio.addParam(factory, paramSet, _C1, t.c1ToString());
+            Pio.addParam(factory, paramSet, _C2, t.c2ToString());
+            paramSet.addParam(t.getPM1().getParam(factory, _PM1));
+            paramSet.addParam(t.getPM2().getParam(factory, _PM2));
+            paramSet.addParam(t.getParallax().getParam(factory, _PARALLAX));
+            paramSet.addParam(t.getRV().getParam(factory, _RV));
+        } else if (target instanceof NonSiderealTarget) {
+            final NonSiderealTarget nst = (NonSiderealTarget) target;
+
+            // Horizons data, if any
+            if (nst.isHorizonsDataPopulated()) {
+                Pio.addLongParam(factory, paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_ID, nst.getHorizonsObjectId());
+                Pio.addLongParam(factory, paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_TYPE_ORDINAL, nst.getHorizonsObjectTypeOrdinal());
+            }
+
+            // OT-495: save and restore RA/Dec for conic targets
+            // XXX FIXME: Temporary, until nonsidereal support is implemented
+            Pio.addParam(factory, paramSet, _C1, nst.c1ToString());
+            Pio.addParam(factory, paramSet, _C2, nst.c2ToString());
+            if (nst.getDateForPosition() != null) {
+                Pio.addParam(factory, paramSet, _VALID_DATE, formatDate(nst.getDateForPosition()));
+            }
+
+            if (target instanceof ConicTarget) {
+                final ConicTarget t = (ConicTarget) target;
+                Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
+                paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
+                Pio.addParam(factory, paramSet, _BRIGHTNESS, t.getBrightness());
+
+                paramSet.addParam(t.getANode().getParam(factory, _ANODE));
+                paramSet.addParam(t.getAQ().getParam(factory, _AQ));
+                Pio.addParam(factory, paramSet, _E, Double.toString(t.getE()));
+                paramSet.addParam(t.getInclination().getParam(factory, _INCLINATION));
+                paramSet.addParam(t.getLM().getParam(factory, _LM));
+                paramSet.addParam(t.getN().getParam(factory, _N));
+                paramSet.addParam(t.getPerihelion().getParam(factory, _PERIHELION));
+                paramSet.addParam(t.getEpochOfPeri().getParam(factory, _EPOCH_OF_PERIHELION));
+            } else if (target instanceof NamedTarget) {
+                final NamedTarget t = (NamedTarget) target;
+                Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
+                Pio.addParam(factory, paramSet, _OBJECT, t.getSolarObject().name());
+            }
+        }
+
+        // Add magnitude information to the paramset.
+        final ImList<Magnitude> magnitudes = target.getMagnitudes();
+        if (magnitudes.size() > 0) {
+            paramSet.addParamSet(MagnitudePio.instance.toParamSet(factory, magnitudes));
+        }
+
+        return paramSet;
+    }
+
+    public static void setParamSet(final ParamSet paramSet, final SPTarget spt) {
+        if (paramSet == null) return;
+
+        final String name = Pio.getValue(paramSet, _NAME);
+        final String system = Pio.getValue(paramSet, _SYSTEM);
+        final String brightness = Pio.getValue(paramSet, _BRIGHTNESS);
+
+        // The system is the tccName, so we need to find it.
+        ITarget itarget = null;
+        for (ITarget.Tag t: ITarget.Tag.values()) {
+            if (t.tccName.equals(system)) {
+                itarget = ITarget.forTag(t);
+                break;
+            }
+        }
+        if (itarget == null)
+            throw new IllegalArgumentException("No target tag with tccName " + system);
+
+        itarget.setName(name);
+
+        if (itarget instanceof HmsDegTarget) {
+            final HmsDegTarget t = (HmsDegTarget)itarget;
+
+            final String c1 = Pio.getValue(paramSet, _C1);
+            final String c2 = Pio.getValue(paramSet, _C2);
+            t.setC1C2(c1, c2);
+
+            final CoordinateTypes.Epoch e = new CoordinateTypes.Epoch();
+            e.setParam(paramSet.getParam(_EPOCH));
+            t.setEpoch(e);
+
+            t.setBrightness(brightness);
+
+            final CoordinateTypes.PM1 pm1 = new CoordinateTypes.PM1();
+            pm1.setParam(paramSet.getParam(_PM1));
+            t.setPM1(pm1);
+
+            final CoordinateTypes.PM2 pm2 = new CoordinateTypes.PM2();
+            pm2.setParam(paramSet.getParam(_PM2));
+            t.setPM2(pm2);
+
+            final CoordinateTypes.Parallax p = new CoordinateTypes.Parallax();
+            p.setParam(paramSet.getParam(_PARALLAX));
+            t.setParallax(p);
+
+            final CoordinateTypes.RV rv = new CoordinateTypes.RV();
+            rv.setParam(paramSet.getParam(_RV));
+            t.setRV(rv);
+
+        } else if (itarget instanceof NonSiderealTarget) {
+
+            final NonSiderealTarget nst = (NonSiderealTarget)itarget;
+
+            // Horizons Info
+            nst.setHorizonsObjectId(Pio.getLongValue(paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_ID, null));
+            nst.setHorizonsObjectTypeOrdinal(Pio.getIntValue(paramSet, NonSiderealTarget.PK_HORIZONS_OBJECT_TYPE_ORDINAL, -1));
+
+            // OT-495: save and restore RA/Dec for conic targets
+            // XXX FIXME: Temporary, until nonsidereal support is implemented
+            final String c1 = Pio.getValue(paramSet, _C1);
+            final String c2 = Pio.getValue(paramSet, _C2);
+            if (c1 != null && c2 != null) {
+                nst.setC1C2(c1, c2);
+            }
+
+            final String dateStr = Pio.getValue(paramSet, _VALID_DATE);
+            final Date validDate = parseDate(dateStr);
+            nst.setDateForPosition(validDate);
+
+
+            if (itarget instanceof ConicTarget) {
+                final ConicTarget t = (ConicTarget) itarget;
+
+
+                final CoordinateTypes.Epoch e = new CoordinateTypes.Epoch();
+                e.setParam(paramSet.getParam(_EPOCH));
+                t.setEpoch(e);
+
+                t.setBrightness(brightness);
+
+                final CoordinateTypes.ANode anode = new CoordinateTypes.ANode();
+                anode.setParam(paramSet.getParam(_ANODE));
+                t.setANode(anode);
+
+                final CoordinateTypes.AQ aq = new CoordinateTypes.AQ();
+                aq.setParam(paramSet.getParam(_AQ));
+                t.setAQ(aq);
+
+                final Double de = Double.valueOf(Pio.getValue(paramSet, _E));
+                t.setE(de);
+
+                final CoordinateTypes.Inclination i = new CoordinateTypes.Inclination();
+                i.setParam(paramSet.getParam(_INCLINATION));
+                t.setInclination(i);
+
+                final CoordinateTypes.LM lm = new CoordinateTypes.LM();
+                lm.setParam(paramSet.getParam(_LM));
+                t.setLM(lm);
+
+                final CoordinateTypes.N n = new CoordinateTypes.N();
+                n.setParam(paramSet.getParam(_N));
+                t.setN(n);
+
+                final CoordinateTypes.Perihelion p = new CoordinateTypes.Perihelion();
+                p.setParam(paramSet.getParam(_PERIHELION));
+                t.setPerihelion(p);
+
+                final CoordinateTypes.Epoch epochOfperi = new CoordinateTypes.Epoch();
+                epochOfperi.setParam(paramSet.getParam(_EPOCH_OF_PERIHELION));
+                t.setEpochOfPeri(epochOfperi);
+            } else if (itarget instanceof NamedTarget) {
+                final NamedTarget t = (NamedTarget) itarget;
+                final String planet = Pio.getValue(paramSet, _OBJECT);
+                try {
+                    t.setSolarObject(NamedTarget.SolarObject.valueOf(planet));
+                } catch (final IllegalArgumentException ex) {
+                    //this shouldn't happen, unless corrupted data
+                    LOGGER.log(Level.WARNING, "Invalid Planet found : " + planet);
+                }
+            }
+        }
+
+        // Add magnitude information to the target.
+        final ParamSet magCollectionPset = paramSet.getParamSet(MagnitudePio.MAG_LIST);
+        if (magCollectionPset != null) {
+            try {
+                itarget.setMagnitudes(MagnitudePio.instance.toList(magCollectionPset));
+            } catch (final ParseException ex) {
+                LOGGER.log(Level.WARNING, "Could not parse target magnitudes", ex);
+            }
+        }
+
+        spt.setTarget(itarget);
+    }
+
+    public static SPTarget fromParamSet(final ParamSet pset) {
+        final SPTarget res = new SPTarget();
+        res.setParamSet(pset);
+        return res;
+    }
+
+}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -207,7 +207,11 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
     @Override
     public GuideProbeTargets cloneTargets() {
         Option<Integer>   primaryIndex = targetOptions.getPrimaryIndex();
-        ImList<SPTarget> clonedTargets = targetOptions.getOptions().map(SPTarget.CLONE_FUNCTION);
+        ImList<SPTarget> clonedTargets = targetOptions.getOptions().map(new Function1<SPTarget, SPTarget>() {
+            public SPTarget apply(final SPTarget target) {
+                return target.clone();
+            }
+        });
         OptionsListImpl<SPTarget> clone = OptionsListImpl.create(primaryIndex, clonedTargets);
         return new GuideProbeTargets(guider, clone);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -325,7 +325,11 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
     public TargetEnvironment cloneTargets() {
         SPTarget clonedBase = (SPTarget) base.clone();
         GuideEnvironment clonedGuide = guide.cloneTargets();
-        ImList<SPTarget> clonedUser  = user.map(SPTarget.CLONE_FUNCTION);
+        ImList<SPTarget> clonedUser  = user.map(new Function1<SPTarget, SPTarget>() {
+            public SPTarget apply(final SPTarget target) {
+                return target.clone();
+            }
+        });
         return new TargetEnvironment(clonedBase, clonedGuide, clonedUser);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -280,7 +280,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     /* ValidatableGuideProbe */
 
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return validate(guideStar.getSkycalcCoordinates(), ctx);
+        return validate(guideStar.getTarget().getSkycalcCoordinates(), ctx);
     }
 
     public boolean validate(SkyObject guideStar, ObsContext ctx) {
@@ -292,7 +292,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx){
-        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
+        return checkBoundaries(guideStar.getTarget().getSkycalcCoordinates(), ctx);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -280,11 +280,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     /* ValidatableGuideProbe */
 
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return validate(result, ctx);
+        return validate(guideStar.getSkycalcCoordinates(), ctx);
     }
 
     public boolean validate(SkyObject guideStar, ObsContext ctx) {
@@ -296,11 +292,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx){
-        Coordinates result;
-        synchronized (guideStar) {
-            result = guideStar.getTarget().getSkycalcCoordinates();
-        }
-        return checkBoundaries(result, ctx);
+        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -280,7 +280,11 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     /* ValidatableGuideProbe */
 
     public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return validate(guideStar.getSkycalcCoordinates(), ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return validate(result, ctx);
     }
 
     public boolean validate(SkyObject guideStar, ObsContext ctx) {
@@ -292,7 +296,11 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     }
 
     public BoundaryPosition checkBoundaries(SPTarget guideStar, ObsContext ctx){
-        return checkBoundaries(guideStar.getSkycalcCoordinates(), ctx);
+        Coordinates result;
+        synchronized (guideStar) {
+            result = guideStar.getTarget().getSkycalcCoordinates();
+        }
+        return checkBoundaries(result, ctx);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -91,7 +91,7 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
             TargetEnvironment env = getTargetEnvironment();
             SPTarget tp = env.getBase();
             if (tp != null) { // base pos should always be defined, so tp should never be null
-                String name = tp.getName();
+                String name = tp.getTarget().getName();
                 if (name == null || name.length() == 0) {
                     // Use the base position
                     return tp.getTarget().getPosition();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -43,7 +43,7 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
     public static final String TARGET_POS_PROP = "TargetPos";
 
     private static TargetEnvironment createEmptyEnvironment() {
-        SPTarget base = SPTarget.createDefaultBasePosition();
+        SPTarget base = new SPTarget();
         return TargetEnvironment.create(base);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
@@ -58,7 +58,7 @@ public class TargetObsCompCB extends AbstractObsComponentCB {
 
         // Patch for a problem in 2009B.1.1.1.  The "telescope:Base:name" param
         // was missing, which caused the FITS OBJECT keyword to be incorrect.
-        String baseName = env.getBase().getName();
+        String baseName = env.getBase().getTarget().getName();
         if ((baseName != null) && !"".equals(baseName)) {
             DefaultConfigParameter cp = DefaultConfigParameter.getInstance("Base");
             ISysConfig sc = (ISysConfig) cp.getValue();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -6,6 +6,8 @@
 //
 package edu.gemini.spModel.target.system;
 
+import edu.gemini.shared.skyobject.SkyObject;
+import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
 import edu.gemini.spModel.target.system.CoordinateParam.Units;
 import edu.gemini.spModel.target.system.CoordinateTypes.*;
 
@@ -63,6 +65,27 @@ public final class HmsDegTarget extends ITarget {
      * The base name of this coordinate system.
      */
     private static final String SYSTEM_NAME = "HMS Deg";
+
+    public static HmsDegTarget fromSkyObject(final SkyObject obj) {
+        final HmsDegCoordinates coords = obj.getHmsDegCoordinates();
+        final HmsDegCoordinates.Epoch e = coords.getEpoch();
+
+        final HmsDegTarget target = new HmsDegTarget();
+        target.setName(obj.getName());
+        target.setMagnitudes(obj.getMagnitudes());
+        target.setEpoch(new Epoch(e.getYear()));
+        target.setC1(new HMS(coords.getRa().toDegrees().getMagnitude()));
+        target.setC2(new DMS(coords.getDec().toDegrees().getMagnitude()));
+
+        // Proper Motion
+        final Units mas = Units.MILLI_ARCSECS_PER_YEAR;
+        final double pmRa  = coords.getPmRa().toMilliarcsecs().getMagnitude();
+        final double pmDec = coords.getPmDec().toMilliarcsecs().getMagnitude();
+        target.setPM1(new PM1(pmRa, mas));
+        target.setPM2(new PM2(pmDec, mas));
+
+        return target;
+    }
 
     /**
      * Provides clone support.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -12,7 +12,6 @@ import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.MapOp;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.PredicateOp;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.target.system.CoordinateTypes.Epoch;
 
 import java.io.Serializable;
@@ -276,10 +275,5 @@ public abstract class ITarget implements Cloneable, Serializable {
     }
 
     public abstract Tag getTag();
-
-    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
-    public Coordinates getSkycalcCoordinates() {
-        return new Coordinates(getC1().getAs(CoordinateParam.Units.DEGREES), getC2().getAs(CoordinateParam.Units.DEGREES));
-    }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -12,6 +12,7 @@ import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.MapOp;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.PredicateOp;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.target.system.CoordinateTypes.Epoch;
 
 import java.io.Serializable;
@@ -275,5 +276,10 @@ public abstract class ITarget implements Cloneable, Serializable {
     }
 
     public abstract Tag getTag();
+
+    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
+    public Coordinates getSkycalcCoordinates() {
+        return new Coordinates(getC1().getAs(CoordinateParam.Units.DEGREES), getC2().getAs(CoordinateParam.Units.DEGREES));
+    }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -12,6 +12,7 @@ import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.MapOp;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.PredicateOp;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.target.system.CoordinateTypes.Epoch;
 
 import java.io.Serializable;
@@ -275,5 +276,10 @@ public abstract class ITarget implements Cloneable, Serializable {
     }
 
     public abstract Tag getTag();
+
+    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
+    public synchronized Coordinates getSkycalcCoordinates() {
+        return new Coordinates(getC1().getAs(CoordinateParam.Units.DEGREES), getC2().getAs(CoordinateParam.Units.DEGREES));
+    }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateParameters.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateParameters.java
@@ -12,6 +12,7 @@ import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.SPTargetPio;
 import edu.gemini.spModel.target.system.ITarget;
 
 /**
@@ -117,7 +118,7 @@ public final class TemplateParameters extends AbstractDataObject {
 
         super.setParamSet(paramSet);
 
-        final ParamSet targetPs = paramSet.getParamSet(SPTarget.PARAM_SET_NAME);
+        final ParamSet targetPs = paramSet.getParamSet(SPTargetPio.PARAM_SET_NAME);
         target = new SPTarget();
         target.setParamSet(targetPs);
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/util/ReadableNodeName.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/util/ReadableNodeName.java
@@ -22,7 +22,7 @@ public final class ReadableNodeName {
 
         private String formatTarget(ISPObsComponent oc) {
             final TargetObsComp toc = (TargetObsComp) oc.getDataObject();
-            return String.format("Target Environment '%s'", toc.getBase().getName());
+            return String.format("Target Environment '%s'", toc.getBase().getTarget().getName());
         }
 
         private String formatInstrument(ISPObsComponent oc) {
@@ -107,7 +107,7 @@ public final class ReadableNodeName {
             final SPSiteQuality c = tp.getSiteQuality();
             final TimeValue     v = tp.getTime();
             if ((t != null) && (c != null) && (v != null)) {
-                final String ts = t.getName();
+                final String ts = t.getTarget().getName();
                 final String cs = c.conditions().toString();
                 final String vs = v.toString(2);
                 if (ts != null) {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -34,7 +34,7 @@ object ObsTargetCalculatorService {
     // Now, based on the SchedulingBlock determine if a TargetCalc should be created.
     // Get the TargetEnvironment if it exists, and from there, extract the RA and Dec.
     def coords = obs.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV).map {
-      _.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment.getBase.getTarget.getSkycalcCoordinates
+      _.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment.getBase.getSkycalcCoordinates
     }
 
     def calc(s: Site, b: SchedulingBlock, c: Coordinates): TargetCalculator = {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -34,7 +34,7 @@ object ObsTargetCalculatorService {
     // Now, based on the SchedulingBlock determine if a TargetCalc should be created.
     // Get the TargetEnvironment if it exists, and from there, extract the RA and Dec.
     def coords = obs.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV).map {
-      _.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment.getBase.getSkycalcCoordinates
+      _.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment.getBase.getTarget.getSkycalcCoordinates
     }
 
     def calc(s: Site, b: SchedulingBlock, c: Coordinates): TargetCalculator = {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -56,7 +56,7 @@ public final class SPTargetSkyObjectTest {
             coords = coords.builder().pmRa(pmRa).pmDec(pmDec).build();
 
             SkyObject   obj = new SkyObject.Builder("xyz", coords).build();
-            SPTarget target = new SPTarget(obj);
+            SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
             assertEquals(0, target.getTarget().getMagnitudes().size());
             assertEquals(0, target.getTarget().getMagnitudeBands().size());
@@ -82,7 +82,7 @@ public final class SPTargetSkyObjectTest {
 
     private void testSkyObjectConstructorMags(ImList<Magnitude> input, ImList<Magnitude> expected) throws Exception {
         SkyObject obj = createSkyObject(input);
-        final SPTarget target = new SPTarget(obj);
+        final SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
         final ImList<Magnitude> mags = target.getTarget().getMagnitudes();
         assertEquals(expected.size(), mags.size());
@@ -116,7 +116,7 @@ public final class SPTargetSkyObjectTest {
     @Test
     public void testPutMagnitude() throws Exception {
         SkyObject   obj = createSkyObject(DefaultImList.create(magJ1));
-        SPTarget target = new SPTarget(obj);
+        SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
         // Put a new magnitude for the K band.
         target.putMagnitude(magK2);
@@ -137,7 +137,7 @@ public final class SPTargetSkyObjectTest {
     @Test
     public void testSetMagnitudes() throws Exception {
         SkyObject   obj = createSkyObject(DefaultImList.create(magJ1));
-        SPTarget target = new SPTarget(obj);
+        SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
         // Put a new magnitude for the K band.
         target.setMagnitudes(DefaultImList.create(magJ3, magK2));

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -58,7 +58,7 @@ public final class SPTargetSkyObjectTest {
             SPTarget target = new SPTarget(obj);
 
             assertEquals(0, target.getTarget().getMagnitudes().size());
-            assertEquals(0, target.getMagnitudeBands().size());
+            assertEquals(0, target.getTarget().getMagnitudeBands().size());
 
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
@@ -86,7 +86,7 @@ public final class SPTargetSkyObjectTest {
         final ImList<Magnitude> mags = target.getTarget().getMagnitudes();
         assertEquals(expected.size(), mags.size());
 
-        final Set<Magnitude.Band> bands = target.getMagnitudeBands();
+        final Set<Magnitude.Band> bands = target.getTarget().getMagnitudeBands();
         assertEquals(expected.size(), bands.size());
         expected.foreach(new ApplyOp<Magnitude>() {
             @Override public void apply(Magnitude magnitude) {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -91,12 +91,12 @@ public final class SPTargetSkyObjectTest {
         expected.foreach(new ApplyOp<Magnitude>() {
             @Override public void apply(Magnitude magnitude) {
                 assertTrue(bands.contains(magnitude.getBand()));
-                assertEquals(magnitude, target.getMagnitude(magnitude.getBand()).getValue());
+                assertEquals(magnitude, target.getTarget().getMagnitude(magnitude.getBand()).getValue());
             }
         });
 
         // okay don't call this method with "M" in the list of expected or input
-        assertTrue(target.getMagnitude(Magnitude.Band.M).isEmpty());
+        assertTrue(target.getTarget().getMagnitude(Magnitude.Band.M).isEmpty());
     }
 
     @Test
@@ -122,15 +122,15 @@ public final class SPTargetSkyObjectTest {
         ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());
-        assertEquals(magJ1, target.getMagnitude(Magnitude.Band.J).getValue());
-        assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
+        assertEquals(magJ1, target.getTarget().getMagnitude(Magnitude.Band.J).getValue());
+        assertEquals(magK2, target.getTarget().getMagnitude(Magnitude.Band.K).getValue());
 
         // Replace the existing J band mag with a new one.
         target.putMagnitude(magJ3);
         magList = target.getTarget().getMagnitudes();
         assertEquals(2, magList.size());
-        assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());
-        assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
+        assertEquals(magJ3, target.getTarget().getMagnitude(Magnitude.Band.J).getValue());
+        assertEquals(magK2, target.getTarget().getMagnitude(Magnitude.Band.K).getValue());
     }
 
     @Test
@@ -143,7 +143,7 @@ public final class SPTargetSkyObjectTest {
         ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());
-        assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());
-        assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
+        assertEquals(magJ3, target.getTarget().getMagnitude(Magnitude.Band.J).getValue());
+        assertEquals(magK2, target.getTarget().getMagnitude(Magnitude.Band.K).getValue());
     }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -13,6 +13,7 @@ import static edu.gemini.shared.skyobject.coords.HmsDegCoordinates.Epoch.Type.JU
 import edu.gemini.shared.util.immutable.ApplyOp;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import edu.gemini.spModel.target.system.CoordinateTypes;
 import edu.gemini.spModel.target.system.HmsDegTarget;
 import static org.junit.Assert.*;
@@ -63,8 +64,8 @@ public final class SPTargetSkyObjectTest {
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
             assertEquals("xyz", target.getTarget().getName());
-            assertEquals(15.0, target.getXaxis(), 0.000001);
-            assertEquals(20.0, target.getYaxis(), 0.000001);
+            assertEquals(15.0, target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES), 0.000001);
+            assertEquals(20.0, target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES), 0.000001);
             assertEquals(1.0, hmsDeg.getPM1().getValue(), 0.000001);
             assertEquals(2.0, hmsDeg.getPM2().getValue(), 0.000001);
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -62,7 +62,7 @@ public final class SPTargetSkyObjectTest {
 
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
-            assertEquals("xyz", target.getName());
+            assertEquals("xyz", target.getTarget().getName());
             assertEquals(15.0, target.getXaxis(), 0.000001);
             assertEquals(20.0, target.getYaxis(), 0.000001);
             assertEquals(1.0, hmsDeg.getPM1().getValue(), 0.000001);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -57,7 +57,7 @@ public final class SPTargetSkyObjectTest {
             SkyObject   obj = new SkyObject.Builder("xyz", coords).build();
             SPTarget target = new SPTarget(obj);
 
-            assertEquals(0, target.getMagnitudes().size());
+            assertEquals(0, target.getTarget().getMagnitudes().size());
             assertEquals(0, target.getMagnitudeBands().size());
 
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
@@ -83,7 +83,7 @@ public final class SPTargetSkyObjectTest {
         SkyObject obj = createSkyObject(input);
         final SPTarget target = new SPTarget(obj);
 
-        final ImList<Magnitude> mags = target.getMagnitudes();
+        final ImList<Magnitude> mags = target.getTarget().getMagnitudes();
         assertEquals(expected.size(), mags.size());
 
         final Set<Magnitude.Band> bands = target.getMagnitudeBands();
@@ -119,7 +119,7 @@ public final class SPTargetSkyObjectTest {
 
         // Put a new magnitude for the K band.
         target.putMagnitude(magK2);
-        ImList<Magnitude> magList = target.getMagnitudes();
+        ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());
         assertEquals(magJ1, target.getMagnitude(Magnitude.Band.J).getValue());
@@ -127,7 +127,7 @@ public final class SPTargetSkyObjectTest {
 
         // Replace the existing J band mag with a new one.
         target.putMagnitude(magJ3);
-        magList = target.getMagnitudes();
+        magList = target.getTarget().getMagnitudes();
         assertEquals(2, magList.size());
         assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());
         assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
@@ -140,7 +140,7 @@ public final class SPTargetSkyObjectTest {
 
         // Put a new magnitude for the K band.
         target.setMagnitudes(DefaultImList.create(magJ3, magK2));
-        ImList<Magnitude> magList = target.getMagnitudes();
+        ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());
         assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
@@ -11,6 +11,7 @@ import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.DefaultImList;
 import edu.gemini.shared.util.immutable.None;
+import edu.gemini.spModel.target.system.CoordinateParam;
 
 import static org.junit.Assert.assertEquals;
 
@@ -109,8 +110,8 @@ final class Fixture {
             // the coordinates and get enough of an idea that they are the
             // same for the purposes of testing GuideProbeTargets.
 
-            assertEquals(t1.getXaxis(), t2.getXaxis(), 0.000001);
-            assertEquals(t1.getYaxis(), t2.getYaxis(), 0.000001);
+            assertEquals(t1.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES), t2.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES), 0.000001);
+            assertEquals(t1.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES), t2.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES), 0.000001);
         }
     }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
@@ -39,7 +39,7 @@ public class Pre2010BTargetEnvironmentIoTest {
     // We're not trying to verify the entire SPTarget parsing code.  It's
     // enough to know that the name is what we expected.
     private static void verifyTarget(String name, SPTarget target) throws Exception {
-        assertEquals(name, target.getName());
+        assertEquals(name, target.getTarget().getName());
     }
 
     private enum Case {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -402,7 +402,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
 	}
 
 	public String getTargetName() {
-		return (targetEnvironment != null ? targetEnvironment.getBase().getName() : "");
+        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getName() : "");
 	}
 
 	public String getWavefrontSensors() {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -42,6 +42,7 @@ import edu.gemini.spModel.obs.plannedtime.PlannedStepSummary;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import edu.gemini.spModel.target.system.NonSiderealTarget;
 import edu.gemini.spModel.too.TooType;
 import edu.gemini.spModel.type.DisplayableSpType;
@@ -571,11 +572,11 @@ public final class Obs implements Serializable, Comparable<Obs> {
 	}
 
 	public double getRa() {
-		return (targetEnvironment != null ? targetEnvironment.getBase().getXaxis() : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getC1().getAs(CoordinateParam.Units.DEGREES) : 0.0);
 	}
 
 	public double getDec() {
-		return (targetEnvironment != null ? targetEnvironment.getBase().getYaxis() : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getC2().getAs(CoordinateParam.Units.DEGREES) : 0.0);
 	}
 
 	public Conds getConditions() {

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
@@ -182,7 +182,7 @@ case class PositionProvider(ctx: QvContext, base: ObservationProvider) extends O
       if (NonSiderealCache.isHorizonsTarget(o)) {
         val pos = NonSiderealCache.get(ctx.site, ctx.referenceDate, o)
         val newTarget = o.getTargetEnvironment.getBase.clone().asInstanceOf[SPTarget]
-        newTarget.setXY(pos.getRaDeg, pos.getDecDeg)
+        newTarget.setRaDecDegrees(pos.getRaDeg, pos.getDecDeg)
         new Obs(
           o.getProg,
           o.getGroup,

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestTemplateGroupMerge.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestTemplateGroupMerge.scala
@@ -56,7 +56,7 @@ class TestTemplateGroupMerge {
     def dataObject  = tp.getDataObject.asInstanceOf[TemplateParameters]
 
     def target: SPTarget = dataObject.getTarget
-    def targetName: String = target.getName
+    def targetName: String = target.getTarget.getName
   }
 
   @Test def testConflictingTemplateGroups() {

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
@@ -35,7 +35,7 @@ enum SPTargetPosListParser {
         List<SPTarget> userTargets = new ArrayList<SPTarget>();
 
         TargetEnvironment toTargetEnv() {
-            if (base == null) base = SPTarget.createDefaultBasePosition();
+            if (base == null) base = new SPTarget();
             ImList<GuideProbeTargets> glst = DefaultImList.create(guideMap.values());
             ImList<SPTarget> ulst = DefaultImList.create(userTargets);
             return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(glst).setUserTargets(ulst);

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015A/To2015A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015A/To2015A.scala
@@ -4,7 +4,7 @@ import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.io.impl.SpIOTags
 import edu.gemini.spModel.pio.xml.PioXmlFactory
 import edu.gemini.spModel.pio._
-import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.{SPTargetPio, SPTarget}
 import edu.gemini.spModel.template.{TemplateParameters, TemplateGroup, TemplateFolder}
 
 import scala.collection.JavaConverters._
@@ -61,7 +61,7 @@ object To2015A {
         m + (key -> f(ps))
       }
 
-    val targetMap = mapParamSets(SPTarget.PARAM_SET_NAME) { ps =>
+    val targetMap = mapParamSets(SPTargetPio.PARAM_SET_NAME) { ps =>
       val t = new SPTarget()
       t.setParamSet(ps)
       t

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015A/TemplateConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015A/TemplateConversionTest.scala
@@ -72,7 +72,7 @@ class TemplateConversionTest {
       assertTrue(tpList.forall(_.getSiteQuality.conditions() == sq.conditions()))
 
       // Different targets
-      assertEquals(List("target_D", "target_C", "target_B", "target_A"), tpList.map(_.getTarget.getName))
+      assertEquals(List("target_D", "target_C", "target_B", "target_A"), tpList.map(_.getTarget.getTarget.getName))
     }
 
     def validateFolder(f: ISPTemplateFolder): Unit = {

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetSurvey.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetSurvey.scala
@@ -33,7 +33,7 @@ object TargetSurvey extends SafeApp {
   type Stats = Map[(String, String), (Int, Map[Magnitude.Band, Int])]
 
   def magnitudeMap(t: SPTarget): Map[Magnitude.Band, Int] =
-    t.getMagnitudes.asScalaList.map(_.getBand).strengthR(1).toMap
+    t.getTarget.getMagnitudes.asScalaList.map(_.getBand).strengthR(1).toMap
 
   def examineTarget(t: SPTarget): Stats =
     Map((t.getTarget.getClass.getSimpleName, t.getTarget.getTag.tccName) -> ((1, magnitudeMap(t))))

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -133,7 +133,7 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.BAND, band);
         row.put(Columns.PROG_TOO_STATUS, tooType.getDisplayValue());
         row.put(Columns.TEMPLATE_ID, templateId);
-        row.put(Columns.TARGET_NAME, target.getName());
+        row.put(Columns.TARGET_NAME, target.getTarget().getName());
         row.put(Columns.RA, target.getXaxisAsString());
         row.put(Columns.DEC, target.getYaxisAsString());
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -134,8 +134,8 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.PROG_TOO_STATUS, tooType.getDisplayValue());
         row.put(Columns.TEMPLATE_ID, templateId);
         row.put(Columns.TARGET_NAME, target.getTarget().getName());
-        row.put(Columns.RA, target.getXaxisAsString());
-        row.put(Columns.DEC, target.getYaxisAsString());
+        row.put(Columns.RA, target.getTarget().c1ToString());
+        row.put(Columns.DEC, target.getTarget().c2ToString());
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));
         row.put(Columns.INST_CONFIG, instConfig);
         row.put(Columns.PHASE1_TIME, String.format("%.2f hrs", time.getTimeAmount()));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
@@ -422,8 +422,8 @@ public class ReportUtils {
         }
 
         // we know it's a ra/dec target, so it's safe to cast here
-        final double r = ((HMS) target.getC1()).getValue();
-        final double d = ((DMS) target.getC2()).getValue();
+        final double r = ((HMS) target.getTarget().getC1()).getValue();
+        final double d = ((DMS) target.getTarget().getC2()).getValue();
 
         if (r == 0.0 && d == 0.0) {
             return Option.empty();

--- a/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
+++ b/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
@@ -46,7 +46,7 @@ object RolloverObservation {
       dataObj    <- Option(targetComp.getDataObject.asInstanceOf[TargetObsComp])
       targetEnv  <- Option(dataObj.getTargetEnvironment)
       science    <- Option(targetEnv.getBase)
-      name       <- Option(science.getName)
+      name       <- Option(science.getTarget.getName)
       ra         <- Option(science.getXaxis)
       dec        <- Option(science.getYaxis)
     } yield RolloverTarget(name, new Angle(ra, Angle.Unit.DEGREES), new Angle(dec, Angle.Unit.DEGREES))

--- a/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
+++ b/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
@@ -5,6 +5,7 @@ import edu.gemini.spModel.gemini.obscomp.SPSiteQuality._
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeCalculator
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import edu.gemini.pot.sp._
+import edu.gemini.spModel.target.system.CoordinateParam.Units
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -47,8 +48,8 @@ object RolloverObservation {
       targetEnv  <- Option(dataObj.getTargetEnvironment)
       science    <- Option(targetEnv.getBase)
       name       <- Option(science.getTarget.getName)
-      ra         <- Option(science.getXaxis)
-      dec        <- Option(science.getYaxis)
+      ra         <- Option(science.getTarget.getC1.getAs(Units.DEGREES))
+      dec        <- Option(science.getTarget.getC2.getAs(Units.DEGREES))
     } yield RolloverTarget(name, new Angle(ra, Angle.Unit.DEGREES), new Angle(dec, Angle.Unit.DEGREES))
 
   private def conditions(o: ISPObservation): Option[RolloverConditions] =

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -125,7 +125,7 @@ public final class ObservationEnvironment {
     }
 
     public String getBasePositionName() {
-        return _targetEnv.getBase().getName();
+        return _targetEnv.getBase().getTarget().getName();
     }
 
     public boolean isNorth() {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -53,9 +53,9 @@ public final class TargetConfig extends ParamSet {
      * Note that only the hmsDegTarget is supported at this time.
      */
     public TargetConfig(SPTarget spTarget) throws WdbaGlueException {
-        super(spTarget.getName());
+        super(spTarget.getTarget().getName());
 
-        putParameter(TccNames.OBJNAME, spTarget.getName());
+        putParameter(TccNames.OBJNAME, spTarget.getTarget().getName());
 
         putParameter(TccNames.BRIGHTNESS, ""); // TODO: can we elide this altogether?
         putParameter(TccNames.TAG, ""); // ugh

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -147,7 +147,7 @@ public final class TargetConfig extends ParamSet {
     }
 
     private Option<Element> _createMagnitudes(SPTarget target) {
-        ImList<Magnitude> magList = target.getMagnitudes();
+        ImList<Magnitude> magList = target.getTarget().getMagnitudes();
         if (magList.size() == 0) return None.instance();
 
         final ParamSet ps = new ParamSet(TccNames.MAGNITUDES);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
@@ -23,7 +23,7 @@ public final class TargetGroupConfig extends ParamSet {
     public static TargetGroupConfig createBaseGroup(TargetEnvironment env) {
         ImList<SPTarget> targets = env.getUserTargets();
         targets = targets.cons(env.getBase());
-        return new TargetGroupConfig(TccNames.BASE, targets, env.getBase().getName());
+        return new TargetGroupConfig(TccNames.BASE, targets, env.getBase().getTarget().getName());
     }
 
     public static TargetGroupConfig createGuideGroup(GuideProbeTargets gt) {
@@ -36,7 +36,7 @@ public final class TargetGroupConfig extends ParamSet {
 //        if ((primary == null) && (targets.size() > 0)) primary = targets.head();
 
         String primaryTargetName = null;
-        if (!primaryOpt.isEmpty()) primaryTargetName = primaryOpt.getValue().getName();
+        if (!primaryOpt.isEmpty()) primaryTargetName = primaryOpt.getValue().getTarget().getName();
 
         String tag = TargetConfig.getTag(guider);
         return new TargetGroupConfig(tag, targets, primaryTargetName);
@@ -53,7 +53,7 @@ public final class TargetGroupConfig extends ParamSet {
 
         List<String> targetNames = new ArrayList<String>(targets.size());
         for (SPTarget target : targets) {
-            targetNames.add(target.getName());
+            targetNames.add(target.getTarget().getName());
         }
 
         putParameter(TccNames.TARGETS, targetNames);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -114,13 +114,13 @@ public class TccFieldConfig extends ParamSet {
     private void addBaseGroup(TargetEnvironment env) throws WdbaGlueException {
         // Add the target itself.
         SPTarget base = env.getBase();
-        if (isEmpty(base.getName())) base.setName(TccNames.BASE);
+        if (isEmpty(base.getTarget().getName())) base.setName(TccNames.BASE);
         add(new TargetConfig(base));
 
         // Add the user targets.
         int pos = 1;
         for (SPTarget user : env.getUserTargets()) {
-            if (isEmpty(user.getName())) {
+            if (isEmpty(user.getTarget().getName())) {
                 user.setName(TargetConfig.formatName("User", pos));
             }
             ++pos;
@@ -145,7 +145,7 @@ public class TccFieldConfig extends ParamSet {
 
         int pos = 1;
         for (SPTarget target : targets) {
-            if (isEmpty(target.getName())) {
+            if (isEmpty(target.getTarget().getName())) {
                 target.setName(TargetConfig.formatName(tag, pos));
             }
             add(new TargetConfig(target));

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -344,7 +344,7 @@ public final class TargetGroupTest extends TestBase {
 
         public String getTargetName(SPTarget target) {
             String name = targetNameMap.get(target);
-            return (name == null) ? target.getName() : name;
+            return (name == null) ? target.getTarget().getName() : name;
         }
 
         public void putTargetName(SPTarget target, String name) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -89,7 +89,7 @@ public final class TargetMagnitudeTest extends TestBase {
 
             Option<SPTarget> target = env.getTargets().find(new PredicateOp<SPTarget>() {
                 public Boolean apply(SPTarget spTarget) {
-                    return name.equals(spTarget.getName());
+                    return name.equals(spTarget.getTarget().getName());
                 }
             });
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -104,7 +104,7 @@ public final class TargetMagnitudeTest extends TestBase {
 
     private void validateMagnitudes(Element element, SPTarget target) {
         final Element magGroupElement = (Element) element.selectSingleNode(MAG_PATH);
-        ImList<Magnitude> mags = target.getMagnitudes();
+        ImList<Magnitude> mags = target.getTarget().getMagnitudes();
         if (magGroupElement == null) {
             assertEquals(0, mags.size());
             return;

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
@@ -34,7 +34,6 @@ import edu.gemini.spModel.pio.xml.PioXmlFactory;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.system.CoordinateParam.Units;
-import edu.gemini.spModel.target.system.HmsDegTarget;
 import edu.gemini.spModel.target.system.ICoordinate;
 import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.time.ChargeClass;
@@ -51,7 +50,6 @@ import jsky.catalog.SearchCondition;
 import jsky.coords.DMS;
 import jsky.coords.HMS;
 
-import javax.security.auth.Subject;
 import java.security.AccessControlException;
 import java.security.Principal;
 import java.util.*;
@@ -451,7 +449,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
             final SPTarget target = targetEnv.getBase();
             if (target == null)
                 return null;
-            return target.getName();
+            return target.getTarget().getName();
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
@@ -284,7 +284,7 @@ class ParamsListTableCellRenderer extends DefaultTableCellRenderer {
 
             // Cell for a target
             final SPTarget target = (SPTarget) value;
-            label.setText(target.getName());
+            label.setText(target.getTarget().getName());
 
             // Two possible icons
             if (target.getTarget() instanceof NonSiderealTarget) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/InstantiationDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/InstantiationDialog.java
@@ -101,7 +101,7 @@ class InstantiationDialogRenderer extends TemplateDialogRenderer {
 
             // Text
             final SPSiteQuality.Conditions conds = tps.getSiteQuality().conditions();
-            setText(spTarget.getName() + " - " + conds);
+            setText(spTarget.getTarget().getName() + " - " + conds);
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1586,8 +1586,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.targetName.setValue(name);
         _w.resolveButton.setEnabled(editable && !"".equals(name));
 
-        _w.xaxis.setValue(_curPos.getXaxisAsString());
-        _w.yaxis.setValue(_curPos.getYaxisAsString());
+        _w.xaxis.setValue(_curPos.getTarget().c1ToString());
+        _w.yaxis.setValue(_curPos.getTarget().c2ToString());
 
         _setCoordSys();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1706,7 +1706,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         }
         _ignorePosUpdate = true;
         try {
-            _curPos.setCoordSys(tag);
+            _curPos.setTargetType(tag);
         } finally {
             _ignorePosUpdate = false;
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1642,7 +1642,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         if (!(dec.equals("-") || dec.equals("+"))) {
             _ignorePosUpdate = true;
             try {
-                _curPos.setXYFromString(ra, dec);
+                _curPos.setHmsDms(ra, dec);
             } finally {
                 _ignorePosUpdate = false;
             }
@@ -1795,7 +1795,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             }
 
             SPTarget base = env.getBase();
-            base.setXY(basePos.getRaDeg(), basePos.getDecDeg());
+            base.setRaDecDegrees(basePos.getRaDeg(), basePos.getDecDeg());
         } else if (w == _w.resolveButton) {
             // REL-1063 Fix OT nonsidereal Solar System Object Horizons name resolution
             if (_curPos.getTarget() instanceof NamedTarget) {
@@ -2092,7 +2092,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                         NonSiderealTarget target = (NonSiderealTarget) _curPos.getTarget();
                         _ignorePosUpdate = true;
                         try {
-                            _curPos.setXYFromString(coords.getRA().toString(),
+                            _curPos.setHmsDms(coords.getRA().toString(),
                                     coords.getDec().toString());
                         } finally {
                             _ignorePosUpdate = false;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -789,7 +789,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         TargetClipboard(SPTarget spTarget) {
             this.target = (ITarget) spTarget.getTarget().clone();
-            this.mag = spTarget.getMagnitudes();
+            this.mag = spTarget.getTarget().getMagnitudes();
         }
 
         TargetClipboard(GuideGroup group) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1581,7 +1581,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _showTargetTag();
         _updateTargetInformationUI();
 
-        String name = _curPos.getName();
+        String name = _curPos.getTarget().getName();
         if (name != null) name = name.trim();
         _w.targetName.setValue(name);
         _w.resolveButton.setEnabled(editable && !"".equals(name));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -163,7 +163,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
 
         public void setTarget(SPTarget target, Mode mode) {
             Option<Magnitude> magOpt = None.instance();
-            if (target != null) magOpt = target.getMagnitude(band);
+            if (target != null) magOpt = target.getTarget().getMagnitude(band);
 
             // Update visibility based upon whether the target has a
             // corresponding magnitude value for this band.
@@ -495,7 +495,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void addBand(Magnitude.Band b) {
-        Option<Magnitude> magOpt = target.getMagnitude(b);
+        Option<Magnitude> magOpt = target.getTarget().getMagnitude(b);
         if (!magOpt.isEmpty()) return; // shouldn't happen ...
 
         Magnitude newMag = new Magnitude(b, Magnitude.UNDEFINED_MAG, 0);
@@ -509,7 +509,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void changeBand(Magnitude.Band from, Magnitude.Band to) {
-        Option<Magnitude> oldMagOpt = target.getMagnitude(from);
+        Option<Magnitude> oldMagOpt = target.getTarget().getMagnitude(from);
         if (oldMagOpt.isEmpty()) return; // shouldn't happen ...
         Magnitude oldMag = oldMagOpt.getValue();
         Magnitude newMag = new Magnitude(to, oldMag.getBrightness(), oldMag.getError(), oldMag.getSystem());
@@ -521,7 +521,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void changeSystem(Magnitude.Band band, Magnitude.System system) {
-        Option<Magnitude> oldMagOpt = target.getMagnitude(band);
+        Option<Magnitude> oldMagOpt = target.getTarget().getMagnitude(band);
         if (oldMagOpt.isEmpty()) return; // shouldn't happen ...
         Magnitude oldMag = oldMagOpt.getValue();
         if (system == oldMag.getSystem()) return;
@@ -534,7 +534,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void updateMagnitudeValue(Magnitude.Band b, double d) {
-        Option<Magnitude> oldMagOpt = target.getMagnitude(b);
+        Option<Magnitude> oldMagOpt = target.getTarget().getMagnitude(b);
         if (oldMagOpt.isEmpty()) return;
         Magnitude oldMag = oldMagOpt.getValue();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -262,7 +262,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
 
             // Make the remove button active if there are existing magnitude
             // values.
-            rmButton.setEnabled(target.getMagnitudes().size()>0);
+            rmButton.setEnabled(target.getTarget().getMagnitudes().size()>0);
 
             // Update the combo-box options to contain the unused magnitude
             // bands and show that nothing is selected.
@@ -422,7 +422,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
         // If there is no magnitude info though, switch to add mode so that
         // the user doesn't have to push the + button.
         Mode mode = Mode.edit;
-        if ((target != null) && (target.getMagnitudes().size() == 0)) {
+        if ((target != null) && (target.getTarget().getMagnitudes().size() == 0)) {
             mode = Mode.add;
         }
         reinit(target, mode);
@@ -455,7 +455,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
                     JScrollBar sb = scroll.getVerticalScrollBar();
                     sb.setValue(sb.getMaximum());
 
-                    if (target.getMagnitudes().size() > 0) {
+                    if (target.getTarget().getMagnitudes().size() > 0) {
                         newRow.getBandCombo().getValue().requestFocusInWindow();
                     }
                 }
@@ -500,12 +500,12 @@ final class MagnitudeEditor implements TelescopePosEditor {
 
         Magnitude newMag = new Magnitude(b, Magnitude.UNDEFINED_MAG, 0);
 
-        target.setMagnitudes(target.getMagnitudes().cons(newMag));
+        target.setMagnitudes(target.getTarget().getMagnitudes().cons(newMag));
         focusOn(b);
     }
 
     void removeBand(Magnitude.Band b) {
-        target.setMagnitudes(target.getMagnitudes().filter(new NotBand(b)));
+        target.setMagnitudes(target.getTarget().getMagnitudes().filter(new NotBand(b)));
     }
 
     void changeBand(Magnitude.Band from, Magnitude.Band to) {
@@ -515,7 +515,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
         Magnitude newMag = new Magnitude(to, oldMag.getBrightness(), oldMag.getError(), oldMag.getSystem());
 
         target.setMagnitudes(
-               target.getMagnitudes().filter(new NotBand(from)).cons(newMag)
+               target.getTarget().getMagnitudes().filter(new NotBand(from)).cons(newMag)
         );
         focusOn(to);
     }
@@ -528,7 +528,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
         Magnitude newMag = new Magnitude(band, oldMag.getBrightness(), oldMag.getError(), system);
 
         target.setMagnitudes(
-               target.getMagnitudes().filter(new NotBand(band)).cons(newMag)
+               target.getTarget().getMagnitudes().filter(new NotBand(band)).cons(newMag)
         );
         focusOn(band);
     }
@@ -542,7 +542,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
             Magnitude newMag = new Magnitude(oldMag.getBand(), d, oldMag.getError(), oldMag.getSystem());
             target.deleteWatcher(watcher);
             target.setMagnitudes(
-                   target.getMagnitudes().filter(new NotBand(b)).cons(newMag)
+                   target.getTarget().getMagnitudes().filter(new NotBand(b)).cons(newMag)
             );
             target.addWatcher(watcher);
         } catch (Exception ex) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -179,7 +179,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
             Set<Magnitude.Band> options = new TreeSet<Magnitude.Band>(Magnitude.Band.WAVELENGTH_COMPARATOR);
             options.addAll(Arrays.asList(Magnitude.Band.values()));
             //noinspection ConstantConditions
-            options.removeAll(target.getMagnitudeBands());
+            options.removeAll(target.getTarget().getMagnitudeBands());
             options.add(band);
             cb.removeActionListener(changeBandAction);
             cb.setModel(new DefaultComboBoxModel(options.toArray()));
@@ -268,7 +268,7 @@ final class MagnitudeEditor implements TelescopePosEditor {
             // bands and show that nothing is selected.
             Set<Magnitude.Band> options = new TreeSet<Magnitude.Band>(Magnitude.Band.WAVELENGTH_COMPARATOR);
             options.addAll(Arrays.asList(Magnitude.Band.values()));
-            options.removeAll(target.getMagnitudeBands());
+            options.removeAll(target.getTarget().getMagnitudeBands());
             cb.setMaximumRowCount(options.size());
             cb.removeActionListener(addAction);
             cb.setModel(new DefaultComboBoxModel(options.toArray()));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -297,7 +297,7 @@ class NonSiderealTargetSupport {
     private final DropDownListBoxWidgetWatcher orbitalElementFormatWatcher =
         new DropDownListBoxWidgetWatcher()  {
             public void dropDownListBoxAction(DropDownListBoxWidget dd, int i, String val) {
-                spTarget.setCoordSys((ITarget.Tag) form.orbitalElementFormat.getSelectedItem());
+                spTarget.setTargetType((ITarget.Tag) form.orbitalElementFormat.getSelectedItem());
                 if (!ignoreResetCacheEvents) {
                     HorizonsService.resetCache();
                 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -332,12 +332,12 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             // An operation that adds a target's bands to the set.
             ApplyOp<SPTarget> op = new ApplyOp<SPTarget>() {
                 @Override public void apply(SPTarget spTarget) {
-                    bands.addAll(spTarget.getMagnitudeBands());
+                    bands.addAll(spTarget.getTarget().getMagnitudeBands());
                 }
             };
 
             // Extract all the magnitude bands from the environment.
-            bands.addAll(env.getBase().getMagnitudeBands());
+            bands.addAll(env.getBase().getTarget().getMagnitudeBands());
             for (GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
                 gt.getOptions().foreach(op);
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -1033,7 +1033,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
 
         boolean isPrimary = src.getPrimary().getOrElse(null) == target;
         GuideProbeTargets newSrc = src.removeTarget(target);
-        SPTarget newTarget = SPTarget.CLONE_FUNCTION.apply(target);
+        SPTarget newTarget = target.clone();
         GuideProbeTargets newSnk = snk.setOptions(snk.getOptions().append(newTarget));
         if (isPrimary) {
             newSnk = newSnk.selectPrimary(newTarget);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -26,7 +26,6 @@ import edu.gemini.spModel.target.offset.OffsetPosBase;
 import edu.gemini.spModel.target.offset.OffsetPosList;
 import edu.gemini.spModel.target.offset.OffsetUtil;
 import edu.gemini.spModel.target.system.CoordinateParam.Units;
-import edu.gemini.spModel.target.system.HmsDegTarget;
 import edu.gemini.spModel.target.system.ICoordinate;
 import edu.gemini.spModel.target.system.ITarget;
 import jsky.app.ot.OT;
@@ -154,7 +153,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             public Option<Magnitude> getMagnitude(final Magnitude.Band band) {
                 return target.flatMap(new MapOp<SPTarget, Option<Magnitude>>() {
                     @Override public Option<Magnitude> apply(SPTarget spTarget) {
-                        return spTarget.getMagnitude(band);
+                        return spTarget.getTarget().getMagnitude(band);
                     }
                 });
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -171,7 +171,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
 
         static final class BaseTargetRow extends AbstractRow {
             BaseTargetRow(SPTarget target) {
-                super(true, TargetEnvironment.BASE_NAME, target.getName(), new Some<>(target));
+                super(true, TargetEnvironment.BASE_NAME, target.getTarget().getName(), new Some<>(target));
             }
         }
 
@@ -179,7 +179,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             final Option<Double> distance;
 
             NonBaseTargetRow(boolean enabled, String tag, SPTarget target, WorldCoords baseCoords) {
-                super(enabled, tag, target.getName(), new Some<>(target));
+                super(enabled, tag, target.getTarget().getName(), new Some<>(target));
                 final WorldCoords coords = getWorldCoords(target);
                 distance = new Some<>(Math.abs(baseCoords.dist(coords)));
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -82,7 +82,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getXaxisAsString();
+                            return t.getTarget().c1ToString();
                         }
                     }).getOrElse("");
                 }
@@ -92,7 +92,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getYaxisAsString();
+                            return t.getTarget().c2ToString();
                         }
                     }).getOrElse("");
                 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -422,7 +422,7 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
 
     // Returns a mascot Star object for the given target.
     private Star targetToStar(SPTarget target) {
-        String name = target.getName();
+        String name = target.getTarget().getName();
         double ra = target.getXaxis();
         double dec = target.getYaxis();
         double baseX = _tii.getBasePos().getRaDeg();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -428,12 +428,12 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
         double baseX = _tii.getBasePos().getRaDeg();
         double baseY = _tii.getBasePos().getDecDeg();
         Magnitude undef = new Magnitude(Magnitude.Band.J, MascotConf.invalidMag());
-        double bmag = target.getMagnitude(Magnitude.Band.B).getOrElse(undef).getBrightness();
-        double vmag = target.getMagnitude(Magnitude.Band.V).getOrElse(undef).getBrightness();
-        double rmag = target.getMagnitude(Magnitude.Band.R).getOrElse(undef).getBrightness();
-        double jmag = target.getMagnitude(Magnitude.Band.J).getOrElse(undef).getBrightness();
-        double hmag = target.getMagnitude(Magnitude.Band.H).getOrElse(undef).getBrightness();
-        double kmag = target.getMagnitude(Magnitude.Band.K).getOrElse(undef).getBrightness();
+        double bmag = target.getTarget().getMagnitude(Magnitude.Band.B).getOrElse(undef).getBrightness();
+        double vmag = target.getTarget().getMagnitude(Magnitude.Band.V).getOrElse(undef).getBrightness();
+        double rmag = target.getTarget().getMagnitude(Magnitude.Band.R).getOrElse(undef).getBrightness();
+        double jmag = target.getTarget().getMagnitude(Magnitude.Band.J).getOrElse(undef).getBrightness();
+        double hmag = target.getTarget().getMagnitude(Magnitude.Band.H).getOrElse(undef).getBrightness();
+        double kmag = target.getTarget().getMagnitude(Magnitude.Band.K).getOrElse(undef).getBrightness();
         return Star.makeStar(name, baseX, baseY, bmag, vmag, rmag, jmag, hmag, kmag, ra, dec);
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -21,6 +21,7 @@ import edu.gemini.spModel.target.WatchablePos;
 import edu.gemini.spModel.target.env.GuideGroup;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.env.TargetEnvironmentDiff;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import jsky.app.ot.tpe.*;
 import jsky.app.ot.util.BasicPropertyList;
 import jsky.app.ot.util.PropertyWatcher;
@@ -423,8 +424,8 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
     // Returns a mascot Star object for the given target.
     private Star targetToStar(SPTarget target) {
         String name = target.getTarget().getName();
-        double ra = target.getXaxis();
-        double dec = target.getYaxis();
+        double ra = target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES);
+        double dec = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
         double baseX = _tii.getBasePos().getRaDeg();
         double baseY = _tii.getBasePos().getDecDeg();
         Magnitude undef = new Magnitude(Magnitude.Band.J, MascotConf.invalidMag());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/PosMap.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/PosMap.java
@@ -137,7 +137,7 @@ public abstract class PosMap <K, T extends WatchablePos>
                 // ignore
             }
         } else {
-            ((SPTarget) tp).setXY(tme.pos.getRaDeg(), tme.pos.getDecDeg());
+            ((SPTarget) tp).setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
         }
 
         tp.addWatcher(this);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -467,8 +467,8 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         if (_baseTarget == null) return;
 
         // XXX FIXME: We shouldn't have to use numeric indexes here
-        queryArgs.setParamValue(2, _baseTarget.getC1().toString());
-        queryArgs.setParamValue(3, _baseTarget.getC2().toString());
+        queryArgs.setParamValue(2, _baseTarget.getTarget().getC1().toString());
+        queryArgs.setParamValue(3, _baseTarget.getTarget().getC2().toString());
         queryArgs.setParamValue(4, _baseTarget.getTarget().getTag().tccName);
         if (args.length > 2) {
             //first argument must be a Double, it represent the size on AstroCatalogs

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -282,7 +282,7 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
             return;
         }
 
-        tp.setXY(basePos.getRaDeg(), basePos.getDecDeg());
+        tp.setRaDecDegrees(basePos.getRaDeg(), basePos.getDecDeg());
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
@@ -144,7 +144,7 @@ public class TpeBasePosFeature extends TpePositionFeature {
             }
 
             SPTarget tp = (SPTarget) _dragObject.taggedPos;
-            tp.setXY(tme.pos.getRaDeg(), tme.pos.getDecDeg());
+            tp.setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -507,7 +507,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
             _dragObject.screenPos.y = tme.yWidget;
 
             SPTarget tp = (SPTarget) _dragObject.taggedPos;
-            tp.setXY(tme.pos.getRaDeg(), tme.pos.getDecDeg());
+            tp.setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -16,6 +16,7 @@ import edu.gemini.spModel.target.env.OptionsList.UpdateOps;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
+import edu.gemini.spModel.target.system.HmsDegTarget;
 import jsky.app.ot.gemini.editor.targetComponent.PrimaryTargetToggle;
 import jsky.app.ot.tpe.*;
 import jsky.app.ot.util.BasicPropertyList;
@@ -126,7 +127,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
 
         Option<SkyObject> skyObjectOpt = tme.getSkyObject();
         if (!skyObjectOpt.isEmpty()) {
-            pos = new SPTarget(skyObjectOpt.getValue());
+            pos = new SPTarget(HmsDegTarget.fromSkyObject(skyObjectOpt.getValue()));
         } else {
             // No SkyObject info is present so we use the old way of creating
             // a target from a mouse event.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -165,7 +165,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         String getId() {
             if (_guideProbeTargets != null) {
                 if (!_guideProbeTargets.getPrimary().isEmpty()) {
-                    return _guideProbeTargets.getPrimary().getValue().getName();
+                    return _guideProbeTargets.getPrimary().getValue().getTarget().getName();
                 }
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.getStrehl();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -184,7 +184,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
                     if (Canopus.Wfs.Group.instance.getMembers().contains(guideProbe)) {
                         band = Magnitude.Band.R;
                     }
-                    Option<Magnitude> magOpt = _guideProbeTargets.getPrimary().getValue().getMagnitude(band);
+                    Option<Magnitude> magOpt = _guideProbeTargets.getPrimary().getValue().getTarget().getMagnitude(band);
                     if (!magOpt.isEmpty()) {
                         return magOpt.getValue().getBrightness() + " (" + band.name() + ")";
                     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -207,7 +207,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         String getRA() {
             if (_guideProbeTargets != null) {
-                return getTarget().getXaxisAsString();
+                return getTarget().getTarget().c1ToString();
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.getStrehl();
                 if (strehl != null) {
@@ -219,7 +219,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         Object getDec() {
             if (_guideProbeTargets != null) {
-                return getTarget().getYaxisAsString();
+                return getTarget().getTarget().c2ToString();
             }
             return null;
         }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -321,7 +321,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
           set = setTarget((target, inc) => {
             if (inc) target.putMagnitude(zero)
             else {
-              val mags = target.getMagnitudes.toList.asScala.filterNot(_.getBand == band)
+              val mags = target.getTarget.getMagnitudes.toList.asScala.filterNot(_.getBand == band)
               target.setMagnitudes(DefaultImList.create(mags.asJava))
             }}
           )

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -308,13 +308,13 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         lazy val zero = new Magnitude(band, 0.0)
 
         def mag(tp: TemplateParameters): Option[Magnitude] =
-          tp.getTarget.getMagnitude(band).asScalaOpt
+          tp.getTarget.getTarget.getMagnitude(band).asScalaOpt
 
         def magOrZero(tp: TemplateParameters): Magnitude =
           mag(tp).getOrElse(zero)
 
         def setMag[A](f: (Magnitude, A) => Magnitude): (TemplateParameters, A) => TemplateParameters =
-          setTarget[A]((t, a) => t.putMagnitude(f(t.getMagnitude(band).getOrElse(zero), a)))
+          setTarget[A]((t, a) => t.putMagnitude(f(t.getTarget.getMagnitude(band).getOrElse(zero), a)))
 
         val magCheck = new BoundCheckbox(
           get = mag(_).isDefined,

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -239,7 +239,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val nameField = new BoundTextField[String](10)(
         read = identity,
         show = identity,
-        get  = _.getTarget.getName,
+        get  = _.getTarget.getTarget.getName,
         set  = setTarget(_.setName(_))
       )
 
@@ -251,7 +251,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
             case Sidereal    => new HmsDegTarget()
             case NonSidereal => new ConicTarget()
           }
-          coords.setName(target.getName)
+          coords.setName(target.getTarget.getName)
           target.setTarget(coords)
           target.setMagnitudes(DefaultImList.create[Magnitude]())
         })}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -72,7 +72,7 @@ final class TargetContext(obs: Option[ISPObservation]) extends TpeSubContext[ISP
 
   def baseOrNull: SPTarget = base.orNull
 
-  def baseOrDefault: SPTarget = base.getOrElse(SPTarget.createDefaultBasePosition())
+  def baseOrDefault: SPTarget = base.getOrElse(new SPTarget))
 
   def selected: Option[SPTarget] = for {
     s <- shell

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -72,7 +72,7 @@ final class TargetContext(obs: Option[ISPObservation]) extends TpeSubContext[ISP
 
   def baseOrNull: SPTarget = base.orNull
 
-  def baseOrDefault: SPTarget = base.getOrElse(new SPTarget))
+  def baseOrDefault: SPTarget = base.getOrElse(new SPTarget)
 
   def selected: Option[SPTarget] = for {
     s <- shell


### PR DESCRIPTION
Many methods on `SPTarget` delegate to the contained `ITarget`, which is unnecessary in some cases and nonsensical in others (since many operations are defined only for specific target types). This is the first set of changes and is all "easy" refactorings: inlining, renaming, and in a couple cases pushing methods down. 

It you're reviewing this commit-by-commit note that I reverted and re-did `push getSkycalcCoordinates down to ITarget`.