### PR TITLE
OCSADV-230: Add catalog query caching

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -3,6 +3,9 @@ package edu.gemini.catalog.api
 import edu.gemini.spModel.core.Coordinates
 import edu.gemini.spModel.core.Target.SiderealTarget
 
+import scalaz._
+import Scalaz._
+
 sealed trait CatalogQuery {
   val id: Option[Int] = None
   val base: Coordinates
@@ -14,7 +17,18 @@ sealed trait CatalogQuery {
 
   def withMagnitudeConstraints(magnitudeConstraints: Option[MagnitudeConstraints]): CatalogQuery
 
-  def isSuperSetOf(c: CatalogQuery) = base == c.base && radiusConstraint.isSuperSefOf(c.radiusConstraint)
+  def isSuperSetOf(c: CatalogQuery) = {
+    // Angular separation, or distance between the two.
+    val distance = Coordinates.difference(base, c.base).distance
+
+    // Add the given query's outer radius limit to the distance to get the
+    // maximum distance from this base position of any potential guide star.
+    val max = distance + c.radiusConstraint.maxLimit
+
+    // See whether the other base position falls out of range of our
+    // radius limits.
+    radiusConstraint.maxLimit > max
+  }
 }
 
 object CatalogQuery {

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -13,6 +13,8 @@ sealed trait CatalogQuery {
   def filter: SiderealTarget => Boolean = (t) => radiusConstraint.targetsFilter(base)(t) && magnitudeConstraints.map(_.filter(t)).getOrElse(true)
 
   def withMagnitudeConstraints(magnitudeConstraints: Option[MagnitudeConstraints]): CatalogQuery
+
+  def isSuperSetOf(c: CatalogQuery) = base == c.base && radiusConstraint.isSuperSefOf(c.radiusConstraint)
 }
 
 object CatalogQuery {

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -102,9 +102,9 @@ trait RemoteBackend extends VoTableBackend {
       @tailrec
       def go(a: QueryCache.CacheContainer[SearchKey, QueryResult], pos: Int):Option[(Int, QueryResult)] = {
         a match {
-          case x if x.isEmpty                            => None
-          case x +: _ if x.k.query.isSuperSetOf(k.query) => Some((pos, x.v))
-          case x +: xs                                   => go(a.tail, pos + 1)
+          case x if x.isEmpty                                                    => None
+          case x +: _ if x.k.query == k.query || x.k.query.isSuperSetOf(k.query) => Some((pos, x.v))
+          case x +: xs                                                           => go(a.tail, pos + 1)
         }
       }
       go(a, 0)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -100,9 +100,8 @@ trait CachedBackend extends VoTableBackend {
       @tailrec
       def go(pos: Int):Option[(Int, QueryResult)] =
         a.lift(pos) match {
-          case None                                                               => None
-          case Some(x) if x.k.query == k.query || x.k.query.isSuperSetOf(k.query) => Some((pos, x.v))
-          case _                                                                  => go(pos + 1)
+          case None    => None
+          case Some(x) => if (x.k.query == k.query || x.k.query.isSuperSetOf(k.query)) Some((pos, x.v)) else go(pos + 1)
         }
       go(0)
     }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -98,14 +98,13 @@ trait CachedBackend extends VoTableBackend {
     // Note that this assumes all catalogues give the same result for a given query
     def contains(a: QueryCache.CacheContainer[SearchKey, QueryResult], k: SearchKey):Option[(Int, QueryResult)] = {
       @tailrec
-      def go(a: QueryCache.CacheContainer[SearchKey, QueryResult], pos: Int):Option[(Int, QueryResult)] = {
-        a match {
-          case x if x.isEmpty                                                    => None
-          case x +: _ if x.k.query == k.query || x.k.query.isSuperSetOf(k.query) => Some((pos, x.v))
-          case x +: xs                                                           => go(a.tail, pos + 1)
+      def go(pos: Int):Option[(Int, QueryResult)] =
+        a.lift(pos) match {
+          case None                                                               => None
+          case Some(x) if x.k.query == k.query || x.k.query.isSuperSetOf(k.query) => Some((pos, x.v))
+          case _                                                                  => go(pos + 1)
         }
-      }
-      go(a, 0)
+      go(0)
     }
 
     QueryCache.buildCache(contains)

--- a/bundle/edu.gemini.catalog/src/test/java/edu/gemini/catalog/api/QueryConstraintTest.java
+++ b/bundle/edu.gemini.catalog/src/test/java/edu/gemini/catalog/api/QueryConstraintTest.java
@@ -16,6 +16,7 @@ import static edu.gemini.skycalc.Angle.Unit.ARCSECS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@Deprecated
 public final class QueryConstraintTest {
 
     private static final Coordinates base = new Coordinates(0, 0);

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQuerySpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQuerySpec.scala
@@ -1,0 +1,115 @@
+package edu.gemini.catalog.votable
+
+import edu.gemini.catalog.api._
+import edu.gemini.spModel.core._
+import org.specs2.matcher.{Expectable, Matcher}
+import org.specs2.mutable.SpecificationWithJUnit
+
+class CatalogQuerySpec extends SpecificationWithJUnit {
+  val a0    = Angle.fromArcsecs( 0.0)
+  val a2    = Angle.fromArcsecs( 2.0)
+  val a4_9  = Angle.fromArcsecs( 4.9)
+  val a5    = Angle.fromArcsecs( 5.0)
+  val a7    = Angle.fromArcsecs( 7.0)
+  val a10   = Angle.fromArcsecs(10.0)
+  val a11   = Angle.fromArcsecs(11.0)
+  val a20   = Angle.fromArcsecs(20.0)
+
+  val rad10 = RadiusConstraint.between(Angle.zero, a10)
+  val rad5 = RadiusConstraint.between(Angle.zero, a5)
+
+  val faint10 = FaintnessConstraint(10)
+  val saturation0= SaturationConstraint(0)
+  val mag10 = MagnitudeConstraints(MagnitudeBand.R, faint10, Some(saturation0))
+  val base = Coordinates.zero
+  val par10_10 = CatalogQuery.catalogQuery(base, rad10, Some(mag10))
+  val par5_10 = CatalogQuery.catalogQuery(base, rad5, Some(mag10))
+  val ma2 = Angle.zero - Angle.fromArcsecs(2)
+  val ma4_9 = Angle.zero - Angle.fromArcsecs(4.99999)
+  val ma7   = Angle.zero - Angle.fromArcsecs(7.0)
+  val ma10  = Angle.zero - Angle.fromArcsecs(10.0)
+  val ma11  = Angle.zero - Angle.fromArcsecs(11.0)
+  val ma20  = Angle.zero - Angle.fromArcsecs(20.0)
+
+  def beSuperSetOf(cq: CatalogQuery) =  new Matcher[CatalogQuery] {
+    override def apply[S <: CatalogQuery](t: Expectable[S]) = {
+      val actual = t.value
+      result(actual.isSuperSetOf(cq) && !cq.isSuperSetOf(actual), s"$actual is a superset of $cq", s"$actual is not a proper superset of $cq", t)
+    }
+  }
+
+  def beNoSuperSetOf(cq: CatalogQuery) =  new Matcher[CatalogQuery] {
+    override def apply[S <: CatalogQuery](t: Expectable[S]) = {
+      val actual = t.value
+      result(!actual.isSuperSetOf(cq) && !cq.isSuperSetOf(actual), s"$actual is not a superset of $cq", s"$actual is a superset of $cq", t)
+    }
+  }
+
+  "CatalogQuerySpec" should {
+    "be a superset of the same base" in {
+      par10_10 should beSuperSetOf(par5_10)
+    }
+    "be a superset within the range limits" in {
+      val rad5 = RadiusConstraint.between(Angle.zero, a5)
+
+      val coordinates = List(
+          Coordinates(RightAscension.fromAngle(a2),    Declination.fromAngle(a0).getOrElse(Declination.zero)),
+          Coordinates(RightAscension.fromAngle(a4_9),  Declination.fromAngle(a0).getOrElse(Declination.zero)),
+          Coordinates(RightAscension.fromAngle(ma2),   Declination.fromAngle(a0).getOrElse(Declination.zero)),
+          Coordinates(RightAscension.fromAngle(ma4_9), Declination.fromAngle(a0).getOrElse(Declination.zero)),
+          Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(a2).getOrElse(Declination.zero)),
+          Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(a4_9).getOrElse(Declination.zero)),
+          Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma2).getOrElse(Declination.zero)),
+          Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma4_9).getOrElse(Declination.zero)))
+      coordinates.map(c =>
+        par10_10 should beSuperSetOf(CatalogQuery.catalogQuery(c, rad5, Some(mag10)))
+      )
+    }
+    "be a superset at the pole" in {
+      val pole = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0)).getOrElse(Declination.zero))
+      val close = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0) - Angle.fromArcsecs(2)).getOrElse(Declination.zero))
+      // 10 arcsec radius at the pole
+      val poleP = CatalogQuery.catalogQuery(pole, rad10, Some(mag10))
+      // 5 arcsec radius close to the pole
+      val closeP = CatalogQuery.catalogQuery(close, rad5, Some(mag10))
+      poleP should beSuperSetOf(closeP)
+    }
+    "not be a superset far of the pole" in {
+      val pole = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0)).getOrElse(Declination.zero))
+      val far = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0) - Angle.fromArcsecs(7)).getOrElse(Declination.zero))
+      // 10 arcsec radius at the pole
+      val poleP = CatalogQuery.catalogQuery(pole, rad10, Some(mag10))
+      // 5 arcsec radius, but a bit too far from the pole
+      val farP = CatalogQuery.catalogQuery(far, rad5, Some(mag10))
+      poleP should beNoSuperSetOf(farP)
+    }
+    "not be a superset out of the range limits" in {
+      val coordinates = List(
+        Coordinates(RightAscension.fromAngle(a7),    Declination.fromAngle(a0).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(ma7),   Declination.fromAngle(a0).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a10),   Declination.fromAngle(a0).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(ma10),  Declination.fromAngle(a0).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a11),   Declination.fromAngle(a0).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(ma11),  Declination.fromAngle(a0).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a20),   Declination.fromAngle(a0).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(ma20),  Declination.fromAngle(a0).getOrElse(Declination.zero)),
+
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(a7).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma7).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(a10).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma10).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(a11).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma11).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(a20).getOrElse(Declination.zero)),
+        Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma20).getOrElse(Declination.zero)))
+      coordinates.map(c =>
+        par10_10 should beNoSuperSetOf(CatalogQuery.catalogQuery(c, rad5, Some(mag10)))
+      )
+    }
+    "not be a supersef far out of range" in {
+      val far = CatalogQuery.catalogQuery(Coordinates(RightAscension.fromDegrees(180), Declination.zero), rad5, Some(mag10))
+      par10_10 should beNoSuperSetOf(far)
+    }
+  }
+
+}

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/QueryCacheSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/QueryCacheSpec.scala
@@ -1,0 +1,111 @@
+package edu.gemini.catalog.votable
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.specs2.mutable.Specification
+import RemoteBackend.QueryCache
+
+import scala.annotation.tailrec
+
+class QueryCacheSpec extends Specification {
+  def factorial(n: Int) = {
+    @tailrec
+    def go(n: Int, result: Int): Int =
+      if (n == 0) {
+        result
+      } else {
+        go(n-1, result * n)
+      }
+
+    go(n, 1)
+  }
+
+  "QueryCache Spec" should {
+    "not cache if contains does not find anything" in {
+      def contains(a: QueryCache.CacheContainer[Int, Int], k: Int):Option[(Int, Int)] = {
+        None
+      }
+      val callCounter = new AtomicInteger(0)
+      def factorialCounter(n: Int) = {
+        callCounter.incrementAndGet()
+        factorial(n)
+      }
+      val memo = QueryCache.buildCache(contains)(factorialCounter)
+      val answers = for {
+          i <- 0 to 10
+        } yield memo(i)
+      answers(10) should beEqualTo(3628800)
+      callCounter.get() should beEqualTo(11)
+    }
+    "cache already called values" in {
+      def contains(a: QueryCache.CacheContainer[Int, Int], k: Int):Option[(Int, Int)] = {
+        a.find(_.k == k).map(i => (k, i.v))
+      }
+      val callCounter = new AtomicInteger(0)
+      def factorialCounter(n: Int) = {
+        callCounter.incrementAndGet()
+        factorial(n)
+      }
+      val memo = QueryCache.buildCache(contains)(factorialCounter)
+
+      // prime the cache
+      val answers = for {
+          i <- 0 to 10
+        } yield memo(i)
+      answers(10) should beEqualTo(3628800)
+      // This should come from the cache
+      memo(10) should beEqualTo(3628800)
+      callCounter.get should beEqualTo(11)
+    }
+    "forget older values" in {
+      def contains(a: QueryCache.CacheContainer[Int, Int], k: Int):Option[(Int, Int)] = {
+        a.find(_.k == k).map(i => (k, i.v))
+      }
+      val callCounter = new AtomicInteger(0)
+      def factorialCounter(n: Int) = {
+        callCounter.incrementAndGet()
+        factorial(n)
+      }
+      val memo = QueryCache.buildCache(contains)(factorialCounter)
+
+      for {
+          i <- 0 to 100
+        } yield memo(i)
+
+      callCounter.get should beEqualTo(101)
+      // Element 10 sholud still be in the cache
+      memo(10) should beEqualTo(3628800)
+      callCounter.get should beEqualTo(101)
+      // The cache should have forgotten element 0, so it will recalculate
+      memo(0) should beEqualTo(1)
+      callCounter.get should beEqualTo(102)
+    }
+    "be performant" in {
+      skipped("Used only for performance checks")
+      def contains(a: QueryCache.CacheContainer[Int, Int], k: Int):Option[(Int, Int)] = {
+        a.find(_.k == k).map(i => (k, i.v))
+      }
+
+      // Performance is linear with maxSize, for the typical case of 100 it is to fast to measure
+      val maxSize = 10000
+      val memo = QueryCache.buildCache(contains, maxSize)(factorial)
+
+      val s = System.currentTimeMillis()
+
+      val hits = 100000
+      for {
+          i <- 0 to hits
+        } yield memo(i)
+
+      // About 19 seconds using mutable ListBuffer
+      // About 20 seconds using mutable ArrayBuffer
+      // About 380 seconds using LinkedList
+      // About 46 seconds using MutableList
+      // About 18 seconds using List
+      // About 17 seconds using Vector
+      val time = System.currentTimeMillis() - s
+
+      time must be_>=(0L)
+    }
+  }
+}

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -1,14 +1,15 @@
 package edu.gemini.catalog.votable
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import edu.gemini.catalog.api.{FaintnessConstraint, MagnitudeConstraints, RadiusConstraint, CatalogQuery}
 import edu.gemini.spModel.core.{MagnitudeBand, Angle, Coordinates}
 import org.apache.commons.httpclient.NameValuePair
 import org.specs2.mutable.SpecificationWithJUnit
 import org.specs2.time.NoTimeConversions
 
-import scala.concurrent.Await
+import scala.concurrent._
 import scala.concurrent.duration._
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with NoTimeConversions {


### PR DESCRIPTION
This is a full rewrite of the previous attempt to do query caching. A traditional key-based cache (like scalaz's `Memo`) will be suboptimal in this case as we can reuse query results for nearby targets, e.g. if we had searched at the pole for a radius 1 and then we try the pole with radius 0.5, we can reuse the previous query doing client-side filtering.

The selected approach for the cache is a LRU cache based on a linear sequence where elements are moved to the front if they are used. To find items on the cache the client needs to provide a function that traverses the existing cache finding compatible queries. This limits performance to O(n) at best but given the relatively small size of the cache it is much faster than redoing the remote query

After some benchmarking `Vector` was selected as the structure for the cache. Some measurements are included on the tests cases

The signature of the API loosely matches scalaz's `Memo` but with  a very different implementation