### PR TITLE
OCSADV-200-E: observation renumbering

### DIFF
--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
@@ -86,12 +86,12 @@ object MergeNode {
     /** A fold over observations contained in this tree node (if any).
       * Doesn't descend into the observation itself.
       */
-    def foldObservations[B](z: B)(f: (Modified, Int, B) => B): B = {
+    def foldObservations[B](z: B)(f: (Modified, Int, Stream[Tree[MergeNode]], B) => B): B = {
       def go(rem: List[Tree[MergeNode]], res: B): B =
         rem match {
           case Nil        => res
           case (t2 :: ts) => t2.rootLabel match {
-            case m@Modified(_, _, _, Obs(n)) => go(ts, f(m, n, res))
+            case m@Modified(_, _, _, Obs(n)) => go(ts, f(m, n, t2.subForest, res))
             case _                           => go(t2.subForest.toList ++ ts, res)
           }
         }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
@@ -1,0 +1,84 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.sp.vcs.diff.NodeDetail.Obs
+import edu.gemini.sp.vcs.diff.ProgramLocation.{Remote, Local}
+import edu.gemini.spModel.rich.pot.sp._
+
+import scalaz._
+import Scalaz._
+
+/** Corrects observation numbers such that all local-only observations have
+  * numbers greater than the maximum remote observation number.
+  *
+  * There are a few implicit assumptions at work here.  First, once an
+  * observation has been created its key is always remembered in the
+  * `VersionMap` (that's true of any node actually).  Second, as new
+  * observations are created they are given the next sequential integer.
+  * That is, observation numbers aren't reused when deleted.  Finally
+  * observation numbers are never modified once assigned (other than by
+  * the merge plan application itself).
+  *
+  * This means that there cannot exist an observation known to both local and
+  * remote program versions with an observation number greater than a
+  * local-only observation.
+  */
+class ObsNumberCorrection(isKnown: (ProgramLocation, SPNodeKey) => Boolean) extends MergeCorrection {
+  def apply(mp: MergePlan): MergePlan = {
+    val t = (mp.update.loc/:renumberedObs(mp)) { case (loc, (key, num)) =>
+      loc.find(_.tree.rootLabel.key === key).fold(loc) { obsLoc =>
+        val mergeNode = obsLoc.tree.rootLabel match {
+          case Modified(k,nv,dob,Obs(_)) => Modified(k, nv, dob, Obs(num))
+          case lab                       => lab
+        }
+        obsLoc.setLabel(mergeNode).root
+      }
+    }.toTree
+
+    mp.copy(update = t)
+  }
+
+  // Obtains a Set of pairs of observation node keys that need to be
+  // renumbered along with the new observation number they should have.
+  private def renumberedObs(mp: MergePlan): Set[(SPNodeKey, Int)] = {
+
+    /** A pair of the max remote-only observation number and a set of all
+      * local-only observation keys with their current observation number.
+      */
+    case class ObsRenum(maxRemote: Option[Int], localOnly: List[(SPNodeKey, Int)]) {
+      def addRemote(num: Int): ObsRenum =
+        if (maxRemote.forall(_ < num)) ObsRenum(Some(num), localOnly) else this
+
+      def addLocal(k: SPNodeKey, num: Int): ObsRenum =
+        ObsRenum(maxRemote, (k, num) :: localOnly)
+    }
+
+    val or = mp.update.foldObservations(ObsRenum(None, List.empty)) { (mod, i, or) =>
+      val k = mod.key
+      (isKnown(Local, k), isKnown(Remote, k)) match {
+        case (false, true) => or.addRemote(i)
+        case (true, false) => or.addLocal(k, i)
+        case _             => or
+      }
+    }
+
+    or.maxRemote.fold(Set.empty[(SPNodeKey, Int)]) { max =>
+      val sortedPairs = or.localOnly.sortBy(_._2) match {
+        case (_, i) :: _ if i > max => Nil
+        case os                     => os
+      }
+      sortedPairs.unzip._1.zipWithIndex.map { case (k, i) => (k, i + max + 1) }.toSet
+    }
+  }
+}
+
+object ObsNumberCorrection {
+  def apply(mc: MergeContext): ObsNumberCorrection = {
+    val isKnown: (ProgramLocation, SPNodeKey) => Boolean = {
+      case (Local, key)  => mc.local.isKnown(key)
+      case (Remote, key) => mc.remote.isKnown(key)
+    }
+
+    new ObsNumberCorrection(isKnown)
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
@@ -3,6 +3,7 @@ package edu.gemini.sp.vcs.diff
 import edu.gemini.pot.sp.SPNodeKey
 import edu.gemini.sp.vcs.diff.NodeDetail.Obs
 import edu.gemini.sp.vcs.diff.ProgramLocation.{Remote, Local}
+import edu.gemini.spModel.obslog.ObsExecLog
 import edu.gemini.spModel.rich.pot.sp._
 
 import scalaz._
@@ -24,50 +25,60 @@ import Scalaz._
   * local-only observation.
   */
 class ObsNumberCorrection(isKnown: (ProgramLocation, SPNodeKey) => Boolean) extends MergeCorrection {
-  def apply(mp: MergePlan): MergePlan = {
-    val t = (mp.update.loc/:renumberedObs(mp)) { case (loc, (key, num)) =>
-      loc.find(_.tree.rootLabel.key === key).fold(loc) { obsLoc =>
-        val mergeNode = obsLoc.tree.rootLabel match {
-          case Modified(k,nv,dob,Obs(_)) => Modified(k, nv, dob, Obs(num))
-          case lab                       => lab
-        }
-        obsLoc.setLabel(mergeNode).root
-      }
-    }.toTree
-
-    mp.copy(update = t)
-  }
+  def apply(mp: MergePlan): Unmergeable \/ MergePlan =
+    renumberedObs(mp).map { obsMap =>
+      if (obsMap.isEmpty)  // usually empty so we might as well check and save a traversal in that case
+        mp
+      else
+        mp.copy(update = mp.update.map {
+          case Modified(k, nv, dob, Obs(n)) => Modified(k, nv, dob, Obs(obsMap.getOrElse(k, n)))
+          case lab                          => lab
+        })
+    }
 
   // Obtains a Set of pairs of observation node keys that need to be
   // renumbered along with the new observation number they should have.
-  private def renumberedObs(mp: MergePlan): Set[(SPNodeKey, Int)] = {
+  private def renumberedObs(mp: MergePlan): Unmergeable \/ Map[SPNodeKey, Int] = {
 
     /** A pair of the max remote-only observation number and a set of all
       * local-only observation keys with their current observation number.
       */
-    case class ObsRenum(maxRemote: Option[Int], localOnly: List[(SPNodeKey, Int)]) {
+    case class ObsRenum(maxRemote: Option[Int], localOnly: List[(SPNodeKey, Int, Boolean)]) {
       def addRemote(num: Int): ObsRenum =
         if (maxRemote.forall(_ < num)) ObsRenum(Some(num), localOnly) else this
 
-      def addLocal(k: SPNodeKey, num: Int): ObsRenum =
-        ObsRenum(maxRemote, (k, num) :: localOnly)
+      def addLocal(k: SPNodeKey, num: Int, executed: Boolean): ObsRenum =
+        ObsRenum(maxRemote, (k, num, executed) :: localOnly)
     }
 
-    val or = mp.update.foldObservations(ObsRenum(None, List.empty)) { (mod, i, or) =>
+    def isExecuted(children: Stream[Tree[MergeNode]]): Boolean =
+      children.toList.exists { _.rootLabel match {
+        case Modified(_, _, log: ObsExecLog, _) => !log.isEmpty
+        case _                                  => false
+      }}
+
+    val or = mp.update.foldObservations(ObsRenum(None, List.empty)) { (mod, i, children, or) =>
       val k = mod.key
       (isKnown(Local, k), isKnown(Remote, k)) match {
         case (false, true) => or.addRemote(i)
-        case (true, false) => or.addLocal(k, i)
+        case (true, false) => or.addLocal(k, i, isExecuted(children))
         case _             => or
       }
     }
 
-    or.maxRemote.fold(Set.empty[(SPNodeKey, Int)]) { max =>
-      val sortedPairs = or.localOnly.sortBy(_._2) match {
-        case (_, i) :: _ if i > max => Nil
-        case os                     => os
-      }
-      sortedPairs.unzip._1.zipWithIndex.map { case (k, i) => (k, i + max + 1) }.toSet
+    val executedLocalOnly = or.localOnly.collect { case (_, num, true) => num }
+
+    if (executedLocalOnly.nonEmpty)
+      ObsNumberCorrection.unmergeable(executedLocalOnly).left
+    else {
+      val localOnly = or.localOnly.map { case (key, num, _) => (key, num) }
+      or.maxRemote.foldMap { max =>
+        val sortedPairs = localOnly.sortBy(_._2) match {
+          case (_, i) :: _ if i > max => Nil
+          case obsList                => obsList
+        }
+        sortedPairs.unzip._1.zipWithIndex.map { case (k, i) => (k, i + max + 1)}.toMap
+      }.right
     }
   }
 }
@@ -81,4 +92,15 @@ object ObsNumberCorrection {
 
     new ObsNumberCorrection(isKnown)
   }
+
+  def unmergeable(obsNum: List[Int]): Unmergeable = {
+    val msg = if (obsNum.size > 1)
+      s"Found executed observations (numbers ${obsNum.sorted.mkString(",")}) that were created outside of the observing database."
+    else
+      s"Found an executed observation (number ${obsNum.mkString}) that was created outside of the observing database."
+
+    Unmergeable(msg)
+  }
+
+
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ProgramLocation.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ProgramLocation.scala
@@ -1,0 +1,12 @@
+package edu.gemini.sp.vcs.diff
+
+import scalaz._
+
+sealed trait ProgramLocation
+
+object ProgramLocation {
+  case object Local  extends ProgramLocation
+  case object Remote extends ProgramLocation
+
+  implicit def ProgramLocationEqual: Equal[ProgramLocation] = Equal.equalA
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Unmergeable.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Unmergeable.scala
@@ -1,0 +1,4 @@
+package edu.gemini.sp.vcs.diff
+
+/** An error case used when a merge cannot be performed for some reason. */
+case class Unmergeable(why: String)

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/package.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/package.scala
@@ -5,6 +5,12 @@ import edu.gemini.spModel.rich.pot.sp._
 
 package object diff {
 
+  /**
+   * A `MergeCorrection` is just a function that modifies an `MergePlan` to
+   * correct some aspect of the merge.
+   */
+  type MergeCorrection = MergePlan => MergePlan
+
   implicit class IspNodeTreeOps(val node: ISPNode) extends AnyVal {
     /** A Map with entries for all nodes rooted at this node, keyed by
       * `SPNodeKey`.

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/package.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/package.scala
@@ -3,13 +3,15 @@ package edu.gemini.sp.vcs
 import edu.gemini.pot.sp.{ISPProgram, SPNodeKey, ISPNode}
 import edu.gemini.spModel.rich.pot.sp._
 
+import scalaz.\/
+
 package object diff {
 
   /**
    * A `MergeCorrection` is just a function that modifies an `MergePlan` to
    * correct some aspect of the merge.
    */
-  type MergeCorrection = MergePlan => MergePlan
+  type MergeCorrection = MergePlan => Unmergeable \/ MergePlan
 
   implicit class IspNodeTreeOps(val node: ISPNode) extends AnyVal {
     /** A Map with entries for all nodes rooted at this node, keyed by

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
@@ -1,0 +1,132 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.pot.sp.version.EmptyNodeVersions
+import edu.gemini.sp.vcs.diff.ProgramLocation.{Remote, Local}
+import edu.gemini.spModel.data.ISPDataObject
+import edu.gemini.spModel.gemini.obscomp.SPProgram
+import edu.gemini.spModel.obs.SPObservation
+import org.specs2.mutable._
+
+import scalaz._
+import Scalaz._
+
+class ObsNumberCorrectionSpec extends Specification {
+  val LocalOnly: Set[ProgramLocation]  = Set(Local)
+  val RemoteOnly: Set[ProgramLocation] = Set(Remote)
+  val Both: Set[ProgramLocation]       = Set(Local, Remote)
+
+  def doTest(expected: List[Int], merged: (Int, Set[ProgramLocation])*): Boolean = {
+    import NodeDetail._
+
+    def mergeNode(dob: ISPDataObject, obsNum: Option[Int]): MergeNode = Modified(
+      new SPNodeKey(),
+      EmptyNodeVersions,
+      dob,
+      obsNum.fold(Empty: NodeDetail) { Obs.apply }
+    )
+
+    def nonObs(dob: ISPDataObject): MergeNode = mergeNode(dob, None)
+
+    def obs(num: Int): MergeNode = mergeNode(new SPObservation, Some(num))
+
+    val obsList = merged.map { case (i,_) => obs(i).leaf }
+
+    val mergeTree =
+      Tree.node(nonObs(new SPProgram), obsList.toStream)
+
+    val known = merged.unzip._2.zip(obsList.map(_.key)).map { case (locs, key) =>
+      locs.map(loc => (loc, key))
+    }.toSet.flatten
+
+    def obsNumbers(t: Tree[MergeNode]): List[Int] =
+      t.subForest.map(_.rootLabel match {
+        case Modified(_, _, _, Obs(i)) => i
+        case _                         => -1
+      }).toList
+
+    val plan = MergePlan(mergeTree, Set.empty)
+    val onc  = new ObsNumberCorrection(Function.untupled(known.contains))
+
+    obsNumbers(onc(plan).update) shouldEqual expected
+  }
+
+  "ObsRenumber" should {
+
+    "handle the no-observation case without exception" in {
+      doTest(Nil)
+    }
+
+    "not change remote only observation numbers" in {
+      doTest(List(3, 2, 1),
+        (3, RemoteOnly),
+        (2, RemoteOnly),
+        (1, RemoteOnly)
+      )
+    }
+
+    "not renumber observations known to both sides" in {
+      doTest(List(1, 2),
+        (1, Both),
+        (2, Both)
+      )
+    }
+
+    "not renumber new local-only observations if there are no remote observations" in {
+      doTest(List(1, 2),
+        (1, LocalOnly),
+        (2, LocalOnly)
+      )
+    }
+
+    "not renumber new local-only observations if they come after the last remote observation" in {
+      doTest(List(2, 1, 3),
+        (2, LocalOnly),
+        (1, Both),
+        (3, LocalOnly)
+      )
+    }
+
+    "renumber a local observation with the same number as a remote observation" in {
+      doTest(List(2, 1),
+        (1, LocalOnly),
+        (1, RemoteOnly)
+      )
+    }
+
+    "renumber new local observations with numbers that come before remote observations" in {
+      doTest(List(5, 2, 6, 4),
+        (1, LocalOnly),
+        (2, RemoteOnly),
+        (3, LocalOnly),
+        (4, RemoteOnly)
+      )
+    }
+
+    "respect the original local-only numbering sort when renumbering" in {
+      doTest(List(6, 2, 5, 4),
+        (3, LocalOnly),
+        (2, RemoteOnly),
+        (1, LocalOnly),
+        (4, RemoteOnly)
+      )
+    }
+
+    "respect the original local-only numbering if there is no need to renumber" in {
+      doTest(List(1, 5, 6),
+        (1, RemoteOnly),
+        (5, LocalOnly),
+        (6, LocalOnly)
+      )
+    }
+
+    "renumber local-only observations sequentially if we must renumber" in {
+      doTest(List(1, 2, 3, 4),
+        (1, RemoteOnly),
+        (1, LocalOnly),
+        (5, LocalOnly),
+        (6, LocalOnly)
+      )
+    }
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/PreliminaryMergePropertyTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/PreliminaryMergePropertyTest.scala
@@ -9,6 +9,8 @@ import edu.gemini.spModel.rich.pot.sp._
 import org.junit.Test
 import org.scalatest.junit.JUnitSuite
 
+import scalaz._
+
 
 class PreliminaryMergePropertyTest extends JUnitSuite {
   import edu.gemini.sp.vcs.diff.MergePropertyTest.NamedProperty
@@ -274,7 +276,7 @@ class PreliminaryMergePropertyTest extends JUnitSuite {
     ("no duplicates after renumbering observations",
       (start, local, remote, pc) => {
         val empty = Map.empty[Int, SPNodeKey]
-        val (localOnly, remoteOnly) = pc.mergePlan.update.foldObservations((empty, empty)) { case (m, i, (lo, ro)) =>
+        val (localOnly, remoteOnly) = pc.mergePlan.update.foldObservations((empty, empty)) { case (m, i, _, (lo, ro)) =>
           val key = m.key
           (pc.local.p.getVersions.contains(key), pc.remote.p.getVersions.contains(key)) match {
             case (true, false) => (lo + (i -> key), ro)
@@ -287,19 +289,27 @@ class PreliminaryMergePropertyTest extends JUnitSuite {
           val localKeys = localOnly.values.toSet
           val remoteMax = remoteOnly.keySet.max
 
-          val t = ObsNumberCorrection(pc.mergeContext).apply(pc.mergePlan).update
+          ObsNumberCorrection(pc.mergeContext).apply(pc.mergePlan) match {
+            case -\/(Unmergeable(msg)) =>
+              // This might start to fail if we update the generator to produce
+              // events or datasets in observation exec logs.
+              Console.err.println(s"Unmergeable: $msg")
+              false
 
-          val emptyMap = Map.empty[Int, Set[SPNodeKey]].withDefaultValue(Set.empty[SPNodeKey])
-          val obsMap = t.foldRight(emptyMap) {
-            case (Modified(k, _, _, Obs(n)), m) => m.updated(n, m(n) + k)
-            case (_, m)                         => m
+            case \/-(mp) =>
+              val t        = mp.update
+              val emptyMap = Map.empty[Int, Set[SPNodeKey]].withDefaultValue(Set.empty[SPNodeKey])
+              val obsMap   = t.foldRight(emptyMap) {
+                case (Modified(k, _, _, Obs(n)), m) => m.updated(n, m(n) + k)
+                case (_, m)                         => m
+              }
+
+              val renumberedKeys = (Set.empty[SPNodeKey]/:((remoteMax + 1) to remoteMax + localKeys.size)) { (s, i) =>
+                s ++ obsMap(i)
+              }
+
+              obsMap.values.forall(_.size == 1) && (localKeys == renumberedKeys)
           }
-
-          val renumberedKeys = (Set.empty[SPNodeKey]/:((remoteMax + 1) to remoteMax + localKeys.size)) { (s, i) =>
-            s ++ obsMap(i)
-          }
-
-          obsMap.values.forall(_.size == 1) && (localKeys == renumberedKeys)
         }
       }
     )


### PR DESCRIPTION
This is the first of a series of corrections to be applied to the preliminary merge.  A `MergeCorrection` is just a function `MergePlan => MergePlan` that potentially modifies the provided plan in some way to correct for a flaw produced by the preliminary merge.  In this particular instance, the issue is that observations created locally can be given the same observation numbers as those created independently in the remote program.  Any such observations must be renumbered to be greater than the maximum remote observation number.  Note that no `ISPObservation` instances themselves are actually changed in this process.  Updates to the `ISPNodes` will be handled when the `MergePlan` is actually applied in a later step.