### PR TITLE
Added NSHighResolutionCapable=true in Info.plist for OSX

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
@@ -124,8 +124,8 @@ case class InfoPlist(meta: ApplicationMeta, version:String, fwJar: File, mainCla
         </array>
         <key>WorkingDirectory</key>
         <string>$APP_ROOT/Contents/Resources</string>
-	<key>NSHighResolutionCapable</key>
-	<true/>
+        <key>NSHighResolutionCapable</key>
+        <true/>
       </dict>
     </plist>
 

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
@@ -124,6 +124,8 @@ case class InfoPlist(meta: ApplicationMeta, version:String, fwJar: File, mainCla
         </array>
         <key>WorkingDirectory</key>
         <string>$APP_ROOT/Contents/Resources</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
       </dict>
     </plist>
 


### PR DESCRIPTION
Adding NSHighResolutionCapable in Info.plist turns on high resolution support for OSX which results in properly rendered fonts instead of fuzzy fluffiness on retina displays. Icons are still scaled up and would need to be replaced with icons with higher resolution. However having crisp texts already goes a long way. I tested this with a locally edited version, but we should probably do a proper test with a properly built OT version before releasing this.

@swalker2m @cquiroz : Is this going to take care of OT, QPT and PIT?