### PR TITLE
REL-2246: hack to work around bug in hdiutil

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
@@ -19,6 +19,7 @@ case class MacDistHandler(jre: Option[String], jreName: String) extends DistHand
     // Output dirs
     val name = meta.osxVisibleName(version)
     val appDir = mkdir(outDir,  s"$name.app")
+    val trashDir = mkdir(appDir, ".Trash")  // http://stackoverflow.com/questions/18621467/error-creating-disk-image-using-hdutil
     val contentsDir = mkdir(appDir, "Contents")
     val macosDir = mkdir(contentsDir, "MacOS")
     val resourcesDir = mkdir(contentsDir, "Resources")


### PR DESCRIPTION
This is a hack to work around an error encountered while creating a Mac `.dmg` for the QPT.  

    release/ocs-2015A.1.1.2 * 19$ hdiutil create -srcfolder /Users/swalker/dev/ocs/app/qpt/target/qpt/2015A-test.1.1.2/MacOS/mac-test/Gemini\ QPT\ 2015A-test.1.1.2.app -volname qpt_2015A-test.1.1.2_macos /Users/swalker/dev/ocs/app/qpt/target/qpt/2015A-test.1.1.2/MacOS/mac-test/qpt_2015A-test.1.1.2_macos.dmg
    .....................................................................................................................................................................................
    hdiutil: create failed - error -5341

Googling that one lead me to this [sketchy “solution”](http://stackoverflow.com/questions/18621467/error-creating-disk-image-using-hdutil) which is basically to add a .Trash folder to the root directory.  This change is not end-user visible and the .Trash folder doesn't even appear to end up in the installed application directory.