### PR TITLE
Prevent RPM binary stripping

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/app/RPMDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/RPMDistHandler.scala
@@ -18,7 +18,8 @@ class RPMDistHandler(jre: Option[String]) extends DistHandler {
 
     // Due to permission issues and limitations on rpmbuild we need to override .rpmmacros
     val rpmbuild = wd // Hardcoded to avoid permission issues
-    val rpmmacros = s"%_topdir $rpmbuild\n"
+    // Set topdir and prevent the binary stripping step on RPM creation
+    val rpmmacros = s"%_topdir $rpmbuild\n%__os_install_post %{nil}\n"
 
     // Overwrite it, it changes per project
     val rpmmacrosFiles = new File(System.getProperty("user.home"), ".rpmmacros")


### PR DESCRIPTION
QPT RPM failed on execution. It was noted that the jar files are different on the rpm than on the plain distribution.

This effect was traced to the binary stripping step for rpm
http://livecipher.blogspot.com/2012/06/disable-binary-stripping-in-rpmbuild.html

This PR changes .rpmmacros to prevent binary stripping