### PR TITLE
REL-2177B: Custom QV charts are lost when application is quit (2)

### DIFF
--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/QvStore.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/QvStore.scala
@@ -180,7 +180,8 @@ object QvStore extends Publisher {
       axesMap = (DefaultAxes ++ savedAxes).map(a => a.label -> a).toMap.withDefaultValue(Axis.RA1)
       savedCharts <- FilterXMLParser.parseHistograms(xml \ "histograms" \ "histogram", axesMap)
       savedTables <- FilterXMLParser.parseTables(xml \ "tables" \ "table", axesMap)
-      savedVisCharts <- FilterXMLParser.parseVisCharts(xml \ "barcharts" \ "barchart", axesMap)
+      barchartAxesMap = axesMap ++ Axis.Dynamics.map(a=>a.label -> a).toMap // include dynamic axes for lookup when loading stored bar charts
+      savedVisCharts <- FilterXMLParser.parseVisCharts(xml \ "barcharts" \ "barchart", barchartAxesMap)
       chartsMap = (DefaultHistograms ++ savedCharts).map(c => c.label -> c).toMap
       tablesMap = (DefaultTables ++ savedTables).map(t => t.label -> t).toMap
       visChartMap = (DefaultBarCharts ++ savedVisCharts).map(c => c.label -> c).toMap

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/Axis.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/Axis.scala
@@ -108,6 +108,14 @@ object Axis {
     FilterAnd(Filter.IQs(ImageQuality.PERCENT_85), Filter.CCs(CloudCover.PERCENT_70))
   ))
 
+  // These axes depend on the actual observations and programs that are available in the data we're looking at.
+  // They are created "on-the-fly" whenever one of these stubs is selected using Program.forPrograms() and
+  // Observation.forObservations() respectively. Note that the axes stubs also need to be used for looking up
+  // axes when loading configurations from disk.
+  val Observations = Axis("Observations",  Seq())
+  val Programs     = Axis("Programs",      Seq())
+  val Dynamics     = Seq(Observations, Programs)
+
   // ra default axes, note: ra values in obd are defined in degrees, not hours
   val RA025 = Axis("RA 0.25", HasDummyTarget(Some(true)) +: raRanges(0.25))
   val RA05  = Axis("RA 0.5", HasDummyTarget(Some(true)) +: raRanges(0.5))

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/ui/CategoriesEditor.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/ui/CategoriesEditor.scala
@@ -97,7 +97,7 @@ class TableCategoriesEditor(ctx: QvContext) extends CategoriesEditor {
 
 /** Editor for chart categories. Charts only support calculations that result in a double value. */
 class BarChartCategoriesEditor(ctx: QvContext) extends CategoriesEditor {
-  val y = AxisSelector(ctx, "y-Axis", () => QvStore.axes ++ Seq(Axis("Observations", Seq()), Axis("Programs", Seq())))
+  val y = AxisSelector(ctx, "y-Axis", () => QvStore.axes ++ Axis.Dynamics)
   val cc = AxisSelector(ctx, "Color Coding")
   val c = new BarChartSelector("Visibility", y, cc)
   val selectors = Seq(c, y, cc)
@@ -121,7 +121,7 @@ class BarChartCategoriesEditor(ctx: QvContext) extends CategoriesEditor {
 
 /** Editor for elevation and hours visibility plots. */
 class VisChartEditor(ctx: QvContext) extends CategoriesEditor {
-  val cc = AxisSelector(ctx, "Color Coding", () => QvStore.axes ++ Seq(Axis("Observations", Seq()), Axis("Programs", Seq())))
+  val cc = AxisSelector(ctx, "Color Coding", () => QvStore.axes ++ Axis.Dynamics)
   val selectors = Seq(cc)
 
   def colorCoding = cc.axis


### PR DESCRIPTION
When loading bar charts from disk the lookup for the "dynamic" axes for Observations and Programs failed because they are currently not part of the default set of axes. (This could/should probably be changed, but when I tried to do that I run into some side-effects which I did not want to deal with in a bugfix release.)

In order to fix this for now, the two axes are manually added to the axes lookup table used to resolve axes by names when a bar chart is loaded from disk.