### PR TITLE
OCSADV-200-H: ValidityCorrection

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/sync/GuideSync.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/sync/GuideSync.java
@@ -126,12 +126,18 @@ public enum GuideSync implements ISPEventMonitor {
     public void propertyChanged(SPCompositeChange change) {
         if (!SPUtil.getDataObjectPropertyName().equals(change.getPropertyName())) return;
 
-        ISPNode node = change.getModifiedNode();
+        final ISPNode node = change.getModifiedNode();
         // Ignore updates to objects that aren't to the target obs component
         // or (REL-542) Altair ... Should be done through a marker interface ...
-        Object dataObj = node.getDataObject();
+        final Object dataObj = node.getDataObject();
         if (!(dataObj instanceof TargetObsComp) && !(dataObj instanceof InstAltair)) return;
-        update((ISPObservation) node.getParent());
+
+        // Ignore updates to objects that aren't in an observation.  This can
+        // happen for example if the component is in a conflict folder.
+        final ISPNode parent = node.getParent();
+        if (parent instanceof ISPObservation) {
+            update((ISPObservation) parent);
+        }
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/validator/Validator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/validator/Validator.scala
@@ -3,13 +3,15 @@ package edu.gemini.pot.sp.validator
 import edu.gemini.pot.sp.{SPNodeKey, ISPNode, ISPProgram, ISPContainerNode}
 import java.awt.{AWTEvent, EventQueue}
 
+import scala.util.Try
+
 object EventCache {
 
   private var previousEvent: Option[AWTEvent] = None
   private val cache: collection.mutable.Map[(ISPContainerNode, Option[SPNodeKey]), TypeTree] = collection.mutable.Map()
 
   def tree(prog: ISPContainerNode, contextKey: Option[SPNodeKey])(a: => TypeTree): TypeTree =
-    Option(EventQueue.getCurrentEvent) match {
+    Option(Try(EventQueue.getCurrentEvent).toOption.orNull) match {
       case None => a
       case o =>
         if (o != previousEvent) {
@@ -107,7 +109,7 @@ object Validator {
 
   private def validate(c: Constraint, tree: TypeTree): Either[Violation, Constraint] = {
     lazy val a = validate1(c, tree)
-    Option(EventQueue.getCurrentEvent) match {
+    Option(Try(EventQueue.getCurrentEvent).toOption.orNull) match {
       case None => a
       case o =>
         if (o != previousEvent) {

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeCorrection.scala
@@ -1,0 +1,31 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.sp.vcs.diff.VcsFailure.Unmergeable
+
+import scalaz._
+import Scalaz._
+
+object MergeCorrection {
+
+  type TryCorrect[A] = Unmergeable \/ A
+
+  implicit class OptionOps[A](o: Option[A]) {
+    def toTryCorrect(msg: => String): TryCorrect[A] =
+      o.toRightDisjunction(Unmergeable(msg))
+  }
+
+  /**
+   * A `CorrectionFunction` is just a function that modifies an `MergePlan` to
+   * correct some aspect of the merge.
+   */
+  type CorrectionFunction = MergePlan => TryCorrect[MergePlan]
+
+  def all(mc: MergeContext): List[CorrectionFunction] =
+    List(
+      ObsNumberCorrection(mc),
+      ValidityCorrection(mc)
+    )
+
+  def apply(mc: MergeContext): CorrectionFunction = (mp: MergePlan) =>
+    (mp.right[Unmergeable]/:all(mc)) { _.flatMap(_) }
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeNode.scala
@@ -10,11 +10,11 @@ import scalaz._
 
 
 /** MergeNodes form a tree with potential links into an existing science
-  * program.  There are two types of MergeNode, [[Modified]] and
-  * [[Unmodified]]s.  `Modified` describes a potential update to an
-  * existing science program node (or the definition of a node missing locally).
-  * `Unmodified` is just a `MergeNode` wrapper for an existing science program
-  * node.
+  * program.  There are two types of MergeNode, [[edu.gemini.sp.vcs.diff.Modified]]
+  * and [[edu.gemini.sp.vcs.diff.Unmodified]]s.  `Modified` describes a
+  * potential update to an existing science program node (or the definition of a
+  * node missing locally). `Unmodified` is just a `MergeNode` wrapper for an
+  * existing science program node.
   */
 sealed trait MergeNode {
   def key: SPNodeKey
@@ -77,6 +77,21 @@ object MergeNode {
         }
 
       go(List(t), z)
+    }
+  }
+
+  implicit class TreeLocOps[A](tl: TreeLoc[A]) {
+    /** Deletes the current node and selects the parent.  Unlike the
+      * `TreeLoc.delete` function, this function will always select the parent
+      * node. */
+    def deleteNodeFocusParent: Option[TreeLoc[A]] = {
+      def combine(ls: Stream[Tree[A]], rs: Stream[Tree[A]]) =
+        ls.foldLeft(rs)((a, b) => b #:: a)
+
+      tl.parents match {
+        case (pls, v, prs) #:: ps => Some(TreeLoc.loc(Tree.node(v, combine(tl.lefts, tl.rights)), pls, prs, ps))
+        case Stream.Empty         => None
+      }
     }
   }
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
@@ -1,11 +1,11 @@
 package edu.gemini.sp.vcs.diff
 
 import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.sp.vcs.diff.MergeCorrection._
 import edu.gemini.sp.vcs.diff.NodeDetail.Obs
 import edu.gemini.sp.vcs.diff.ProgramLocation.{Remote, Local}
 import edu.gemini.sp.vcs.diff.VcsFailure.Unmergeable
 import edu.gemini.spModel.obslog.ObsExecLog
-import edu.gemini.spModel.rich.pot.sp._
 
 import scalaz._
 import Scalaz._
@@ -25,8 +25,8 @@ import Scalaz._
   * remote program versions with an observation number greater than a
   * local-only observation.
   */
-class ObsNumberCorrection(isKnown: (ProgramLocation, SPNodeKey) => Boolean) extends MergeCorrection {
-  def apply(mp: MergePlan): Unmergeable \/ MergePlan =
+class ObsNumberCorrection(isKnown: (ProgramLocation, SPNodeKey) => Boolean) extends CorrectionFunction {
+  def apply(mp: MergePlan): TryCorrect[MergePlan] =
     renumberedObs(mp).map { obsMap =>
       if (obsMap.isEmpty)  // usually empty so we might as well check and save a traversal in that case
         mp
@@ -39,7 +39,7 @@ class ObsNumberCorrection(isKnown: (ProgramLocation, SPNodeKey) => Boolean) exte
 
   // Obtains a Set of pairs of observation node keys that need to be
   // renumbered along with the new observation number they should have.
-  private def renumberedObs(mp: MergePlan): Unmergeable \/ Map[SPNodeKey, Int] = {
+  private def renumberedObs(mp: MergePlan): TryCorrect[Map[SPNodeKey, Int]] = {
 
     /** A pair of the max remote-only observation number and a set of all
       * local-only observation keys with their current observation number.

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ValidityCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ValidityCorrection.scala
@@ -1,0 +1,120 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.{SPComponentType, ISPNode, SPNodeKey}
+import edu.gemini.pot.sp.validator._
+import edu.gemini.pot.sp.version.{EmptyNodeVersions, LifespanId}
+import edu.gemini.spModel.conflict.ConflictFolder
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.sp.vcs.diff.MergeCorrection._
+import edu.gemini.sp.vcs.diff.VcsFailure.Unmergeable
+
+import scalaz._
+import Scalaz._
+
+/** Corrects merge plans that form invalid science programs by introducing
+  * conflict nodes. */
+class ValidityCorrection(lifespanId: LifespanId, nodeMap: Map[SPNodeKey, ISPNode]) extends CorrectionFunction {
+
+  // Applies corrections to invalid science programs, shunting problem nodes off
+  // into a conflict folder.  The Validator finds one issue at a time so we
+  // find and fix an issue and then start over with the updated MergePlan until
+  // there are no more issues.
+  def apply(mp: MergePlan): TryCorrect[MergePlan] =
+    toTypeTree(mp.update).flatMap { tt =>
+      Validator.validate(tt) match {
+        case Left(v)  => fix(mp, v).flatMap(apply)
+        case Right(_) => mp.right
+      }
+    }
+
+  private def toTypeTree(t: Tree[MergeNode]): TryCorrect[TypeTree] =
+    t.rootLabel match {
+      case Unmodified(k)          =>
+        // We need the types of the immediate children of a node, even if not
+        // modified.
+        nodeMap.get(k).toTryCorrect(s"Could not find unmodified node: $k").map { n =>
+          TypeTree(NodeType.forNode(n), Some(k), Nil)
+        }
+
+      case Modified(k, _, dob, _) =>
+        NodeType.forComponentType(dob.getType).toTryCorrect(s"Unusable node type: ${dob.getType}").flatMap { nt =>
+          t.subForest.traverseU(toTypeTree).map { cs =>
+            TypeTree(nt, Some(k), cs.toList)
+          }
+        }
+    }
+
+  private def fix(mp: MergePlan, v: Violation): TryCorrect[MergePlan] = {
+    def key(v: Violation): TryCorrect[SPNodeKey] =
+      v match {
+        case CardinalityViolation(nt, Some(k), _) => k.right
+
+        case cv@CardinalityViolation(_, None, _)  =>
+          Unmergeable(s"Cardinality violation with missing node key: $cv").left
+
+        case DuplicateKeyViolation(k)             =>
+          Unmergeable(s"Duplicate program node key found: $k").left
+      }
+
+    def zip(k: SPNodeKey): TryCorrect[TreeLoc[MergeNode]] =
+      mp.update.loc.find(_.getLabel.key === k).toTryCorrect(s"Couldn't find node involved in validate constraint violation: $k")
+
+    for {
+      k <- key(v)
+      z <- zip(k)
+      f <- fix(mp, z)
+    } yield f
+  }
+
+  // Moves the tree at the focus of the given zipper into a conflict folder of
+  // the parent node.
+  private def fix(mp: MergePlan, z: TreeLoc[MergeNode]): TryCorrect[MergePlan] = {
+
+    def incr(z: TreeLoc[MergeNode]): TryCorrect[TreeLoc[MergeNode]] =
+      z.getLabel match {
+        case m: Modified => \/-(z.modifyLabel(_ => m.copy(nv = m.nv.incr(lifespanId))))
+        case _           => -\/(Unmergeable("Could not increment version of unmodified node"))
+      }
+
+    def isConflictFolder(t: Tree[MergeNode]): Boolean =
+      t.rootLabel match {
+        case Modified(_, _, _: ConflictFolder, _) => true
+        case Unmodified(k)                        => nodeMap.get(k).exists { n =>
+          n.getDataObject.getType == SPComponentType.CONFLICT_FOLDER
+        }
+        case _                                    => false
+      }
+
+    // Guarantee that the focus refers to a Modified merge node, converting
+    // an Unmodified node to Modified if necessary.
+    def asModified(t: TreeLoc[MergeNode]): TreeLoc[MergeNode] =
+      t.getLabel match {
+        case m: Modified => t
+        case _           => t.modifyTree { mn =>
+          val spNode   = nodeMap(mn.key)
+          val conflict = MergeNode.modified(spNode)
+          conflict.node(spNode.children.map(c => MergeNode.unmodified(c).leaf): _*)
+        }
+      }
+
+    def addConflictFolder(t: TreeLoc[MergeNode]): TreeLoc[MergeNode] = {
+      val k   = new SPNodeKey()
+      val nv  = EmptyNodeVersions
+      val dob = new ConflictFolder()
+      val mn  = MergeNode.modified(k, nv, dob, NodeDetail.Empty)
+      t.insertDownFirst(mn.leaf)
+    }
+
+    for {
+      p0  <- z.deleteNodeFocusParent.toTryCorrect("Validity constraint violation for root node")
+      p1  <- incr(p0)
+      cf0  = p1.findChild(isConflictFolder).fold(addConflictFolder(p1))(asModified)
+      cf1 <- incr(cf0)
+    } yield mp.copy(update = cf1.insertDownLast(z.tree).toTree)
+  }
+}
+
+object ValidityCorrection {
+  def apply(mc: MergeContext): ValidityCorrection =
+    new ValidityCorrection(mc.local.prog.getLifespanId, mc.local.nodeMap)
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Vcs.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Vcs.scala
@@ -56,7 +56,7 @@ class Vcs(user: VcsAction[Set[Principal]], server: VcsServer, service: Peer => V
         _     <- validateProgKey(p, diffs)
         mc     = MergeContext(p, diffs)
         prelim = PreliminaryMerge.merge(mc)
-        plan  <- ObsNumberCorrection(mc).apply(prelim).liftVcs
+        plan  <- MergeCorrection(mc)(prelim).liftVcs
       } yield MergeEval(plan, p, mc.remote.vm)
 
     // Only do the merge if the merge plan has something new to offer.

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/package.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/package.scala
@@ -9,12 +9,6 @@ import scalaz.concurrent._
 
 package object diff {
 
-  /**
-   * A `MergeCorrection` is just a function that modifies an `MergePlan` to
-   * correct some aspect of the merge.
-   */
-  type MergeCorrection = MergePlan => VcsFailure.Unmergeable \/ MergePlan
-
   implicit class IspNodeTreeOps(val node: ISPNode) extends AnyVal {
     /** A Map with entries for all nodes rooted at this node, keyed by
       * `SPNodeKey`.

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeCorrectionSpec.scala
@@ -1,0 +1,108 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.pot.sp.version._
+import edu.gemini.spModel.conflict.ConflictFolder
+import edu.gemini.spModel.data.ISPDataObject
+import edu.gemini.spModel.gemini.gmos.InstGmosSouth
+import edu.gemini.spModel.gemini.obscomp.{SPSiteQuality, SPProgram}
+import edu.gemini.spModel.obs.SPObservation
+import edu.gemini.spModel.obslog.{ObsQaLog, ObsExecLog}
+import edu.gemini.spModel.seqcomp.SeqBase
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.template.TemplateFolder
+import org.specs2.matcher.{MatchResult, Expectable, Matcher}
+
+import org.specs2.mutable.Specification
+
+import scalaz._
+import Scalaz._
+
+class MergeCorrectionSpec extends Specification {
+  import NodeDetail._
+
+  def mergeNode(dob: ISPDataObject, obsNum: Option[Int]): MergeNode = Modified(
+    new SPNodeKey(),
+    EmptyNodeVersions,
+    dob,
+    obsNum.fold(Empty: NodeDetail) { Obs.apply }
+  )
+
+  def nonObs(dob: ISPDataObject): MergeNode = mergeNode(dob, None)
+
+  def conflictFolder: MergeNode = nonObs(new ConflictFolder)
+
+  def prog: MergeNode = nonObs(new SPProgram)
+
+  def templateFolder: MergeNode = nonObs(new TemplateFolder)
+
+  def obs(num: Int): MergeNode = mergeNode(new SPObservation, Some(num))
+
+  def obsTree(num: Int): Tree[MergeNode] =
+    obs(num).node(
+      nonObs(new TargetObsComp).leaf,
+      nonObs(new SPSiteQuality).leaf,
+      nonObs(new InstGmosSouth).leaf,
+      nonObs(new ObsQaLog).leaf,
+      nonObs(new ObsExecLog).leaf,
+      nonObs(new SeqBase).leaf
+    )
+
+  def plan(t: Tree[MergeNode]): MergePlan = MergePlan(t, Set.empty)
+
+  def treeComparisonFailureMessage(msg: String, expected: Tree[MergeNode], actual: Tree[MergeNode]): String =
+    s"$msg\n\nExpected:\n${expected.drawTree}\nActual:\n${actual.drawTree}"
+
+  def correspondTo(expected: Tree[MergeNode]) = new Matcher[Tree[MergeNode]] {
+    def compare(expected: Tree[MergeNode], actual: Tree[MergeNode]): Option[String] = {
+      val e = expected.rootLabel
+      val a = actual.rootLabel
+
+      (e, a) match {
+        case (Modified(ek, env, edob, edet), Modified(ak, anv, adob, adet)) =>
+          val ect = edob.getType
+          val act = adob.getType
+
+          // conflict folders are created by the validity correction so we don't
+          // know what key to expect ahead of time.  match any key for conflict
+          // folders
+          def key: Option[String] =
+            ((ect != ConflictFolder.SP_TYPE) && (ek != ak)) option s"Keys don't match. Expected: $ek, Actual: $ak"
+
+          def nodeVersion: Option[String] =
+            env != anv option s"NodeVersions don't match for $ak. Expected: $env, Actual: $anv"
+
+          def componentType: Option[String] =
+            ect != act option s"Component type doesn't match for $ak. Expected: $ect, Actual: $act"
+
+          def detail: Option[String] =
+            edet != adet option s"NodeDetail doesn't match for $ak. Expected: $edet, Actual: $adet"
+
+          def childKeys(t: Tree[MergeNode]): String =
+            t.subForest.map(_.key).mkString("{", ", ", "}")
+
+          def childrenSize: Option[String] =
+            expected.subForest.size != actual.subForest.size option s"Children differ. Expected: ${childKeys(expected)}, Actual: ${childKeys(actual)}"
+
+          def deepChildren: Option[String] =
+            (Option.empty[String]/:expected.subForest.zip(actual.subForest)) { case (opt, (echild, achild)) =>
+                opt orElse compare(echild, achild)
+            }
+
+          key orElse nodeVersion orElse componentType orElse detail orElse childrenSize orElse deepChildren
+
+        case (eu: Unmodified, au: Unmodified) =>
+          eu.key != au.key option s"Unmodified node keys don't match. Expected: ${eu.key}, Actual: ${au.key}"
+
+        case _                                =>
+          Some(s"Modified/Unmodified mix.  Expected: $e, Actual: $a")
+      }
+    }
+
+    override def apply[S <: Tree[MergeNode]](t: Expectable[S]): MatchResult[S] = {
+      val actual  = t.value
+      val problem = compare(expected, actual).map(treeComparisonFailureMessage(_, expected, actual))
+      result(problem.isEmpty, "", problem.getOrElse("unknown"), t)
+    }
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
@@ -1,42 +1,24 @@
 package edu.gemini.sp.vcs.diff
 
 import edu.gemini.pot.sp.{SPObservationID, SPNodeKey}
-import edu.gemini.pot.sp.version.EmptyNodeVersions
+import edu.gemini.sp.vcs.diff.NodeDetail.Obs
 import edu.gemini.sp.vcs.diff.ProgramLocation.{Remote, Local}
-import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.event.SlewEvent
 import edu.gemini.spModel.gemini.obscomp.SPProgram
-import edu.gemini.spModel.obs.SPObservation
 import edu.gemini.spModel.obslog.ObsExecLog
-import org.specs2.mutable._
 
 import scalaz._
 import Scalaz._
 
-class ObsNumberCorrectionSpec extends Specification {
+class ObsNumberCorrectionSpec extends MergeCorrectionSpec {
   val LocalOnly: Set[ProgramLocation]  = Set(Local)
   val RemoteOnly: Set[ProgramLocation] = Set(Remote)
   val Both: Set[ProgramLocation]       = Set(Local, Remote)
 
-
-  import NodeDetail._
-
-  def mergeNode(dob: ISPDataObject, obsNum: Option[Int]): MergeNode = Modified(
-    new SPNodeKey(),
-    EmptyNodeVersions,
-    dob,
-    obsNum.fold(Empty: NodeDetail) { Obs.apply }
-  )
-
-  def nonObs(dob: ISPDataObject): MergeNode = mergeNode(dob, None)
-
-  def obs(num: Int): MergeNode = mergeNode(new SPObservation, Some(num))
-
-  def doTest(expected: List[Int], merged: (Int, Set[ProgramLocation])*): Boolean = {
+  def test(expected: List[Int], merged: (Int, Set[ProgramLocation])*): Boolean = {
     val obsList = merged.map { case (i,_) => obs(i).leaf }
 
-    val mergeTree =
-      Tree.node(nonObs(new SPProgram), obsList.toStream)
+    val mergeTree = Tree.node(prog, obsList.toStream)
 
     val known = merged.unzip._2.zip(obsList.map(_.key)).map { case (locs, key) =>
       locs.map(loc => (loc, key))
@@ -54,14 +36,14 @@ class ObsNumberCorrectionSpec extends Specification {
     onc(plan).map(mp => obsNumbers(mp.update)) shouldEqual \/-(expected)
   }
 
-  "ObsRenumber" should {
+  "ObsNumberCorrection" should {
 
     "handle the no-observation case without exception" in {
-      doTest(Nil)
+      test(Nil)
     }
 
     "not change remote only observation numbers" in {
-      doTest(List(3, 2, 1),
+      test(List(3, 2, 1),
         (3, RemoteOnly),
         (2, RemoteOnly),
         (1, RemoteOnly)
@@ -69,21 +51,21 @@ class ObsNumberCorrectionSpec extends Specification {
     }
 
     "not renumber observations known to both sides" in {
-      doTest(List(1, 2),
+      test(List(1, 2),
         (1, Both),
         (2, Both)
       )
     }
 
     "not renumber new local-only observations if there are no remote observations" in {
-      doTest(List(1, 2),
+      test(List(1, 2),
         (1, LocalOnly),
         (2, LocalOnly)
       )
     }
 
     "not renumber new local-only observations if they come after the last remote observation" in {
-      doTest(List(2, 1, 3),
+      test(List(2, 1, 3),
         (2, LocalOnly),
         (1, Both),
         (3, LocalOnly)
@@ -91,14 +73,14 @@ class ObsNumberCorrectionSpec extends Specification {
     }
 
     "renumber a local observation with the same number as a remote observation" in {
-      doTest(List(2, 1),
+      test(List(2, 1),
         (1, LocalOnly),
         (1, RemoteOnly)
       )
     }
 
     "renumber new local observations with numbers that come before remote observations" in {
-      doTest(List(5, 2, 6, 4),
+      test(List(5, 2, 6, 4),
         (1, LocalOnly),
         (2, RemoteOnly),
         (3, LocalOnly),
@@ -107,7 +89,7 @@ class ObsNumberCorrectionSpec extends Specification {
     }
 
     "respect the original local-only numbering sort when renumbering" in {
-      doTest(List(6, 2, 5, 4),
+      test(List(6, 2, 5, 4),
         (3, LocalOnly),
         (2, RemoteOnly),
         (1, LocalOnly),
@@ -116,7 +98,7 @@ class ObsNumberCorrectionSpec extends Specification {
     }
 
     "respect the original local-only numbering if there is no need to renumber" in {
-      doTest(List(1, 5, 6),
+      test(List(1, 5, 6),
         (1, RemoteOnly),
         (5, LocalOnly),
         (6, LocalOnly)
@@ -124,7 +106,7 @@ class ObsNumberCorrectionSpec extends Specification {
     }
 
     "renumber local-only observations sequentially if we must renumber" in {
-      doTest(List(1, 2, 3, 4),
+      test(List(1, 2, 3, 4),
         (1, RemoteOnly),
         (1, LocalOnly),
         (5, LocalOnly),

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ValidityCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ValidityCorrectionSpec.scala
@@ -1,0 +1,116 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.pot.sp.version.LifespanId
+import edu.gemini.pot.spdb.DBLocalDatabase
+import edu.gemini.sp.vcs.diff.VcsFailure.Unmergeable
+import org.specs2.matcher.MatchResult
+
+import scalaz._
+import Scalaz._
+
+class ValidityCorrectionSpec extends MergeCorrectionSpec {
+  val lifespanId         = LifespanId.random
+  val validityCorrection = new ValidityCorrection(lifespanId, Map.empty)
+
+  def incr(mn: MergeNode): MergeNode =
+    mn match {
+      case m: Modified => m.copy(nv = m.nv.incr(lifespanId))
+      case _           => failure("trying to increment unmodified node")
+    }
+
+  private def test(start: Tree[MergeNode], expected: Tree[MergeNode], vc: ValidityCorrection = validityCorrection): MatchResult[Tree[MergeNode]] =
+    vc.apply(plan(start)) match {
+      case -\/(Unmergeable(msg)) => failure(msg)
+      case \/-(mp)               => mp.update must correspondTo(expected)
+    }
+
+  "MergeValidityCorrection" should {
+    "not modify an already valid program" in {
+      val start = prog.node(obsTree(1))
+      test(start, start)
+    }
+
+    "move validity constraint violations into a conflict folder" in {
+      val p   = prog
+      val tf1 = templateFolder
+      val tf2 = templateFolder
+
+      val start    = p.node(tf1.leaf, tf2.leaf)
+      val expected = incr(p).node(
+        incr(conflictFolder).node(tf2.leaf),
+        tf1.leaf
+      )
+
+      test(start, expected)
+    }
+
+    "take into account unmodified node types" in {
+      val odb = DBLocalDatabase.createTransient()
+      try {
+        // Create a template folder node, put it in the node map, and make a
+        // corresponding Unmodified merge node.
+        val key = new SPNodeKey()
+        val pn  = odb.getFactory.createProgram(null, null)
+        val tfn = odb.getFactory.createTemplateFolder(pn, key)
+        val nodeMap = Map(key -> tfn)
+        val un  = MergeNode.unmodified(tfn)
+
+        val tf2 = templateFolder
+        val p   = prog
+
+        val start    = p.node(un.leaf, tf2.leaf)
+        val expected = incr(p).node(
+          incr(conflictFolder).node(tf2.leaf),
+          un.leaf
+        )
+
+        test(start, expected, new ValidityCorrection(lifespanId, nodeMap))
+      } finally {
+        odb.getDBAdmin.shutdown()
+      }
+    }
+
+    "handle multiple validity constraint violations" in {
+      val p   = prog
+      val tf1 = templateFolder
+      val tf2 = templateFolder
+      val tf3 = templateFolder
+
+      val start    = p.node(tf1.leaf, tf2.leaf, tf3.leaf)
+      val expected = incr(incr(p)).node(
+        incr(incr(conflictFolder)).node(tf2.leaf, tf3.leaf),
+        tf1.leaf
+      )
+
+      test(start, expected)
+    }
+
+    "expand an unmodified conflict folder if necessary" in {
+      val odb = DBLocalDatabase.createTransient()
+      try {
+        // Create a conflict folder node, put it in the node map, and make a
+        // corresponding Unmodified merge node.
+        val key = new SPNodeKey()
+        val pn  = odb.getFactory.createProgram(null, null)
+        val cfn = odb.getFactory.createConflictFolder(pn, key)
+        val nodeMap = Map(key -> cfn)
+        val un  = MergeNode.unmodified(cfn)
+
+        val p   = prog
+        val tf1 = templateFolder
+        val tf2 = templateFolder
+
+        val start    = p.node(un.leaf, tf1.leaf, tf2.leaf)
+        val expected = incr(p).node(
+          incr(MergeNode.modified(cfn)).node(tf2.leaf),
+          tf1.leaf
+        )
+
+        test(start, expected, new ValidityCorrection(lifespanId, nodeMap))
+      } finally {
+        odb.getDBAdmin.shutdown()
+      }
+    }
+  }
+}

--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
@@ -11,6 +11,7 @@ import java.security.{AccessControlException, Principal, Permission}
 import javax.security.auth.Subject
 import java.util.logging.{Level, Logger}
 
+import scala.util.Try
 import scalaz._
 import Scalaz._
 import edu.gemini.spModel.core.SPProgramID
@@ -143,18 +144,9 @@ object ImplicitPolicy {
 
     // EventQueue.getCurrentEvent sometimes throws a NPE, at least in headless
     // mode, so we'll wrap it here.
-    //
-    // Could also be
-    //    \/.fromTryCatch(Option(EventQueue.getCurrentEvent)).toOption.flatten
-    private def currentEvent: Option[AWTEvent] =
-      try {
-        Option(EventQueue.getCurrentEvent)
-      } catch {
-        case _: Throwable => None
-      }
 
     def check(p: Permission)(a: => Boolean): Boolean =
-      currentEvent match {
+      Option(Try(EventQueue.getCurrentEvent).toOption.orNull) match {
         case None => a
         case o =>
           if (o != previousEvent) {


### PR DESCRIPTION
This update brings validity corrections to the program merge.  Validity corrections refer to repairing a `MergePlan` so that it can be used to make valid edits to a Science Program.  It uses the existing program `Validator` to detect cardinality violations in the merge tree and then moves them into a `ConflictFolder` in the parent node, just as the existing production merge algorithm does.  The important commit is the first one, which introduces the `ValidityCorrection` class.

__Testing:__ I added a `ValidityCorrectionSpec` unit test that exercises basic functionality.  More importantly the property tests with their generated programs and edits now perform the validity correction, a new property was added that states that the end result must pass the `Validator`, and I removed a previously required catch clause that ignored exceptions thrown while editing programs according to the merge plan.