### PR TITLE
OCSADV-154  ITarget Cleanup

### DIFF
--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStars.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStars.java
@@ -170,9 +170,9 @@ public class GemsGuideStars implements Comparable<GemsGuideStars> {
             SPTarget target = guideGroup.get(guideProbe).getValue().getPrimary().getValue();
             sb.append(guideProbe);
             sb.append("[");
-            sb.append(target.getTarget().getC1());
+            sb.append(target.getTarget().getRa());
             sb.append(",");
-            sb.append(target.getTarget().getC2());
+            sb.append(target.getTarget().getDec());
             sb.append("] ");
         }
         return "GemsGuideStars{" +

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
@@ -180,14 +180,14 @@ object MascotGuideStar {
 
     val inst = ctx.getInstrument
     val savedPa = inst.getPosAngleDegrees
-    val savedRa = ctx.getTargets.getBase.getTarget.getC1.getAs(Units.DEGREES)
-    val savedDec = ctx.getTargets.getBase.getTarget.getC2.getAs(Units.DEGREES)
+    val savedRa = ctx.getTargets.getBase.getTarget.getRa.getAs(Units.DEGREES)
+    val savedDec = ctx.getTargets.getBase.getTarget.getDec.getAs(Units.DEGREES)
     val settingsList = settingsToTry(savedPa, savedRa, savedDec, posAngleTolerance, basePosTolerance)
     try {
       val result = for ((pa, ra, dec) <- settingsList) yield {
         inst.setPosAngle(pa)
-        ctx.getTargets.getBase.getTarget.getC1.setAs(ra, Units.DEGREES)
-        ctx.getTargets.getBase.getTarget.getC2.setAs(dec, Units.DEGREES)
+        ctx.getTargets.getBase.getTarget.getRa.setAs(ra, Units.DEGREES)
+        ctx.getTargets.getBase.getTarget.getDec.setAs(dec, Units.DEGREES)
         // XXX TODO use a cache map in the filter?
         val l = strehlList.filter(_.stars.forall(guideStarFilter))
         (l, pa, ra, dec)
@@ -197,8 +197,8 @@ object MascotGuideStar {
     finally {
       // restore settings
       inst.setPosAngleDegrees(savedPa)
-      ctx.getTargets.getBase.getTarget.getC1.setAs(savedRa, Units.DEGREES)
-      ctx.getTargets.getBase.getTarget.getC2.setAs(savedDec, Units.DEGREES)
+      ctx.getTargets.getBase.getTarget.getRa.setAs(savedRa, Units.DEGREES)
+      ctx.getTargets.getBase.getTarget.getDec.setAs(savedDec, Units.DEGREES)
     }
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -111,8 +111,8 @@ object SingleProbeStrategy {
     val ra1    = st.coordinates.ra.toAngle.toRadians
     val dec1   = st.coordinates.dec.toAngle.toRadians
     val target = HmsDegTarget.fromSkyObject(st.toOldModel)
-    val ra2    = Angle.fromDegrees(target.getC1.getAs(Units.DEGREES)).toRadians
-    val dec2   = Angle.fromDegrees(target.getC2.getAs(Units.DEGREES)).toRadians
+    val ra2    = Angle.fromDegrees(target.getRa.getAs(Units.DEGREES)).toRadians
+    val dec2   = Angle.fromDegrees(target.getDec.getAs(Units.DEGREES)).toRadians
     val raDiff = ra2 - ra1
     val angle  = atan2(sin(raDiff), cos(dec1) * tan(dec2) - sin(dec1) * cos(raDiff))
     Angle.fromRadians(angle)

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -268,11 +268,11 @@ public class GeneralRule implements IRule {
             // Okay, this kind of sucks, but I want to compare the coordinates
             // in the same way they are externalized and displayed.  That is,
             // ignore any extra precision that we end up throwing away.
-            String baseC1 = base.getTarget().c1ToString();
-            String baseC2 = base.getTarget().c2ToString();
+            String baseC1 = base.getTarget().getRaHMS();
+            String baseC2 = base.getTarget().getDecDMS();
 
-            String guideC1 = guide.getTarget().c1ToString();
-            String guideC2 = guide.getTarget().c2ToString();
+            String guideC1 = guide.getTarget().getRaHMS();
+            String guideC2 = guide.getTarget().getDecDMS();
 
             return baseC1.equals(guideC1) && baseC2.equals(guideC2);
         }
@@ -427,11 +427,11 @@ public class GeneralRule implements IRule {
 
     private static boolean _areTargetsEquals(SPTarget p1Target, SPTarget target, ObservationElements elems) {
 
-        double spRA = target.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
-        double spDec = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+        double spRA = target.getTarget().getRa().getAs(CoordinateParam.Units.HMS);
+        double spDec = target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
 
-        double p1RA = p1Target.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
-        double p1Dec = p1Target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+        double p1RA = p1Target.getTarget().getRa().getAs(CoordinateParam.Units.HMS);
+        double p1Dec = p1Target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
 
         return _closeEnough(elems, spRA, spDec, p1RA, p1Dec);
     }
@@ -444,8 +444,8 @@ public class GeneralRule implements IRule {
         final ISPObservation obs = elems.getObservationNode();
         if (obs == null || !Too.isToo(obs)) return false;
 
-        double p1RA = p1Target.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
-        double p1Dec = p1Target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+        double p1RA = p1Target.getTarget().getRa().getAs(CoordinateParam.Units.HMS);
+        double p1Dec = p1Target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
         return (p1RA == 0.0) && (p1Dec == 0.0);
     }
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -268,11 +268,11 @@ public class GeneralRule implements IRule {
             // Okay, this kind of sucks, but I want to compare the coordinates
             // in the same way they are externalized and displayed.  That is,
             // ignore any extra precision that we end up throwing away.
-            String baseC1 = base.getTarget().getRaHms();
-            String baseC2 = base.getTarget().getDecDms();
+            String baseC1 = base.getTarget().getRa().toString();
+            String baseC2 = base.getTarget().getDec().toString();
 
-            String guideC1 = guide.getTarget().getRaHms();
-            String guideC2 = guide.getTarget().getDecDms();
+            String guideC1 = guide.getTarget().getRa().toString();
+            String guideC2 = guide.getTarget().getDec().toString();
 
             return baseC1.equals(guideC1) && baseC2.equals(guideC2);
         }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -268,11 +268,11 @@ public class GeneralRule implements IRule {
             // Okay, this kind of sucks, but I want to compare the coordinates
             // in the same way they are externalized and displayed.  That is,
             // ignore any extra precision that we end up throwing away.
-            String baseC1 = base.getTarget().getRaHMS();
-            String baseC2 = base.getTarget().getDecDMS();
+            String baseC1 = base.getTarget().getRaHms();
+            String baseC2 = base.getTarget().getDecDms();
 
-            String guideC1 = guide.getTarget().getRaHMS();
-            String guideC2 = guide.getTarget().getDecDMS();
+            String guideC1 = guide.getTarget().getRaHms();
+            String guideC2 = guide.getTarget().getDecDms();
 
             return baseC1.equals(guideC1) && baseC2.equals(guideC2);
         }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
@@ -191,14 +191,14 @@ public final class NifsRule implements IRule {
                 if (baseTarget == null || oiTarget.isEmpty() || aoTarget.isEmpty()) return null;
                 //now, let's compare coordinates. If they are the same, raise an error
 
-                double baseC1 = baseTarget.getTarget().getC1().getAs(CoordinateParam.Units.HMS);
-                double baseC2 = baseTarget.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+                double baseC1 = baseTarget.getTarget().getRa().getAs(CoordinateParam.Units.HMS);
+                double baseC2 = baseTarget.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
 
-                double oiC1 = oiTarget.getValue().getTarget().getC1().getAs(CoordinateParam.Units.HMS);
-                double oiC2 = oiTarget.getValue().getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+                double oiC1 = oiTarget.getValue().getTarget().getRa().getAs(CoordinateParam.Units.HMS);
+                double oiC2 = oiTarget.getValue().getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
 
-                double aoC1 = aoTarget.getValue().getTarget().getC1().getAs(CoordinateParam.Units.HMS);
-                double aoC2 = aoTarget.getValue().getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+                double aoC1 = aoTarget.getValue().getTarget().getRa().getAs(CoordinateParam.Units.HMS);
+                double aoC2 = aoTarget.getValue().getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
 
 
                 if (Double.compare(baseC1, oiC1) == 0

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
@@ -16,7 +16,6 @@ import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.system.CoordinateParam;
-import edu.gemini.spModel.target.system.HmsDegTarget;
 import edu.gemini.spModel.target.system.ICoordinate;
 import edu.gemini.spModel.target.system.ITarget;
 import jsky.coords.WorldCoords;
@@ -357,8 +356,8 @@ public class TrecsRule implements IRule {
         // Return the world coordinates for the give target
         private WorldCoords _getWorldCoords(SPTarget tp) {
             ITarget target = tp.getTarget();
-            ICoordinate c1 = target.getC1();
-            ICoordinate c2 = target.getC2();
+            ICoordinate c1 = target.getRa();
+            ICoordinate c2 = target.getDec();
             double x = c1.getAs(CoordinateParam.Units.DEGREES);
             double y = c2.getAs(CoordinateParam.Units.DEGREES);
             return new WorldCoords(x, y, 2000.);

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
@@ -88,8 +88,8 @@ object SpTargetFactory {
 
   private def setRaDec(itarget: SP.system.ITarget, c: Coordinates) {
     val degDeg   = c.toDegDeg
-    itarget.setC1(new SP.system.HMS(degDeg.ra.toDouble))
-    itarget.setC2(new SP.system.DMS(degDeg.dec.toDouble))
+    itarget.setRa(new SP.system.HMS(degDeg.ra.toDouble))
+    itarget.setDec(new SP.system.DMS(degDeg.dec.toDouble))
   }
 
   private def siderealMags(sid: SiderealTarget): Either[String, List[SO.Magnitude]] = {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
@@ -4,6 +4,7 @@ package edu.gemini.phase2.skeleton.factory
 import edu.gemini.model.p1.immutable._
 import edu.gemini.shared.{skyobject => SO}
 import edu.gemini.shared.util.immutable.DefaultImList
+import edu.gemini.spModel.target.system.CoordinateParam.Units
 import edu.gemini.spModel.{target => SP}
 import edu.gemini.spModel.target.system.CoordinateTypes.{PM1 => SPProperMotionRA}
 import edu.gemini.spModel.target.system.CoordinateTypes.{PM2 => SPProperMotionDec}
@@ -88,8 +89,8 @@ object SpTargetFactory {
 
   private def setRaDec(itarget: SP.system.ITarget, c: Coordinates) {
     val degDeg   = c.toDegDeg
-    itarget.setRa(new SP.system.HMS(degDeg.ra.toDouble))
-    itarget.setDec(new SP.system.DMS(degDeg.dec.toDouble))
+    itarget.getRa.setAs(degDeg.ra.toDouble, Units.DEGREES)
+    itarget.getDec.setAs(degDeg.dec.toDouble, Units.DEGREES)
   }
 
   private def siderealMags(sid: SiderealTarget): Either[String, List[SO.Magnitude]] = {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
@@ -131,8 +131,8 @@ public final class ObsSchedulingReport implements Serializable {
         SPTarget target = env.getBase();
         if (target == null) return null;
 
-        double ra  = target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES);
-        double dec = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+        double ra  = target.getTarget().getRa().getAs(CoordinateParam.Units.DEGREES);
+        double dec = target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
         return new WorldCoords(ra, dec);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -445,7 +445,7 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
         } else {
             final TargetObsComp toc = (TargetObsComp) targetComp.getDataObject();
             final SPTarget target = toc.getBase();
-            return (target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES) != 0.0) || (target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES) != 0.0);
+            return (target.getTarget().getRa().getAs(CoordinateParam.Units.DEGREES) != 0.0) || (target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES) != 0.0);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -264,8 +264,8 @@ public final class ObsContext {
 
     public Coordinates getBaseCoordinates() {
         SPTarget target = targets.getBase();
-        double raDeg = target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES);
-        double decDeg = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+        double raDeg = target.getTarget().getRa().getAs(CoordinateParam.Units.DEGREES);
+        double decDeg = target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
         return new Coordinates(raDeg, decDeg);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
@@ -63,8 +63,8 @@ public class ObsTargetDesc extends TargetDesc {
 
         SPTarget basePos = targetEnv.getBase();
         ITarget target = basePos.getTarget();
-        ICoordinate c1 = target.getC1();
-        ICoordinate c2 = target.getC2();
+        ICoordinate c1 = target.getRa();
+        ICoordinate c2 = target.getDec();
         double x = c1.getAs(Units.DEGREES);
         double y = c2.getAs(Units.DEGREES);
         WorldCoords pos = new WorldCoords(x, y, 2000.);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -9,7 +9,6 @@ package edu.gemini.spModel.target;
 
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
-import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.system.*;
@@ -37,8 +36,8 @@ public final class SPTarget extends WatchablePos {
     /** SPTarget with the given RA/Dec in degrees. */
     public SPTarget(final double raDeg, final double degDec) {
         this();
-        _target.getC1().setAs(raDeg, Units.DEGREES);
-        _target.getC2().setAs(degDec, Units.DEGREES);
+        _target.getRa().setAs(raDeg, Units.DEGREES);
+        _target.getDec().setAs(degDec, Units.DEGREES);
     }
 
     /** Return the contained target. */
@@ -112,14 +111,14 @@ public final class SPTarget extends WatchablePos {
     public void setHmsDms(final String hms, final String dms) {
         synchronized (this) {
             try {
-                _target.setC1(hms);
+                _target.setRaHMS(hms);
             } catch (final IllegalArgumentException ex) {
-                _target.setC1("00:00:00.0");
+                _target.setRaHMS("00:00:00.0");
             }
             try {
-                _target.setC2(dms);
+                _target.setDecDMS(dms);
             } catch( final IllegalArgumentException ex) {
-                _target.setC2("00:00:00.0");
+                _target.setDecDMS("00:00:00.0");
             }
         }
         _notifyOfUpdate();
@@ -237,8 +236,8 @@ public final class SPTarget extends WatchablePos {
     /** Set the contained target RA/Dec in degrees and notify observers. */
     public void setRaDecDegrees(final double raDeg, final double decDeg) {
         synchronized (this) {
-            _target.getC1().setAs(raDeg, Units.DEGREES);
-            _target.getC2().setAs(decDeg, Units.DEGREES);
+            _target.getRa().setAs(raDeg, Units.DEGREES);
+            _target.getDec().setAs(decDeg, Units.DEGREES);
         }
         _notifyOfUpdate();
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -111,14 +111,14 @@ public final class SPTarget extends WatchablePos {
     public void setHmsDms(final String hms, final String dms) {
         synchronized (this) {
             try {
-                _target.setRaHms(hms);
+                _target.getRa().setValue(hms);
             } catch (final IllegalArgumentException ex) {
-                _target.setRaHms("00:00:00.0");
+                _target.getRa().setValue("00:00:00.0");
             }
             try {
-                _target.setDecDms(dms);
+                _target.getDec().setValue(dms);
             } catch( final IllegalArgumentException ex) {
-                _target.setDecDms("00:00:00.0");
+                _target.getDec().setValue("00:00:00.0");
             }
         }
         _notifyOfUpdate();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -111,14 +111,14 @@ public final class SPTarget extends WatchablePos {
     public void setHmsDms(final String hms, final String dms) {
         synchronized (this) {
             try {
-                _target.setRaHMS(hms);
+                _target.setRaHms(hms);
             } catch (final IllegalArgumentException ex) {
-                _target.setRaHMS("00:00:00.0");
+                _target.setRaHms("00:00:00.0");
             }
             try {
-                _target.setDecDMS(dms);
+                _target.setDecDms(dms);
             } catch( final IllegalArgumentException ex) {
-                _target.setDecDMS("00:00:00.0");
+                _target.setDecDms("00:00:00.0");
             }
         }
         _notifyOfUpdate();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -88,8 +88,8 @@ public class SPTargetPio {
             final HmsDegTarget t = (HmsDegTarget) target;
             Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
             paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
-            Pio.addParam(factory, paramSet, _C1, t.c1ToString());
-            Pio.addParam(factory, paramSet, _C2, t.c2ToString());
+            Pio.addParam(factory, paramSet, _C1, t.getRaHMS());
+            Pio.addParam(factory, paramSet, _C2, t.getDecDMS());
             paramSet.addParam(t.getPM1().getParam(factory, _PM1));
             paramSet.addParam(t.getPM2().getParam(factory, _PM2));
             paramSet.addParam(t.getParallax().getParam(factory, _PARALLAX));
@@ -105,8 +105,8 @@ public class SPTargetPio {
 
             // OT-495: save and restore RA/Dec for conic targets
             // XXX FIXME: Temporary, until nonsidereal support is implemented
-            Pio.addParam(factory, paramSet, _C1, nst.c1ToString());
-            Pio.addParam(factory, paramSet, _C2, nst.c2ToString());
+            Pio.addParam(factory, paramSet, _C1, nst.getRaHMS());
+            Pio.addParam(factory, paramSet, _C2, nst.getDecDMS());
             if (nst.getDateForPosition() != null) {
                 Pio.addParam(factory, paramSet, _VALID_DATE, formatDate(nst.getDateForPosition()));
             }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -88,8 +88,8 @@ public class SPTargetPio {
             final HmsDegTarget t = (HmsDegTarget) target;
             Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
             paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
-            Pio.addParam(factory, paramSet, _C1, t.getRaHMS());
-            Pio.addParam(factory, paramSet, _C2, t.getDecDMS());
+            Pio.addParam(factory, paramSet, _C1, t.getRaHms());
+            Pio.addParam(factory, paramSet, _C2, t.getDecDms());
             paramSet.addParam(t.getPM1().getParam(factory, _PM1));
             paramSet.addParam(t.getPM2().getParam(factory, _PM2));
             paramSet.addParam(t.getParallax().getParam(factory, _PARALLAX));
@@ -105,8 +105,8 @@ public class SPTargetPio {
 
             // OT-495: save and restore RA/Dec for conic targets
             // XXX FIXME: Temporary, until nonsidereal support is implemented
-            Pio.addParam(factory, paramSet, _C1, nst.getRaHMS());
-            Pio.addParam(factory, paramSet, _C2, nst.getDecDMS());
+            Pio.addParam(factory, paramSet, _C1, nst.getRaHms());
+            Pio.addParam(factory, paramSet, _C2, nst.getDecDms());
             if (nst.getDateForPosition() != null) {
                 Pio.addParam(factory, paramSet, _VALID_DATE, formatDate(nst.getDateForPosition()));
             }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -29,7 +29,6 @@ public class SPTargetPio {
     private static final String _OBJECT = "object";
     private static final String _SYSTEM = "system";
     private static final String _EPOCH = "epoch";
-    private static final String _BRIGHTNESS = "brightness";
     private static final String _C1 = "c1";
     private static final String _C2 = "c2";
     private static final String _VALID_DATE = "validAt";
@@ -89,7 +88,6 @@ public class SPTargetPio {
             final HmsDegTarget t = (HmsDegTarget) target;
             Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
             paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
-            Pio.addParam(factory, paramSet, _BRIGHTNESS, t.getBrightness());
             Pio.addParam(factory, paramSet, _C1, t.c1ToString());
             Pio.addParam(factory, paramSet, _C2, t.c2ToString());
             paramSet.addParam(t.getPM1().getParam(factory, _PM1));
@@ -117,7 +115,6 @@ public class SPTargetPio {
                 final ConicTarget t = (ConicTarget) target;
                 Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
                 paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
-                Pio.addParam(factory, paramSet, _BRIGHTNESS, t.getBrightness());
 
                 paramSet.addParam(t.getANode().getParam(factory, _ANODE));
                 paramSet.addParam(t.getAQ().getParam(factory, _AQ));
@@ -148,7 +145,6 @@ public class SPTargetPio {
 
         final String name = Pio.getValue(paramSet, _NAME);
         final String system = Pio.getValue(paramSet, _SYSTEM);
-        final String brightness = Pio.getValue(paramSet, _BRIGHTNESS);
 
         // The system is the tccName, so we need to find it.
         ITarget itarget = null;
@@ -173,8 +169,6 @@ public class SPTargetPio {
             final CoordinateTypes.Epoch e = new CoordinateTypes.Epoch();
             e.setParam(paramSet.getParam(_EPOCH));
             t.setEpoch(e);
-
-            t.setBrightness(brightness);
 
             final CoordinateTypes.PM1 pm1 = new CoordinateTypes.PM1();
             pm1.setParam(paramSet.getParam(_PM1));
@@ -220,8 +214,6 @@ public class SPTargetPio {
                 final CoordinateTypes.Epoch e = new CoordinateTypes.Epoch();
                 e.setParam(paramSet.getParam(_EPOCH));
                 t.setEpoch(e);
-
-                t.setBrightness(brightness);
 
                 final CoordinateTypes.ANode anode = new CoordinateTypes.ANode();
                 anode.setParam(paramSet.getParam(_ANODE));

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -88,8 +88,8 @@ public class SPTargetPio {
             final HmsDegTarget t = (HmsDegTarget) target;
             Pio.addParam(factory, paramSet, _SYSTEM, t.getTag().tccName);
             paramSet.addParam(t.getEpoch().getParam(factory, _EPOCH));
-            Pio.addParam(factory, paramSet, _C1, t.getRaHms());
-            Pio.addParam(factory, paramSet, _C2, t.getDecDms());
+            Pio.addParam(factory, paramSet, _C1, t.getRa().toString());
+            Pio.addParam(factory, paramSet, _C2, t.getDec().toString());
             paramSet.addParam(t.getPM1().getParam(factory, _PM1));
             paramSet.addParam(t.getPM2().getParam(factory, _PM2));
             paramSet.addParam(t.getParallax().getParam(factory, _PARALLAX));
@@ -105,8 +105,8 @@ public class SPTargetPio {
 
             // OT-495: save and restore RA/Dec for conic targets
             // XXX FIXME: Temporary, until nonsidereal support is implemented
-            Pio.addParam(factory, paramSet, _C1, nst.getRaHms());
-            Pio.addParam(factory, paramSet, _C2, nst.getDecDms());
+            Pio.addParam(factory, paramSet, _C1, nst.getRa().toString());
+            Pio.addParam(factory, paramSet, _C2, nst.getDec().toString());
             if (nst.getDateForPosition() != null) {
                 Pio.addParam(factory, paramSet, _VALID_DATE, formatDate(nst.getDateForPosition()));
             }
@@ -164,7 +164,8 @@ public class SPTargetPio {
 
             final String c1 = Pio.getValue(paramSet, _C1);
             final String c2 = Pio.getValue(paramSet, _C2);
-            t.setC1C2(c1, c2);
+            t.getRa().setValue(c1);
+            t.getDec().setValue(c2);
 
             final CoordinateTypes.Epoch e = new CoordinateTypes.Epoch();
             e.setParam(paramSet.getParam(_EPOCH));
@@ -199,7 +200,8 @@ public class SPTargetPio {
             final String c1 = Pio.getValue(paramSet, _C1);
             final String c2 = Pio.getValue(paramSet, _C2);
             if (c1 != null && c2 != null) {
-                nst.setC1C2(c1, c2);
+                nst.getRa().setValue(c1);
+                nst.getDec().setValue(c2);
             }
 
             final String dateStr = Pio.getValue(paramSet, _VALID_DATE);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -19,6 +19,7 @@ import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.TelescopePosWatcher;
 import edu.gemini.spModel.target.WatchablePos;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.system.ITarget;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -90,14 +91,18 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
             // assume user did not edit title manually
             TargetEnvironment env = getTargetEnvironment();
             SPTarget tp = env.getBase();
-            if (tp != null) { // base pos should always be defined, so tp should never be null
-                String name = tp.getTarget().getName();
-                if (name == null || name.length() == 0) {
-                    // Use the base position
-                    return tp.getTarget().getPosition();
+            if (tp != null) {
+                ITarget t = tp.getTarget();
+                String name = t.getName();
+                if (name == null || name.trim().length() == 0) {
+                    name = "<Untitled>";
                 }
-                // Else return the name of the base position
-                return "Targets" + " (" + name + ")";
+                switch (t.getTag()) {
+                    case JPL_MINOR_BODY:   return "Comet: " + name;
+                    case MPC_MINOR_PLANET: return "Minor Planet: " + name;
+                    case NAMED:            return "Solar System Object: " + name;
+                    case SIDEREAL:         return "Sidereal: " + name;
+                }
             }
         }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
@@ -23,30 +23,7 @@ public final class ConicTarget extends NonSiderealTarget  {
         return _tag;
     }
 
-    /**
-     * Options for the system type.
-     */
-    public static final class SystemType extends TypeBase {
-        public static int _count = 0;
 
-        public static final SystemType JPL_MINOR_BODY =
-                new SystemType("JPL minor body");
-        public static final SystemType MPC_MINOR_PLANET =
-                new SystemType("MPC minor planet");
-
-        public static final SystemType[] TYPES = new SystemType[]{
-            JPL_MINOR_BODY,
-            MPC_MINOR_PLANET,
-        };
-
-        private SystemType(String name) {
-            super(_count++, name);
-        }
-    }
-
-    /**
-     * Default system type.
-     */
     private static final Tag DEFAULT_TAG = Tag.JPL_MINOR_BODY;
 
     private static final double DEFAULT_E = 0.0;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
@@ -289,12 +289,4 @@ public final class ConicTarget extends NonSiderealTarget  {
         _perihelion = newValue;
     }
 
-    /**
-     * Gets a short description of the position.
-     */
-    public String getPosition() {
-        // what should be returned here
-        return "Orbital Elements";
-    }
-
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
@@ -65,7 +65,7 @@ public final class ConicTarget extends NonSiderealTarget  {
     /**
      * Provides clone support.
      */
-    public Object clone() {
+    public ConicTarget clone() {
         ConicTarget result = (ConicTarget) super.clone();
 
         if (_anode != null) result._anode = (ANode) _anode.clone();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -135,34 +135,6 @@ public final class HmsDegTarget extends ITarget {
     }
 
     /**
-     * Gets the first coordinate (right ascension) as a String.
-     */
-    public String raToString() {
-        return _ra.toString();
-    }
-
-    /**
-     * Gets the first coordinate (right ascension) as a String.
-     */
-    public String getRaHms() {
-        return raToString();
-    }
-
-    /**
-     * Gets the second coordinate (declination) as a String.
-     */
-    public String decToString() {
-        return _dec.toString();
-    }
-
-    /**
-     * Gets the second coordinate (right ascension) as a String.
-     */
-    public String getDecDms() {
-        return decToString();
-    }
-
-    /**
      * General method to return the first coordinate (right ascension).
      * This returns a reference to the actual object an {@link HMS HMS}
      * object so take care!
@@ -227,59 +199,6 @@ public final class HmsDegTarget extends ITarget {
             throw new IllegalArgumentException();
         }
         _dec = (DMS) dec;
-    }
-
-    /**
-     * General method to set the first and second coordinates together.
-     */
-    public void setC1C2(ICoordinate c1, ICoordinate c2)
-            throws IllegalArgumentException {
-        setRa(c1);
-        setDec(c2);
-    }
-
-    /**
-     * Sets the first coordinate (right ascension) using a String.
-     */
-    void setRa(String newStringValue) {
-        _ra.setValue(newStringValue);
-    }
-
-    /**
-     * Sets the first coordinate (right ascension) using a String.
-     */
-    public void setRaHms(String hms) {
-        setRa(hms);
-    }
-
-    /**
-     * Sets the second coordinate (declination) using a String.
-     */
-    void setDec(String newStringValue) {
-        _dec.setValue(newStringValue);
-    }
-
-    /**
-     * Sets the second coordinate (declination) using a String.
-     */
-    public void setDecDms(String dms) {
-        setDec(dms);
-    }
-
-    /**
-     * Sets the right ascension and declination using String objects.
-     */
-    public void setRaDec(String newRa, String newDec) {
-        setRa(newRa);
-        setDec(newDec);
-    }
-
-    /**
-     * Sets the first and second coordinates using String objects.
-     */
-    public void setC1C2(String c1, String c2) {
-        setRaHms(c1);
-        setDecDms(c2);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -92,7 +92,7 @@ public final class HmsDegTarget extends ITarget {
      * As expected, cloning an HmsDegTarget provides a copy of the
      * object with all new instances of the member objects.
      */
-    public Object clone() {
+    public HmsDegTarget clone() {
         HmsDegTarget result = (HmsDegTarget) super.clone();
         result._ra = (HMS) _ra.clone();
         result._dec = (DMS) _dec.clone();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -293,18 +293,4 @@ public final class HmsDegTarget extends ITarget {
         }
     }
 
-    /**
-     * Gets a short description of the position (its RA and Dec, epoch).
-     */
-    public String getPosition() {
-        return (getName().isEmpty() ? "" : getName() + " ") + "RA: " + getRa() + " Dec: " + getDec() + " " + SYSTEM_NAME + " (" + TAG.tccName + ")";
-    }
-
-    /**
-     * Convenience method for printing out a position.
-     */
-    public String toString() {
-        return getPosition();
-    }
-
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -57,8 +57,8 @@ public final class HmsDegTarget extends ITarget {
     private RV _rv = DEFAULT_RV;
     private Parallax _parallax = DEFAULT_PARALLAX;
     private Date _taiz = DEFAULT_TAIZ;
-    private HMS _ra = new HMS();
-    private DMS _dec = new DMS();
+    private final HMS _ra = new HMS();
+    private final DMS _dec = new DMS();
 
     /**
      * The base name of this coordinate system.
@@ -73,8 +73,8 @@ public final class HmsDegTarget extends ITarget {
         target.setName(obj.getName());
         target.setMagnitudes(obj.getMagnitudes());
         target.setEpoch(new Epoch(e.getYear()));
-        target.setRa(new HMS(coords.getRa().toDegrees().getMagnitude()));
-        target.setDec(new DMS(coords.getDec().toDegrees().getMagnitude()));
+        target.getRa().setAs(coords.getRa().toDegrees().getMagnitude(), Units.DEGREES);
+        target.getDec().setAs(coords.getDec().toDegrees().getMagnitude(), Units.DEGREES);
 
         // Proper Motion
         final Units mas = Units.MILLI_ARCSECS_PER_YEAR;
@@ -93,8 +93,8 @@ public final class HmsDegTarget extends ITarget {
      */
     public HmsDegTarget clone() {
         HmsDegTarget result = (HmsDegTarget) super.clone();
-        result._ra = (HMS) _ra.clone();
-        result._dec = (DMS) _dec.clone();
+        result._ra.setValue(_ra.getValue());
+        result._dec.setValue(_dec.getValue());
         if (_epoch != null) result._epoch = (Epoch) _epoch.clone();
         if (_pm1 != null) result._pm1 = (PM1) _pm1.clone();
         if (_pm2 != null) result._pm2 = (PM2) _pm2.clone();
@@ -151,53 +151,6 @@ public final class HmsDegTarget extends ITarget {
     public ICoordinate getDec() {
         // Dec exists at instance creation.
         return _dec;
-    }
-
-    /**
-     * Sets the right ascension coordinate using an object implementing
-     * the {@link ICoordinate ICoordinate} interface (an HMS object).
-     * The input object is not cloned.  Therefore, the caller can
-     * alter the contents if he is not careful.
-     * <p>
-     * If newValue is null, the method returns without changing the
-     * internal value.  This ensures that the object always has a
-     * valid <code>ICoordinate</code>(HMS) object.
-     * <p>
-     * This method throws IllegalArgumentException if the ICoordinate is
-     * not an instance of {@link HMS HMS}.
-     */
-    public void setRa(ICoordinate ra)
-            throws IllegalArgumentException {
-        if (ra == null) {
-            ra = new HMS();
-        }
-        if (!(ra instanceof HMS)) {
-            throw new IllegalArgumentException();
-        }
-        _ra = (HMS) ra;
-    }
-
-    /**
-     * Sets the right ascension coordinate using an object implementing
-     * the {@link ICoordinate ICoordinate} interface (an DMS object).
-     * The input object is not cloned.  Therefore, the caller can
-     * alter the contents if not careful.
-     * <p>
-     * If newValue is null, the method returns without changing the
-     * internal value.  This ensures the object always has a valid
-     * <code>ICoordinate</code>(DMS) object.
-     * <p>
-     * This method throws IllegalArgumentException if the ICoordinate is
-     * not an instance of {@link HMS HMS}.
-     */
-    public void setDec(ICoordinate dec) {
-        if (dec == null) {
-            dec = new DMS();
-        }
-        if (!(dec instanceof DMS)) {
-            throw new IllegalArgumentException();
-        }
-        _dec = (DMS) dec;
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -48,7 +48,6 @@ public final class HmsDegTarget extends ITarget {
     private static final Date DEFAULT_TAIZ = null;
     private static final String DEFAULT_NAME = "";
 
-    private String _brightness = DEFAULT_NAME;
     private String _name = DEFAULT_NAME;
     private Epoch _epoch = _createDefaultEpoch();
     private PM1 _pm1 = DEFAULT_PM1;
@@ -320,24 +319,6 @@ public final class HmsDegTarget extends ITarget {
      */
     public void setParallax(Parallax newValue) {
         _parallax = newValue;
-    }
-
-    /**
-     * Gets the optional brightness for a coordinate.
-     * This returns a String description of the brightness.
-     */
-    public String getBrightness() {
-        return _brightness;
-    }
-
-    /**
-     * Sets the optional brightness for the position.
-     */
-    public void setBrightness(String brightness) {
-        // Make sure the name is never set to null
-        if (brightness != null) {
-            _brightness = brightness;
-        }
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -144,7 +144,7 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Gets the first coordinate (right ascension) as a String.
      */
-    public String getRaHMS() {
+    public String getRaHms() {
         return raToString();
     }
 
@@ -158,7 +158,7 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Gets the second coordinate (right ascension) as a String.
      */
-    public String getDecDMS() {
+    public String getDecDms() {
         return decToString();
     }
 
@@ -248,7 +248,7 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Sets the first coordinate (right ascension) using a String.
      */
-    public void setRaHMS(String hms) {
+    public void setRaHms(String hms) {
         setRa(hms);
     }
 
@@ -262,8 +262,8 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Sets the second coordinate (declination) using a String.
      */
-    public void setDecDMS(String dec) {
-        setDec(dec);
+    public void setDecDms(String dms) {
+        setDec(dms);
     }
 
     /**
@@ -278,8 +278,8 @@ public final class HmsDegTarget extends ITarget {
      * Sets the first and second coordinates using String objects.
      */
     public void setC1C2(String c1, String c2) {
-        setRaHMS(c1);
-        setDecDMS(c2);
+        setRaHms(c1);
+        setDecDms(c2);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -74,8 +74,8 @@ public final class HmsDegTarget extends ITarget {
         target.setName(obj.getName());
         target.setMagnitudes(obj.getMagnitudes());
         target.setEpoch(new Epoch(e.getYear()));
-        target.setC1(new HMS(coords.getRa().toDegrees().getMagnitude()));
-        target.setC2(new DMS(coords.getDec().toDegrees().getMagnitude()));
+        target.setRa(new HMS(coords.getRa().toDegrees().getMagnitude()));
+        target.setDec(new DMS(coords.getDec().toDegrees().getMagnitude()));
 
         // Proper Motion
         final Units mas = Units.MILLI_ARCSECS_PER_YEAR;
@@ -144,7 +144,7 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Gets the first coordinate (right ascension) as a String.
      */
-    public String c1ToString() {
+    public String getRaHMS() {
         return raToString();
     }
 
@@ -158,7 +158,7 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Gets the second coordinate (right ascension) as a String.
      */
-    public String c2ToString() {
+    public String getDecDMS() {
         return decToString();
     }
 
@@ -167,7 +167,7 @@ public final class HmsDegTarget extends ITarget {
      * This returns a reference to the actual object an {@link HMS HMS}
      * object so take care!
      */
-    public ICoordinate getC1() {
+    public ICoordinate getRa() {
         // Ra exists at instance creation.
         return _ra;
     }
@@ -177,7 +177,7 @@ public final class HmsDegTarget extends ITarget {
      * This returns a reference to the actual object an {@link DMS DMS}
      * object so take care!
      */
-    public ICoordinate getC2() {
+    public ICoordinate getDec() {
         // Dec exists at instance creation.
         return _dec;
     }
@@ -195,15 +195,15 @@ public final class HmsDegTarget extends ITarget {
      * This method throws IllegalArgumentException if the ICoordinate is
      * not an instance of {@link HMS HMS}.
      */
-    public void setC1(ICoordinate newValue)
+    public void setRa(ICoordinate ra)
             throws IllegalArgumentException {
-        if (newValue == null) {
-            newValue = new HMS();
+        if (ra == null) {
+            ra = new HMS();
         }
-        if (!(newValue instanceof HMS)) {
+        if (!(ra instanceof HMS)) {
             throw new IllegalArgumentException();
         }
-        _ra = (HMS) newValue;
+        _ra = (HMS) ra;
     }
 
     /**
@@ -219,14 +219,14 @@ public final class HmsDegTarget extends ITarget {
      * This method throws IllegalArgumentException if the ICoordinate is
      * not an instance of {@link HMS HMS}.
      */
-    public void setC2(ICoordinate newValue) {
-        if (newValue == null) {
-            newValue = new DMS();
+    public void setDec(ICoordinate dec) {
+        if (dec == null) {
+            dec = new DMS();
         }
-        if (!(newValue instanceof DMS)) {
+        if (!(dec instanceof DMS)) {
             throw new IllegalArgumentException();
         }
-        _dec = (DMS) newValue;
+        _dec = (DMS) dec;
     }
 
     /**
@@ -234,8 +234,8 @@ public final class HmsDegTarget extends ITarget {
      */
     public void setC1C2(ICoordinate c1, ICoordinate c2)
             throws IllegalArgumentException {
-        setC1(c1);
-        setC2(c2);
+        setRa(c1);
+        setDec(c2);
     }
 
     /**
@@ -248,8 +248,8 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Sets the first coordinate (right ascension) using a String.
      */
-    public void setC1(String c1) {
-        setRa(c1);
+    public void setRaHMS(String hms) {
+        setRa(hms);
     }
 
     /**
@@ -262,8 +262,8 @@ public final class HmsDegTarget extends ITarget {
     /**
      * Sets the second coordinate (declination) using a String.
      */
-    public void setC2(String c2) {
-        setDec(c2);
+    public void setDecDMS(String dec) {
+        setDec(dec);
     }
 
     /**
@@ -278,8 +278,8 @@ public final class HmsDegTarget extends ITarget {
      * Sets the first and second coordinates using String objects.
      */
     public void setC1C2(String c1, String c2) {
-        setC1(c1);
-        setC2(c2);
+        setRaHMS(c1);
+        setDecDMS(c2);
     }
 
     /**
@@ -444,7 +444,7 @@ public final class HmsDegTarget extends ITarget {
      * Gets a short description of the position (its RA and Dec, epoch).
      */
     public String getPosition() {
-        return (getName().isEmpty() ? "" : getName() + " ") + "RA: " + getC1() + " Dec: " + getC2() + " " + SYSTEM_NAME + " (" + TAG.tccName + ")";
+        return (getName().isEmpty() ? "" : getName() + " ") + "RA: " + getRa() + " Dec: " + getDec() + " " + SYSTEM_NAME + " (" + TAG.tccName + ")";
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -79,61 +79,29 @@ public abstract class ITarget implements Cloneable, Serializable {
      */
     public abstract String getPosition();
 
-    /**
-     * Set the first Coordinate using an appropriate ICoordinate.
-     *
-     * @throws IllegalArgumentException if the <code>ICoordinate</code> is
-     * not an appropriate type.
-     */
-    public abstract void setC1(ICoordinate c1);
+    /** Set the RA. */
+    public abstract void setRa(ICoordinate ra);
 
-    /**
-     * Get the first Coordinate as an {@link ICoordinate}.
-     * This is generally, the internally used <code>ICoordinate</code> and
-     * should be used with care.
-     */
-    public abstract ICoordinate getC1();
+    /** Get the RA. */
+    public abstract ICoordinate getRa();
 
-    /**
-     * Set the second Coordinate using an appropriate {@link ICoordinate}.
-     *
-     * @throws IllegalArgumentException if the <code>ICoordinate</code> is
-     * not an appropriate type.
-     */
-    public abstract void setC2(ICoordinate c2);
+    /** Set the Dec. */
+    public abstract void setDec(ICoordinate dec);
 
-    /**
-     * Get the second Coordinate as an {@link ICoordinate}.
-     * This is generally, the internally used <code>ICoordinate</code>
-     * and should be used with care.
-     */
-    public abstract ICoordinate getC2();
+    /** Get the Dec. */
+    public abstract ICoordinate getDec();
 
-    /**
-     * Set the first Coordinate using a String.
-     *
-     * @throws IllegalArgumentException if the argument can not be parsed
-     * correctly.
-     */
-    public abstract void setC1(String c1);
+    /** Set the RA in HMS format. */
+    public abstract void setRaHMS(String hms);
 
-    /**
-     * Gets the first coordinate as a String.
-     */
-    public abstract String c1ToString();
+    /** Get the RA in HMS format. */
+    public abstract String getRaHMS();
 
-    /**
-     * Set the second Coordinate using a String.
-     *
-     * @throws IllegalArgumentException if the argument can not be parsed
-     * correctly.
-     */
-    public abstract void setC2(String c2);
+    /** Set the Dec in DMS format. */
+    public abstract void setDecDMS(String dec);
 
-    /**
-     * Gets the second coordinate as a String.
-     */
-    public abstract String c2ToString();
+    /** Get the Dec in DMS format. */
+    public abstract String getDecDMS();
 
     /**
      * Return the Epoch of this target position.
@@ -264,7 +232,7 @@ public abstract class ITarget implements Cloneable, Serializable {
 
     /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
     public synchronized Coordinates getSkycalcCoordinates() {
-        return new Coordinates(getC1().getAs(CoordinateParam.Units.DEGREES), getC2().getAs(CoordinateParam.Units.DEGREES));
+        return new Coordinates(getRa().getAs(CoordinateParam.Units.DEGREES), getDec().getAs(CoordinateParam.Units.DEGREES));
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -60,24 +60,11 @@ public abstract class ITarget implements Cloneable, Serializable {
     }
 
 
-    /**
-     * Returns an optional name for the target.
-     */
+    /** Get the name. */
     public abstract String getName();
 
-    /**
-     * Sets an optional name for the target.
-     */
+    /** Set the name. */
     public abstract void setName(String name);
-
-    /**
-     * Gets a short description of the position.  For instance, the
-     * {@link HmsDegTarget} might return its RA and Dec in a
-     * formated String such as "RA=12:34:56 Dec=00:11:22".  To actually
-     * use a coordinate system's position, the client will have to use its
-     * particular interface rather than this method.
-     */
-    public abstract String getPosition();
 
     /** Get the RA. */
     public abstract ICoordinate getRa();
@@ -85,18 +72,10 @@ public abstract class ITarget implements Cloneable, Serializable {
     /** Get the Dec. */
     public abstract ICoordinate getDec();
 
-    /**
-     * Return the Epoch of this target position.
-     * @throws IllegalArgumentException if the coordinate system does not
-     * support the Epoch concept.
-     */
+    /** Get the Epoch */
     public abstract Epoch getEpoch();
 
-    /**
-     * Set the Epoch of this target position.
-     * @throws IllegalArgumentException if the coordinate system does not
-     * support the Epoch concept.
-     */
+    /** Set the Epoch */
     public abstract void setEpoch(Epoch e);
 
 
@@ -210,6 +189,10 @@ public abstract class ITarget implements Cloneable, Serializable {
     /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
     public synchronized Coordinates getSkycalcCoordinates() {
         return new Coordinates(getRa().getAs(CoordinateParam.Units.DEGREES), getDec().getAs(CoordinateParam.Units.DEGREES));
+    }
+
+    public final String toString() {
+        return String.format("ITarget(%s, %s)", getTag(), getName());
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -79,14 +79,8 @@ public abstract class ITarget implements Cloneable, Serializable {
      */
     public abstract String getPosition();
 
-    /** Set the RA. */
-    public abstract void setRa(ICoordinate ra);
-
     /** Get the RA. */
     public abstract ICoordinate getRa();
-
-    /** Set the Dec. */
-    public abstract void setDec(ICoordinate dec);
 
     /** Get the Dec. */
     public abstract ICoordinate getDec();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -85,8 +85,7 @@ public abstract class ITarget implements Cloneable, Serializable {
      * @throws IllegalArgumentException if the <code>ICoordinate</code> is
      * not an appropriate type.
      */
-    public abstract void setC1(ICoordinate c1)
-            throws IllegalArgumentException;
+    public abstract void setC1(ICoordinate c1);
 
     /**
      * Get the first Coordinate as an {@link ICoordinate}.
@@ -101,8 +100,7 @@ public abstract class ITarget implements Cloneable, Serializable {
      * @throws IllegalArgumentException if the <code>ICoordinate</code> is
      * not an appropriate type.
      */
-    public abstract void setC2(ICoordinate c2)
-            throws IllegalArgumentException;
+    public abstract void setC2(ICoordinate c2);
 
     /**
      * Get the second Coordinate as an {@link ICoordinate}.
@@ -117,8 +115,7 @@ public abstract class ITarget implements Cloneable, Serializable {
      * @throws IllegalArgumentException if the argument can not be parsed
      * correctly.
      */
-    public abstract void setC1(String c1)
-            throws IllegalArgumentException;
+    public abstract void setC1(String c1);
 
     /**
      * Gets the first coordinate as a String.
@@ -131,8 +128,7 @@ public abstract class ITarget implements Cloneable, Serializable {
      * @throws IllegalArgumentException if the argument can not be parsed
      * correctly.
      */
-    public abstract void setC2(String c2)
-            throws IllegalArgumentException;
+    public abstract void setC2(String c2);
 
     /**
      * Gets the second coordinate as a String.
@@ -140,29 +136,18 @@ public abstract class ITarget implements Cloneable, Serializable {
     public abstract String c2ToString();
 
     /**
-     * Set the first and second coordinates using appropriate String objects.
-     *
-     * @throws IllegalArgumentException if either of the arguments can not
-     * be parsed correctly.
-     */
-    public abstract void setC1C2(String c1, String c2)
-            throws IllegalArgumentException;
-
-    /**
      * Return the Epoch of this target position.
      * @throws IllegalArgumentException if the coordinate system does not
      * support the Epoch concept.
      */
-    public abstract Epoch getEpoch()
-            throws IllegalArgumentException;
+    public abstract Epoch getEpoch();
 
     /**
      * Set the Epoch of this target position.
      * @throws IllegalArgumentException if the coordinate system does not
      * support the Epoch concept.
      */
-    public abstract void setEpoch(Epoch e)
-            throws IllegalArgumentException;
+    public abstract void setEpoch(Epoch e);
 
     /**
      * Provides testing of equality of two targets.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -91,18 +91,6 @@ public abstract class ITarget implements Cloneable, Serializable {
     /** Get the Dec. */
     public abstract ICoordinate getDec();
 
-    /** Set the RA in HMS format. */
-    public abstract void setRaHms(String hms);
-
-    /** Get the RA in HMS format. */
-    public abstract String getRaHms();
-
-    /** Set the Dec in DMS format. */
-    public abstract void setDecDms(String dms);
-
-    /** Get the Dec in DMS format. */
-    public abstract String getDecDms();
-
     /**
      * Return the Epoch of this target position.
      * @throws IllegalArgumentException if the coordinate system does not

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -92,16 +92,16 @@ public abstract class ITarget implements Cloneable, Serializable {
     public abstract ICoordinate getDec();
 
     /** Set the RA in HMS format. */
-    public abstract void setRaHMS(String hms);
+    public abstract void setRaHms(String hms);
 
     /** Get the RA in HMS format. */
-    public abstract String getRaHMS();
+    public abstract String getRaHms();
 
     /** Set the Dec in DMS format. */
-    public abstract void setDecDMS(String dec);
+    public abstract void setDecDms(String dms);
 
     /** Get the Dec in DMS format. */
-    public abstract String getDecDMS();
+    public abstract String getDecDms();
 
     /**
      * Return the Epoch of this target position.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -117,11 +117,6 @@ public abstract class ITarget implements Cloneable, Serializable {
      */
     public abstract void setEpoch(Epoch e);
 
-    /**
-     * Provides testing of equality of two targets.
-     */
-    public abstract boolean equals(Object obj);
-
 
     // RCN: pushed across from SPTarget
 
@@ -220,9 +215,9 @@ public abstract class ITarget implements Cloneable, Serializable {
 
     // pushed down from CoordinateSystem
 
-    public Object clone() {
+    public ITarget clone() {
         try {
-            return super.clone();
+            return (ITarget) super.clone();
         } catch (CloneNotSupportedException cnse) {
             throw new Error(cnse);
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
@@ -95,11 +95,4 @@ public final class NamedTarget extends NonSiderealTarget {
         _solarObject = solarObject;
     }
 
-    /**
-     * Gets a short description of the position.
-     */
-    public String getPosition() {
-        return (_solarObject != null) ?  _solarObject.getDisplayValue() : "Named Target";
-    }
-
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
@@ -6,7 +6,7 @@ package edu.gemini.spModel.target.system;
  */
 public final class NamedTarget extends NonSiderealTarget {
 
-    public static Tag TAG = Tag.NAMED;
+    public static final Tag TAG = Tag.NAMED;
 
     public Tag getTag() {
         return TAG;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
@@ -84,7 +84,7 @@ public abstract class NonSiderealTarget extends ITarget {
     /**
      * Sets the first coordinate (right ascension) using a String.
      */
-    public void setRaHMS(String hms) {
+    public void setRaHms(String hms) {
         setRa(hms);
     }
 
@@ -105,7 +105,7 @@ public abstract class NonSiderealTarget extends ITarget {
     /**
      * Gets the first coordinate (right ascension) as a String.
      */
-    public String getRaHMS() {
+    public String getRaHms() {
         return raToString();
     }
 
@@ -135,8 +135,8 @@ public abstract class NonSiderealTarget extends ITarget {
     /**
      * Sets the second coordinate (declination) using a String.
      */
-    public void setDecDMS(String dec) {
-        setDec(dec);
+    public void setDecDms(String dms) {
+        setDec(dms);
     }
 
     /**
@@ -156,7 +156,7 @@ public abstract class NonSiderealTarget extends ITarget {
     /**
      * Gets the second coordinate (right ascension) as a String.
      */
-    public String getDecDMS() {
+    public String getDecDms() {
         return decToString();
     }
 
@@ -174,8 +174,8 @@ public abstract class NonSiderealTarget extends ITarget {
      * Sets the first and second coordinates using String objects.
      */
     public void setC1C2(String c1, String c2) {
-        setRaHMS(c1);
-        setDecDMS(c2);
+        setRaHms(c1);
+        setDecDms(c2);
     }
 
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
@@ -70,28 +70,28 @@ public abstract class NonSiderealTarget extends ITarget {
      * This method throws IllegalArgumentException if the ICoordinate is
      * not an instance of {@link HMS HMS}.
      */
-    public void setC1(ICoordinate newValue)
+    public void setRa(ICoordinate ra)
             throws IllegalArgumentException {
-        if (newValue == null) {
-            newValue = new HMS();
+        if (ra == null) {
+            ra = new HMS();
         }
-        if (!(newValue instanceof HMS)) {
+        if (!(ra instanceof HMS)) {
             throw new IllegalArgumentException();
         }
-        _ra = (HMS) newValue;
+        _ra = (HMS) ra;
     }
 
     /**
      * Sets the first coordinate (right ascension) using a String.
      */
-    public void setC1(String c1) {
-        setRa(c1);
+    public void setRaHMS(String hms) {
+        setRa(hms);
     }
 
     /**
      * Get the first Coordinate as an ICoordinate.
      */
-    public ICoordinate getC1() {
+    public ICoordinate getRa() {
         return _ra;
     }
 
@@ -105,7 +105,7 @@ public abstract class NonSiderealTarget extends ITarget {
     /**
      * Gets the first coordinate (right ascension) as a String.
      */
-    public String c1ToString() {
+    public String getRaHMS() {
         return raToString();
     }
 
@@ -122,27 +122,27 @@ public abstract class NonSiderealTarget extends ITarget {
      * This method throws IllegalArgumentException if the ICoordinate is
      * not an instance of {@link HMS HMS}.
      */
-    public void setC2(ICoordinate newValue) {
-        if (newValue == null) {
-            newValue = new DMS();
+    public void setDec(ICoordinate dec) {
+        if (dec == null) {
+            dec = new DMS();
         }
-        if (!(newValue instanceof DMS)) {
+        if (!(dec instanceof DMS)) {
             throw new IllegalArgumentException();
         }
-        _dec = (DMS) newValue;
+        _dec = (DMS) dec;
     }
 
     /**
      * Sets the second coordinate (declination) using a String.
      */
-    public void setC2(String c2) {
-        setDec(c2);
+    public void setDecDMS(String dec) {
+        setDec(dec);
     }
 
     /**
      * Get the second Coordinate as an ICoordinate.
      */
-    public ICoordinate getC2() {
+    public ICoordinate getDec() {
         return _dec;
     }
 
@@ -156,7 +156,7 @@ public abstract class NonSiderealTarget extends ITarget {
     /**
      * Gets the second coordinate (right ascension) as a String.
      */
-    public String c2ToString() {
+    public String getDecDMS() {
         return decToString();
     }
 
@@ -166,16 +166,16 @@ public abstract class NonSiderealTarget extends ITarget {
      */
     public void setC1C2(ICoordinate c1, ICoordinate c2)
             throws IllegalArgumentException {
-        setC1(c1);
-        setC2(c2);
+        setRa(c1);
+        setDec(c2);
     }
 
     /**
      * Sets the first and second coordinates using String objects.
      */
     public void setC1C2(String c1, String c2) {
-        setC1(c1);
-        setC2(c2);
+        setRaHMS(c1);
+        setDecDMS(c2);
     }
 
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
@@ -14,7 +14,6 @@ public abstract class NonSiderealTarget extends ITarget {
     private HMS _ra = new HMS();
     private DMS _dec = new DMS();
     private CoordinateTypes.Epoch _epoch = new CoordinateTypes.Epoch("2000", CoordinateParam.Units.YEARS);
-    private String _brightness = DEFAULT_NAME;
     private String _name = DEFAULT_NAME;
     private Date _date = null; // The date for which the position is valid
 
@@ -43,25 +42,7 @@ public abstract class NonSiderealTarget extends ITarget {
         }
     }
 
-    /**
-     * Gets the optional brightness for a coordinate.
-     * This returns a String description of the brightness.
-     */
-    public String getBrightness() {
-        return _brightness;
-    }
-
-    /**
-     * Sets the optional brightness for the position.
-     */
-    public void setBrightness(String brightness) {
-        // Make sure the name is never set to null
-        if (brightness != null) {
-            _brightness = brightness;
-        }
-    }
-
-    /**
+     /**
      * Sets the first coordinate (right ascension) using a String.
      */
     void setRa(String newStringValue) {
@@ -238,7 +219,7 @@ public abstract class NonSiderealTarget extends ITarget {
      * CoordinateParam}</code> implements hashCode.
      */
     public int hashCode() {
-        long hc = _name.hashCode() ^ _epoch.hashCode() ^ _brightness.hashCode();
+        long hc = _name.hashCode() ^ _epoch.hashCode();
         if (_date != null) hc = hc ^ _date.hashCode();
         return (int) hc ^ (int) (hc >> 32);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
@@ -42,20 +42,6 @@ public abstract class NonSiderealTarget extends ITarget {
         }
     }
 
-     /**
-     * Sets the first coordinate (right ascension) using a String.
-     */
-    void setRa(String newStringValue) {
-        _ra.setValue(newStringValue);
-    }
-
-    /**
-     * Sets the second coordinate (declination) using a String.
-     */
-    void setDec(String newStringValue) {
-        _dec.setValue(newStringValue);
-    }
-
 
     /**
      * Sets the right ascension coordinate using an object implementing
@@ -70,8 +56,7 @@ public abstract class NonSiderealTarget extends ITarget {
      * This method throws IllegalArgumentException if the ICoordinate is
      * not an instance of {@link HMS HMS}.
      */
-    public void setRa(ICoordinate ra)
-            throws IllegalArgumentException {
+    public void setRa(ICoordinate ra) {
         if (ra == null) {
             ra = new HMS();
         }
@@ -82,31 +67,10 @@ public abstract class NonSiderealTarget extends ITarget {
     }
 
     /**
-     * Sets the first coordinate (right ascension) using a String.
-     */
-    public void setRaHms(String hms) {
-        setRa(hms);
-    }
-
-    /**
      * Get the first Coordinate as an ICoordinate.
      */
     public ICoordinate getRa() {
         return _ra;
-    }
-
-    /**
-     * Gets the first coordinate (right ascension) as a String.
-     */
-    String raToString() {
-        return _ra.toString();
-    }
-
-    /**
-     * Gets the first coordinate (right ascension) as a String.
-     */
-    public String getRaHms() {
-        return raToString();
     }
 
     /**
@@ -133,51 +97,11 @@ public abstract class NonSiderealTarget extends ITarget {
     }
 
     /**
-     * Sets the second coordinate (declination) using a String.
-     */
-    public void setDecDms(String dms) {
-        setDec(dms);
-    }
-
-    /**
      * Get the second Coordinate as an ICoordinate.
      */
     public ICoordinate getDec() {
         return _dec;
     }
-
-    /**
-     * Gets the second coordinate (declination) as a String.
-     */
-    String decToString() {
-        return _dec.toString();
-    }
-
-    /**
-     * Gets the second coordinate (right ascension) as a String.
-     */
-    public String getDecDms() {
-        return decToString();
-    }
-
-    /**
-     * Set the first and second coordinates using appropriate
-     * <code>ICoordinate</code>.
-     */
-    public void setC1C2(ICoordinate c1, ICoordinate c2)
-            throws IllegalArgumentException {
-        setRa(c1);
-        setDec(c2);
-    }
-
-    /**
-     * Sets the first and second coordinates using String objects.
-     */
-    public void setC1C2(String c1, String c2) {
-        setRaHms(c1);
-        setDecDms(c2);
-    }
-
 
     /**
      * Gets the epoch of this object.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
@@ -248,7 +248,7 @@ public abstract class NonSiderealTarget extends ITarget {
     }
 
 
-    public Object clone() {
+    public NonSiderealTarget clone() {
         NonSiderealTarget result = (NonSiderealTarget) super.clone();
         if (_epoch != null) result._epoch = (CoordinateTypes.Epoch) _epoch.clone();
         if (_date != null) result._date = (Date) _date.clone();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
@@ -11,8 +11,8 @@ public abstract class NonSiderealTarget extends ITarget {
     private static final String DEFAULT_NAME = "";
 
     // XXX temporary, until there is conversion code
-    private HMS _ra = new HMS();
-    private DMS _dec = new DMS();
+    private final HMS _ra = new HMS();
+    private final DMS _dec = new DMS();
     private CoordinateTypes.Epoch _epoch = new CoordinateTypes.Epoch("2000", CoordinateParam.Units.YEARS);
     private String _name = DEFAULT_NAME;
     private Date _date = null; // The date for which the position is valid
@@ -42,58 +42,11 @@ public abstract class NonSiderealTarget extends ITarget {
         }
     }
 
-
-    /**
-     * Sets the right ascension coordinate using an object implementing
-     * the {@link ICoordinate ICoordinate} interface (an HMS object).
-     * The input object is not cloned.  Therefore, the caller can
-     * alter the contents if he is not careful.
-     * <p/>
-     * If newValue is null, the method returns without changing the
-     * internal value.  This ensures that the object always has a
-     * valid <code>ICoordinate</code>(HMS) object.
-     * <p/>
-     * This method throws IllegalArgumentException if the ICoordinate is
-     * not an instance of {@link HMS HMS}.
-     */
-    public void setRa(ICoordinate ra) {
-        if (ra == null) {
-            ra = new HMS();
-        }
-        if (!(ra instanceof HMS)) {
-            throw new IllegalArgumentException();
-        }
-        _ra = (HMS) ra;
-    }
-
     /**
      * Get the first Coordinate as an ICoordinate.
      */
     public ICoordinate getRa() {
         return _ra;
-    }
-
-    /**
-     * Sets the right ascension coordinate using an object implementing
-     * the {@link ICoordinate ICoordinate} interface (an DMS object).
-     * The input object is not cloned.  Therefore, the caller can
-     * alter the contents if not careful.
-     * <p/>
-     * If newValue is null, the method returns without changing the
-     * internal value.  This ensures the object always has a valid
-     * <code>ICoordinate</code>(DMS) object.
-     * <p/>
-     * This method throws IllegalArgumentException if the ICoordinate is
-     * not an instance of {@link HMS HMS}.
-     */
-    public void setDec(ICoordinate dec) {
-        if (dec == null) {
-            dec = new DMS();
-        }
-        if (!(dec instanceof DMS)) {
-            throw new IllegalArgumentException();
-        }
-        _dec = (DMS) dec;
     }
 
     /**
@@ -176,12 +129,8 @@ public abstract class NonSiderealTarget extends ITarget {
         NonSiderealTarget result = (NonSiderealTarget) super.clone();
         if (_epoch != null) result._epoch = (CoordinateTypes.Epoch) _epoch.clone();
         if (_date != null) result._date = (Date) _date.clone();
-        if (_ra != null) {
-            result._ra = (HMS) _ra.clone();
-        }
-        if (_dec != null) {
-            result._dec = (DMS) _dec.clone();
-        }
+        result._ra.setValue(_ra.getValue());
+        result._dec.setValue(_dec.getValue());
         result._hObjId = _hObjId; // immutable, so don't need to clone
         result._hObjTypeOrd = _hObjTypeOrd;
         return result;

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -64,8 +64,8 @@ public final class SPTargetSkyObjectTest {
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
             assertEquals("xyz", target.getTarget().getName());
-            assertEquals(15.0, target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES), 0.000001);
-            assertEquals(20.0, target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES), 0.000001);
+            assertEquals(15.0, target.getTarget().getRa().getAs(CoordinateParam.Units.DEGREES), 0.000001);
+            assertEquals(20.0, target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES), 0.000001);
             assertEquals(1.0, hmsDeg.getPM1().getValue(), 0.000001);
             assertEquals(2.0, hmsDeg.getPM2().getValue(), 0.000001);
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
@@ -110,8 +110,8 @@ final class Fixture {
             // the coordinates and get enough of an idea that they are the
             // same for the purposes of testing GuideProbeTargets.
 
-            assertEquals(t1.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES), t2.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES), 0.000001);
-            assertEquals(t1.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES), t2.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES), 0.000001);
+            assertEquals(t1.getTarget().getRa().getAs(CoordinateParam.Units.DEGREES), t2.getTarget().getRa().getAs(CoordinateParam.Units.DEGREES), 0.000001);
+            assertEquals(t1.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES), t2.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES), 0.000001);
         }
     }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
@@ -38,18 +38,19 @@ public final class HmsDegTargetCase {
 
         ICoordinate ra = new HMS("10:11:12.345");
         ICoordinate dec = new DMS("-20:30:40.567");
-        t1.setC1C2(ra, dec);
+        t1.setRa(ra);
+        t1.setDec(dec);
 
-        assertEquals(t1.raToString(), "10:11:12.345");
-        assertEquals(t1.decToString(), "-20:30:40.57");
+        assertEquals(t1.getRa().toString(), "10:11:12.345");
+        assertEquals(t1.getDec().toString(), "-20:30:40.57");
     }
 
     private void _doTestOne(String raIn, String decIn,
                             String raEx, String decEx) {
-        _t1.setRaHms(raIn);
-        _t1.setDecDms(decIn);
-        String raOut = _t1.getRaHms();
-        String decOut = _t1.getDecDms();
+        _t1.getRa().setValue(raIn);
+        _t1.getDec().setValue(decIn);
+        String raOut = _t1.getRa().toString();
+        String decOut = _t1.getDec().toString();
 
         assertEquals("Failed comparison,", raEx, raOut);
         assertEquals("Failed comparison,", decEx, decOut);
@@ -65,7 +66,8 @@ public final class HmsDegTargetCase {
     @Test
     public void testSerialization() throws Exception {
         final HmsDegTarget outObject = new HmsDegTarget();
-        outObject.setRaDec("10:11:12.34", "-11:12:13.4");
+        outObject.getRa().setValue("10:11:12.34");
+        outObject.getDec().setValue("-11:12:13.4");
         final HmsDegTarget inObject = ser(outObject);
         assertTrue(outObject.equals(inObject));
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
@@ -46,10 +46,10 @@ public final class HmsDegTargetCase {
 
     private void _doTestOne(String raIn, String decIn,
                             String raEx, String decEx) {
-        _t1.setRaHMS(raIn);
-        _t1.setDecDMS(decIn);
-        String raOut = _t1.getRaHMS();
-        String decOut = _t1.getDecDMS();
+        _t1.setRaHms(raIn);
+        _t1.setDecDms(decIn);
+        String raOut = _t1.getRaHms();
+        String decOut = _t1.getDecDms();
 
         assertEquals("Failed comparison,", raEx, raOut);
         assertEquals("Failed comparison,", decEx, decOut);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
@@ -6,7 +6,6 @@
  */
 package edu.gemini.spModel.target.system.test;
 
-import edu.gemini.spModel.target.system.CoordinateTypes.Epoch;
 import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.target.system.HmsDegTarget;
 import edu.gemini.spModel.target.system.HMS;
@@ -47,10 +46,10 @@ public final class HmsDegTargetCase {
 
     private void _doTestOne(String raIn, String decIn,
                             String raEx, String decEx) {
-        _t1.setC1(raIn);
-        _t1.setC2(decIn);
-        String raOut = _t1.c1ToString();
-        String decOut = _t1.c2ToString();
+        _t1.setRaHMS(raIn);
+        _t1.setDecDMS(decIn);
+        String raOut = _t1.getRaHMS();
+        String decOut = _t1.getDecDMS();
 
         assertEquals("Failed comparison,", raEx, raOut);
         assertEquals("Failed comparison,", decEx, decOut);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/HmsDegTargetCase.java
@@ -36,10 +36,8 @@ public final class HmsDegTargetCase {
         HmsDegTarget t1 = new HmsDegTarget();
         assertNotNull(t1);
 
-        ICoordinate ra = new HMS("10:11:12.345");
-        ICoordinate dec = new DMS("-20:30:40.567");
-        t1.setRa(ra);
-        t1.setDec(dec);
+        t1.getRa().setValue("10:11:12.345");
+        t1.getDec().setValue("-20:30:40.567");
 
         assertEquals(t1.getRa().toString(), "10:11:12.345");
         assertEquals(t1.getDec().toString(), "-20:30:40.57");

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
@@ -30,8 +30,8 @@ public final class NamedTargetCase {
         DMS c2 = new DMS("-20:30:40.567");
         t1.setC1C2(c1, c2);
 
-        assertEquals("16:11:12.345", t1.c1ToString());
-        assertEquals("-20:30:40.57", t1.c2ToString());
+        assertEquals("16:11:12.345", t1.getRaHMS());
+        assertEquals("-20:30:40.57", t1.getDecDMS());
 
         //Planet
         t1.setSolarObject(NamedTarget.SolarObject.NEPTUNE);
@@ -40,10 +40,10 @@ public final class NamedTargetCase {
 
     private void _doTestOne(String lIn, String bIn,
                             String lEx, String bEx) {
-        _t1.setC1(lIn);
-        _t1.setC2(bIn);
-        String lOut = _t1.c1ToString();
-        String bOut = _t1.c2ToString();
+        _t1.setRaHMS(lIn);
+        _t1.setDecDMS(bIn);
+        String lOut = _t1.getRaHMS();
+        String bOut = _t1.getDecDMS();
 
         assertEquals("Failed comparison,", lEx, lOut);
         assertEquals("Failed comparison,", bEx, bOut);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
@@ -28,10 +28,11 @@ public final class NamedTargetCase {
         // Alt/Az
         HMS c1 = new HMS("16:11:12.345");
         DMS c2 = new DMS("-20:30:40.567");
-        t1.setC1C2(c1, c2);
+        t1.setRa(c1);
+        t1.setDec(c2);
 
-        assertEquals("16:11:12.345", t1.getRaHms());
-        assertEquals("-20:30:40.57", t1.getDecDms());
+        assertEquals("16:11:12.345", t1.getRa().toString());
+        assertEquals("-20:30:40.57", t1.getDec().toString());
 
         //Planet
         t1.setSolarObject(NamedTarget.SolarObject.NEPTUNE);
@@ -40,10 +41,10 @@ public final class NamedTargetCase {
 
     private void _doTestOne(String lIn, String bIn,
                             String lEx, String bEx) {
-        _t1.setRaHms(lIn);
-        _t1.setDecDms(bIn);
-        String lOut = _t1.getRaHms();
-        String bOut = _t1.getDecDms();
+        _t1.getRa().setValue(lIn);
+        _t1.getDec().setValue(bIn);
+        String lOut = _t1.getRa().toString();
+        String bOut = _t1.getDec().toString();
 
         assertEquals("Failed comparison,", lEx, lOut);
         assertEquals("Failed comparison,", bEx, bOut);
@@ -59,7 +60,8 @@ public final class NamedTargetCase {
     @Test
     public void testSerialization() throws Exception {
         final NamedTarget outObject = new NamedTarget();
-        outObject.setC1C2("210:11:12.4", "-11:12:13.4");
+        outObject.getRa().setValue("210:11:12.4");
+        outObject.getDec().setValue("-11:12:13.4");
         outObject.setSolarObject(NamedTarget.SolarObject.URANUS);
         final NamedTarget inObject = ser(outObject);
         assertTrue(outObject.equals(inObject));

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
@@ -26,10 +26,8 @@ public final class NamedTargetCase {
         assertNotNull(t1);
 
         // Alt/Az
-        HMS c1 = new HMS("16:11:12.345");
-        DMS c2 = new DMS("-20:30:40.567");
-        t1.setRa(c1);
-        t1.setDec(c2);
+        t1.getRa().setValue("16:11:12.345");
+        t1.getDec().setValue("-20:30:40.567");
 
         assertEquals("16:11:12.345", t1.getRa().toString());
         assertEquals("-20:30:40.57", t1.getDec().toString());

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/system/test/NamedTargetCase.java
@@ -30,8 +30,8 @@ public final class NamedTargetCase {
         DMS c2 = new DMS("-20:30:40.567");
         t1.setC1C2(c1, c2);
 
-        assertEquals("16:11:12.345", t1.getRaHMS());
-        assertEquals("-20:30:40.57", t1.getDecDMS());
+        assertEquals("16:11:12.345", t1.getRaHms());
+        assertEquals("-20:30:40.57", t1.getDecDms());
 
         //Planet
         t1.setSolarObject(NamedTarget.SolarObject.NEPTUNE);
@@ -40,10 +40,10 @@ public final class NamedTargetCase {
 
     private void _doTestOne(String lIn, String bIn,
                             String lEx, String bEx) {
-        _t1.setRaHMS(lIn);
-        _t1.setDecDMS(bIn);
-        String lOut = _t1.getRaHMS();
-        String bOut = _t1.getDecDMS();
+        _t1.setRaHms(lIn);
+        _t1.setDecDms(bIn);
+        String lOut = _t1.getRaHms();
+        String bOut = _t1.getDecDms();
 
         assertEquals("Failed comparison,", lEx, lOut);
         assertEquals("Failed comparison,", bEx, bOut);

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -572,11 +572,11 @@ public final class Obs implements Serializable, Comparable<Obs> {
 	}
 
 	public double getRa() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getC1().getAs(CoordinateParam.Units.DEGREES) : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getRa().getAs(CoordinateParam.Units.DEGREES) : 0.0);
 	}
 
 	public double getDec() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getC2().getAs(CoordinateParam.Units.DEGREES) : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getDec().getAs(CoordinateParam.Units.DEGREES) : 0.0);
 	}
 
 	public Conds getConditions() {

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -134,8 +134,8 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.PROG_TOO_STATUS, tooType.getDisplayValue());
         row.put(Columns.TEMPLATE_ID, templateId);
         row.put(Columns.TARGET_NAME, target.getTarget().getName());
-        row.put(Columns.RA, target.getTarget().getRaHms());
-        row.put(Columns.DEC, target.getTarget().getDecDms());
+        row.put(Columns.RA, target.getTarget().getRa().toString());
+        row.put(Columns.DEC, target.getTarget().getDec().toString());
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));
         row.put(Columns.INST_CONFIG, instConfig);
         row.put(Columns.PHASE1_TIME, String.format("%.2f hrs", time.getTimeAmount()));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -134,8 +134,8 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.PROG_TOO_STATUS, tooType.getDisplayValue());
         row.put(Columns.TEMPLATE_ID, templateId);
         row.put(Columns.TARGET_NAME, target.getTarget().getName());
-        row.put(Columns.RA, target.getTarget().c1ToString());
-        row.put(Columns.DEC, target.getTarget().c2ToString());
+        row.put(Columns.RA, target.getTarget().getRaHMS());
+        row.put(Columns.DEC, target.getTarget().getDecDMS());
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));
         row.put(Columns.INST_CONFIG, instConfig);
         row.put(Columns.PHASE1_TIME, String.format("%.2f hrs", time.getTimeAmount()));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -134,8 +134,8 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.PROG_TOO_STATUS, tooType.getDisplayValue());
         row.put(Columns.TEMPLATE_ID, templateId);
         row.put(Columns.TARGET_NAME, target.getTarget().getName());
-        row.put(Columns.RA, target.getTarget().getRaHMS());
-        row.put(Columns.DEC, target.getTarget().getDecDMS());
+        row.put(Columns.RA, target.getTarget().getRaHms());
+        row.put(Columns.DEC, target.getTarget().getDecDms());
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));
         row.put(Columns.INST_CONFIG, instConfig);
         row.put(Columns.PHASE1_TIME, String.format("%.2f hrs", time.getTimeAmount()));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
@@ -422,8 +422,8 @@ public class ReportUtils {
         }
 
         // we know it's a ra/dec target, so it's safe to cast here
-        final double r = ((HMS) target.getTarget().getC1()).getValue();
-        final double d = ((DMS) target.getTarget().getC2()).getValue();
+        final double r = ((HMS) target.getTarget().getRa()).getValue();
+        final double d = ((DMS) target.getTarget().getDec()).getValue();
 
         if (r == 0.0 && d == 0.0) {
             return Option.empty();

--- a/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
+++ b/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
@@ -48,8 +48,8 @@ object RolloverObservation {
       targetEnv  <- Option(dataObj.getTargetEnvironment)
       science    <- Option(targetEnv.getBase)
       name       <- Option(science.getTarget.getName)
-      ra         <- Option(science.getTarget.getC1.getAs(Units.DEGREES))
-      dec        <- Option(science.getTarget.getC2.getAs(Units.DEGREES))
+      ra         <- Option(science.getTarget.getRa.getAs(Units.DEGREES))
+      dec        <- Option(science.getTarget.getDec.getAs(Units.DEGREES))
     } yield RolloverTarget(name, new Angle(ra, Angle.Unit.DEGREES), new Angle(dec, Angle.Unit.DEGREES))
 
   private def conditions(o: ISPObservation): Option[RolloverConditions] =

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -95,8 +95,8 @@ public final class TargetConfig extends ParamSet {
     private void _buildHmsDegTarget(SPTarget target) {
 
         HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
-        putParameter(TccNames.C1, hmsDeg.getRaHms());
-        putParameter(TccNames.C2, hmsDeg.getDecDms());
+        putParameter(TccNames.C1, hmsDeg.getRa().toString());
+        putParameter(TccNames.C2, hmsDeg.getDec().toString());
         add(_addProperMotion(hmsDeg));
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -95,8 +95,8 @@ public final class TargetConfig extends ParamSet {
     private void _buildHmsDegTarget(SPTarget target) {
 
         HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
-        putParameter(TccNames.C1, hmsDeg.c1ToString());
-        putParameter(TccNames.C2, hmsDeg.c2ToString());
+        putParameter(TccNames.C1, hmsDeg.getRaHMS());
+        putParameter(TccNames.C2, hmsDeg.getDecDMS());
         add(_addProperMotion(hmsDeg));
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -95,8 +95,8 @@ public final class TargetConfig extends ParamSet {
     private void _buildHmsDegTarget(SPTarget target) {
 
         HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
-        putParameter(TccNames.C1, hmsDeg.getRaHMS());
-        putParameter(TccNames.C2, hmsDeg.getDecDMS());
+        putParameter(TccNames.C1, hmsDeg.getRaHms());
+        putParameter(TccNames.C2, hmsDeg.getDecDms());
         add(_addProperMotion(hmsDeg));
     }
 

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
@@ -561,8 +561,8 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
         final TargetObsComp targetEnv = (TargetObsComp) targetObsComp.getDataObject();
         final SPTarget tp = targetEnv.getBase();
         final ITarget target = tp.getTarget();
-        final ICoordinate c1 = target.getC1();
-        final ICoordinate c2 = target.getC2();
+        final ICoordinate c1 = target.getRa();
+        final ICoordinate c2 = target.getDec();
         final double ra = c1.getAs(Units.DEGREES) / 15.;
         final double dec = c2.getAs(Units.DEGREES);
 
@@ -661,8 +661,8 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
             final TargetObsComp targetEnv = (TargetObsComp) targetObsComp.getDataObject();
             final SPTarget tp = targetEnv.getBase();
             final ITarget target = tp.getTarget();
-            final ICoordinate c1 = target.getC1();
-            final ICoordinate c2 = target.getC2();
+            final ICoordinate c1 = target.getRa();
+            final ICoordinate c2 = target.getDec();
             ra = c1.getAs(Units.DEGREES);
             dec = c2.getAs(Units.DEGREES);
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1586,8 +1586,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.targetName.setValue(name);
         _w.resolveButton.setEnabled(editable && !"".equals(name));
 
-        _w.xaxis.setValue(_curPos.getTarget().getRaHms());
-        _w.yaxis.setValue(_curPos.getTarget().getDecDms());
+        _w.xaxis.setValue(_curPos.getTarget().getRa().toString());
+        _w.yaxis.setValue(_curPos.getTarget().getDec().toString());
 
         _setCoordSys();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1586,8 +1586,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.targetName.setValue(name);
         _w.resolveButton.setEnabled(editable && !"".equals(name));
 
-        _w.xaxis.setValue(_curPos.getTarget().c1ToString());
-        _w.yaxis.setValue(_curPos.getTarget().c2ToString());
+        _w.xaxis.setValue(_curPos.getTarget().getRaHMS());
+        _w.yaxis.setValue(_curPos.getTarget().getDecDMS());
 
         _setCoordSys();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1586,8 +1586,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.targetName.setValue(name);
         _w.resolveButton.setEnabled(editable && !"".equals(name));
 
-        _w.xaxis.setValue(_curPos.getTarget().getRaHMS());
-        _w.yaxis.setValue(_curPos.getTarget().getDecDMS());
+        _w.xaxis.setValue(_curPos.getTarget().getRaHms());
+        _w.yaxis.setValue(_curPos.getTarget().getDecDms());
 
         _setCoordSys();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -241,8 +241,8 @@ class NonSiderealTargetSupport {
         }
 
         // Update the RA and Dec
-        form.xaxis.setText(target.getRaHms());
-        form.yaxis.setText(target.getDecDms());
+        form.xaxis.setText(target.getRa().toString());
+        form.yaxis.setText(target.getDec().toString());
 
         // Update the valid-at date
         Date date = target.getDateForPosition();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -241,8 +241,8 @@ class NonSiderealTargetSupport {
         }
 
         // Update the RA and Dec
-        form.xaxis.setText(target.getRaHMS());
-        form.yaxis.setText(target.getDecDMS());
+        form.xaxis.setText(target.getRaHms());
+        form.yaxis.setText(target.getDecDms());
 
         // Update the valid-at date
         Date date = target.getDateForPosition();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/NonSiderealTargetSupport.java
@@ -241,8 +241,8 @@ class NonSiderealTargetSupport {
         }
 
         // Update the RA and Dec
-        form.xaxis.setText(target.c1ToString());
-        form.yaxis.setText(target.c2ToString());
+        form.xaxis.setText(target.getRaHMS());
+        form.yaxis.setText(target.getDecDMS());
 
         // Update the valid-at date
         Date date = target.getDateForPosition();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -82,7 +82,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getTarget().getRaHms();
+                            return t.getTarget().getRa().toString();
                         }
                     }).getOrElse("");
                 }
@@ -92,7 +92,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getTarget().getDecDms();
+                            return t.getTarget().getDec().toString();
                         }
                     }).getOrElse("");
                 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -82,7 +82,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getTarget().c1ToString();
+                            return t.getTarget().getRaHMS();
                         }
                     }).getOrElse("");
                 }
@@ -92,7 +92,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getTarget().c2ToString();
+                            return t.getTarget().getDecDMS();
                         }
                     }).getOrElse("");
                 }
@@ -489,8 +489,8 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
     // Return the world coordinates for the given target
     private static WorldCoords getWorldCoords(SPTarget tp) {
         ITarget target = tp.getTarget();
-        ICoordinate c1 = target.getC1();
-        ICoordinate c2 = target.getC2();
+        ICoordinate c1 = target.getRa();
+        ICoordinate c2 = target.getDec();
         double x = c1.getAs(Units.DEGREES);
         double y = c2.getAs(Units.DEGREES);
         return new WorldCoords(x, y, 2000.);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -82,7 +82,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getTarget().getRaHMS();
+                            return t.getTarget().getRaHms();
                         }
                     }).getOrElse("");
                 }
@@ -92,7 +92,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 public Object getValue(Row row) {
                     return row.target().map(new MapOp<SPTarget, String>() {
                         @Override public String apply(SPTarget t) {
-                            return t.getTarget().getDecDMS();
+                            return t.getTarget().getDecDms();
                         }
                     }).getOrElse("");
                 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -424,8 +424,8 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
     // Returns a mascot Star object for the given target.
     private Star targetToStar(SPTarget target) {
         String name = target.getTarget().getName();
-        double ra = target.getTarget().getC1().getAs(CoordinateParam.Units.DEGREES);
-        double dec = target.getTarget().getC2().getAs(CoordinateParam.Units.DEGREES);
+        double ra = target.getTarget().getRa().getAs(CoordinateParam.Units.DEGREES);
+        double dec = target.getTarget().getDec().getAs(CoordinateParam.Units.DEGREES);
         double baseX = _tii.getBasePos().getRaDeg();
         double baseY = _tii.getBasePos().getDecDeg();
         Magnitude undef = new Magnitude(Magnitude.Band.J, MascotConf.invalidMag());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -296,8 +296,8 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         if (tp != null) {
             // Get the RA and Dec from the pos list.
             ITarget target = tp.getTarget();
-            ICoordinate c1 = target.getC1();
-            ICoordinate c2 = target.getC2();
+            ICoordinate c1 = target.getRa();
+            ICoordinate c2 = target.getDec();
             ra = c1.getAs(Units.DEGREES);
             dec = c2.getAs(Units.DEGREES);
         }
@@ -327,9 +327,9 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         ITarget oldBase = oldBasePos.getTarget();
         ITarget newBase = newBasePos.getTarget();
 
-        if (oldBase.getC1().getAs(Units.DEGREES) != newBase.getC1().getAs(Units.DEGREES))
+        if (oldBase.getRa().getAs(Units.DEGREES) != newBase.getRa().getAs(Units.DEGREES))
             return true;
-        return oldBase.getC2().getAs(Units.DEGREES) != newBase.getC2().getAs(Units.DEGREES);
+        return oldBase.getDec().getAs(Units.DEGREES) != newBase.getDec().getAs(Units.DEGREES);
     }
 
     private final PropertyChangeListener obsListener = new PropertyChangeListener() {
@@ -467,8 +467,8 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         if (_baseTarget == null) return;
 
         // XXX FIXME: We shouldn't have to use numeric indexes here
-        queryArgs.setParamValue(2, _baseTarget.getTarget().getC1().toString());
-        queryArgs.setParamValue(3, _baseTarget.getTarget().getC2().toString());
+        queryArgs.setParamValue(2, _baseTarget.getTarget().getRa().toString());
+        queryArgs.setParamValue(3, _baseTarget.getTarget().getDec().toString());
         queryArgs.setParamValue(4, _baseTarget.getTarget().getTag().tccName);
         if (args.length > 2) {
             //first argument must be a Double, it represent the size on AstroCatalogs

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -14,7 +14,6 @@ import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.*;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
 import edu.gemini.spModel.target.system.CoordinateParam.Units;
-import edu.gemini.spModel.target.system.HmsDegTarget;
 import edu.gemini.spModel.target.system.ICoordinate;
 import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.util.Angle;
@@ -508,8 +507,8 @@ public class TpeImageWidget extends NavigatorImageDisplay implements MouseInputL
         // Get the equinox assumed by the coordinate conversion methods (depends on current image)
         //double equinox = getCoordinateConverter().getEquinox();
         ITarget target = ((SPTarget) tp).getTarget();
-        ICoordinate c1 = target.getC1();
-        ICoordinate c2 = target.getC2();
+        ICoordinate c1 = target.getRa();
+        ICoordinate c2 = target.getDec();
         double x = c1.getAs(Units.DEGREES);
         double y = c2.getAs(Units.DEGREES);
         WorldCoords pos = new WorldCoords(x, y, 2000.);
@@ -882,8 +881,8 @@ public class TpeImageWidget extends NavigatorImageDisplay implements MouseInputL
      * The Base position has been updated.
      */
     public void basePosUpdate(ITarget target) {
-        ICoordinate c1 = target.getC1();
-        ICoordinate c2 = target.getC2();
+        ICoordinate c1 = target.getRa();
+        ICoordinate c2 = target.getDec();
         double x = c1.getAs(Units.DEGREES);
         double y = c2.getAs(Units.DEGREES);
         WorldCoords pos = new WorldCoords(x, y, 2000.);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -207,7 +207,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         String getRA() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().getRaHms();
+                return getTarget().getTarget().getRa().toString();
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.getStrehl();
                 if (strehl != null) {
@@ -219,7 +219,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         Object getDec() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().getDecDms();
+                return getTarget().getTarget().getDec().toString();
             }
             return null;
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -207,7 +207,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         String getRA() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().c1ToString();
+                return getTarget().getTarget().getRaHMS();
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.getStrehl();
                 if (strehl != null) {
@@ -219,7 +219,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         Object getDec() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().c2ToString();
+                return getTarget().getTarget().getDecDMS();
             }
             return null;
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -207,7 +207,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         String getRA() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().getRaHMS();
+                return getTarget().getTarget().getRaHms();
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.getStrehl();
                 if (strehl != null) {
@@ -219,7 +219,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         Object getDec() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().getDecDMS();
+                return getTarget().getTarget().getDecDms();
             }
             return null;
         }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -261,16 +261,16 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val raField = new BoundTextField[HMS](10)(
         read = s => new HMS(hms.parse(s)),
         show = _.toString,
-        get  = _.getTarget.getTarget.getC1.asInstanceOf[HMS],
-        set  = setTarget(_.getTarget.setC1(_))
+        get  = _.getTarget.getTarget.getRa.asInstanceOf[HMS],
+        set  = setTarget(_.getTarget.setRa(_))
       )
 
       val dms = new DMSFormat()
       val decField = new BoundTextField[DMS](10)(
         read = s => new DMS(dms.parse(s)),
         show = _.toString,
-        get  = _.getTarget.getTarget.getC2.asInstanceOf[DMS],
-        set  = setTarget(_.getTarget.setC2(_))
+        get  = _.getTarget.getTarget.getDec.asInstanceOf[DMS],
+        set  = setTarget(_.getTarget.setDec(_))
       )
 
       def pmField(getPM: SPTarget => Double, setPM: (SPTarget, Double) => Unit): BoundTextField[Double] =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -262,7 +262,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         read = s => new HMS(hms.parse(s)),
         show = _.toString,
         get  = _.getTarget.getTarget.getRa.asInstanceOf[HMS],
-        set  = setTarget(_.getTarget.setRa(_))
+        set  = setTarget((a, b) => a.getTarget.getRa.setValue(b.toString))
       )
 
       val dms = new DMSFormat()
@@ -270,7 +270,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         read = s => new DMS(dms.parse(s)),
         show = _.toString,
         get  = _.getTarget.getTarget.getDec.asInstanceOf[DMS],
-        set  = setTarget(_.getTarget.setDec(_))
+        set  = setTarget((a, b) => a.getTarget.getDec.setValue(b.toString))
       )
 
       def pmField(getPM: SPTarget => Double, setPM: (SPTarget, Double) => Unit): BoundTextField[Double] =


### PR DESCRIPTION
This PR removes a bunch of unnecessary methods from `ITarget` and renames `X/Y` and `C1/C2` as `Ra/Dec`. This was almost entirely mechanical refactoring.