### PR TITLE
OCSADV-200: rename old MergePlan and old VcsFailure

### DIFF
--- a/bundle/edu.gemini.sp.vcs.tui/src/main/scala/edu/gemini/sp/vcs/server/VcsServerImpl.scala
+++ b/bundle/edu.gemini.sp.vcs.tui/src/main/scala/edu/gemini/sp/vcs/server/VcsServerImpl.scala
@@ -5,7 +5,7 @@ import edu.gemini.pot.sp.version._
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.pot.spdb.ProgramSummoner.{IdNotFound, LookupOrCreate}
 import edu.gemini.sp.vcs._
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.util.security.permission.ProgramPermission
 import edu.gemini.util.security.policy.ImplicitPolicy
@@ -25,7 +25,7 @@ case class VcsServerImpl(odb: IDBDatabaseService, log: VcsLog, user: Set[Princip
   def geminiPrincipals: Set[GeminiPrincipal] =
     user.collect { case p: GeminiPrincipal => p }
 
-  private def prog(id: SPProgramID): VcsFailure \/ ISPProgram =
+  private def prog(id: SPProgramID): OldVcsFailure \/ ISPProgram =
     Option(odb.lookupProgramByID(id)).\/>(SummonFailure(IdNotFound(id)))
 
   private def accessControlled[T](id: SPProgramID)(body: => TryVcs[T]): TryVcs[T] =
@@ -55,11 +55,11 @@ case class VcsServerImpl(odb: IDBDatabaseService, log: VcsLog, user: Set[Princip
       } yield a
     }
 
-  def log(p: SPProgramID, offset: Int, length: Int): VcsFailure.TryVcs[(List[VcsEventSet], Boolean)] =
+  def log(p: SPProgramID, offset: Int, length: Int): OldVcsFailure.TryVcs[(List[VcsEventSet], Boolean)] =
     try {
       log.selectByProgram(p, offset, length).right
     } catch {
-      case e:Exception => VcsException(e).left
+      case e:Exception => OldVcsException(e).left
     }
 }
 

--- a/bundle/edu.gemini.sp.vcs.tui/src/main/scala/edu/gemini/sp/vcs/tui/osgi/CommandsImpl.scala
+++ b/bundle/edu.gemini.sp.vcs.tui/src/main/scala/edu/gemini/sp/vcs/tui/osgi/CommandsImpl.scala
@@ -1,7 +1,7 @@
 package edu.gemini.sp.vcs.tui.osgi
 
 import edu.gemini.pot.spdb.IDBDatabaseService
-import edu.gemini.sp.vcs.{VcsFailure, TrpcVcsServer, VersionControlSystem}
+import edu.gemini.sp.vcs.{OldVcsFailure, TrpcVcsServer, VersionControlSystem}
 import edu.gemini.sp.vcs.log.VcsLog
 import edu.gemini.sp.vcs.reg.VcsRegistrar
 import edu.gemini.spModel.core.{Peer, SPProgramID, SPBadIDException}
@@ -99,19 +99,19 @@ class CommandsImpl(odb: IDBDatabaseService, reg: VcsRegistrar, auth: KeyChain, l
 
   val checkout: VcsIdOp = (id, vcs) =>
     vcs.checkout(id).toEither.fold(
-      f => VcsFailure.explain(f, id, "checkout", Some(locationFor(id))),
+      f => OldVcsFailure.explain(f, id, "checkout", Some(locationFor(id))),
       _ => "Checked out %s".format(id.toString)
     )
 
   val commit: VcsIdOp = (id, vcs) =>
     vcs.commit(id).toEither.fold(
-      f => VcsFailure.explain(f, id, "commit", Some(locationFor(id))),
+      f => OldVcsFailure.explain(f, id, "commit", Some(locationFor(id))),
       _ => "Commited %s".format(id.toString)
     )
 
   val status: VcsIdOp = (id, vcs) =>
     vcs.nodeStatus(id).toEither.fold(
-      f => VcsFailure.explain(f, id, "get status", Some(locationFor(id))),
+      f => OldVcsFailure.explain(f, id, "get status", Some(locationFor(id))),
       m => StatusFormat(m)
     )
 
@@ -119,13 +119,13 @@ class CommandsImpl(odb: IDBDatabaseService, reg: VcsRegistrar, auth: KeyChain, l
 
   val update: VcsIdOp = (id, vcs) =>
     vcs.update(id, auth.subject.getPrincipals.asScala.toSet).toEither.fold(
-      f => VcsFailure.explain(f, id, "update", Some(locationFor(id))),
+      f => OldVcsFailure.explain(f, id, "update", Some(locationFor(id))),
       _ => "Updated %s".format(id.toString)
     )
 
   val showlog: VcsIdOp = (id, vcs) =>
     vcs.log(id, 0, Int.MaxValue).toEither.fold(
-      f => VcsFailure.explain(f, id, "log", Some(locationFor(id))),
+      f => OldVcsFailure.explain(f, id, "log", Some(locationFor(id))),
       r => r._1.mkString("\n")
     )
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/Commit.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/Commit.scala
@@ -4,7 +4,7 @@ import edu.gemini.pot.sp.{ISPStaffOnlyFieldProtected, ISPNode, ISPProgram}
 import edu.gemini.pot.sp.version._
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.sp.vcs.VcsLocking.MergeOp
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.spModel.rich.pot.sp._
 
 import scalaz._

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/TrpcVcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/TrpcVcsServer.scala
@@ -3,7 +3,7 @@ package edu.gemini.sp.vcs
 import edu.gemini.spModel.core.{Peer, SPProgramID}
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.pot.sp.version._
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 
 import scalaz._
 import edu.gemini.sp.vcs.log.VcsEventSet
@@ -15,10 +15,10 @@ import edu.gemini.util.security.auth.keychain.KeyChain
 case class TrpcVcsServer(kc: KeyChain, host: String, port: Int) extends VcsServer {
   import edu.gemini.util.trpc.client.TrpcClient
 
-  private def mergeLefts[F>:VcsException,T](v: \/[Exception, F \/ T]): F \/ T =
-    v.fold(ex => -\/(VcsException(ex)), identity)
+  private def mergeLefts[F>:OldVcsException,T](v: \/[Exception, F \/ T]): F \/ T =
+    v.fold(ex => -\/(OldVcsException(ex)), identity)
 
-  private def call[F>:VcsException,T](op: VcsServer => F \/ T): F \/ T = {
+  private def call[F>:OldVcsException,T](op: VcsServer => F \/ T): F \/ T = {
     val vcsServer = TrpcClient(host, port).withKeyChain(kc)
     mergeLefts(vcsServer { remote => op(remote[VcsServer]) })
   }
@@ -32,7 +32,7 @@ case class TrpcVcsServer(kc: KeyChain, host: String, port: Int) extends VcsServe
   def store(p: ISPProgram): TryVcs[VersionMap] =
     call(_.store(p))
 
-  def log(p: SPProgramID, offset: Int, length: Int): VcsFailure.TryVcs[(List[VcsEventSet], Boolean)] =
+  def log(p: SPProgramID, offset: Int, length: Int): OldVcsFailure.TryVcs[(List[VcsEventSet], Boolean)] =
     call(_.log(p, offset, length))
 
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/Update.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/Update.scala
@@ -3,7 +3,7 @@ package edu.gemini.sp.vcs
 import edu.gemini.sp.vcs.VcsLocking.MergeOp
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.pot.sp.{ISPStaffOnlyFieldProtected, ISPProgram}
-import edu.gemini.sp.vcs.VcsFailure.TryVcs
+import edu.gemini.sp.vcs.OldVcsFailure.TryVcs
 import java.security.Principal
 
 /**

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/VcsLocking.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/VcsLocking.scala
@@ -5,7 +5,7 @@ import edu.gemini.pot.spdb.Locking.{commit,discard}
 import edu.gemini.pot.spdb.ProgramSummoner._
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.pot.sp.{ISPNode, ISPProgram}
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.spModel.rich.pot.sp._
 
 import scalaz._

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/VcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/VcsServer.scala
@@ -2,7 +2,7 @@ package edu.gemini.sp.vcs
 
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.pot.sp.version._
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.sp.vcs.log.VcsEventSet
 import java.security.Principal

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/VersionControlSystem.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/VersionControlSystem.scala
@@ -4,7 +4,7 @@ import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.pot.spdb.ProgramSummoner.{IdNotFound, LookupOrFail}
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.sp.vcs.log.VcsEventSet
 
 import scalaz._

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMerge.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMerge.scala
@@ -2,7 +2,7 @@ package edu.gemini.sp.vcs
 
 import edu.gemini.pot.sp._
 import edu.gemini.pot.sp.Conflict._
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.rich.pot.sp._
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMergePlan.scala
@@ -6,7 +6,7 @@ import edu.gemini.pot.spdb.DBLocalDatabase
 import org.junit.Assert._
 import org.junit.Test
 import edu.gemini.pot.sp.{SPNodeKey, Conflicts}
-import edu.gemini.sp.vcs.MergePlan.Zipper
+import edu.gemini.sp.vcs.OldMergePlan.Zipper
 import edu.gemini.spModel.data.ISPDataObject
 
 /**
@@ -23,21 +23,21 @@ class TestMergePlan {
     val d = newLeaf("d").copy(children = List(newLeaf("d.0"), newLeaf("d.1"), newLeaf("d.2")))
     val root = newLeaf("root").copy(children = List(a, b, c, d))
 
-    val zip = MergePlan.Zipper(root)
+    val zip = OldMergePlan.Zipper(root)
 
-    def newLeaf(title: String): MergePlan = {
+    def newLeaf(title: String): OldMergePlan = {
       val sp = odb.getFactory.createProgram(new SPNodeKey(), null) // the kind of node is irrelevant here
       val ob = sp.getDataObject.asInstanceOf[ISPDataObject]
       ob.setTitle(title)
       sp.setDataObject(ob)
-      MergePlan(sp, EmptyNodeVersions, ob, Conflicts.EMPTY, Nil)
+      OldMergePlan(sp, EmptyNodeVersions, ob, Conflicts.EMPTY, Nil)
     }
 
-    implicit def testZip(zip: MergePlan.Zipper) = new Object {
-      def isAt(mp: MergePlan): Boolean = mp == zip.focus
+    implicit def testZip(zip: OldMergePlan.Zipper) = new Object {
+      def isAt(mp: OldMergePlan): Boolean = mp == zip.focus
     }
 
-    def arrivesAt(mp: MergePlan, dirs: (Zipper => Option[Zipper])*): Unit = {
+    def arrivesAt(mp: OldMergePlan, dirs: (Zipper => Option[Zipper])*): Unit = {
       assertTrue(zip.seq(dirs: _*).exists(_.isAt(mp)))
     }
 
@@ -48,7 +48,7 @@ class TestMergePlan {
     def childrenTitles(z: Zipper): List[String] =
       z.focus.children.map(_.sp.getDataObject.asInstanceOf[ISPDataObject].getTitle)
 
-    def testAdd(testBlock: MergePlan => (List[String], Zipper)) {
+    def testAdd(testBlock: OldMergePlan => (List[String], Zipper)) {
       val zipChildren = List("a", "b", "c", "d")
       assertEquals(zipChildren, childrenTitles(zip))
       val (expected, zipper) = testBlock(newLeaf("x"))

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMergeSecurity.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMergeSecurity.scala
@@ -2,7 +2,7 @@ package edu.gemini.sp.vcs
 
 import edu.gemini.pot.sp.Conflict.{DeletePermissionFail, CreatePermissionFail, UpdatePermissionFail}
 import edu.gemini.pot.sp.{SPComponentType, ISPObservation, ISPSeqComponent}
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.spModel.config2.DefaultConfig
 import edu.gemini.spModel.dataset._
 import edu.gemini.spModel.obs.{ObservationStatus, SPObservation, ObsPhase2Status}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMergeValidity.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMergeValidity.scala
@@ -29,16 +29,16 @@ class TestMergeValidity {
   }
 
 
-  private def node(n: ISPNode): MergePlan.Node =
-    MergePlan.Node(n, EmptyNodeVersions, n.getDataObject, Conflicts.EMPTY)
+  private def node(n: ISPNode): OldMergePlan.Node =
+    OldMergePlan.Node(n, EmptyNodeVersions, n.getDataObject, Conflicts.EMPTY)
 
-  private def mp(n: ISPNode, children: MergePlan*): MergePlan =
-    MergePlan(node(n), children.toList)
+  private def mp(n: ISPNode, children: OldMergePlan*): OldMergePlan =
+    OldMergePlan(node(n), children.toList)
 
   private def tt(nt: NodeType[_ <: ISPNode], children: TypeTree*): TypeTree =
     TypeTree(nt, None, children.toList)
 
-  private def same(expected: TypeTree, prog: ISPProgram, plan: MergePlan) {
+  private def same(expected: TypeTree, prog: ISPProgram, plan: OldMergePlan) {
     assertEquals(expected, MergeValidity(prog, odb).process(plan).right.get.toTypeTree.withoutKeys)
   }
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestStaffOnlyFields.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestStaffOnlyFields.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.obs.ObsQaState
 import edu.gemini.spModel.obscomp.{SPNote, ProgramNote}
-import edu.gemini.sp.vcs.VcsFailure.NeedsUpdate
+import edu.gemini.sp.vcs.OldVcsFailure.NeedsUpdate
 
 class TestStaffOnlyFields {
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestingEnvironment.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestingEnvironment.scala
@@ -3,7 +3,7 @@ package edu.gemini.sp.vcs
 import edu.gemini.pot.sp._
 import edu.gemini.pot.sp.version._
 import edu.gemini.pot.spdb.{DBLocalDatabase, IDBDatabaseService}
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.gemini.init.ObservationNI
 import edu.gemini.spModel.obs.{ObsPhase2Status, SPObservation}
@@ -177,7 +177,7 @@ object TestingEnvironment {
     def version(id: SPProgramID): TryVcs[VersionMap] = prog(id).getVersions.right
     def fetch(id: SPProgramID): TryVcs[ISPProgram] = prog(id).right
     def store(p: ISPProgram): TryVcs[VersionMap] = VcsLocking(odb).merge(LookupOrFail, p, user)(Commit)
-    def log(p: SPProgramID, offset: Int, length: Int): VcsFailure.TryVcs[(List[VcsEventSet], Boolean)] = (Nil, false).right
+    def log(p: SPProgramID, offset: Int, length: Int): OldVcsFailure.TryVcs[(List[VcsEventSet], Boolean)] = (Nil, false).right
   }
 
   def withTestEnv(p: Principal)(block: TestingEnvironment => Unit): Unit = {
@@ -324,7 +324,7 @@ case class TestingEnvironment(user: Set[Principal]) {
   def commit(): Unit =
     assertTrue(cloned.vcs.commit(id).isRight)
 
-  def cantCommit(expected: VcsFailure): Unit =
+  def cantCommit(expected: OldVcsFailure): Unit =
     cloned.vcs.commit(id) match {
       case -\/(actual) => assertEquals(expected, actual)
       case _ => fail("Shouldn't be able to commit, expecting: " + expected)

--- a/bundle/jsky.app.ot.plugin/src/main/scala/jsky/app/ot/plugin/OtViewerService.scala
+++ b/bundle/jsky.app.ot.plugin/src/main/scala/jsky/app/ot/plugin/OtViewerService.scala
@@ -1,7 +1,7 @@
 package jsky.app.ot.plugin
 
 import edu.gemini.pot.sp.{ISPObservation, SPObservationID, ISPProgram}
-import edu.gemini.sp.vcs.VcsFailure
+import edu.gemini.sp.vcs.OldVcsFailure
 import edu.gemini.spModel.core.SPProgramID
 
 import scalaz._
@@ -9,8 +9,8 @@ import scalaz._
 trait OtViewerService {
   def registerView(view: AnyRef)
   def unregisterView(view: AnyRef)
-  def load(pid: SPProgramID): \/[VcsFailure, ISPProgram]
-  def load(oid: SPObservationID): \/[VcsFailure, Option[ISPObservation]]
-  def loadAndView(pid: SPProgramID): \/[VcsFailure, ISPProgram]
-  def loadAndView(oid: SPObservationID): \/[VcsFailure, Option[ISPObservation]]
+  def load(pid: SPProgramID): \/[OldVcsFailure, ISPProgram]
+  def load(oid: SPObservationID): \/[OldVcsFailure, Option[ISPObservation]]
+  def loadAndView(pid: SPProgramID): \/[OldVcsFailure, ISPProgram]
+  def loadAndView(oid: SPObservationID): \/[OldVcsFailure, Option[ISPObservation]]
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EdProgramHelper.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EdProgramHelper.scala
@@ -9,7 +9,7 @@ import edu.gemini.sp.vcs.VcsServer
 import java.util.logging.{Level, Logger}
 import edu.gemini.pot.client.SPDB
 import edu.gemini.sp.vcs.log._
-import edu.gemini.sp.vcs.VcsFailure.VcsException
+import edu.gemini.sp.vcs.OldVcsFailure.OldVcsException
 import scala.util.Success
 import edu.gemini.sp.vcs.VersionControlSystem
 import scala.util.Failure
@@ -84,7 +84,7 @@ object EdProgramHelper {
       r =>
         val remote = VersionControlSystem(SPDB.get(), r[VcsServer])
         remote.log(pid, 0, 100).fold({
-          case VcsException(e) => throw e
+          case OldVcsException(e) => throw e
           case f => throw new RuntimeException(f.toString)
         }, identity)
     } onComplete {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/too/TooHandler.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/too/TooHandler.scala
@@ -4,7 +4,7 @@ import edu.gemini.pot.client.SPDB
 import edu.gemini.pot.sp.{ISPProgram, ISPObservation}
 import edu.gemini.spModel.core.Peer
 import edu.gemini.spModel.obs.ObsSchedulingReport
-import edu.gemini.sp.vcs.{VcsFailure, VersionControlSystem, TrpcVcsServer}
+import edu.gemini.sp.vcs.{OldVcsFailure, VersionControlSystem, TrpcVcsServer}
 import edu.gemini.too.event.api.TooEvent
 
 import jsky.app.ot.userprefs.observer.ObserverPreferences
@@ -51,7 +51,7 @@ final class TooHandler(evt: TooEvent, peer: Peer, parent: JComponent) extends Ru
 
     def update(p: ISPProgram): Either[String, ISPProgram] = {
       val srv = TrpcVcsServer(OT.getKeyChain, peer.host, peer.port)
-      VersionControlSystem.apply(db, srv).update(pid, currentUser).toEither.left.map(failure => VcsFailure.explain(failure, pid, "update", Some(peer)))
+      VersionControlSystem.apply(db, srv).update(pid, currentUser).toEither.left.map(failure => OldVcsFailure.explain(failure, pid, "update", Some(peer)))
     }
 
     // Left means the updated failed, Right(None) means we don't have the

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/SyncAllModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/SyncAllModel.scala
@@ -2,7 +2,7 @@ package jsky.app.ot.vcs
 
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.pot.sp.version.VersionMap
-import edu.gemini.sp.vcs.{VcsFailure, ProgramStatus}
+import edu.gemini.sp.vcs.{OldVcsFailure, ProgramStatus}
 import edu.gemini.sp.vcs.ProgramStatus._
 import edu.gemini.spModel.core.SPProgramID
 
@@ -28,7 +28,7 @@ object SyncAllModel {
 
     case class SyncInProgress(ps: ProgramStatus) extends State
 
-    case class SyncFailed(t: Option[VcsFailure]) extends State {
+    case class SyncFailed(t: Option[OldVcsFailure]) extends State {
       override def isTerminal: Boolean = true
     }
 
@@ -98,7 +98,7 @@ case class SyncAllModel(programs: Vector[ProgramSync]) {
       }
     })
 
-  def markSyncFailed(pid: SPProgramID, t: Option[VcsFailure]): SyncAllModel =
+  def markSyncFailed(pid: SPProgramID, t: Option[OldVcsFailure]): SyncAllModel =
     updateState(pid) { _ => State.SyncFailed(t) }
 
   def markSyncConflict(pid: SPProgramID): SyncAllModel =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsGuiOp.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsGuiOp.scala
@@ -5,7 +5,7 @@ import edu.gemini.spModel.core.{VersionException, SPProgramID}
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.pot.sp.version._
 import edu.gemini.sp.vcs._
-import edu.gemini.sp.vcs.VcsFailure._
+import edu.gemini.sp.vcs.OldVcsFailure._
 import scalaz.{-\/, \/-}
 import java.util.logging.Logger
 import edu.gemini.pot.spdb.ProgramSummoner.{IdNotFound, LookupOrFail}
@@ -112,7 +112,7 @@ trait VcsGuiOp {
    */
   def apply(id: SPProgramID, gui: Ui, server: VcsServer): Result
 
-  def explanation: PartialFunction[VcsFailure, String] = { case _ if false => "" }
+  def explanation: PartialFunction[OldVcsFailure, String] = { case _ if false => "" }
 }
 
 
@@ -160,9 +160,9 @@ object VcsSyncOp extends VcsGuiOp {
         // it means the program has received an exec event (or other remote
         // update) since the update succeeded.  If that is the case, just retry
         // until it works or fails for some other reason.
-        case -\/(up: VcsFailure.NeedsUpdate.type) =>
+        case -\/(up: OldVcsFailure.NeedsUpdate.type) =>
           if (count < MaxCommitTry) apply(id, gui, server, count + 1)
-          else Some(-\/(VcsFailure.Unexpected(s"Your version of $id appears to be incompatible.")))
+          else Some(-\/(OldVcsFailure.Unexpected(s"Your version of $id appears to be incompatible.")))
         case otherResult => Some(otherResult)
       }
       case -\/(SummonFailure(IdNotFound(_))) =>
@@ -171,8 +171,8 @@ object VcsSyncOp extends VcsGuiOp {
       case failure => Some(failure)
     }
 
-  override val explanation: PartialFunction[VcsFailure, String] = {
-    case VcsException(ex: VersionException) => ex.getLongMessage // :-\
+  override val explanation: PartialFunction[OldVcsFailure, String] = {
+    case OldVcsException(ex: VersionException) => ex.getLongMessage // :-\
     case HasConflict => "Your program has been updated but you must resolve conflicting edits before storing changes."
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsProgressDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsProgressDialog.scala
@@ -128,11 +128,11 @@ class VcsProgressDialog(id: SPProgramID, viewer: SPViewer, comp: Option[Componen
       val cancelled = isCancelled
 
       lazy val conflictedProg = result.flatMap(_.toEither.left.toOption).collect {
-        case VcsFailure.HasConflict => SPDB.get().lookupProgramByID(id)
+        case OldVcsFailure.HasConflict => SPDB.get().lookupProgramByID(id)
       }
 
       lazy val errorMessage = result.flatMap(_.toEither.left.toOption map { failure =>
-        op.explanation.lift(failure).getOrElse(VcsFailure.explain(failure, id, op.name, VcsGui.peer(id)))
+        op.explanation.lift(failure).getOrElse(OldVcsFailure.explain(failure, id, op.name, VcsGui.peer(id)))
       })
 
       Swing.onEDT {


### PR DESCRIPTION
This is a trivial rename of a few classes in order to simplify continuing development.  The changes apply to classes in the _original merge algorithm_ whose names were the same as similar classes in the new algorithm.  Of course they were already in different packages and compiled and worked fine, but the Idea Scala plugin could not distinguish them properly in a package object.  For example in

````scala
package edu.gemini.sp.vcs
...
package object diff {
  type MergeCorrection = MergePlan => Unmergeable \/ MergePlan
  type TryVcs[A] = VcsFailure \/ A
  type VcsAction[+A] = EitherT[Task, VcsFailure, A]
  ...
}
````

the plugin would pick up the `MergePlan` and the `VcsFailure` from `edu.gemini.sp.vcs` instead of `edu.gemini.sp.vcs.diff`. The change simply performs the following renaming:

````
  edu.gemini.sp.vcs.MergePlan -> edu.gemini.sp.vcs.OldMergePlan
  edu.gemini.sp.vcs.VcsFailure -> edu.gemini.sp.vcs.OldVcsFailure
  edu.gemini.sp.vcs.VcsFailure.VcsException -> edu.gemini.sp.vcs.OldVcsFailure.OldVcsException

````

You might want to ignore the details of the code itself because when the new algorithm is complete these classes along with everything else in `edu.gemini.sp.vcs.*` will be deleted anyway.