### PR TITLE
REL-2177C: Additional bug fixes for dealing with dynamic axes.

### DIFF
--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/Chart.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/Chart.scala
@@ -7,6 +7,7 @@ import edu.gemini.qv.plugin.QvStore.NamedElement
 object Chart {
 
   trait ChartFunction extends NamedElement {
+    override val isEditable = false
     def label: String
   }
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/ui/AxisEditor.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/ui/AxisEditor.scala
@@ -1,14 +1,15 @@
 package edu.gemini.qv.plugin.chart.ui
 
+import java.awt.Color
+import javax.swing.UIManager
+
 import edu.gemini.qv.plugin.chart.Axis
 import edu.gemini.qv.plugin.filter.core._
 import edu.gemini.qv.plugin.filter.ui.CategoriesFilter
 import edu.gemini.qv.plugin.filter.ui.FilterElement.FilterElementChanged2
-import edu.gemini.qv.plugin.{QvContext, QvStore}
 import edu.gemini.qv.plugin.ui.QvGui
-import java.awt.Color
-import javax.swing.UIManager
-import scala.Some
+import edu.gemini.qv.plugin.{QvContext, QvStore}
+
 import scala.swing.GridBagPanel.Fill._
 import scala.swing.Swing._
 import scala.swing._
@@ -24,7 +25,8 @@ object AxisEditor {
  * Editor for axes of charts and categorized tables.
  */
 class AxisEditor(ctx: QvContext, initial: String, panel: AxisEditorPanel) extends
-  ElementEditor("Axis", initial, QvStore.DefaultAxes.map(_.label).toSet, QvStore.axes.map(_.label).toSet, Some(panel)) {
+// TODO: The dynamic on-the-fly axes should become part of the default axes, so we don't need to treat them separately.
+  ElementEditor("Axis", initial, (QvStore.DefaultAxes ++ Axis.Dynamics).map(_.label).toSet, QvStore.axes.map(_.label).toSet, Some(panel)) {
 
   def axis = panel.axis
 
@@ -33,7 +35,7 @@ class AxisEditor(ctx: QvContext, initial: String, panel: AxisEditorPanel) extend
   }
 
   def save() {
-    val newAxis = new Axis(elementName, panel.axis.groups)
+    val newAxis = Axis(elementName, panel.axis.groups)
     QvStore.addAxis(newAxis)
   }
 
@@ -122,7 +124,7 @@ class AxisEditorPanel(ctx: QvContext, var axis: Axis) extends SplitPane(Orientat
     layout(Swing.VGlue)       = new Constraints() {gridx=0; gridy=yPos; weighty=1.0; gridwidth=5; fill=Vertical}
 
     def deleteAll() {
-      axis = new Axis(axis.label, Seq(new EmptyFilter("<<New>>")))
+      axis = Axis(axis.label, Seq(new EmptyFilter("<<New>>")))
       replaceGroupEditor()
       replaceFilterEditor()
     }
@@ -147,7 +149,7 @@ class AxisEditorPanel(ctx: QvContext, var axis: Axis) extends SplitPane(Orientat
     def filter_= (f: Filter): Unit = {
       _filter = f
       groupButton.text = f.name
-      axis = new Axis(axis.label, axis.groups.updated(ix, f))
+      axis = Axis(axis.label, axis.groups.updated(ix, f))
     }
 
     def groupButtonF(filter: Filter) = new Button {
@@ -203,13 +205,13 @@ class AxisEditorPanel(ctx: QvContext, var axis: Axis) extends SplitPane(Orientat
       }
     }
 
-    def swapOnAxis(a: Axis, i: Int, j: Int) = new Axis(a.label, a.groups.updated(i, a.groups(j)).updated(j, a.groups(i)))
+    def swapOnAxis(a: Axis, i: Int, j: Int) = Axis(a.label, a.groups.updated(i, a.groups(j)).updated(j, a.groups(i)))
     def removeFromAxis(a: Axis, ix: Int) = {
       val shortenedGroups = a.groups.zipWithIndex.filter(_._2 != ix).unzip._1
       val newGroups = if (shortenedGroups.isEmpty) Seq(new EmptyFilter("<<New>>")) else shortenedGroups
-      new Axis(a.label, newGroups)
+      Axis(a.label, newGroups)
     }
-    def insertIntoAxis(a: Axis, ix: Int) = new Axis(a.label, (a.groups.slice(0, ix) :+ new EmptyFilter("<<New>>")) ++ a.groups.slice(ix, a.groups.length))
+    def insertIntoAxis(a: Axis, ix: Int) = Axis(a.label, (a.groups.slice(0, ix) :+ new EmptyFilter("<<New>>")) ++ a.groups.slice(ix, a.groups.length))
   }
 
 }

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/ui/CategoriesEditor.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/chart/ui/CategoriesEditor.scala
@@ -1,19 +1,14 @@
 package edu.gemini.qv.plugin.chart.ui
 
-import scala.swing._
-import scala.swing.event._
-import edu.gemini.qv.plugin.chart.Chart._
-import edu.gemini.qv.plugin.chart.ui.CategoriesEditor._
-import edu.gemini.qv.plugin.table.renderer.{CalculationRenderer, CellRenderer}
-import edu.gemini.qv.plugin.data.ObservationProvider
-import scala.swing.Swing.EmptyBorder
-import edu.gemini.qv.plugin.chart.editor._
-import edu.gemini.qv.plugin.chart.editor.AxisSelector
-import scala.swing.event.SelectionChanged
-import edu.gemini.qv.plugin.chart.Chart.Calculation
-import edu.gemini.qv.plugin.{QvContext, QvStore}
 import edu.gemini.qv.plugin.chart.Axis
+import edu.gemini.qv.plugin.chart.editor.{AxisSelector, _}
+import edu.gemini.qv.plugin.chart.ui.CategoriesEditor._
 import edu.gemini.qv.plugin.filter.ui.MainFilter
+import edu.gemini.qv.plugin.{QvContext, QvStore}
+
+import scala.swing.Swing.EmptyBorder
+import scala.swing._
+import scala.swing.event.{SelectionChanged, _}
 
 object CategoriesEditor {
 
@@ -148,21 +143,16 @@ trait CategoriesEditor extends GridBagPanel with Publisher {
   border = EmptyBorder(10,10,10,10)
 
   def layoutSelectors() {
-    selectors.zipWithIndex.foreach({case (s, posY) => {
-      // create label
-      val label = new Label(s.label){horizontalAlignment = Alignment.Right}
-
-      // layout all three elements, editor part is optional
-      layout(label)           = new Constraints { gridx=0; gridy=posY; weightx=0.05 }
-      layout(s.selector)      = new Constraints { gridx=1; gridy=posY; weightx=0.90; fill = GridBagPanel.Fill.Horizontal}
-      if (s.editor != null)
-        layout(s.editButton)  = new Constraints { gridx=2; gridy=posY; weightx=0.05 }
-    }})
+    selectors.zipWithIndex.foreach { case (s, posY) =>
+      // create label and layout elements
+      val label             = new Label(s.label) { horizontalAlignment=Alignment.Right }
+      layout(label)         = new Constraints { gridx=0; gridy=posY; weightx=0.05 }
+      layout(s.selector)    = new Constraints { gridx=1; gridy=posY; weightx=0.90; fill=GridBagPanel.Fill.Horizontal }
+      layout(s.editButton)  = new Constraints { gridx=2; gridy=posY; weightx=0.05 }
+    }
     listenTo(selectors:_*)
     reactions += {
-      case SelectionChanged(source) => source match {
-        case s => doUpdate(source)
-      }
+      case SelectionChanged(source) => doUpdate(source)
     }
   }
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/FilterXMLFormatter.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/FilterXMLFormatter.scala
@@ -21,11 +21,11 @@ object FilterXMLFormatter {
   // TODO: The dynamic on-the-fly axes should become part of the default axes, so we don't need to treat them separately.
   def formatSome(filters: Seq[FilterSet] = Seq(), axes: Seq[Axis] = Seq(), histograms: Seq[Histogram] = Seq(), tables: Seq[Table] = Seq(), barCharts: Seq[BarChart] = Seq()): Node =
     <qvTool>
-      <filters>{filters.filter(!QvStore.DefaultFilters.contains(_)).map(format)}</filters>
-      <axes>{axes.filter(!(QvStore.DefaultAxes ++ Axis.Dynamics).contains(_)).map(format)}</axes>
-      <histograms>{histograms.filter(!QvStore.DefaultHistograms.contains(_)).map(_.toXml)}</histograms>
-      <tables>{tables.filter(!QvStore.DefaultTables.contains(_)).map(_.toXml)}</tables>
-      <barcharts>{barCharts.filter(!QvStore.DefaultBarCharts.contains(_)).map(_.toXml)}</barcharts>
+      <filters>{filters.filterNot(QvStore.DefaultFilters.contains(_)).map(format)}</filters>
+      <axes>{axes.filterNot((QvStore.DefaultAxes ++ Axis.Dynamics).contains(_)).map(format)}</axes>
+      <histograms>{histograms.filterNot(QvStore.DefaultHistograms.contains(_)).map(_.toXml)}</histograms>
+      <tables>{tables.filterNot(QvStore.DefaultTables.contains(_)).map(_.toXml)}</tables>
+      <barcharts>{barCharts.filterNot(QvStore.DefaultBarCharts.contains(_)).map(_.toXml)}</barcharts>
     </qvTool>
 
   def format(filterSet: FilterSet): Node = {

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/FilterXMLFormatter.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/FilterXMLFormatter.scala
@@ -10,27 +10,22 @@ import scala.xml.Node
 
 object FilterXMLFormatter {
 
-  /** Only store customer made elements, don't store pre defined ones.
+  /** Store everything. */
+  def formatAll: Node = formatSome(QvStore.filters, QvStore.axes, QvStore.histograms, QvStore.tables, QvStore.visCharts)
+
+  /** Store some data.
+    * Only store customer made elements, don't store pre-defined/default ones.
     * This makes sure a fail proof minimal set of axes, charts and tables is always available.
     * @return
     */
-  def formatAll: Node =
+  // TODO: The dynamic on-the-fly axes should become part of the default axes, so we don't need to treat them separately.
+  def formatSome(filters: Seq[FilterSet] = Seq(), axes: Seq[Axis] = Seq(), histograms: Seq[Histogram] = Seq(), tables: Seq[Table] = Seq(), barCharts: Seq[BarChart] = Seq()): Node =
     <qvTool>
-      <filters>{QvStore.filters.filter(!QvStore.DefaultFilters.contains(_)).map(format)}</filters>
-      <axes>{QvStore.axes.filter(!QvStore.DefaultAxes.contains(_)).map(format)}</axes>
-      <histograms>{QvStore.histograms.filter(!QvStore.DefaultHistograms.contains(_)).map(_.toXml)}</histograms>
-      <tables>{QvStore.tables.filter(!QvStore.DefaultTables.contains(_)).map(_.toXml)}</tables>
-      <barcharts>{QvStore.visCharts.filter(!QvStore.DefaultBarCharts.contains(_)).map(_.toXml)}</barcharts>
-    </qvTool>
-
-
-  def formatSome(filters: Set[FilterSet] = Set(), axes: Set[Axis] = Set(), histograms: Set[Histogram] = Set(), tables: Set[Table] = Set(), barCharts: Set[BarChart] = Set()): Node =
-    <qvTool>
-      <filters>{filters.map(format)}</filters>
-      <axes>{axes.map(format)}</axes>
-      <histograms>{histograms.map(_.toXml)}</histograms>
-      <tables>{tables.map(_.toXml)}</tables>
-      <barcharts>{barCharts.map(_.toXml)}</barcharts>
+      <filters>{filters.filter(!QvStore.DefaultFilters.contains(_)).map(format)}</filters>
+      <axes>{axes.filter(!(QvStore.DefaultAxes ++ Axis.Dynamics).contains(_)).map(format)}</axes>
+      <histograms>{histograms.filter(!QvStore.DefaultHistograms.contains(_)).map(_.toXml)}</histograms>
+      <tables>{tables.filter(!QvStore.DefaultTables.contains(_)).map(_.toXml)}</tables>
+      <barcharts>{barCharts.filter(!QvStore.DefaultBarCharts.contains(_)).map(_.toXml)}</barcharts>
     </qvTool>
 
   def format(filterSet: FilterSet): Node = {
@@ -41,7 +36,6 @@ object FilterXMLFormatter {
       </filterset>
     </filter>
   }
-
 
   def format(axis: Axis): Node = {
     <axis>

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/panels/HistogramChartPanel.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/panels/HistogramChartPanel.scala
@@ -85,7 +85,7 @@ class HistogramChartPanel(ctx: QvContext) extends GridBagPanel {
         case RA(fmin, fmax)     if min <= max => fmax > min && fmin < max
         case RA(fmin, fmax)                   => fmin >= 0
       }
-      new Axis(axis.label, limitedGroups)
+      Axis(axis.label, limitedGroups)
     } else axis
   }
 


### PR DESCRIPTION
Another bug fix for QV. Hopefully it can still make it into the bug fix release. It has been tested by Kristin with a test version I created locally for her.

This is a set of fixes that deal with problems with dynamic or "on-the-fly" axes in QV. (An axis in QV is a sequence of filters that is used to define a sequence of bins for an axis of a histogram or table. The same concept btw. is used in QV for color coding in graphs, i.e. splitting the data into several bins which each are differentiated by a different color.)

First the changes in this PR address a problem that is caused by the fact that dynamic axes are actually stubs that don't contain any filters because those are created on-the-fly based on the currently available data (e.g. the available observations if separate bins for all available observations are needed). This caused a problem with creation of the axis editors which rely on at least one filter being available. However since dynamic axes are not meant to be user editable anyway this problem was addressed by differentiating between editable and non-editable axes and not displaying an edit button nor creating an axis editor for dynamic axes.

The second problem addressed with this PR is that QV has a set of "default" axes which are meant to be a collection of basic axes, that can not be edited. Those axes (and other default elements) are not meant to be imported/exported in order to save space and also to make sure they are always present/valid. Unfortunately older versions of QV incorrectly exported the dynamic axes "Observations" and "Programs" which after importing will cause a second axis with the same name to appear in QV. This is not very grave but annoying. For now these elements are filtered out on import as a temporary solution; this will go away/be replaced with a more permanent solution.

A more permanent solution for the second issue will hopefully be implement as part of the next release. Making the dynamic axes default axes (which they actually are) will also allow to simplify the code in a few places. See TODOs in code.