### PR TITLE
Command to create a tar ball of the phase1 model schema

### DIFF
--- a/bundle/edu.gemini.model.p1/build.sbt
+++ b/bundle/edu.gemini.model.p1/build.sbt
@@ -51,4 +51,15 @@ sourceGenerators in Compile += Def.task {
 unmanagedResourceDirectories in Compile += 
   sourceDirectory.value / "main" / "xsd"
 
-
+// > modelDist
+commands += {
+  import scala.sys.process._
+  Command.command("modelDist") { state =>
+    val version = s"${pitVersion.value.semester}.${pitVersion.value.xmlCompatibility}.${pitVersion.value.serialCompatibility}"
+    val schemaName = s"p1-schema-$version"
+    println(s"packaging model $schemaName")
+    val main = sourceDirectory.value / "main"
+    s"tar cvfz $schemaName.tar.gz -s /xsd/$schemaName/ -C $main xsd".!
+    state
+  }
+}


### PR DESCRIPTION
We used to have a command to create the schema tarball distributed to NGOs.
This PR restore this capability on the sbt build