### PR TITLE
OCSADV-154  remove SPTarget mutators

### DIFF
--- a/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
+++ b/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
@@ -181,7 +181,9 @@ public enum ToContext {
             // pick the right guider.
             case nonsidereal:
                 t = new SPTarget(new ConicTarget());
-                t.setRaDecDegrees(raDeg, decDeg);
+                t.getTarget().getRa().setAs(raDeg, CoordinateParam.Units.DEGREES);
+                t.getTarget().getDec().setAs(decDeg, CoordinateParam.Units.DEGREES);
+                t.notifyOfGenericUpdate();
                 break;
             default:
                 t = new SPTarget(raDeg, decDeg);

--- a/bundle/edu.gemini.lchquery.servlet/src/test/java/edu/gemini/lchquery/servlet/LchQueryFunctorTest.java
+++ b/bundle/edu.gemini.lchquery.servlet/src/test/java/edu/gemini/lchquery/servlet/LchQueryFunctorTest.java
@@ -157,7 +157,8 @@ public class LchQueryFunctorTest {
     protected void addTargetObsCompAOP1(ISPProgram prog) throws SPUnknownIDException, RemoteException, SPTreeStateException, SPNodeNotLocalException {
         TargetObsComp target = new TargetObsComp();
         SPTarget sptarget = new SPTarget();
-        sptarget.setName("name");
+        sptarget.getTarget().setName("name");
+        sptarget.notifyOfGenericUpdate();
         Set<GuideProbe> guideProbes = new HashSet<GuideProbe>();
         guideProbes.add(AltairAowfsGuider.instance);
         guideProbes.add(PwfsGuideProbe.pwfs1);
@@ -193,7 +194,8 @@ public class LchQueryFunctorTest {
     protected void addTargetObsCompAO(ISPProgram prog) throws SPUnknownIDException, RemoteException, SPTreeStateException, SPNodeNotLocalException {
         TargetObsComp target = new TargetObsComp();
         SPTarget sptarget = new SPTarget();
-        sptarget.setName("name");
+        sptarget.getTarget().setName("name");
+        sptarget.notifyOfGenericUpdate();
         Set<GuideProbe> guideProbes = new HashSet<GuideProbe>();
         guideProbes.add(AltairAowfsGuider.instance);
 

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -238,11 +238,10 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
         SPTarget base = targetEnv.getBase();
 
         base.getTarget().setName(tooTarget.getName());
-        base.notifyOfGenericUpdate();
         base.getTarget().getRa().setAs(tooTarget.getRa(), CoordinateParam.Units.DEGREES);
         base.getTarget().getDec().setAs(tooTarget.getDec(), CoordinateParam.Units.DEGREES);
-        base.notifyOfGenericUpdate();
         base.getTarget().setMagnitudes(tooTarget.getMagnitudes());
+        base.notifyOfGenericUpdate();
 
         // Set the guide star, if present.
         TooGuideTarget gs = update.getGuideStar();
@@ -283,12 +282,11 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
 
                         target.getTarget().getRa().setAs(gs.getRa(), CoordinateParam.Units.DEGREES);
                         target.getTarget().getDec().setAs(gs.getDec(), CoordinateParam.Units.DEGREES);
-                        target.notifyOfGenericUpdate();
                         String name = gs.getName();
                         if (name != null) {
                             target.getTarget().setName(name);
-                            target.notifyOfGenericUpdate();
                         }
+                        target.notifyOfGenericUpdate();
 
                         target.getTarget().setMagnitudes(gs.getMagnitudes());
 

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -22,6 +22,7 @@ import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import edu.gemini.spModel.too.TooConstraintService;
 import edu.gemini.spdb.rapidtoo.*;
 import edu.gemini.util.security.auth.keychain.KeyService;
@@ -236,8 +237,11 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
         TargetEnvironment targetEnv = targetObsComp.getTargetEnvironment();
         SPTarget base = targetEnv.getBase();
 
-        base.setName(tooTarget.getName());
-        base.setRaDecDegrees(tooTarget.getRa(), tooTarget.getDec());
+        base.getTarget().setName(tooTarget.getName());
+        base.notifyOfGenericUpdate();
+        base.getTarget().getRa().setAs(tooTarget.getRa(), CoordinateParam.Units.DEGREES);
+        base.getTarget().getDec().setAs(tooTarget.getDec(), CoordinateParam.Units.DEGREES);
+        base.notifyOfGenericUpdate();
         base.getTarget().setMagnitudes(tooTarget.getMagnitudes());
 
         // Set the guide star, if present.
@@ -277,9 +281,14 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
                         Option<SPTarget> targetOpt = gt.getPrimary();
                         SPTarget target = targetOpt.isEmpty() ? new SPTarget() : targetOpt.getValue();
 
-                        target.setRaDecDegrees(gs.getRa(), gs.getDec());
+                        target.getTarget().getRa().setAs(gs.getRa(), CoordinateParam.Units.DEGREES);
+                        target.getTarget().getDec().setAs(gs.getDec(), CoordinateParam.Units.DEGREES);
+                        target.notifyOfGenericUpdate();
                         String name = gs.getName();
-                        if (name != null) target.setName(name);
+                        if (name != null) {
+                            target.getTarget().setName(name);
+                            target.notifyOfGenericUpdate();
+                        }
 
                         target.getTarget().setMagnitudes(gs.getMagnitudes());
 

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -238,7 +238,7 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
 
         base.setName(tooTarget.getName());
         base.setRaDecDegrees(tooTarget.getRa(), tooTarget.getDec());
-        base.setMagnitudes(tooTarget.getMagnitudes());
+        base.getTarget().setMagnitudes(tooTarget.getMagnitudes());
 
         // Set the guide star, if present.
         TooGuideTarget gs = update.getGuideStar();
@@ -281,7 +281,7 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
                         String name = gs.getName();
                         if (name != null) target.setName(name);
 
-                        target.setMagnitudes(gs.getMagnitudes());
+                        target.getTarget().setMagnitudes(gs.getMagnitudes());
 
                         if (targetOpt.isEmpty()) {
                             ImList<SPTarget> lst = gt.getOptions().cons(target);

--- a/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
+++ b/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
@@ -238,7 +238,8 @@ public class AbstractRuleTest {
     protected void addTargetObsCompAOP1() throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
         TargetObsComp target = new TargetObsComp();
         SPTarget sptarget = new SPTarget();
-        sptarget.setName("name");
+        sptarget.getTarget().setName("name");
+        sptarget.notifyOfGenericUpdate();
         Set<GuideProbe> guideProbes = new HashSet<GuideProbe>();
         guideProbes.add(AltairAowfsGuider.instance);
         guideProbes.add(PwfsGuideProbe.pwfs1);
@@ -277,7 +278,8 @@ public class AbstractRuleTest {
     protected void addTargetObsCompAO() throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
         TargetObsComp target = new TargetObsComp();
         SPTarget sptarget = new SPTarget();
-        sptarget.setName("name");
+        sptarget.getTarget().setName("name");
+        sptarget.notifyOfGenericUpdate();
         Set<GuideProbe> guideProbes = new HashSet<GuideProbe>();
         guideProbes.add(AltairAowfsGuider.instance);
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
@@ -61,7 +61,7 @@ object SpTargetFactory {
       // Add apparent magnitude, if any.
       nsid.magnitude(time)
         .map(new SO.Magnitude(SO.Magnitude.Band.AP, _))
-        .foreach(spTarget.putMagnitude)
+        .foreach(spTarget.getTarget.putMagnitude)
 
       spTarget
     }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
@@ -83,7 +83,7 @@ object SpTargetFactory {
 
       val spTarget = new SP.SPTarget(itarget)
       spTarget.setName(sid.name)
-      spTarget.setMagnitudes(DefaultImList.create(mags.asJava))
+      spTarget.getTarget.setMagnitudes(DefaultImList.create(mags.asJava))
       spTarget
     }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
@@ -23,7 +23,7 @@ object SpTargetFactory {
 
   private def createTooTarget(too: TooTarget): SP.SPTarget = {
     val sp   = new SP.SPTarget(0.0, 0.0)
-    sp.setName(too.name)
+    sp.getTarget.setName(too.name)
     sp
   }
 
@@ -56,7 +56,7 @@ object SpTargetFactory {
       itarget.setDateForPosition(new java.util.Date(when))
 
       val spTarget = new SP.SPTarget(itarget)
-      spTarget.setName(nsid.name)
+      spTarget.getTarget.setName(nsid.name)
 
       // Add apparent magnitude, if any.
       nsid.magnitude(time)
@@ -82,7 +82,7 @@ object SpTargetFactory {
       }
 
       val spTarget = new SP.SPTarget(itarget)
-      spTarget.setName(sid.name)
+      spTarget.getTarget.setName(sid.name)
       spTarget.getTarget.setMagnitudes(DefaultImList.create(mags.asJava))
       spTarget
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -85,12 +85,6 @@ public final class SPTarget extends WatchablePos {
     /// END OF PUBLIC API ... EVERYTHING FROM HERE DOWN GOES AWAY
     ///
 
-    /** Set a magnitude on the contained target and notify listeners. */
-    public void putMagnitude(final Magnitude mag) {
-        _target.putMagnitude(mag);
-        _notifyOfUpdate();
-    }
-
     /** Set the contained target's name and notify listeners. */
     public void setName(final String name) {
         _target.setName(name);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -85,13 +85,6 @@ public final class SPTarget extends WatchablePos {
     /// END OF PUBLIC API ... EVERYTHING FROM HERE DOWN GOES AWAY
     ///
 
-
-    /** Set contained target magnitudes and notify listeners. */
-    public void setMagnitudes(final ImList<Magnitude> magnitudes) {
-        _target.setMagnitudes(magnitudes);
-        _notifyOfUpdate();
-    }
-
     /** Set a magnitude on the contained target and notify listeners. */
     public void putMagnitude(final Magnitude mag) {
         _target.putMagnitude(mag);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -13,10 +13,7 @@ import edu.gemini.spModel.target.system.*;
 import edu.gemini.spModel.target.system.CoordinateParam.Units;
 import edu.gemini.spModel.target.system.CoordinateTypes.*;
 
-/**
- * A data object that describes a telescope position and includes methods
- * for extracting positions.
- */
+/** A mutable cell containing an ITarget. */
 public final class SPTarget extends WatchablePos {
 
     private ITarget _target;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -75,19 +75,13 @@ public final class SPTarget extends WatchablePos {
 
     /** Clone this SPTarget. */
     public SPTarget clone() {
-        return new SPTarget((ITarget) _target.clone());
+        return new SPTarget(_target.clone());
     }
 
 
     ///
     /// END OF PUBLIC API ... EVERYTHING FROM HERE DOWN GOES AWAY
     ///
-
-    /** Set the contained target's name and notify listeners. */
-    public void setName(final String name) {
-        _target.setName(name);
-        _notifyOfUpdate();
-    }
 
     /** Get the PM RA in mas/y if the contained target is sidereal, otherwise zero. */
     public double getPropMotionRA() {
@@ -196,15 +190,6 @@ public final class SPTarget extends WatchablePos {
     /** @deprecated */
     public void notifyOfGenericUpdate() {
     	super._notifyOfUpdate();
-    }
-
-    /** Set the contained target RA/Dec in degrees and notify observers. */
-    public void setRaDecDegrees(final double raDeg, final double decDeg) {
-        synchronized (this) {
-            _target.getRa().setAs(raDeg, Units.DEGREES);
-            _target.getDec().setAs(decDeg, Units.DEGREES);
-        }
-        _notifyOfUpdate();
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -7,8 +7,6 @@
 //
 package edu.gemini.spModel.target;
 
-import edu.gemini.shared.skyobject.Magnitude;
-import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.system.*;
@@ -88,26 +86,6 @@ public final class SPTarget extends WatchablePos {
     /** Set the contained target's name and notify listeners. */
     public void setName(final String name) {
         _target.setName(name);
-        _notifyOfUpdate();
-    }
-
-    /**
-     * Set the contained target's RA and Dec from Strings in HMS/DMS format and notify listeners.
-     * Invalid values are replaced with 00:00:00.
-     */
-    public void setHmsDms(final String hms, final String dms) {
-        synchronized (this) {
-            try {
-                _target.getRa().setValue(hms);
-            } catch (final IllegalArgumentException ex) {
-                _target.getRa().setValue("00:00:00.0");
-            }
-            try {
-                _target.getDec().setValue(dms);
-            } catch( final IllegalArgumentException ex) {
-                _target.getDec().setValue("00:00:00.0");
-            }
-        }
         _notifyOfUpdate();
     }
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -140,7 +140,7 @@ public final class SPTargetSkyObjectTest {
         SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
         // Put a new magnitude for the K band.
-        target.setMagnitudes(DefaultImList.create(magJ3, magK2));
+        target.getTarget().setMagnitudes(DefaultImList.create(magJ3, magK2));
         ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -119,7 +119,7 @@ public final class SPTargetSkyObjectTest {
         SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
         // Put a new magnitude for the K band.
-        target.putMagnitude(magK2);
+        target.getTarget().putMagnitude(magK2);
         ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());
@@ -127,7 +127,7 @@ public final class SPTargetSkyObjectTest {
         assertEquals(magK2, target.getTarget().getMagnitude(Magnitude.Band.K).getValue());
 
         // Replace the existing J band mag with a new one.
-        target.putMagnitude(magJ3);
+        target.getTarget().putMagnitude(magJ3);
         magList = target.getTarget().getMagnitudes();
         assertEquals(2, magList.size());
         assertEquals(magJ3, target.getTarget().getMagnitude(Magnitude.Band.J).getValue());

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
@@ -6,6 +6,7 @@ import edu.gemini.qv.plugin.{ReferenceDateChanged, QvContext}
 import edu.gemini.qv.plugin.util.ConstraintsCache.ConstraintCalculationEnd
 import edu.gemini.qv.plugin.util.{SolutionProvider, NonSiderealCache}
 import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.system.CoordinateParam.Units
 import scala.collection.JavaConversions._
 import scala.swing.event.Event
 import scala.swing.{Swing, Publisher}
@@ -181,8 +182,9 @@ case class PositionProvider(ctx: QvContext, base: ObservationProvider) extends O
     _observations = base.observations.map(o => {
       if (NonSiderealCache.isHorizonsTarget(o)) {
         val pos = NonSiderealCache.get(ctx.site, ctx.referenceDate, o)
-        val newTarget = o.getTargetEnvironment.getBase.clone().asInstanceOf[SPTarget]
-        newTarget.setRaDecDegrees(pos.getRaDeg, pos.getDecDeg)
+        val newTarget = o.getTargetEnvironment.getBase.clone()
+        newTarget.getTarget.getRa.setAs(pos.getRaDeg, Units.DEGREES)
+        newTarget.getTarget.getDec.setAs(pos.getDecDeg, Units.DEGREES)
         new Obs(
           o.getProg,
           o.getGroup,

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -114,14 +114,18 @@ public class TccFieldConfig extends ParamSet {
     private void addBaseGroup(TargetEnvironment env) throws WdbaGlueException {
         // Add the target itself.
         SPTarget base = env.getBase();
-        if (isEmpty(base.getTarget().getName())) base.setName(TccNames.BASE);
+        if (isEmpty(base.getTarget().getName())) {
+            base.getTarget().setName(TccNames.BASE);
+            base.notifyOfGenericUpdate();
+        }
         add(new TargetConfig(base));
 
         // Add the user targets.
         int pos = 1;
         for (SPTarget user : env.getUserTargets()) {
             if (isEmpty(user.getTarget().getName())) {
-                user.setName(TargetConfig.formatName("User", pos));
+                user.getTarget().setName(TargetConfig.formatName("User", pos));
+                user.notifyOfGenericUpdate();
             }
             ++pos;
             add(new TargetConfig(user));
@@ -146,7 +150,8 @@ public class TccFieldConfig extends ParamSet {
         int pos = 1;
         for (SPTarget target : targets) {
             if (isEmpty(target.getTarget().getName())) {
-                target.setName(TargetConfig.formatName(tag, pos));
+                target.getTarget().setName(TargetConfig.formatName(tag, pos));
+                target.notifyOfGenericUpdate();
             }
             add(new TargetConfig(target));
             ++pos;

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
@@ -36,7 +36,8 @@ public final class GsaoiSupportTest extends InstrumentSupportTestBase<Gsaoi> {
         super(Gsaoi.SP_TYPE);
 
         base = new SPTarget();
-        base.setName("Base Pos");
+        base.getTarget().setName("Base Pos");
+        base.notifyOfGenericUpdate();
     }
 
     @Before public void setUp() throws Exception {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
@@ -42,7 +42,8 @@ public class GuideConfigTest extends TestBase {
         super.setUp();
 
         base = new SPTarget();
-        base.setName("Base Pos");
+        base.getTarget().setName("Base Pos");
+        base.notifyOfGenericUpdate();
     }
 
     private static GuideProbeTargets createGuideTargets(GuideProbe probe) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
@@ -36,7 +36,8 @@ public final class GuideGroupTest extends TestBase {
         super.setUp();
 
         base = new SPTarget();
-        base.setName("Base Pos");
+        base.getTarget().setName("Base Pos");
+        base.notifyOfGenericUpdate();
     }
 
     private static GuideProbeTargets createGuideTargets(GuideProbe probe) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -47,17 +47,22 @@ public final class TargetGroupTest extends TestBase {
         nameMap = new NameMap();
 
         base = new SPTarget();
-        base.setName("Base Pos");
+        base.getTarget().setName("Base Pos");
+        base.notifyOfGenericUpdate();
 
         pwfs1_1 = new SPTarget();
-        pwfs1_1.setName("PWFS1-1");
+        pwfs1_1.getTarget().setName("PWFS1-1");
+        pwfs1_1.notifyOfGenericUpdate();
         pwfs1_2 = new SPTarget();
-        pwfs1_2.setName("PWFS1-2");
+        pwfs1_2.getTarget().setName("PWFS1-2");
+        pwfs1_2.notifyOfGenericUpdate();
 
         pwfs2_1 = new SPTarget();
-        pwfs2_1.setName("PWFS2-1");
+        pwfs2_1.getTarget().setName("PWFS2-1");
+        pwfs2_1.notifyOfGenericUpdate();
         pwfs2_2 = new SPTarget();
-        pwfs2_2.setName("PWFS2-2");
+        pwfs2_2.getTarget().setName("PWFS2-2");
+        pwfs2_2.notifyOfGenericUpdate();
     }
 
     /**
@@ -141,9 +146,11 @@ public final class TargetGroupTest extends TestBase {
      */
     public void testDisabledGuideTargets() throws Exception {
         SPTarget guide1 = new SPTarget();
-        guide1.setName("OIWFS-1");
+        guide1.getTarget().setName("OIWFS-1");
+        guide1.notifyOfGenericUpdate();
         SPTarget guide2 = new SPTarget();
-        guide2.setName("OIWFS-2");
+        guide2.getTarget().setName("OIWFS-2");
+        guide2.notifyOfGenericUpdate();
 
         ImList<SPTarget> targetList;
         targetList = ImCollections.singletonList(guide2).cons(guide1);
@@ -479,7 +486,8 @@ public final class TargetGroupTest extends TestBase {
         ImList<SPTarget> targets = ImCollections.emptyList();
         for (int i=names.length-1; i>=0; --i) {
             SPTarget target = new SPTarget();
-            target.setName(names[i]);
+            target.getTarget().setName(names[i]);
+            target.notifyOfGenericUpdate();
             targets = targets.cons(target);
         }
         return GuideProbeTargets.create(guider, targets).setPrimaryIndex(1);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -48,21 +48,16 @@ public final class TargetGroupTest extends TestBase {
 
         base = new SPTarget();
         base.getTarget().setName("Base Pos");
-        base.notifyOfGenericUpdate();
 
         pwfs1_1 = new SPTarget();
         pwfs1_1.getTarget().setName("PWFS1-1");
-        pwfs1_1.notifyOfGenericUpdate();
         pwfs1_2 = new SPTarget();
         pwfs1_2.getTarget().setName("PWFS1-2");
-        pwfs1_2.notifyOfGenericUpdate();
 
         pwfs2_1 = new SPTarget();
         pwfs2_1.getTarget().setName("PWFS2-1");
-        pwfs2_1.notifyOfGenericUpdate();
         pwfs2_2 = new SPTarget();
         pwfs2_2.getTarget().setName("PWFS2-2");
-        pwfs2_2.notifyOfGenericUpdate();
     }
 
     /**
@@ -147,10 +142,8 @@ public final class TargetGroupTest extends TestBase {
     public void testDisabledGuideTargets() throws Exception {
         SPTarget guide1 = new SPTarget();
         guide1.getTarget().setName("OIWFS-1");
-        guide1.notifyOfGenericUpdate();
         SPTarget guide2 = new SPTarget();
         guide2.getTarget().setName("OIWFS-2");
-        guide2.notifyOfGenericUpdate();
 
         ImList<SPTarget> targetList;
         targetList = ImCollections.singletonList(guide2).cons(guide1);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -50,20 +50,20 @@ public final class TargetMagnitudeTest extends TestBase {
     }
 
     public void testOneMagnitude() throws Exception {
-        pwfs1_1.putMagnitude(new Magnitude(Magnitude.Band.J, 10));
+        pwfs1_1.getTarget().putMagnitude(new Magnitude(Magnitude.Band.J, 10));
         testTargetEnvironment(env);
     }
 
     public void testNonSiderealMagnitude() throws Exception {
-        pwfs1_1.putMagnitude(new Magnitude(Magnitude.Band.J, 10));
+        pwfs1_1.getTarget().putMagnitude(new Magnitude(Magnitude.Band.J, 10));
         pwfs1_1.setTarget(new ConicTarget());
         pwfs1_1.setName("PWFS1-1");
         testTargetEnvironment(env);
     }
 
     public void testTwoMagnitudes() throws Exception {
-        pwfs1_1.putMagnitude(new Magnitude(Magnitude.Band.J, 10));
-        pwfs1_1.putMagnitude(new Magnitude(Magnitude.Band.K, 20));
+        pwfs1_1.getTarget().putMagnitude(new Magnitude(Magnitude.Band.J, 10));
+        pwfs1_1.getTarget().putMagnitude(new Magnitude(Magnitude.Band.K, 20));
         testTargetEnvironment(env);
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -35,11 +35,9 @@ public final class TargetMagnitudeTest extends TestBase {
 
         SPTarget base = new SPTarget();
         base.getTarget().setName("Base Pos");
-        base.notifyOfGenericUpdate();
 
         pwfs1_1 = new SPTarget();
         pwfs1_1.getTarget().setName("PWFS1-1");
-        pwfs1_1.notifyOfGenericUpdate();
 
         env = TargetEnvironment.create(base);
         GuideProbeTargets gpt = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, pwfs1_1);
@@ -60,7 +58,6 @@ public final class TargetMagnitudeTest extends TestBase {
         pwfs1_1.getTarget().putMagnitude(new Magnitude(Magnitude.Band.J, 10));
         pwfs1_1.setTarget(new ConicTarget());
         pwfs1_1.getTarget().setName("PWFS1-1");
-        pwfs1_1.notifyOfGenericUpdate();
         testTargetEnvironment(env);
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -34,10 +34,12 @@ public final class TargetMagnitudeTest extends TestBase {
         super.setUp();
 
         SPTarget base = new SPTarget();
-        base.setName("Base Pos");
+        base.getTarget().setName("Base Pos");
+        base.notifyOfGenericUpdate();
 
         pwfs1_1 = new SPTarget();
-        pwfs1_1.setName("PWFS1-1");
+        pwfs1_1.getTarget().setName("PWFS1-1");
+        pwfs1_1.notifyOfGenericUpdate();
 
         env = TargetEnvironment.create(base);
         GuideProbeTargets gpt = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, pwfs1_1);
@@ -57,7 +59,8 @@ public final class TargetMagnitudeTest extends TestBase {
     public void testNonSiderealMagnitude() throws Exception {
         pwfs1_1.getTarget().putMagnitude(new Magnitude(Magnitude.Band.J, 10));
         pwfs1_1.setTarget(new ConicTarget());
-        pwfs1_1.setName("PWFS1-1");
+        pwfs1_1.getTarget().setName("PWFS1-1");
+        pwfs1_1.notifyOfGenericUpdate();
         testTargetEnvironment(env);
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -233,6 +233,26 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         return pan;
     }
 
+    /**
+     * Set the contained target's RA and Dec from Strings in HMS/DMS format and notify listeners.
+     * Invalid values are replaced with 00:00:00.
+     */
+    private static void setHmsDms(SPTarget spTarget, final String hms, final String dms) {
+        synchronized (spTarget) {
+            try {
+                spTarget.getTarget().getRa().setValue(hms);
+            } catch (final IllegalArgumentException ex) {
+                spTarget.getTarget().getRa().setValue("00:00:00.0");
+            }
+            try {
+                spTarget.getTarget().getDec().setValue(dms);
+            } catch( final IllegalArgumentException ex) {
+                spTarget.getTarget().getDec().setValue("00:00:00.0");
+            }
+        }
+        spTarget.notifyOfGenericUpdate();
+    }
+
     // Initialize the widgets involved in editing positions. This includes the
     // RA/Dec + sidereal or nonsidereal information.  Takes the GUI built by
     // JFormDesigner in _w.coordinatesPanel and morphs it a bit.  This is all
@@ -1643,7 +1663,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         if (!(dec.equals("-") || dec.equals("+"))) {
             _ignorePosUpdate = true;
             try {
-                _curPos.setHmsDms(ra, dec);
+                setHmsDms(_curPos, ra, dec);
             } finally {
                 _ignorePosUpdate = false;
             }
@@ -2093,7 +2113,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                         NonSiderealTarget target = (NonSiderealTarget) _curPos.getTarget();
                         _ignorePosUpdate = true;
                         try {
-                            _curPos.setHmsDms(coords.getRA().toString(),
+                            setHmsDms(_curPos, coords.getRA().toString(),
                                     coords.getDec().toString());
                         } finally {
                             _ignorePosUpdate = false;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -532,7 +532,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 String name = tbwe.getText();
                 if (name != null) name = name.trim();
                 _curPos.deleteWatcher(EdCompTargetList.this);
-                _curPos.setName(name);
+                _curPos.getTarget().setName(name);
+                _curPos.notifyOfGenericUpdate();
                 _curPos.addWatcher(EdCompTargetList.this);
                 _w.resolveButton.setEnabled(!"".equals(name));
             }
@@ -1118,7 +1119,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 final HorizonsService service = HorizonsService.getInstance();
                 if (service != null) {
                     final String objectId = service.getObjectId();
-                    _curPos.setName(objectId);
+                    _curPos.getTarget().setName(objectId);
+                    _curPos.notifyOfGenericUpdate();
                 }
 
 
@@ -1816,7 +1818,9 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             }
 
             SPTarget base = env.getBase();
-            base.setRaDecDegrees(basePos.getRaDeg(), basePos.getDecDeg());
+            base.getTarget().getRa().setAs(basePos.getRaDeg(), CoordinateParam.Units.DEGREES);
+            base.getTarget().getDec().setAs(basePos.getDecDeg(), CoordinateParam.Units.DEGREES);
+            base.notifyOfGenericUpdate();
         } else if (w == _w.resolveButton) {
             // REL-1063 Fix OT nonsidereal Solar System Object Horizons name resolution
             if (_curPos.getTarget() instanceof NamedTarget) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -807,7 +807,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             if (spTarget != null) {
                 if (target != null) {
                     spTarget.setTarget((ITarget) target.clone());
-                    spTarget.setMagnitudes(mag);
+                    spTarget.getTarget().setMagnitudes(mag);
+                    spTarget.notifyOfGenericUpdate();
                 }
             } else {
                 final GuideGroup group = TargetSelection.getGuideGroup(dataObject.getTargetEnvironment(), obsComponent);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -500,12 +500,14 @@ final class MagnitudeEditor implements TelescopePosEditor {
 
         Magnitude newMag = new Magnitude(b, Magnitude.UNDEFINED_MAG, 0);
 
-        target.setMagnitudes(target.getTarget().getMagnitudes().cons(newMag));
+        target.getTarget().setMagnitudes(target.getTarget().getMagnitudes().cons(newMag));
+        target.notifyOfGenericUpdate();
         focusOn(b);
     }
 
     void removeBand(Magnitude.Band b) {
-        target.setMagnitudes(target.getTarget().getMagnitudes().filter(new NotBand(b)));
+        target.getTarget().setMagnitudes(target.getTarget().getMagnitudes().filter(new NotBand(b)));
+        target.notifyOfGenericUpdate();
     }
 
     void changeBand(Magnitude.Band from, Magnitude.Band to) {
@@ -514,9 +516,10 @@ final class MagnitudeEditor implements TelescopePosEditor {
         Magnitude oldMag = oldMagOpt.getValue();
         Magnitude newMag = new Magnitude(to, oldMag.getBrightness(), oldMag.getError(), oldMag.getSystem());
 
-        target.setMagnitudes(
+        target.getTarget().setMagnitudes(
                target.getTarget().getMagnitudes().filter(new NotBand(from)).cons(newMag)
         );
+        target.notifyOfGenericUpdate();
         focusOn(to);
     }
 
@@ -527,9 +530,10 @@ final class MagnitudeEditor implements TelescopePosEditor {
         if (system == oldMag.getSystem()) return;
         Magnitude newMag = new Magnitude(band, oldMag.getBrightness(), oldMag.getError(), system);
 
-        target.setMagnitudes(
+        target.getTarget().setMagnitudes(
                target.getTarget().getMagnitudes().filter(new NotBand(band)).cons(newMag)
         );
+        target.notifyOfGenericUpdate();
         focusOn(band);
     }
 
@@ -541,9 +545,10 @@ final class MagnitudeEditor implements TelescopePosEditor {
         try {
             Magnitude newMag = new Magnitude(oldMag.getBand(), d, oldMag.getError(), oldMag.getSystem());
             target.deleteWatcher(watcher);
-            target.setMagnitudes(
+            target.getTarget().setMagnitudes(
                    target.getTarget().getMagnitudes().filter(new NotBand(b)).cons(newMag)
             );
+            target.notifyOfGenericUpdate();
             target.addWatcher(watcher);
         } catch (Exception ex) {
             // do nothing

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/PosMap.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/PosMap.java
@@ -10,6 +10,7 @@ import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.TelescopePosWatcher;
 import edu.gemini.spModel.target.WatchablePos;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import edu.gemini.spModel.telescope.IssPort;
 
 import java.awt.geom.Point2D;
@@ -137,7 +138,9 @@ public abstract class PosMap <K, T extends WatchablePos>
                 // ignore
             }
         } else {
-            ((SPTarget) tp).setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
+            ((SPTarget) tp).getTarget().getRa().setAs(tme.pos.getRaDeg(), CoordinateParam.Units.DEGREES);
+            ((SPTarget) tp).getTarget().getDec().setAs(tme.pos.getDecDeg(), CoordinateParam.Units.DEGREES);
+            ((SPTarget) tp).notifyOfGenericUpdate();
         }
 
         tp.addWatcher(this);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -282,7 +282,9 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
             return;
         }
 
-        tp.setRaDecDegrees(basePos.getRaDeg(), basePos.getDecDeg());
+        tp.getTarget().getRa().setAs(basePos.getRaDeg(), Units.DEGREES);
+        tp.getTarget().getDec().setAs(basePos.getDecDeg(), Units.DEGREES);
+        tp.notifyOfGenericUpdate();
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
@@ -13,6 +13,7 @@ import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import jsky.app.ot.tpe.*;
 
 import java.awt.*;
@@ -144,7 +145,9 @@ public class TpeBasePosFeature extends TpePositionFeature {
             }
 
             SPTarget tp = (SPTarget) _dragObject.taggedPos;
-            tp.setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
+            tp.getTarget().getRa().setAs(tme.pos.getRaDeg(), CoordinateParam.Units.DEGREES);
+            tp.getTarget().getDec().setAs(tme.pos.getDecDeg(), CoordinateParam.Units.DEGREES);
+            tp.notifyOfGenericUpdate();
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -16,6 +16,7 @@ import edu.gemini.spModel.target.env.OptionsList.UpdateOps;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
+import edu.gemini.spModel.target.system.CoordinateParam;
 import edu.gemini.spModel.target.system.HmsDegTarget;
 import jsky.app.ot.gemini.editor.targetComponent.PrimaryTargetToggle;
 import jsky.app.ot.tpe.*;
@@ -135,7 +136,10 @@ public class TpeGuidePosFeature extends TpePositionFeature
             double dec = tme.pos.getDecDeg();
 
             pos = new SPTarget(ra, dec);
-            if (tme.name != null) pos.setName(tme.name);
+            if (tme.name != null) {
+                pos.getTarget().setName(tme.name);
+                pos.notifyOfGenericUpdate();
+            }
         }
 
         return pos;
@@ -507,7 +511,9 @@ public class TpeGuidePosFeature extends TpePositionFeature
             _dragObject.screenPos.y = tme.yWidget;
 
             SPTarget tp = (SPTarget) _dragObject.taggedPos;
-            tp.setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
+            tp.getTarget().getRa().setAs(tme.pos.getRaDeg(), CoordinateParam.Units.DEGREES);
+            tp.getTarget().getDec().setAs(tme.pos.getDecDeg(), CoordinateParam.Units.DEGREES);
+            tp.notifyOfGenericUpdate();
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -315,13 +315,18 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
           mag(tp).getOrElse(zero)
 
         def setMag[A](f: (Magnitude, A) => Magnitude): (TemplateParameters, A) => TemplateParameters =
-          setTarget[A]((t, a) => t.putMagnitude(f(t.getTarget.getMagnitude(band).getOrElse(zero), a)))
+          setTarget[A]{ (t, a) =>
+            t.getTarget.putMagnitude(f(t.getTarget.getMagnitude(band).getOrElse(zero), a))
+            t.notifyOfGenericUpdate()
+          }
 
         val magCheck = new BoundCheckbox(
           get = mag(_).isDefined,
           set = setTarget((target, inc) => {
-            if (inc) target.putMagnitude(zero)
-            else {
+            if (inc) {
+              target.getTarget.putMagnitude(zero)
+              target.notifyOfGenericUpdate()
+            } else {
               val mags = target.getTarget.getMagnitudes.toList.asScala.filterNot(_.getBand == band)
               target.getTarget.setMagnitudes(DefaultImList.create(mags.asJava))
               target.notifyOfGenericUpdate()

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -240,7 +240,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         read = identity,
         show = identity,
         get  = _.getTarget.getTarget.getName,
-        set  = setTarget(_.setName(_))
+        set  = setTarget(_.getTarget.setName(_))
       )
 
       val typeCombo = new BoundNullableCombo[TargetType](AllTargetTypes)(

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -253,7 +253,8 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
           }
           coords.setName(target.getTarget.getName)
           target.setTarget(coords)
-          target.setMagnitudes(DefaultImList.create[Magnitude]())
+          target.getTarget.setMagnitudes(DefaultImList.create[Magnitude]())
+          target.notifyOfGenericUpdate()
         })}
       )
 
@@ -322,7 +323,8 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
             if (inc) target.putMagnitude(zero)
             else {
               val mags = target.getTarget.getMagnitudes.toList.asScala.filterNot(_.getBand == band)
-              target.setMagnitudes(DefaultImList.create(mags.asJava))
+              target.getTarget.setMagnitudes(DefaultImList.create(mags.asJava))
+              target.notifyOfGenericUpdate()
             }}
           )
         )


### PR DESCRIPTION
This PR removes the remaining mutators on `SPTarget` with the exception of those associated with proper motion. These will be pushed down into `HmsDegTarget` in a distinct PR. The implementations have been inlined and in some cases include an explicit call to tell the `SPTarget` to notify listeners. This is terrible but it will go away soon enough; all target mods will soon be done via `setTarget`.