### PR TITLE
Export edu.gemini.catalog.votable package

### DIFF
--- a/bundle/edu.gemini.catalog/build.sbt
+++ b/bundle/edu.gemini.catalog/build.sbt
@@ -28,6 +28,7 @@ OsgiKeys.privatePackage := Seq(
 OsgiKeys.exportPackage := Seq(
   "edu.gemini.catalog.api",
   "edu.gemini.catalog.impl",
+  "edu.gemini.catalog.votable",
   "edu.gemini.catalog.skycat",
   "edu.gemini.catalog.skycat.binding.adapter",
   "edu.gemini.catalog.skycat.binding.skyobj",


### PR DESCRIPTION
SPDB is broken due to a missing package on the catalog bundle, this PR fixes that without bringing other non-completed AGS work