### PR TITLE
OCSADV-200-D: (preliminary) preliminary merge algorithm

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/version/VersionComparison.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/version/VersionComparison.scala
@@ -1,0 +1,46 @@
+package edu.gemini.pot.sp.version
+
+/** A comparison between two NodeVersions or VersionMaps.
+  *
+  * This class simply provides a more readable enum of the version comparison
+  * outcomes.
+  */
+sealed trait VersionComparison
+
+import scalaz._
+import Scalaz._
+
+object VersionComparison {
+  case object Same        extends VersionComparison
+  case object Newer       extends VersionComparison
+  case object Older       extends VersionComparison
+  case object Conflicting extends VersionComparison
+
+  def apply(o: Option[Int]): VersionComparison =
+    o match {
+      case Some(0)          => Same
+      case Some(i) if i < 0 => Older
+      case Some(i) if i > 0 => Newer
+      case None             => Conflicting
+    }
+
+  def compare(nv0: NodeVersions, nv1: NodeVersions): VersionComparison =
+    VersionComparison(nv0.tryCompareTo(nv1))
+
+  def compare(vm0: VersionMap, vm1: VersionMap): VersionComparison =
+    VersionComparison(VersionMap.tryCompare(vm0, vm1))
+
+  implicit def VersionComparisonEqual: Equal[VersionComparison] = Equal.equalA
+
+  implicit val VersionComparisonMonoid: Monoid[VersionComparison] =
+    new Monoid[VersionComparison] {
+      val zero = Same
+      def append(a: VersionComparison, b: => VersionComparison): VersionComparison =
+        (a, b) match {
+          case (x,    y) if x === y => x
+          case (x, Same)            => x
+          case (Same, x)            => x
+          case _                    => Conflicting
+        }
+    }
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
@@ -39,4 +39,6 @@ package object sp {
     val t = Tree.unfoldTree(n)(n0 => (n0, () => n0.children.toStream))
     t.draw.zipWithIndex.collect { case (s, n0) if n0 % 2 == 0 => s}.mkString("\n")
   }
+
+  implicit def SpNodeKeyEqual: Equal[SPNodeKey] = Equal.equalA
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
@@ -35,9 +35,9 @@ package object sp {
       case n                   => s"${n.key} ${n.getClass.getSimpleName}"
     }
 
-  def drawNodeTree(n: ISPNode): String = {
+  def drawNodeTree(n: ISPNode)(implicit ev: Show[ISPNode]): String = {
     val t = Tree.unfoldTree(n)(n0 => (n0, () => n0.children.toStream))
-    t.draw.zipWithIndex.collect { case (s, n0) if n0 % 2 == 0 => s}.mkString("\n")
+    t.draw(ev).zipWithIndex.collect { case (s, n0) if n0 % 2 == 0 => s}.mkString("\n")
   }
 
   implicit def SpNodeKeyEqual: Equal[SPNodeKey] = Equal.equalA

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Diff.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Diff.scala
@@ -14,6 +14,8 @@ import scala.annotation.tailrec
 sealed trait Diff {
   def key: SPNodeKey
   def nv: NodeVersions
+  def isMissing: Boolean
+  def isPresent: Boolean = !isMissing
 }
 
 object Diff {
@@ -21,7 +23,9 @@ object Diff {
   /** Marks a node that either never existed in the program or else has been
     * removed and had different version information.
     */
-  final case class Missing(key: SPNodeKey, nv: NodeVersions) extends Diff
+  final case class Missing(key: SPNodeKey, nv: NodeVersions) extends Diff {
+    def isMissing: Boolean = true
+  }
 
   /** Describes the content of a node that potentially differs and is still in
     * use in the local program.  Contains enough information to merge the node
@@ -34,7 +38,9 @@ object Diff {
                            nv:       NodeVersions,
                            dob:      ISPDataObject,
                            children: List[SPNodeKey],
-                           detail:   NodeDetail      ) extends Diff
+                           detail:   NodeDetail      ) extends Diff {
+    def isMissing: Boolean = false
+  }
 
   /** Creates an [[Present]] `Diff` from the provided program node. */
   def present(n: ISPNode): Present = {

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Diff.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Diff.scala
@@ -36,15 +36,8 @@ object Diff {
                            children: List[SPNodeKey],
                            detail:   NodeDetail      ) extends Diff
 
-  /** Creates an [[Missing]] `Diff` from the provided program node.
-    *
-    * The only thing this offers over the Missing object's apply is that the
-    * resulting object has a more convenient type.
-    */
-  def missing(key: SPNodeKey, nv: NodeVersions): Diff = Missing(key, nv)
-
   /** Creates an [[Present]] `Diff` from the provided program node. */
-  def present(n: ISPNode): Diff = {
+  def present(n: ISPNode): Present = {
     val detail = n match {
       case o: ISPObservation => NodeDetail.Obs(o.getObservationNumber)
       case _                 => NodeDetail.Empty

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeContext.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeContext.scala
@@ -51,10 +51,8 @@ object ProgContext {
     def isTreeModified(k: SPNodeKey): Boolean =
       nodeMap.get(k).exists { n =>
         VersionComparison.compare(version(k), remoteVm.get(k) | EmptyNodeVersions) match {
-          case Same        => n.children.map(_.key).exists(isTreeModified)
-          case Newer       => true
-          case Older       => n.children.map(_.key).exists(isTreeModified)
-          case Conflicting => true
+          case Same  | Older       => n.children.map(_.key).exists(isTreeModified)
+          case Newer | Conflicting => true
         }
       }
   }
@@ -75,9 +73,7 @@ object ProgContext {
           case Nil       => parents
           case (k :: ks) =>
             diffMap.get(k) match {
-              case None                          =>
-                go(ks, parents)
-              case Some(Missing(_, _))           =>
+              case None | Some(Missing(_,_))     =>
                 go(ks, parents)
               case Some(Present(_, _, _, cs, _)) =>
                 go(cs ++ ks, (parents/:cs) { (pm, c) => pm + (c -> k) })
@@ -96,10 +92,8 @@ object ProgContext {
         case Missing(_, _)                  => false
         case Present(_, nv, _, children, _) =>
           VersionComparison.compare(localVm.get(k) | EmptyNodeVersions, nv) match {
-            case Same        => children.exists(isTreeModified)
-            case Newer       => children.exists(isTreeModified)
-            case Older       => true
-            case Conflicting => true
+            case Same  | Newer       => children.exists(isTreeModified)
+            case Older | Conflicting => true
           }
       }
   }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeContext.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeContext.scala
@@ -1,0 +1,130 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.version.VersionComparison.{Conflicting, Newer, Older, Same}
+import edu.gemini.pot.sp.version._
+import edu.gemini.pot.sp.{ISPNode, ISPProgram, SPNodeKey}
+import edu.gemini.sp.vcs.diff.Diff.{Present, Missing}
+import edu.gemini.spModel.rich.pot.sp._
+
+import scalaz._
+import Scalaz._
+
+/** Provides a common interface to queries we must make during the merge process
+  * about the local and remote versions of a program.  The local context is
+  * based upon the local `ISPProgram` which the remote context is extracted from
+  * the `Diff`s we collect from the remote program.
+  */
+sealed trait ProgContext[A] {
+  def get(k: SPNodeKey): Option[A]
+
+  def parent(k: SPNodeKey): Option[SPNodeKey]
+
+  def vm: VersionMap
+  def version(k: SPNodeKey): NodeVersions =
+    vm.getOrElse(k, EmptyNodeVersions)
+
+  def isKnown(k: SPNodeKey): Boolean =
+    vm.contains(k)
+
+  def isDeleted(k: SPNodeKey): Boolean
+  def isTreeModified(k: SPNodeKey): Boolean
+}
+
+object ProgContext {
+
+  final case class Local(prog: ISPProgram, remoteVm: VersionMap) extends ProgContext[ISPNode] {
+    val nodeMap = prog.nodeMap
+    val vm = prog.getVersions
+
+    def get(k: SPNodeKey): Option[ISPNode] =
+      nodeMap.get(k)
+
+    def parent(k: SPNodeKey): Option[SPNodeKey] =
+      for {
+        n <- nodeMap.get(k)
+        p <- Option(n.getParent)
+      } yield p.key
+
+    def isDeleted(k: SPNodeKey): Boolean =
+      isKnown(k) && !nodeMap.contains(k)
+
+    def isTreeModified(k: SPNodeKey): Boolean =
+      nodeMap.get(k).exists { n =>
+        VersionComparison.compare(version(k), remoteVm.get(k) | EmptyNodeVersions) match {
+          case Same        => n.children.map(_.key).exists(isTreeModified)
+          case Newer       => true
+          case Older       => n.children.map(_.key).exists(isTreeModified)
+          case Conflicting => true
+        }
+      }
+  }
+
+  final case class Remote(diffs: List[Diff], remoteVm: VersionMap, root: SPNodeKey, localVm: VersionMap) extends ProgContext[Diff] {
+    val diffMap: Map[SPNodeKey, Diff] = diffs.map(d => d.key -> d).toMap
+
+    def vm: VersionMap = remoteVm
+
+    def get(k: SPNodeKey): Option[Diff] =
+      diffMap.get(k)
+
+    def parent(k: SPNodeKey): Option[SPNodeKey] = remoteParents.get(k)
+
+    private val remoteParents: Map[SPNodeKey, SPNodeKey] = {
+      def go(rem: List[SPNodeKey], parents: Map[SPNodeKey, SPNodeKey]): Map[SPNodeKey, SPNodeKey] = {
+        rem match {
+          case Nil       => parents
+          case (k :: ks) =>
+            diffMap.get(k) match {
+              case None                          =>
+                go(ks, parents)
+              case Some(Missing(_, _))           =>
+                go(ks, parents)
+              case Some(Present(_, _, _, cs, _)) =>
+                go(cs ++ ks, (parents/:cs) { (pm, c) => pm + (c -> k) })
+            }
+        }
+      }
+
+      go(List(root), Map.empty)
+    }
+
+    def isDeleted(k: SPNodeKey): Boolean =
+     isKnown(k) && diffMap.get(k).exists(_.isMissing)
+
+    def isTreeModified(k: SPNodeKey): Boolean =
+      diffMap.get(k).exists {
+        case Missing(_, _)                  => false
+        case Present(_, nv, _, children, _) =>
+          VersionComparison.compare(localVm.get(k) | EmptyNodeVersions, nv) match {
+            case Same        => children.exists(isTreeModified)
+            case Newer       => children.exists(isTreeModified)
+            case Older       => true
+            case Conflicting => true
+          }
+      }
+  }
+}
+
+/** Holds the local and remote context for convenience. */
+final case class MergeContext(local: ProgContext.Local, remote: ProgContext.Remote)
+
+object MergeContext {
+  def apply(prog: ISPProgram, diffs: List[Diff]): MergeContext = {
+    val localVm  = prog.getVersions
+
+    // Start with the local version map and apply the differences.  Generally if
+    // a diff has EmptyNodeVersions it's because it doesn't exist in the remote
+    // program.  TODO: However, for some ridiculous reason that I hope to fix
+    // the root node is explicitly reset to EmptyNodeVersions after creation.  Both
+    // version maps should contain an entry for the root so we work around this
+    // here for now.
+    val remoteVm = (localVm/:diffs) { (vm, diff) =>
+      if ((diff.nv === EmptyNodeVersions) && /*hack*/ diff.key != prog.key)
+        vm - diff.key
+      else
+        vm.updated(diff.key, diff.nv)
+    }
+
+    MergeContext(ProgContext.Local(prog, remoteVm), ProgContext.Remote(diffs, remoteVm, prog.key, localVm))
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
@@ -1,0 +1,108 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.{ISPNode, SPNodeKey}
+import edu.gemini.pot.sp.version.NodeVersions
+import edu.gemini.spModel.data.ISPDataObject
+import edu.gemini.spModel.rich.pot.sp._
+
+import scalaz._
+import Scalaz._
+
+
+// This is just a Diff.Present without the children.
+final case class Update(key: SPNodeKey,
+                        nv: NodeVersions,
+                        dob: ISPDataObject,
+                        detail: NodeDetail)
+
+
+/** MergeNodes form a tree with potential links into an existing science
+  * program.  There are two types of MergeNode, [[ModifiedNode]]s and
+  * [[UnmodifiedNode]]s.  `ModifiedNode` describes a potential update to an
+  * existing science program node (or the definition of a node missing locally).
+  * They have children which can be another `ModifiedNode` or else an
+  * `UnmodifiedNode` which is just a link to an existing science program
+  * node.
+  */
+sealed trait MergeNode {
+  def key: SPNodeKey
+}
+
+
+final case class ModifiedNode(u: Update, children: List[MergeNode]) extends MergeNode {
+  def key: SPNodeKey = u.key
+}
+
+final case class UnmodifiedNode(n: ISPNode) extends MergeNode {
+  def key: SPNodeKey = n.key
+}
+
+
+object MergeNode {
+
+  def fold[A](z: A, root: MergeNode)(op: (A, MergeNode) => A): A = {
+    def go(rem: List[MergeNode], res: A): A =
+      rem match {
+        case Nil     => res
+        case n :: ns =>
+          n match {
+            case ModifiedNode(_, children) => go(children ++ ns, op(res, n))
+            case _                         => go(ns,             op(res, n))
+          }
+      }
+    go(List(root), z)
+  }
+
+
+  /** Zipper will be used for applying corrections to the merge tree.
+    *
+    * TODO: work in progress
+    */
+
+  object Zipper {
+    final case class Crumb(parent: Update, prev: List[MergeNode], next: List[MergeNode])
+  }
+
+  import Zipper.Crumb
+
+  final case class Zipper(focus: MergeNode, crumbs: List[Zipper.Crumb] = Nil) {
+    def up: Option[Zipper] = crumbs match {
+      case Crumb(parent, prev, next) :: cs =>
+        some(Zipper(ModifiedNode(parent, (focus :: prev).reverse ++ next), cs))
+      case _ =>
+        none
+    }
+
+    def top: Zipper = up.map(_.top) | this
+
+    def down: Option[Zipper] = focus match {
+      case ModifiedNode(u, children) =>
+        children match {
+          case n :: ns => some(Zipper(n, Crumb(u, Nil, ns) :: crumbs))
+          case _       => none
+        }
+      case _ =>
+        none
+    }
+
+    def nextSibling: Option[Zipper] = crumbs match {
+      case Crumb(parent, prev, n :: ns) :: cs =>
+        some(Zipper(n, Crumb(parent, focus :: prev, ns) :: cs))
+      case _ =>
+        none
+    }
+
+    def prevSibling: Option[Zipper] = crumbs match {
+      case Crumb(parent, n :: ns, next) :: cs =>
+        some(Zipper(n, Crumb(parent, ns, focus :: next) :: cs))
+      case _ =>
+        none
+    }
+
+    def find(p: MergeNode => Boolean): Option[Zipper] =
+      if (p(focus))
+        some(this)
+      else
+        down.flatMap(_.find(p)) orElse nextSibling.flatMap(_.find(p))
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
@@ -29,6 +29,10 @@ sealed trait MergeNode {
 }
 
 
+/** Describes an [[Update]] to an existing node and the children it should have.
+  * The children are separated in order to facilitate the construction of a
+  * Zipper.
+  */
 final case class ModifiedNode(u: Update, children: List[MergeNode]) extends MergeNode {
   def key: SPNodeKey = u.key
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
@@ -9,19 +9,11 @@ import scalaz._
 import Scalaz._
 
 
-// This is just a Diff.Present without the children.
-final case class Update(key: SPNodeKey,
-                        nv: NodeVersions,
-                        dob: ISPDataObject,
-                        detail: NodeDetail)
-
-
 /** MergeNodes form a tree with potential links into an existing science
-  * program.  There are two types of MergeNode, [[ModifiedNode]]s and
-  * [[UnmodifiedNode]]s.  `ModifiedNode` describes a potential update to an
+  * program.  There are two types of MergeNode, [[Modified]] and
+  * [[Unmodified]]s.  `Modified` describes a potential update to an
   * existing science program node (or the definition of a node missing locally).
-  * They have children which can be another `ModifiedNode` or else an
-  * `UnmodifiedNode` which is just a link to an existing science program
+  * `Unmodified` is just a `MergeNode` wrapper for an existing science program
   * node.
   */
 sealed trait MergeNode {
@@ -29,84 +21,27 @@ sealed trait MergeNode {
 }
 
 
-/** Describes an [[Update]] to an existing node and the children it should have.
-  * The children are separated in order to facilitate the construction of a
-  * Zipper.
-  */
-final case class ModifiedNode(u: Update, children: List[MergeNode]) extends MergeNode {
-  def key: SPNodeKey = u.key
-}
+// This is just a Diff.Present without the children.
+final case class Modified(key: SPNodeKey,
+                          nv: NodeVersions,
+                          dob: ISPDataObject,
+                          detail: NodeDetail) extends MergeNode
 
-final case class UnmodifiedNode(n: ISPNode) extends MergeNode {
+
+final case class Unmodified(n: ISPNode) extends MergeNode {
   def key: SPNodeKey = n.key
 }
 
-
 object MergeNode {
+  def unmodified(n: ISPNode): MergeNode =
+    Unmodified(n)
 
-  def fold[A](z: A, root: MergeNode)(op: (A, MergeNode) => A): A = {
-    def go(rem: List[MergeNode], res: A): A =
-      rem match {
-        case Nil     => res
-        case n :: ns =>
-          n match {
-            case ModifiedNode(_, children) => go(children ++ ns, op(res, n))
-            case _                         => go(ns,             op(res, n))
-          }
-      }
-    go(List(root), z)
-  }
+  def modified(key: SPNodeKey, nv: NodeVersions, dob: ISPDataObject, detail: NodeDetail): MergeNode =
+    Modified(key, nv, dob, detail)
 
-
-  /** Zipper will be used for applying corrections to the merge tree.
-    *
-    * TODO: work in progress
-    */
-
-  object Zipper {
-    final case class Crumb(parent: Update, prev: List[MergeNode], next: List[MergeNode])
-  }
-
-  import Zipper.Crumb
-
-  final case class Zipper(focus: MergeNode, crumbs: List[Zipper.Crumb] = Nil) {
-    def up: Option[Zipper] = crumbs match {
-      case Crumb(parent, prev, next) :: cs =>
-        some(Zipper(ModifiedNode(parent, (focus :: prev).reverse ++ next), cs))
-      case _ =>
-        none
-    }
-
-    def top: Zipper = up.map(_.top) | this
-
-    def down: Option[Zipper] = focus match {
-      case ModifiedNode(u, children) =>
-        children match {
-          case n :: ns => some(Zipper(n, Crumb(u, Nil, ns) :: crumbs))
-          case _       => none
-        }
-      case _ =>
-        none
-    }
-
-    def nextSibling: Option[Zipper] = crumbs match {
-      case Crumb(parent, prev, n :: ns) :: cs =>
-        some(Zipper(n, Crumb(parent, focus :: prev, ns) :: cs))
-      case _ =>
-        none
-    }
-
-    def prevSibling: Option[Zipper] = crumbs match {
-      case Crumb(parent, n :: ns, next) :: cs =>
-        some(Zipper(n, Crumb(parent, ns, focus :: next) :: cs))
-      case _ =>
-        none
-    }
-
-    def find(p: MergeNode => Boolean): Option[Zipper] =
-      if (p(focus))
-        some(this)
-      else
-        down.flatMap(_.find(p)) orElse nextSibling.flatMap(_.find(p))
+  implicit class TreeOps[A](t: Tree[A]) {
+    /** A `foldRight` with strict evaluation of the `B` value of `f`. */
+    def sFoldRight[B](z: => B)(f: (A, B) => B): B =
+      t.foldRight(z) { (a, b) => f(a,b) }
   }
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergePlan.scala
@@ -1,0 +1,13 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.ISPProgram
+import edu.gemini.sp.vcs.diff.Diff.Missing
+
+/** Describes the modifications required for a local program to complete a
+  * merge.
+  */
+case class MergePlan(update: MergeNode, delete: Set[Missing]) {
+
+  /** Accepts a program and edits it according to this merge plan. */
+  def merge(p: ISPProgram): Unit = ???
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergePlan.scala
@@ -3,10 +3,12 @@ package edu.gemini.sp.vcs.diff
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.sp.vcs.diff.Diff.Missing
 
+import scalaz._
+
 /** Describes the modifications required for a local program to complete a
   * merge.
   */
-case class MergePlan(update: MergeNode, delete: Set[Missing]) {
+case class MergePlan(update: Tree[MergeNode], delete: Set[Missing]) {
 
   /** Accepts a program and edits it according to this merge plan. */
   def merge(p: ISPProgram): Unit = ???

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeRecord.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeRecord.scala
@@ -1,0 +1,62 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.{ISPNode, DataObjectBlob, SPNodeKey}
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.data.ISPDataObject
+
+import scalaz._
+import Scalaz._
+
+/** A base trait for a description of the various changes that may be applied
+  * to a local program node.
+  */
+sealed trait MergeRecord {
+  def key: SPNodeKey
+}
+
+object MergeRecord {
+  case class Create(key: SPNodeKey)                                extends MergeRecord
+  case class Resurrect(key: SPNodeKey)                             extends MergeRecord
+
+  case class AddChild(key: SPNodeKey, child: SPNodeKey)            extends MergeRecord
+  case class RemoveChild(key: SPNodeKey, child: SPNodeKey)         extends MergeRecord
+  case class ReorderChildren(key: SPNodeKey, was: List[SPNodeKey]) extends MergeRecord
+
+  case class UpdateDataObject(key: SPNodeKey, was: ISPDataObject)  extends MergeRecord
+
+
+  /** Compares the given [[ModifiedNode]] to the corresponding local program node,
+    * if any, and returns the list of changes that were applied.
+    *
+    * @return changes to the given local node applied by the merge
+    */
+  def changes(mc: MergeContext, mn: ModifiedNode): List[MergeRecord] = {
+    val k = mn.key
+
+    def created: List[MergeRecord] = {
+      val mr = if (mc.local.vm.contains(k)) Resurrect(k) else Create(k)
+      mr :: mn.children.map(c => AddChild(k, c.key))
+    }
+
+    def updated(n: ISPNode): List[MergeRecord] = {
+      val dob        = n.getDataObject
+      val updateDob  = !DataObjectBlob.same(mn.u.dob, dob) option UpdateDataObject(k, dob)
+
+      val children   = n.children.map(_.key)
+      val mnChildren = mn.children.map(_.key)
+      val added      = mnChildren.diff(children)
+      val removed    = children.diff(mnChildren)
+
+      // ignoring what has been added and removed, have we reordered?
+      val rKeys      = removed.toSet
+      val lst0       = children.filterNot(rKeys.contains)
+      val aKeys      = added.toSet
+      val lst1       = mnChildren.filterNot(aKeys.contains)
+      val reorder    = (lst0 =/= lst1) option ReorderChildren(k, children)
+
+      updateDob.toList ++ reorder.toList ++ added.map(AddChild(k, _)) ++ removed.map(RemoveChild(k, _))
+    }
+
+    mc.local.get(k).fold(created)(updated)
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/PreliminaryMerge.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/PreliminaryMerge.scala
@@ -1,0 +1,152 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.version._
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.pot.sp.version.VersionComparison._
+import edu.gemini.sp.vcs.diff.Diff._
+import edu.gemini.spModel.rich.pot.sp._
+
+import scala.collection.breakOut
+import scalaz._
+import Scalaz._
+
+/** Produces a preliminary [[MergePlan]]. Before using it to complete a merge
+  * however, various special case corrections (e.g., observation renumbering)
+  * must be applied to the plan.
+  */
+object PreliminaryMerge {
+
+  def merge(mc: MergeContext): MergePlan =
+    plan(mc, mergedDiffs(mc))
+
+  // TODO: remove after upgrading to scalaz 7.1
+  implicit class HackityHack[A,B](abs: List[A \/ B]) {
+    def separate: (List[A], List[B]) =
+      abs.foldRight((List.empty[A], List.empty[B])) {
+        case (-\/(a), (as, bs)) => (a :: as, bs)
+        case (\/-(b), (as, bs)) => (as, b :: bs)
+      }
+  }
+
+  private def mergedDiffs(mc: MergeContext): (List[Missing], List[Present]) =
+    mc.remote.diffs.map { diff =>
+      val key  = diff.key
+      (mc.local.get(key), diff) match {
+        case (None, Missing(_, nv)) =>
+          Missing(key, nv.sync(mc.local.version(key))).left
+
+        case (Some(n), _: Missing) =>
+          val localP   = present(n)
+          val remoteP  = localP.copy(nv = mc.remote.version(key), children = Nil)
+          mergedPresent(mc, localP, Newer, remoteP).right
+
+        case (None,    p: Present) =>
+          val localP   = p.copy(nv = mc.local.version(key), children = Nil)
+          mergedPresent(mc, localP, Older, p).right
+
+        case (Some(n), p: Present) =>
+          val comp     = VersionComparison.compare(mc.local.version(key), diff.nv)
+          mergedPresent(mc, present(n), comp, p).right
+      }
+    }.separate
+
+  private def mergedPresent(mc: MergeContext, local: Present, comp: VersionComparison, remote: Present): Present = {
+    val key = local.key
+
+    val present = comp match {
+      case Same        =>
+        local
+
+      case Newer       =>
+        val localResurrect = remote.children.diff(local.children).filter { c =>
+          mc.local.isDeleted(c) && mc.remote.isTreeModified(c)
+        }
+        local.copy(children = localResurrect ++ local.children)
+
+      case Older       =>
+        val remoteResurrect = local.children.diff(remote.children).filter { c =>
+          mc.remote.isDeleted(c) && mc.local.isTreeModified(c)
+        }
+        remote.copy(children = remoteResurrect ++ remote.children)
+
+      case Conflicting =>
+        val mergedChildren = local.children.diff(remote.children) ++ remote.children
+        remote.copy(children = mergedChildren)
+    }
+
+    present.copy(nv = local.nv.sync(remote.nv))
+  }
+
+
+  private def plan(mc: MergeContext, mdiffs: (List[Missing], List[Present])): MergePlan = {
+    val (missing, presents) = mdiffs
+
+    val presentMap = presents.map(p => p.key -> p)(breakOut): Map[SPNodeKey, Present]
+    val parentMap  = validParents(mc, presentMap)
+
+    val root: MergeNode = {
+      def go(root: SPNodeKey): MergeNode =
+        presentMap.get(root).fold(UnmodifiedNode(mc.local.nodeMap(root)): MergeNode) { p =>
+          val up = Update(p.key, p.nv, p.dob, p.detail)
+          val cs = p.children.filter(c => parentMap(c) === p.key)
+          ModifiedNode(up, cs.map(go))
+        }
+      go(mc.local.prog.key)
+    }
+
+    val mergedKeys  = MergeNode.fold(Set.empty[SPNodeKey], root) { _ + _.key }
+    val deletedKeys = presentMap.keySet &~ mergedKeys
+
+    // This node has been deleted in the merged tree so turn it into a Missing
+    // Diff.
+    val deleted = deletedKeys.map { k =>
+      val p = presentMap(k)
+      Missing(p.key, p.nv)
+    }
+
+    MergePlan(root, deleted ++ missing)
+  }
+
+  //
+  // validParents - returns a map from child key to the correct parent key
+  //
+  // The same child node may appear in two different Present Diffs.  For
+  // example, consider a program with three groups: g1, g2, and g3.  Assume
+  // g1 has a node n and g2 and g3 are both empty.  Now locally we move n to g2
+  // while someone else moves n to g3.  In this case the merge at this point
+  // will produce merged Presents which each consider n to be a child since g2
+  // is newer locally and g3 is newer remotely.
+  //
+  // The purpose of this method is to establish which parent to use in this
+  // case.  We choose the parent in the remote version of the program.
+  //
+  private def validParents(mc: MergeContext, m: Map[SPNodeKey, Present]): Map[SPNodeKey, SPNodeKey] = {
+    // fold over the map with a DF traversal, ignoring values that aren't
+    // reachable
+    def fold[A](root: SPNodeKey, z: A)(op: (A, Present) => A): A = {
+      def go(rem: List[SPNodeKey], res: A): A =
+        rem match {
+          case Nil     => res
+          case k :: ks =>
+            val (children, res2) = m.get(k).fold((List.empty[SPNodeKey], res)) { p =>
+              (p.children, op(res, p))
+            }
+            go(children ++ ks, res2)
+        }
+      go(List(root), z)
+    }
+
+    // returns Map[SPNodeKey, SPNodeKey] where the keys are child keys and
+    // the values are their corresponding parent key
+    fold(mc.local.prog.key, Map.empty[SPNodeKey, SPNodeKey]) { (pMap, p) =>
+      (pMap/:p.children) { (pMap2, childKey) =>
+        pMap2.get(childKey).fold(pMap2 + (childKey -> p.key)) { existingParent =>
+          if ((existingParent === p.key) || mc.remote.parent(childKey).exists(_ === existingParent))
+            pMap2
+          else
+            pMap2.updated(childKey, p.key)
+        }
+      }
+    }
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ProgramDiff.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ProgramDiff.scala
@@ -2,7 +2,7 @@ package edu.gemini.sp.vcs.diff
 
 import edu.gemini.pot.sp.version._
 import edu.gemini.pot.sp.{ISPNode, ISPObservation, ISPProgram, SPNodeKey}
-import edu.gemini.sp.vcs.diff.Diff.{missing, present}
+import edu.gemini.sp.vcs.diff.Diff.{present, Missing}
 import edu.gemini.spModel.rich.pot.sp._
 
 import scalaz._
@@ -106,7 +106,7 @@ object ProgramDiff {
 
     import scala.collection.breakOut
     def missingDiffs(keys: Set[SPNodeKey]): List[Diff] =
-      keys.map(k => missing(k, local.getVersions(k)))(breakOut)
+      keys.map(k => Missing(k, local.getVersions(k)))(breakOut)
 
     val localKeys       = local.getVersions.keySet
     val remoteKeys      = remoteVm.keySet

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergePropertyTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergePropertyTest.scala
@@ -39,9 +39,10 @@ import scalaz._
 
 /** Support for testing program merge.
   *
-  * @param f combines two edited programs into a single result of type A
+  * @param f combines a starting program and two edited versions into a single
+  *          result of type A
   */
-class MergePropertyTest[A](f: (ISPProgram, ISPProgram) => A) extends Checkers {
+class MergePropertyTest[A](f: (ISPProgram, ISPProgram, ISPProgram) => A) extends Checkers {
 
   import MergePropertyTest._
 
@@ -79,7 +80,7 @@ class MergePropertyTest[A](f: (ISPProgram, ISPProgram) => A) extends Checkers {
     try {
       check(Prop.forAll(genProgs) { fun =>
         val (start, local, remote) = fun(fact)
-        p(start, local, remote, f(local, remote))
+        p(start, local, remote, f(start, local, remote))
       })
     } finally {
       odb.getDBAdmin.shutdown()

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergePropertyTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergePropertyTest.scala
@@ -1,0 +1,100 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.{ISPFactory, ISPProgram}
+import edu.gemini.pot.spdb.DBLocalDatabase
+import edu.gemini.spModel.rich.pot.sp._
+import org.scalacheck.Prop
+import org.scalatest.prop.Checkers
+
+//
+// Program property testing is a bit unorthodox in that there is one big
+// "property" that combines a bunch of smaller ones.  Program generation is
+// complicated by the fact that the ScienceProgram is mutable and must be
+// created and manipulated in the context of a database and factory.
+//
+// Only about 3% of the total time is taken verifying the properties plus
+// actually running the ProgramDiff for all the generated programs and edits.
+// In other words, about 97% of the time is the overhead of the program and edit
+// generation. If we separate the properties and generate programs and edits for
+// each, the time required to run the tests will be multiplied by the number of
+// properties (so instead of ~14 seconds it would take ~100 seconds).
+//
+// Because of the mutable science program, the generated programs and edits are
+// actually functions which make the normal property failure output less useful.
+// It will tell us that a property failed but the arguments it displays are
+// only functions, as in:
+//
+//  Falsified after 0 successful property evaluations.
+//  Location: (ProgramDiffPropertyTest.scala:154)
+//  Occurred when passed generated values (
+//    arg0 = <function1>
+//  )
+//
+// For that reason, we explicitly write out the generated programs that trigger
+// a failure.
+//
+
+/** Support for testing program merge.
+  *
+  * @param f combines two edited programs into a single result of type A
+  */
+class MergePropertyTest[A](f: (ISPProgram, ISPProgram) => A) extends Checkers {
+
+  import MergePropertyTest._
+
+  def checkOneProperty(p: MergeProperty[A]): Unit = {
+    val odb  = DBLocalDatabase.createTransient()
+    val fact = odb.getFactory
+
+    import edu.gemini.pot.sp.ProgramGen._
+
+    // Generate a starting program and two independently edited copies of it.
+    val genProgs = for {
+      fStart <- genProg
+      fEd0   <- genEditedProg
+      fEd1   <- genEditedProg
+    } yield {(f: ISPFactory) => {
+      val start = fStart(f)
+      val ed0   = fEd0(f, start)
+      val ed1   = fEd1(f, start)
+      (start, ed0, ed1)
+    }}
+
+    try {
+      check(Prop.forAll(genProgs) { fun =>
+        val (start, ed0, ed1) = fun(fact)
+        p(start, ed0, ed1, f(ed0, ed1))
+      })
+    } finally {
+      odb.getDBAdmin.shutdown()
+    }
+  }
+
+  def checkAllProperties(ps: List[NamedProperty[A]]): Unit =
+    checkOneProperty { (start, local, remote, a) =>
+      val failure = ps.find { case (_, p) => !p(start, local, remote, a) }
+
+      failure.foreach { case (name, _) =>
+        Console.err.println("*** Program property failure: " + name)
+        val titles = List("Start", "Local", "Remote")
+        val progs  = List(start,   local,   remote)
+        titles.zip(progs).foreach { case (title, prog) =>
+          Console.err.println(s"\n$title")
+          Console.err.println(drawNodeTree(prog))
+        }
+      }
+
+      failure.isEmpty
+    }
+}
+
+object MergePropertyTest {
+  /** A property that evaluates a starting program, a potentially  edited
+    * "local" version, a potentially edited "remote" version, and a result of
+    * combining the two edited versions.
+    */
+  type MergeProperty[A] = (ISPProgram, ISPProgram, ISPProgram, A) => Boolean
+
+  /** A program property with a name / description. */
+  type NamedProperty[A] = (String, MergeProperty[A])
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/PreliminaryMergePropertyTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/PreliminaryMergePropertyTest.scala
@@ -122,8 +122,45 @@ class PreliminaryMergePropertyTest extends JUnitSuite {
 
         (commonKeys &~ pc.deletedKeys).isEmpty
       }
-    )
+    ),
 
+    ("a node that is newer and still present in the local program must appear in merge tree",
+      (start, local, remote, pc) => (pc.local.editedKeys &~ pc.mergeMap.keySet).isEmpty
+    ),
+
+    ("a node that is older and still present in the remote program must appear in the merge tree",
+      (start, local, remote, pc) => (pc.remote.editedKeys &~ pc.mergeMap.keySet).isEmpty
+    ),
+
+    ("",
+      (start, local, remote, pc) => {
+        true
+      }
+    ),
+
+    ("",
+      (start, local, remote, pc) => {
+        true
+      }
+    ),
+
+    ("",
+      (start, local, remote, pc) => {
+        true
+      }
+    ),
+
+    ("",
+      (start, local, remote, pc) => {
+        true
+      }
+    ),
+
+    ("",
+      (start, local, remote, pc) => {
+        true
+      }
+    )
     // ....
 
   )

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/PreliminaryMergePropertyTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/PreliminaryMergePropertyTest.scala
@@ -1,0 +1,141 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.{DataObjectBlob => DOB, ISPNode, ISPProgram, SPNodeKey}
+import edu.gemini.sp.vcs.diff.Diff.{Missing, Present}
+import edu.gemini.pot.sp.version._
+import edu.gemini.spModel.rich.pot.sp._
+
+import org.junit.Test
+import org.scalatest.junit.JUnitSuite
+
+import scalaz._
+import Scalaz._
+
+
+class PreliminaryMergePropertyTest extends JUnitSuite {
+  import edu.gemini.sp.vcs.diff.MergePropertyTest.NamedProperty
+
+  private def drawMergeNode(mn: MergeNode): String = {
+    implicit val ShowNode = Show.shows[MergeNode] {
+      case ModifiedNode(u, c) => s"m ${u.key} (${u.dob.getType})"
+      case UnmodifiedNode(n)  => s"u ${n.key} (${n.getDataObject.getType})"
+    }
+
+    val t = Tree.unfoldTree(mn)(n => (n, () => n match {
+      case ModifiedNode(_, c) => c.toStream
+      case _                  => Stream.empty[MergeNode]
+    }))
+    t.draw.zipWithIndex.collect { case (s0, n) if n % 2 == 0 => s0 }.mkString("\n")
+  }
+
+  case class PropContext(sp: ISPProgram, lp: ISPProgram, rp: ISPProgram, diffs: List[Diff], mergePlan: MergePlan) {
+    val startMap = sp.nodeMap
+    val startId  = sp.getLifespanId
+
+    def keys(l: List[ISPNode]): Set[SPNodeKey] = l.map(_.key).toSet
+
+    case class EditFacts(p: ISPProgram) {
+      val nodeMap     = p.nodeMap
+      val id          = p.getLifespanId
+      val editedNodes = p.fold(List.empty[ISPNode]) { (lst, n) =>
+        if (n.getVersion.clocks.contains(id)) n :: lst else lst
+      }
+      val editedKeys  = keys(editedNodes)
+
+      val dataObjectEditedNodes = editedNodes.filter { n =>
+        startMap.get(n.key).exists { s => !DOB.same(s.getDataObject, n.getDataObject) }
+      }
+
+      val childrenEditedNodes = editedNodes.filter { n =>
+        startMap.get(n.key).exists { s =>
+          s.children.map(_.key).equals(n.children.map(_.key))
+        }
+      }
+
+      val newNodes    = editedNodes.filterNot(n => startMap.contains(n.key))
+      val newKeys     = keys(newNodes)
+      val deletedKeys = p.getVersions.keySet &~ nodeMap.keySet
+    }
+
+    val local  = new EditFacts(lp)
+    val remote = new EditFacts(rp)
+
+    val mergeMap    = MergeNode.fold(Map.empty[SPNodeKey, MergeNode], mergePlan.update) { (m, mn) =>
+      m + (mn.key -> mn)
+    }
+
+    val deletedKeys = mergePlan.delete.map(_.key).toSet
+
+    def modifiedNode(k: SPNodeKey): ModifiedNode =
+      mergeMap(k) match {
+        case m: ModifiedNode => m
+        case _ => error("expecting modified node but was unmodified: " + k)
+      }
+  }
+
+  val props = List[NamedProperty[PropContext]] (
+    ("all diffs are accounted for in the MergePlan",
+      (start, local, remote, pc) => {
+        val modCount = MergeNode.fold(0, pc.mergePlan.update) { (count,mn) =>
+          mn match {
+            case _: ModifiedNode => count + 1
+            case _               => count
+          }
+        }
+        val deleteCount = pc.mergePlan.delete.size
+        pc.diffs.size == modCount + deleteCount
+      }
+    ),
+
+    ("the MergeNode graph is a tree, not a dag",
+      (start, local, remote, pc) => {
+        val emptyCounts = Map.empty[SPNodeKey, Int].withDefaultValue(0)
+        val parentCount = MergeNode.fold(emptyCounts, pc.mergePlan.update) { (m,mn) =>
+          mn match {
+            case ModifiedNode(_, children) =>
+              (m/:children) { (m2, c) => m2.updated(c.key, m2(c.key) + 1) }
+            case _                         =>
+              m
+          }
+        }
+        parentCount.values.forall(_ == 1)
+      }
+    ),
+
+    ("any node present in both edited versions must be present in the merged result",
+      (start, local, remote, pc) => {
+        val commonKeys = pc.local.nodeMap.keySet & pc.remote.nodeMap.keySet & pc.diffs.collect {
+          case Present(k, _, _, _, _) => k
+        }.toSet
+
+        val mergeKeys = pc.mergeMap.collect { case (k,ModifiedNode(_,_)) => k }.toSet
+        (commonKeys &~ mergeKeys).isEmpty
+      }
+    ),
+
+    ("any node missing in both edited versions must be missing in the merged result",
+      (start, local, remote, pc) => {
+
+        val commonKeys = pc.local.deletedKeys & pc.remote.deletedKeys & pc.diffs.collect {
+          case Missing(k, _) => k
+        }.toSet
+
+        (commonKeys &~ pc.deletedKeys).isEmpty
+      }
+    )
+
+    // ....
+
+  )
+
+  @Test
+  def testAllPreliminaryMergeProperties(): Unit = {
+    def mkPropContext(start: ISPProgram, local: ISPProgram, remote: ISPProgram): PropContext = {
+      val diffs = ProgramDiff.compare(remote, local.getVersions, removedKeys(local))
+      val mc    = MergeContext(local, diffs)
+      PropContext(start, local, remote, diffs, PreliminaryMerge.merge(mc))
+    }
+
+    new MergePropertyTest(mkPropContext).checkAllProperties(props)
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffPropertyTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffPropertyTest.scala
@@ -1,54 +1,22 @@
 package edu.gemini.sp.vcs.diff
 
-import edu.gemini.pot.sp.{SPNodeKey, ISPFactory, ISPProgram, ProgramGen}
+import edu.gemini.pot.sp.{SPNodeKey, ISPProgram}
 import edu.gemini.pot.sp.version._
-import edu.gemini.pot.spdb.DBLocalDatabase
 import edu.gemini.spModel.rich.pot.sp._
 
 import org.junit.Test
-
 import org.scalatest.junit.JUnitSuite
-import org.scalatest.prop.Checkers
-import org.scalacheck.Prop
 
 import scala.collection.JavaConverters._
 
 import scalaz._
 import Scalaz._
 
-//
-// ProgramDiff property testing is a bit unorthodox in that there is one big
-// "property" that combines a bunch of smaller ones.  Program generation is
-// complicated by the fact that the ScienceProgram is mutable and must be
-// created and manipulated in the context of a database and factory.
-//
-// Only about 3% of the total time is taken verifying the properties plus
-// actually running the ProgramDiff for all the generated programs and edits.
-// In other words, about 97% of the time is the overhead of the program and edit
-// generation. If we separate the properties and generate programs and edits for
-// each, the time required to run the tests will be multiplied by the number of
-// properties (so instead of ~14 seconds it would take ~100 seconds).
-//
-// Because of the mutable science program, the generated programs and edits are
-// actually functions which make the normal property failure output less useful.
-// It will tell us that a property failed but the arguments it displays are
-// only functions, as in:
-//
-//  Falsified after 0 successful property evaluations.
-//  Location: (ProgramDiffPropertyTest.scala:154)
-//  Occurred when passed generated values (
-//    arg0 = <function1>
-//  )
-//
-// For that reason, we explicitly write out the generated programs that trigger
-// a failure.
-//
 
-class ProgramDiffPropertyTest extends JUnitSuite with Checkers {
+class ProgramDiffPropertyTest extends JUnitSuite {
+  import MergePropertyTest.NamedProperty
 
-  type DiffProperty = (ISPProgram, ISPProgram, ISPProgram, List[Diff]) => Boolean
-
-  val props = List[(String, DiffProperty)] (
+  val props = List[NamedProperty[List[Diff]]] (
     ("any node that differs must appear in diff list",
       (start, local, remote, diffList) => {
         val allKeys      = local.getVersions.keySet ++ remote.getVersions.keySet
@@ -139,52 +107,11 @@ class ProgramDiffPropertyTest extends JUnitSuite with Checkers {
   private def presentKeys(diffList: List[Diff]): Set[SPNodeKey] =
     diffList.collect { case Diff.Present(k, _, _, _, _) =>  k }.toSet
 
-  private def checkDiffProperty(p: DiffProperty): Unit = {
-    val odb  = DBLocalDatabase.createTransient()
-    val fact = odb.getFactory
-
-    import ProgramGen._
-
-    // Generate a starting program and two independently edited copies of it.
-    val genProgs = for {
-      fStart <- genProg
-      fEd0   <- genEditedProg
-      fEd1   <- genEditedProg
-    } yield {(f: ISPFactory) => {
-      val start = fStart(f)
-      val ed0   = fEd0(f, start)
-      val ed1   = fEd1(f, start)
-      (start, ed0, ed1)
-    }}
-
-    try {
-      check(Prop.forAll(genProgs) { fun =>
-        val (start, ed0, ed1) = fun(fact)
-        val diffs = ProgramDiff.compare(ed0, ed1.getVersions, removedKeys(ed1))
-        p(start, ed0, ed1, diffs)
-      })
-    } finally {
-      odb.getDBAdmin.shutdown()
-    }
-  }
-
   @Test
   def testAllDiffProperties(): Unit = {
-    checkDiffProperty { (start, local, remote, diffs) =>
-      val failure = props.find { case (_, p) => !p(start, local, remote, diffs) }
+    def mkDiffList(ed0: ISPProgram, ed1: ISPProgram): List[Diff] =
+      ProgramDiff.compare(ed0, ed1.getVersions, removedKeys(ed1))
 
-      failure.foreach { case (desc, _) =>
-        println("*** Diff property failure: " + desc)
-
-        val titles = List("Start", "Local", "Remote")
-        val progs  = List(start,   local,   remote)
-        titles.zip(progs).foreach { case (title, prog) =>
-          println(s"\n$title")
-          println(drawNodeTree(prog))
-        }
-      }
-
-      failure.isEmpty
-    }
+    new MergePropertyTest(mkDiffList).checkAllProperties(props)
   }
 }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffPropertyTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffPropertyTest.scala
@@ -109,7 +109,7 @@ class ProgramDiffPropertyTest extends JUnitSuite {
 
   @Test
   def testAllDiffProperties(): Unit = {
-    def mkDiffList(ed0: ISPProgram, ed1: ISPProgram): List[Diff] =
+    def mkDiffList(s: ISPProgram, ed0: ISPProgram, ed1: ISPProgram): List[Diff] =
       ProgramDiff.compare(ed0, ed1.getVersions, removedKeys(ed1))
 
     new MergePropertyTest(mkDiffList).checkAllProperties(props)

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffTest.scala
@@ -229,7 +229,7 @@ class ProgramDiffTest {
   // combinations of locally and remotely editing (or not) and/or removing (or
   // not) the note.
   @Test def removalTests(): Unit = {
-    case class RmTest(pc: TestingEnvironment => ProgContext, edited: Boolean, removed: Boolean) {
+    case class RmTest(pc: TestingEnvironment => TestingEnvironment.ProgContext, edited: Boolean, removed: Boolean) {
       def setup(env: TestingEnvironment, key: SPNodeKey): Unit = {
         val ctx  = pc(env)
         val note = ctx.find(key)


### PR DESCRIPTION
This PR is not ready to be merged.  :-1:  I'm posting it early in order to get feedback on the `PreliminaryMerge` algorithm and the tree of `MergeNode`s that it creates.  You can focus on the last commit if you have time to review this now.  I will continue cleaning it up and testing regardless.

The basic idea is to pair up the `Diff` nodes retrieved from the remote version of a program with their local `ISPNode` science program counterparts and come up with merged `Diff` nodes based upon a comparison of the vector clocks.  A merged `Diff.Present` will choose the data object and children from the local program and/or the remote diff according to the vector clock comparison.  A merged `Diff.Missing` is simply an update to the deleted node's vector clock

We then traverse the merged `Diff.Present`s from the root down, following the children in a DF traversal and building a `MergeNode` tree.  There are two types of `MergeNode`: `ModifiedNode` and `UnmodifiedNode`.  `ModifiedNode`s are created for every surviving (i.e., reachable from the root) merged `Diff.Present`.  When a `ModifiedNode` has a child for which there was no `Diff.Present`, the child is represented as an `UnmodifiedNode` leaf which simply refers to the matching `ISPNode`.  I realize this probably makes little or no sense as described.  Perhaps a picture would help ...

The `MergeNode` tree will ultimately be manipulated to handle special cases like observation renumbering.  This PR will cover just up to the initial creation of the `MergeNode` tree with no additional corrections.  In other words, a preliminary merge (see `PreliminaryMerge`).