### PR TITLE
REL-1841: Update GRACES PIT options

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Graces.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Graces.scala
@@ -2,24 +2,38 @@ package edu.gemini.model.p1.dtree.inst
 
 import edu.gemini.model.p1.dtree._
 import edu.gemini.model.p1.immutable._
-import scala.Some
 
 object Graces {
   def apply() = new FiberNode
 
-  class FiberNode extends SingleSelectNode[Unit, GracesFiberMode, GracesBlueprint](()) {
+  class FiberNode extends SingleSelectNode[Unit, GracesFiberMode, GracesFiberMode](()) {
     val title = "Fiber Mode"
     val description = "Select a fiber mode for your configuration."
 
     def choices: List[GracesFiberMode] = GracesFiberMode.values.toList
 
-    def apply(fm: GracesFiberMode) = Right(GracesBlueprint(fm))
+    def apply(fm: GracesFiberMode) = Left(new ReadNode(fm))
 
     override def default = Some(GracesFiberMode.forName("ONE_FIBER"))
 
     def unapply = {
       case b: GracesBlueprint => b.fiberMode
     }
+  }
+
+  class ReadNode(fm: GracesFiberMode)  extends SingleSelectNode[GracesFiberMode, GracesReadMode, GracesBlueprint](fm) {
+    def title = "Read Mode"
+    def description = "Select a read mode for your configuration."
+
+    def apply(rm: GracesReadMode) = Right(GracesBlueprint(fm, rm))
+
+    override def default = Some(GracesReadMode.forName("NORMAL"))
+
+    def unapply = {
+      case b: GracesBlueprint => b.readMode
+    }
+
+    def choices = GracesReadMode.values.toList
   }
 
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GracesBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GracesBlueprint.scala
@@ -6,12 +6,12 @@ object GracesBlueprint {
   def apply(m: M.GracesBlueprint): GracesBlueprint = new GracesBlueprint(m)
 }
 
-case class GracesBlueprint(fiberMode: GracesFiberMode) extends GeminiBlueprintBase {
-  def name: String = s"Graces ${fiberMode.value}"
+case class GracesBlueprint(fiberMode: GracesFiberMode, readMode: GracesReadMode) extends GeminiBlueprintBase {
+  def name: String = s"Graces ${fiberMode.value} ${readMode.value}"
   override val visitor = true
 
   def this(m: M.GracesBlueprint) = this(
-    m.getFiberMode
+    m.getFiberMode, m.getReadMode
   )
 
   override def instrument: Instrument = Instrument.Graces
@@ -22,6 +22,7 @@ case class GracesBlueprint(fiberMode: GracesFiberMode) extends GeminiBlueprintBa
     m.setId(n.nameOf(this))
     m.setName(name)
     m.setFiberMode(fiberMode)
+    m.setReadMode(readMode)
     m.setVisitor(visitor)
     m
   }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -227,6 +227,9 @@ package object immutable {
   type GracesFiberMode = mutable.GracesFiberMode
   object GracesFiberMode extends EnumObject[mutable.GracesFiberMode]
 
+  type GracesReadMode = mutable.GracesReadMode
+  object GracesReadMode extends EnumObject[mutable.GracesReadMode]
+
   type GpiObservingMode = mutable.GpiObservingMode
   object GpiObservingMode extends EnumObject[mutable.GpiObservingMode] {
     def isCoronographMode(mode: GpiObservingMode):Boolean = mode.value.startsWith("Coronograph")

--- a/bundle/edu.gemini.model.p1/src/main/xjb/Graces.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/Graces.xjb
@@ -6,10 +6,10 @@
     <jxb:bindings schemaLocation="../xsd/Graces.xsd" node="/xsd:schema">
         <!-- GracesFiberMode => Graces.GracesFiberMode -->
         <jxb:bindings node="./xsd:simpleType[@name='GracesFiberMode']/xsd:restriction">
-            <jxb:bindings node="./xsd:enumeration[@value='1 fiber (target, R~50000)']">
+            <jxb:bindings node="./xsd:enumeration[@value='1 fiber (target, R~48k)']">
                 <jxb:typesafeEnumMember name="ONE_FIBER"/>
             </jxb:bindings>
-            <jxb:bindings node="./xsd:enumeration[@value='2 fibers (target + sky, R~30000)']">
+            <jxb:bindings node="./xsd:enumeration[@value='2 fibers (target + sky, R~37k)']">
                 <jxb:typesafeEnumMember name="TWO_FIBER"/>
             </jxb:bindings>
         </jxb:bindings>

--- a/bundle/edu.gemini.model.p1/src/main/xjb/Graces.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/Graces.xjb
@@ -13,6 +13,18 @@
                 <jxb:typesafeEnumMember name="TWO_FIBER"/>
             </jxb:bindings>
         </jxb:bindings>
+        <!-- GracesReadMode => Graces.GracesReadMode -->
+        <jxb:bindings node="./xsd:simpleType[@name='GracesReadMode']/xsd:restriction">
+            <jxb:bindings node="./xsd:enumeration[@value='Fast (Gain=1.6e/ADU, Read noise=4.7e)']">
+                <jxb:typesafeEnumMember name="FAST"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='Normal (Gain=1.3e/ADU, Read noise=4.3e)']">
+                <jxb:typesafeEnumMember name="NORMAL"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='Slow (Gain=1.2e/ADU, Read noise=2.9e)']">
+                <jxb:typesafeEnumMember name="SLOW"/>
+            </jxb:bindings>
+        </jxb:bindings>
     </jxb:bindings>
 
 </jxb:bindings>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -5,6 +5,7 @@ Gemini Phase I Schema Changes
 
 * Offer GRACES as a blueprint option
 * Rename Graces' fiber modes to 1 fiber (target, R~48k) and 2 fibers (target + sky, R~37k)
+* Added Read modes to Graces' blueprints
 
 # Version 2015.1.2 - 2015A
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -4,6 +4,7 @@ Gemini Phase I Schema Changes
 ##########################
 
 * Offer GRACES as a blueprint option
+* Rename Graces' fiber modes to 1 fiber (target, R~48k) and 2 fibers (target + sky, R~37k)
 
 # Version 2015.1.2 - 2015A
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Graces.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Graces.xsd
@@ -25,18 +25,30 @@
             <xsd:extension base="BlueprintBase">
                 <xsd:sequence>
                     <xsd:element name="fiberMode" type="GracesFiberMode" maxOccurs="1"/>
+                    <xsd:element name="readMode" type="GracesReadMode" maxOccurs="1"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
 
     <!--
-      GRACES Filter options.
+      GRACES Fiber Mode options.
     -->
     <xsd:simpleType name="GracesFiberMode">
         <xsd:restriction base="xsd:token">
             <xsd:enumeration value="1 fiber (target, R~48k)"/>
             <xsd:enumeration value="2 fibers (target + sky, R~37k)"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!--
+      GRACES Read Mode options.
+    -->
+    <xsd:simpleType name="GracesReadMode">
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="Fast (Gain=1.6e/ADU, Read noise=4.7e)"/>
+            <xsd:enumeration value="Normal (Gain=1.3e/ADU, Read noise=4.3e)"/>
+            <xsd:enumeration value="Slow (Gain=1.2e/ADU, Read noise=2.9e)"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Graces.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Graces.xsd
@@ -35,8 +35,8 @@
     -->
     <xsd:simpleType name="GracesFiberMode">
         <xsd:restriction base="xsd:token">
-            <xsd:enumeration value="1 fiber (target, R~50000)"/>
-            <xsd:enumeration value="2 fibers (target + sky, R~30000)"/>
+            <xsd:enumeration value="1 fiber (target, R~48k)"/>
+            <xsd:enumeration value="2 fibers (target + sky, R~37k)"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_graces.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_graces.xml
@@ -23,9 +23,9 @@
     <blueprints>
         <graces>
             <Graces id="blueprint-0">
-                <name>Graces 1 fiber (target, R~50000)</name>
+                <name>Graces 1 fiber (target, R~48k)</name>
                 <visitor>false</visitor>
-                <fiberMode>1 fiber (target, R~50000)</fiberMode>
+                <fiberMode>1 fiber (target, R~48k)</fiberMode>
             </Graces>
         </graces>
     </blueprints>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_graces.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_graces.xml
@@ -23,9 +23,10 @@
     <blueprints>
         <graces>
             <Graces id="blueprint-0">
-                <name>Graces 1 fiber (target, R~48k)</name>
+                <name>Graces 1 fiber (target, R~48k) Normal (Gain=1.3e/ADU, Read noise=4.3e)</name>
                 <visitor>false</visitor>
                 <fiberMode>1 fiber (target, R~48k)</fiberMode>
+                <readMode>Normal (Gain=1.3e/ADU, Read noise=4.3e)</readMode>
             </Graces>
         </graces>
     </blueprints>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_graces.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_graces.xml
@@ -24,15 +24,22 @@
     <blueprints>
         <graces>
             <Graces id="blueprint-0">
-                <name>Graces 2 fibers (target + sky, R~37k) Slow (Gain=1.2e/ADU, Read noise=2.9e)</name>
+                <name>Graces 2 fibers (target + sky, R~30000)</name>
                 <visitor>true</visitor>
-                <fiberMode>2 fibers (target + sky, R~37k)</fiberMode>
-                <readMode>Slow (Gain=1.2e/ADU, Read noise=2.9e)</readMode>
+                <fiberMode>2 fibers (target + sky, R~30000)</fiberMode>
+            </Graces>
+        </graces>
+        <graces>
+            <Graces id="blueprint-1">
+                <name>Graces 1 fiber (target, R~50000)</name>
+                <visitor>true</visitor>
+                <fiberMode>1 fiber (target, R~50000)</fiberMode>
             </Graces>
         </graces>
     </blueprints>
     <observations>
         <observation blueprint="blueprint-0" enabled="true" band="Band 1/2"/>
+        <observation blueprint="blueprint-1" enabled="true" band="Band 1/2"/>
     </observations>
     <proposalClass>
         <queue tooOption="None"/>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/GracesSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/GracesSpec.scala
@@ -1,18 +1,30 @@
 package edu.gemini.model.p1.dtree.inst
 
 import org.specs2.mutable.SpecificationWithJUnit
-import edu.gemini.model.p1.immutable.GracesFiberMode
+import edu.gemini.model.p1.immutable.{GracesReadMode, GracesFiberMode}
 
 class GracesSpec extends SpecificationWithJUnit {
   "The Graces decision tree" should {
-    "includes Graces observing modes" in {
+    "includes Graces fiber modes" in {
       val graces = Graces()
       graces.title must beEqualTo("Fiber Mode")
-      graces.choices must have size (2)
+      graces.choices must have size 2
+    }
+    "includes Graces read modes" in {
+      val graces = Graces()
+      val readModeChoice = graces.apply(GracesFiberMode.forName("ONE_FIBER"))
+      readModeChoice must beLeft
+      val readMode = readModeChoice.left.get
+      readMode.title must beEqualTo("Read Mode")
+      readMode.choices must have size 3
     }
     "build a Graces blueprint" in {
-      val gpi = Graces()
-      val blueprint = gpi.apply(GracesFiberMode.forName("ONE_FIBER"))
+      val graces = Graces()
+      val readModeChoice = graces.apply(GracesFiberMode.forName("ONE_FIBER"))
+      readModeChoice must beLeft
+      val readMode = readModeChoice.left.get
+
+      val blueprint = readMode.apply(GracesReadMode.forName("SLOW"))
       blueprint must beRight
     }
   }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/GracesBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/GracesBlueprintSpec.scala
@@ -8,21 +8,22 @@ import java.io.InputStreamReader
 class GracesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
 
   "The Graces Blueprint" should {
-    "has an observing mode and a disperser" in {
+    "has a fiber mode and a read mode" in {
       // trivial sanity tests
-      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
+      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER, M.GracesReadMode.NORMAL)
       blueprint.fiberMode must beEqualTo(M.GracesFiberMode.ONE_FIBER)
+      blueprint.readMode must beEqualTo(M.GracesReadMode.NORMAL)
     }
     "never uses Lgs" in {
-      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
+      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER, M.GracesReadMode.NORMAL)
       blueprint.ao must beEqualTo(AoNone)
     }
-    "have an appropriate public name" in {
-      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
-      blueprint.name must beEqualTo("Graces 1 fiber (target, R~48k)")
+    "has an appropriate public name" in {
+      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER, M.GracesReadMode.NORMAL)
+      blueprint.name must beEqualTo("Graces 1 fiber (target, R~48k) Normal (Gain=1.3e/ADU, Read noise=4.3e)")
     }
     "is a visitor" in {
-      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
+      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER, M.GracesReadMode.NORMAL)
       blueprint.visitor must beTrue
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
@@ -32,8 +33,8 @@ class GracesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties
       // verify the blueprint has a false attribute
       xml must \\("Graces") \"visitor" \> "true"
     }
-    "export fiber mode to XML" in {
-      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
+    "export fiber mode and read mode to XML" in {
+      val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER, M.GracesReadMode.NORMAL)
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
       val proposal = Proposal.empty.copy(observations = observation :: Nil)
@@ -41,12 +42,13 @@ class GracesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties
 
       // verify the exported value
       xml must \\("fiberMode") \> "1 fiber (target, R~48k)"
+      xml must \\("readMode") \> "Normal (Gain=1.3e/ADU, Read noise=4.3e)"
     }
     "be possible to deserialize" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_graces.xml")))
 
       proposal.blueprints(0).visitor must beTrue
-      proposal.blueprints must beEqualTo(GracesBlueprint(M.GracesFiberMode.ONE_FIBER) :: Nil)
+      proposal.blueprints must beEqualTo(GracesBlueprint(M.GracesFiberMode.ONE_FIBER, M.GracesReadMode.NORMAL) :: Nil)
     }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/GracesBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/GracesBlueprintSpec.scala
@@ -19,7 +19,7 @@ class GracesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties
     }
     "have an appropriate public name" in {
       val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
-      blueprint.name must beEqualTo("Graces 1 fiber (target, R~50000)")
+      blueprint.name must beEqualTo("Graces 1 fiber (target, R~48k)")
     }
     "is a visitor" in {
       val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
@@ -30,7 +30,7 @@ class GracesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
       // verify the blueprint has a false attribute
-      xml must \\("Graces") \("visitor") \> "true"
+      xml must \\("Graces") \"visitor" \> "true"
     }
     "export fiber mode to XML" in {
       val blueprint = GracesBlueprint(M.GracesFiberMode.ONE_FIBER)
@@ -40,7 +40,7 @@ class GracesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
       // verify the exported value
-      xml must \\("fiberMode") \> ("1 fiber (target, R~50000)")
+      xml must \\("fiberMode") \> "1 fiber (target, R~48k)"
     }
     "be possible to deserialize" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_graces.xml")))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -639,8 +639,11 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 3
+          changes must have length 5
           result \\ "graces" must \\("fiberMode") \> "2 fibers (target + sky, R~37k)"
+          result \\ "graces" must \\("name") \> "Graces 2 fibers (target + sky, R~37k)"
+          result \\ "graces" must \\("fiberMode") \> "1 fiber (target, R~48k)"
+          result \\ "graces" must \\("name") \> "Graces 1 fiber (target, R~48k)"
       }
     }
   }


### PR DESCRIPTION
This PR contains two updates to the Graces model:

* Rename of fiber modes
* Addition of read mode

The PR takes care of the xml, model and decision tree changes plus tests