### PR TITLE
REL-2032: Do not submit to partners with zero requested time

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SubmissionRequestEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SubmissionRequestEditor.scala
@@ -77,7 +77,7 @@ class SubmissionRequestEditor[A] private (s:SubmissionRequest, partner:Option[A]
 
     if (partner.isDefined) {
       addRow(new Label("Partner:"), partnerLabel)
-      if (!is.isEmpty)
+      if (is.nonEmpty)
         addRow(new Label("Partner Lead:"), leads)
       addSpacer()
     }
@@ -105,7 +105,9 @@ class SubmissionRequestEditor[A] private (s:SubmissionRequest, partner:Option[A]
   def value = {
     val s0 = timeLens.set(s, editor.time.value)
     val s1 = minTimeLens.set(s0, editor.minTime.value)
-    (s1, editor.leads.selection.item, remove.selected)
+    // REL-2032 Consider a request with 0 times the same as remove
+    val removed = (s0.time == TimeAmount.empty && s1.time == TimeAmount.empty) || remove.selected
+    (s1, editor.leads.selection.item, removed)
   }
 
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -476,7 +476,7 @@ object TimeProblems {
         } yield for {
             ps <- sub
             if ps.request.time.value <= 0.0
-          } yield new Problem(Severity.Error, s"Please specify a time request for ${Partners.name.getOrElse(ps.partner, "")} or remove partner", SCHEDULING_SECTION, s.showPartnersView())
+          } yield new Problem(Severity.Error, s"Please specify a time request for ${Partners.name.getOrElse(ps.partner, "")} or remove partner", SCHEDULING_SECTION, s.inPartnersView(_.editSubmissionTime(ps)))
       probs.right.getOrElse(Nil)
     case _                            => Nil
   }


### PR DESCRIPTION
On this PR the UI has been changed so when a PI selects a 0 time for a partner it is the same as removing the partner
The other change will open the partner time editor if the zero partner time problem is selected