### PR TITLE
OCSADV-248,OCSADV-250: Adding ITC panels to OT

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/EdIteratorFolder.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/EdIteratorFolder.java
@@ -96,10 +96,10 @@ public final class EdIteratorFolder
 
         // show/hide ITC result panels depending on instrument
         final ISPObsComponent instrument = getContextInstrument();
+        _w.tabbedPane.remove(itcImagingPanel.peer());
+        _w.tabbedPane.remove(itcSpectroscopyPanel.peer());
         if (instrument != null) {
             final SPComponentType type = instrument.getType();
-            _w.tabbedPane.remove(itcImagingPanel.peer());
-            _w.tabbedPane.remove(itcSpectroscopyPanel.peer());
             if (itcImagingPanel.visibleFor(type))      _w.tabbedPane.add("ITC Imaging",      itcImagingPanel.peer());
             if (itcSpectroscopyPanel.visibleFor(type)) _w.tabbedPane.add("ITC Spectroscopy", itcSpectroscopyPanel.peer());
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/EdIteratorFolder.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/EdIteratorFolder.java
@@ -6,10 +6,7 @@
 //
 package jsky.app.ot.editor.seq;
 
-import edu.gemini.pot.sp.ISPObsExecLog;
-import edu.gemini.pot.sp.ISPObservation;
-import edu.gemini.pot.sp.ISPSeqComponent;
-import edu.gemini.pot.sp.SPUtil;
+import edu.gemini.pot.sp.*;
 import edu.gemini.spModel.seqcomp.SeqBase;
 import jsky.app.ot.editor.OtItemEditor;
 import jsky.util.gui.TextBoxWidget;
@@ -18,18 +15,22 @@ import jsky.util.gui.TextBoxWidgetWatcher;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 
 /**
- * This is the editor for the "iterator folder" or "Sequence" item.
- * It displays two tabs:
+ * This is the editor for the "iterator folder" or "Sequence" item. It displays the following tabs:
  * <p>
  *  Sequence: a table into which the iteration sequence of contained
  * iterators is written, and
  * <p>
  * Timeline: which shows the sequence as a timeline.
+ * <p>
+ * ITC Imaging: All unique imaging configurations and their ITC calculation results (if applicable).
+ * <p>
+ * ITC Spectroscopy: All unique spectroscopy configurations and their ITC calculation results (if applicable).
  */
 public final class EdIteratorFolder
         extends OtItemEditor<ISPSeqComponent, SeqBase>
@@ -37,6 +38,10 @@ public final class EdIteratorFolder
 
     /** the GUI layout panel */
     private final IterFolderForm _w;
+
+    /** ITC result panels */
+    private final ItcImagingPanel itcImagingPanel;
+    private final ItcSpectroscopyPanel itcSpectroscopyPanel;
 
     /** The data for the note */
     private final SequenceTab _sequenceTab;
@@ -60,6 +65,10 @@ public final class EdIteratorFolder
         _origSequenceTab = new OrigSequenceTab(_w, this);
 
         _w.tabbedPane.addChangeListener(this);
+
+        itcImagingPanel      = ItcPanel$.MODULE$.forImaging(this);
+        itcSpectroscopyPanel = ItcPanel$.MODULE$.forSpectroscopy(this);
+
     }
 
     /** Return the window containing the editor */
@@ -80,11 +89,21 @@ public final class EdIteratorFolder
     /** Set the data object corresponding to this editor. */
     @Override public void init() {
         final ISPObservation obs = getContextObservation();
-        // No context observation if this sequence component is in a conflict
-        // folder!
+        // No context observation if this sequence component is in a conflict folder!
         if (obs != null) {
             obs.addCompositeChangeListener(obslogUpdater);
         }
+
+        // show/hide ITC result panels depending on instrument
+        final ISPObsComponent instrument = getContextInstrument();
+        if (instrument != null) {
+            final SPComponentType type = instrument.getType();
+            _w.tabbedPane.remove(itcImagingPanel.peer());
+            _w.tabbedPane.remove(itcSpectroscopyPanel.peer());
+            if (itcImagingPanel.visibleFor(type))      _w.tabbedPane.add("ITC Imaging",      itcImagingPanel.peer());
+            if (itcSpectroscopyPanel.visibleFor(type)) _w.tabbedPane.add("ITC Spectroscopy", itcSpectroscopyPanel.peer());
+        }
+
 
         _origSequenceTab.init(this);
 
@@ -122,6 +141,11 @@ public final class EdIteratorFolder
             case 1:
                 _origSequenceTab.update();
                 break;
+            default:
+                // itc panels can be at different indices depending on instrument
+                final Component c = _w.tabbedPane.getComponentAt(index);
+                if (c == itcImagingPanel.peer())      itcImagingPanel.update();
+                if (c == itcSpectroscopyPanel.peer()) itcSpectroscopyPanel.update();
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/Keys.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/Keys.java
@@ -27,9 +27,12 @@ final class Keys {
     static final ItemKey TEL_Q_KEY       = new ItemKey("telescope:q");
     static final ItemKey TEL_VERSION_KEY = new ItemKey("telescope:version");
 
-    static final ItemKey INST_EXP_TIME_KEY = new ItemKey("instrument:exposureTime");
-    static final ItemKey INST_COADDS_KEY   = new ItemKey("instrument:coadds");
-    static final ItemKey INST_VERSION_KEY  = new ItemKey("instrument:version");
+    static final ItemKey INST_EXP_TIME_KEY   = new ItemKey("instrument:exposureTime");
+    static final ItemKey INST_TIME_ON_SRC_KEY= new ItemKey("instrument:timeOnSource");
+    static final ItemKey INST_COADDS_KEY     = new ItemKey("instrument:coadds");
+    static final ItemKey INST_VERSION_KEY    = new ItemKey("instrument:version");
+    static final ItemKey INST_INSTRUMENT_KEY = new ItemKey("instrument:instrument");
+    static final ItemKey INST_DISPERSER_KEY  = new ItemKey("instrument:disperser");
 
     static final ItemKey SP_NODE_KEY = new ItemKey(MetaDataConfig.NAME + ":" + MetaDataConfig.SP_NODE);
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -90,6 +90,7 @@ class ItcSpectroscopyPanel(val owner: EdIteratorFolder, val table: ItcSpectrosco
     case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
     case SPComponentType.INSTRUMENT_GMOS        => true
     case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
+    case SPComponentType.INSTRUMENT_GNIRS       => true
     case SPComponentType.INSTRUMENT_MICHELLE    => true
     case SPComponentType.INSTRUMENT_NIFS        => true
     case SPComponentType.INSTRUMENT_NIRI        => true

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -1,0 +1,114 @@
+package jsky.app.ot.editor.seq
+
+import javax.swing.BorderFactory
+
+import edu.gemini.pot.sp.SPComponentType
+
+import scala.swing.ScrollPane.BarPolicy._
+import scala.swing.{Label, GridBagPanel, ScrollPane}
+
+object ItcPanel {
+
+  /** Creates a panel for ITC imaging results. */
+  def forImaging(owner: EdIteratorFolder)       = new ItcImagingPanel(owner, new ItcImagingTable(owner))
+
+  /** Creates a panel for ITC spectroscopy results. */
+  def forSpectroscopy(owner: EdIteratorFolder)  = new ItcSpectroscopyPanel(owner, new ItcSpectroscopyTable(owner))
+
+}
+
+/** Base trait for different panels which are used to present ITC calculation results to the users. */
+sealed trait ItcPanel extends GridBagPanel {
+  val owner: EdIteratorFolder
+  val table: ItcTable
+  def visibleFor(t: SPComponentType): Boolean
+
+  def update() = table.update()
+}
+
+/** Panel holding the ITC imaging calculation result table. */
+class ItcImagingPanel(val owner: EdIteratorFolder, val table: ItcImagingTable) extends ItcPanel {
+
+  border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+
+  private val scrollPane = new ScrollPane(table) {
+    verticalScrollBarPolicy = AsNeeded
+    horizontalScrollBarPolicy = AsNeeded
+  }
+
+  layout(scrollPane) = new Constraints {
+    gridx = 0
+    gridy = 0
+    weightx = 1
+    weighty = 1
+    fill = GridBagPanel.Fill.Both
+  }
+
+  /** True for all instruments which support ITC calculations for imaging. */
+  def visibleFor(t: SPComponentType): Boolean = t match {
+    case SPComponentType.INSTRUMENT_ACQCAM      => true
+    case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
+    case SPComponentType.INSTRUMENT_GMOS        => true
+    case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
+    case SPComponentType.INSTRUMENT_GSAOI       => true
+    case SPComponentType.INSTRUMENT_MICHELLE    => true
+    case SPComponentType.INSTRUMENT_NIRI        => true
+    case SPComponentType.INSTRUMENT_TRECS       => true
+    case _                                      => false
+  }
+}
+
+/** Panel holding the ITC spectroscopy calculation result table and charts. */
+class ItcSpectroscopyPanel(val owner: EdIteratorFolder, val table: ItcSpectroscopyTable) extends ItcPanel {
+
+  border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+
+  private val scrollPane = new ScrollPane(table) {
+    verticalScrollBarPolicy = AsNeeded
+    horizontalScrollBarPolicy = AsNeeded
+  }
+
+  private val charts = new ItcChartsPanel()
+
+  layout(scrollPane) = new Constraints {
+    gridx   = 0
+    gridy   = 0
+    weightx = 1
+    weighty = 0.5
+    fill    = GridBagPanel.Fill.Both
+  }
+  layout(charts) = new Constraints {
+    gridx   = 0
+    gridy   = 1
+    weightx = 1
+    weighty = 0.5
+    fill    = GridBagPanel.Fill.Both
+  }
+
+  /** True for all instruments which support ITC calculations for spectroscopy. */
+  def visibleFor(t: SPComponentType): Boolean = t match {
+    case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
+    case SPComponentType.INSTRUMENT_GMOS        => true
+    case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
+    case SPComponentType.INSTRUMENT_MICHELLE    => true
+    case SPComponentType.INSTRUMENT_NIFS        => true
+    case SPComponentType.INSTRUMENT_NIRI        => true
+    case SPComponentType.INSTRUMENT_TRECS       => true
+    case _                                      => false
+  }
+}
+
+/** Panel holding spectroscopy charts. */
+private class ItcChartsPanel extends GridBagPanel {
+
+  // TODO...
+  private val label = new Label("Spectroscopy charts will go here..")
+
+  layout(label) = new Constraints {
+    gridx   = 0
+    gridy   = 0
+    weightx = 1
+    weighty = 1
+    fill    = GridBagPanel.Fill.Both
+  }
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -1,0 +1,95 @@
+package jsky.app.ot.editor.seq
+
+import java.awt.Color
+
+import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances
+import edu.gemini.spModel.config2.{ConfigSequence, ItemKey}
+import jsky.app.ot.util.OtColor
+
+import scala.swing.Table
+
+/**
+ * A table to display ITC calculation results to users.
+ */
+trait ItcTable extends Table {
+
+  val owner: EdIteratorFolder
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcTableModel
+
+  import jsky.app.ot.editor.seq.Keys._
+
+  // set this to the same values as in SequenceTableUI
+  autoResizeMode = Table.AutoResizeMode.Off
+  background     = OtColor.VERY_LIGHT_GREY
+  focusable      = false
+  peer.setRowSelectionAllowed(false)
+  peer.setColumnSelectionAllowed(false)
+  peer.getTableHeader.setReorderingAllowed(false)
+
+  def update() = {
+    val seq       = sequence()
+    val allKeys   = seq.getStaticKeys.toSeq ++ seq.getIteratedKeys.toSeq
+    val showKeys  = seq.getIteratedKeys.toSeq.
+      filterNot(_.equals(DATALABEL_KEY)).       // don't show the original data label (step number)
+      filterNot(_.equals(OBS_TYPE_KEY)).        // don't show the type (science vs. calibration)
+      filterNot(_.equals(OBS_EXP_TIME_KEY)).    // don't show observe exp time
+      filterNot(_.equals(INST_EXP_TIME_KEY)).   // don't show instrument exp time
+      filterNot(_.equals(TEL_P_KEY)).           // don't show offsets
+      filterNot(_.equals(TEL_Q_KEY)).           // don't show offsets
+      filterNot(_.getParent().equals(CALIBRATION_KEY)). // calibration settings are not relevant
+      sortBy(_.getPath)
+
+    val itcModel  = tableModel(showKeys, seq)
+    val renderer  = new ItcCellRenderer(itcModel)
+    peer.setDefaultRenderer(classOf[java.lang.Object], renderer)
+    model = itcModel
+
+    // make all columns as wide as needed
+    SequenceTabUtil.resizeTableColumns(this.peer, itcModel)
+
+  }
+
+  private def sequence() = Option(owner.getContextObservation).fold(new ConfigSequence) {
+    ConfigBridge.extractSequence(_, null, ConfigValMapInstances.IDENTITY_MAP, true)
+  }
+
+}
+
+class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
+  private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(Seq(), Seq())
+
+  /**
+   * Creates a new table model for the current context (instrument) and config sequence.
+   * Note that GMOS has a different table model with separate columns for its three CCDs.
+   */
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel =
+    Option(owner.getContextInstrument).fold(emptyTable) {
+    _.getType match {
+      case SPComponentType.INSTRUMENT_GMOS        => new ItcGmosImagingTableModel(keys, UniqueConfig.imagingConfigs(seq))
+      case SPComponentType.INSTRUMENT_GMOSSOUTH   => new ItcGmosImagingTableModel(keys, UniqueConfig.imagingConfigs(seq))
+      case _                                      => new ItcGenericImagingTableModel(keys, UniqueConfig.imagingConfigs(seq))
+    }
+  }
+}
+
+class ItcSpectroscopyTable(val owner: EdIteratorFolder) extends ItcTable {
+
+  /** Creates a new table model for the current context and config sequence. */
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, UniqueConfig.spectroscopyConfigs(seq))
+
+}
+
+
+/**
+ * Cell renderer based on the sequence cell renderer used for other sequence tables. This gives us coherent
+ * formatting and color coding throughout the different tables in the sequence node.
+ * @param model
+ */
+private class ItcCellRenderer(model: ItcTableModel) extends SequenceCellRenderer {
+  override def lookupColor(row: Int, col: Int): Color = model.getKeyAt(col) match {
+    case Some(k)  => SequenceCellRenderer.lookupColor(k)
+    case None     => Color.LIGHT_GRAY
+  }
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -67,9 +67,9 @@ class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
   def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel =
     Option(owner.getContextInstrument).fold(emptyTable) {
     _.getType match {
-      case SPComponentType.INSTRUMENT_GMOS        => new ItcGmosImagingTableModel(keys, UniqueConfig.imagingConfigs(seq))
-      case SPComponentType.INSTRUMENT_GMOSSOUTH   => new ItcGmosImagingTableModel(keys, UniqueConfig.imagingConfigs(seq))
-      case _                                      => new ItcGenericImagingTableModel(keys, UniqueConfig.imagingConfigs(seq))
+      case SPComponentType.INSTRUMENT_GMOS        => new ItcGmosImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
+      case SPComponentType.INSTRUMENT_GMOSSOUTH   => new ItcGmosImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
+      case _                                      => new ItcGenericImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
     }
   }
 }
@@ -77,7 +77,7 @@ class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
 class ItcSpectroscopyTable(val owner: EdIteratorFolder) extends ItcTable {
 
   /** Creates a new table model for the current context and config sequence. */
-  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, UniqueConfig.spectroscopyConfigs(seq))
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, ItcUniqueConfig.spectroscopyConfigs(seq))
 
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -1,0 +1,101 @@
+package jsky.app.ot.editor.seq
+
+import javax.swing.table.AbstractTableModel
+
+import edu.gemini.shared.util.StringUtil
+import edu.gemini.spModel.config2.ItemKey
+
+/** Columns in the table are defined by their header label and a function on the unique config of the row. */
+case class Column(label: String, value: UniqueConfig => Object)
+
+object ItcTableModel {
+  /** Defines a set of header columns for all tables. */
+  val headers = Seq(
+    Column("Data Labels",     c => c.labels),
+    Column("Images",          c => new java.lang.Integer(c.count)),             // must be an object for JTable
+    Column("Exposure Time",   c => new java.lang.Double(c.singleExposureTime)), // must be an object for JTable
+    Column("Total Exp. Time", c => new java.lang.Double(c.totalExposureTime))   // must be an object for JTable
+  )
+}
+
+/**
+ * ITC tables have three types of columns: a series of header columns, then all the values that change and are
+ * relevant for the different unique configs (denoted by their ItemKey values) and finally the ITC calculation
+ * results.
+ */
+sealed trait ItcTableModel extends AbstractTableModel {
+
+  val headers: Seq[Column]
+  val keys:    Seq[ItemKey]
+  val results: Seq[Column]
+  val uniqueSteps: Seq[UniqueConfig]
+
+  def getRowCount: Int = uniqueSteps.size
+
+  def getColumnCount: Int = headers.size + keys.size + results.size
+
+  def getKeyAt(col: Int): Option[ItemKey] = col match {
+    case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
+    case _                                                      => None
+  }
+
+  def getValueAt(row: Int, col: Int): Object = col match {
+    case c if c <  headers.size               => header(col).value(uniqueSteps(row))
+    case c if c >= headers.size + keys.size   => result(col).value(uniqueSteps(row))
+    case c                                    => uniqueSteps(row).config.getItemValue(key(col))
+  }
+
+  override def getColumnName(col: Int): String = col match {
+    case c if c <  headers.size               => header(col).label
+    case c if c >= headers.size + keys.size   => result(col).label
+    case c                                    => StringUtil.toDisplayName(key(col).getName)
+  }
+
+  // Translate overall column index into the corresponding header, column or key value.
+  private def header(col: Int) = headers(col)
+  private def key   (col: Int) = keys   (col - headers.size)
+  private def result(col: Int) = results(col - headers.size - keys.size)
+
+ }
+
+/** Generic ITC imaging tables model. */
+sealed trait ItcImagingTableModel extends ItcTableModel
+
+class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[UniqueConfig]) extends ItcImagingTableModel {
+  val headers = ItcTableModel.headers
+  val results = Seq(
+    Column("PPF",             c => ""),
+    Column("S/N Single",      c => ""),
+    Column("S/N Total",       c => ""),
+    Column("Messages",        c => "OK")
+  )
+}
+
+/** GMOS specific ITC imaging table model. */
+class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[UniqueConfig]) extends ItcImagingTableModel {
+  val headers = ItcTableModel.headers
+  val results = Seq(
+    Column("CCD1 PPF",        c => ""),
+    Column("CCD1 S/N Single", c => ""),
+    Column("CCD1 S/N Total",  c => ""),
+    Column("CCD2 PPF",        c => ""),
+    Column("CCD2 S/N Single", c => ""),
+    Column("CCD2 S/N Total",  c => ""),
+    Column("CCD3 PPF",        c => ""),
+    Column("CCD3 S/N Single", c => ""),
+    Column("CCD3 S/N Total",  c => ""),
+    Column("Messages",        c => "OK")
+  )
+}
+
+
+/** Generic ITC spectroscopy table model. */
+sealed trait ItcSpectroscopyTableModel extends ItcTableModel
+
+class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[UniqueConfig]) extends ItcSpectroscopyTableModel {
+  val headers = ItcTableModel.headers
+  val results = Seq(
+    Column("Messages",        c => "OK")
+  )
+}
+

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -6,7 +6,7 @@ import edu.gemini.shared.util.StringUtil
 import edu.gemini.spModel.config2.ItemKey
 
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
-case class Column(label: String, value: UniqueConfig => Object)
+case class Column(label: String, value: ItcUniqueConfig => Object)
 
 object ItcTableModel {
   /** Defines a set of header columns for all tables. */
@@ -28,7 +28,7 @@ sealed trait ItcTableModel extends AbstractTableModel {
   val headers: Seq[Column]
   val keys:    Seq[ItemKey]
   val results: Seq[Column]
-  val uniqueSteps: Seq[UniqueConfig]
+  val uniqueSteps: Seq[ItcUniqueConfig]
 
   def getRowCount: Int = uniqueSteps.size
 
@@ -61,7 +61,7 @@ sealed trait ItcTableModel extends AbstractTableModel {
 /** Generic ITC imaging tables model. */
 sealed trait ItcImagingTableModel extends ItcTableModel
 
-class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[UniqueConfig]) extends ItcImagingTableModel {
+class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
     Column("PPF",             c => ""),
@@ -72,7 +72,7 @@ class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[U
 }
 
 /** GMOS specific ITC imaging table model. */
-class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[UniqueConfig]) extends ItcImagingTableModel {
+class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
     Column("CCD1 PPF",        c => ""),
@@ -92,7 +92,7 @@ class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[Uniq
 /** Generic ITC spectroscopy table model. */
 sealed trait ItcSpectroscopyTableModel extends ItcTableModel
 
-class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[UniqueConfig]) extends ItcSpectroscopyTableModel {
+class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcSpectroscopyTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
     Column("Messages",        c => "OK")

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/UniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/UniqueConfig.scala
@@ -102,10 +102,10 @@ object UniqueConfig {
   // Note, this is done backwards, so we can always prepend the newest element.
   private def findSpans(ns: Seq[Int]): Seq[Seq[Int]] = {
     val e: Seq[Seq[Int]] = Seq()
-    ns.reverse.foldLeft(e) {
-      case (a, i) if a.isEmpty           => Seq(Seq(i))
-      case (a, i) if a.head.head == i+1  => (i +: a.head) +: a.tail
-      case (a, i)                        => Seq(i) +: a
+    ns.foldRight(e) {
+      case (i, a) if a.isEmpty           => Seq(Seq(i))
+      case (i, a) if a.head.head == i+1  => (i +: a.head) +: a.tail
+      case (i, a)                        => Seq(i) +: a
     }
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/UniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/UniqueConfig.scala
@@ -1,0 +1,112 @@
+package jsky.app.ot.editor.seq
+
+import edu.gemini.spModel.config2.{Config, ConfigSequence}
+import edu.gemini.spModel.gemini.acqcam.InstAcqCam
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2
+import edu.gemini.spModel.gemini.gmos.{GmosNorthType, GmosSouthType, InstGmosNorth, InstGmosSouth}
+import edu.gemini.spModel.gemini.gnirs.GNIRSConstants
+import edu.gemini.spModel.gemini.gsaoi.Gsaoi
+import edu.gemini.spModel.gemini.michelle.{InstMichelle, MichelleParams}
+import edu.gemini.spModel.gemini.nifs.InstNIFS
+import edu.gemini.spModel.gemini.niri.{InstNIRI, Niri}
+import edu.gemini.spModel.gemini.trecs.{InstTReCS, TReCSParams}
+import jsky.app.ot.editor.seq.Keys._
+
+
+/**
+ * Unique configurations represent sets of observes in a sequence which are done with the same
+ * instrument configuration and exposure times.
+ */
+case class UniqueConfig(count: Int, labels: String, config: Config) {
+
+  /** Single exposure time is either the given exposure time or the time on source divided by the number of images. */
+  def singleExposureTime: Double = singleTime.getOrElse(totalTime.getOrElse(0.0) / count)
+
+  /** Total exposure time is either total time on source (TReCS/Michelle) or the single exposure time times the number of images. */
+  def totalExposureTime: Double = totalTime.getOrElse(singleTime.getOrElse(0.0) * count)
+
+  /** TReCS and Michelle have an optional total time on source. */
+  private val totalTime = Option(config.getItemValue(INST_TIME_ON_SRC_KEY)).map(_.toString.toDouble)
+
+  /** Instruments other than TReCS and Michelle have a defined exposure time per image. */
+  private val singleTime = Option(config.getItemValue(INST_EXP_TIME_KEY)).map(_.toString.toDouble)
+
+}
+
+/**
+ * Utility functions to get unique configurations from ConfigurationSequence objects.
+ */
+object UniqueConfig {
+
+  /** Gets all unique science imaging configurations from the given sequence. */
+  def imagingConfigs(seq: ConfigSequence): Seq[UniqueConfig] =
+    uniqueConfigs(seq, c => isScience(c) && isImaging(c))
+
+  /** Gets all unique spectroscopy configurations from the given sequence. */
+  def spectroscopyConfigs(seq: ConfigSequence): Seq[UniqueConfig] =
+    uniqueConfigs(seq, c => isScience(c) && isSpectroscopy(c))
+
+  // Checks if a config is science or not; only science observations are relevant for ITC
+  private def isScience(c: Config): Boolean =
+    Option(c.getItemValue(OBS_TYPE_KEY)).fold(false)(!_.equals("CAL"))
+
+  // Decides if a configuration is for spectroscopy or not.
+  private def isSpectroscopy(c: Config): Boolean = !isImaging(c)
+
+  // Decides if a configuration is for imaging or spectroscopy based on the presence of a disperser element.
+  private def isImaging(c: Config): Boolean = c.getItemValue(INST_INSTRUMENT_KEY) match {
+    case InstAcqCam.INSTRUMENT_NAME_PROP    => true  // Acq cam is imaging only
+    case Flamingos2.INSTRUMENT_NAME_PROP    => c.getItemValue(INST_DISPERSER_KEY).equals(Flamingos2.Disperser.NONE)
+    case InstGmosNorth.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(GmosNorthType.DisperserNorth.MIRROR)
+    case InstGmosSouth.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(GmosSouthType.DisperserSouth.MIRROR)
+    case GNIRSConstants.INSTRUMENT_NAME_PROP=> false // GNIRS is spectroscopy only
+    case Gsaoi.INSTRUMENT_NAME_PROP         => true  // Gsaoi is imaging only
+    case InstMichelle.INSTRUMENT_NAME_PROP  => c.getItemValue(INST_DISPERSER_KEY).equals(MichelleParams.Disperser.MIRROR)
+    case InstNIFS.INSTRUMENT_NAME_PROP      => false // NIFS is spectroscopy only
+    case InstNIRI.INSTRUMENT_NAME_PROP      => c.getItemValue(INST_DISPERSER_KEY).equals(Niri.Disperser.NONE)
+    case InstTReCS.INSTRUMENT_NAME_PROP     => c.getItemValue(INST_DISPERSER_KEY).equals(TReCSParams.Disperser.MIRROR)
+  }
+
+  // Gets all "unique configs" (i.e. configs that are relevant for ITC) from the given sequence. The predicate
+  // defines which steps have to be taken into account, i.e. spectroscopy vs imaging and no calibrations.
+  private def uniqueConfigs(seq: ConfigSequence, predicate: Config => Boolean): Seq[UniqueConfig] = {
+    val steps        = seq.getAllSteps.toSeq.filter(predicate)
+    val groupedSteps = steps.groupBy(hash).toSeq
+    val mappedSteps  = groupedSteps.map{case (h, cs) => UniqueConfig(cs.size, labels(cs), cs.head)}.toSeq
+    mappedSteps.sortBy(_.config.getItemValue(DATALABEL_KEY).toString)
+  }
+
+  // Creates a hash for the given config step taking into account only the values that are relevant for ITC
+  // calculations, e.g. ignoring offsets and data labels.
+  private def hash(step: Config): Int = step.getKeys.
+      filterNot(_.getParent.equals(CALIBRATION_KEY)).
+      filterNot(_.equals(DATALABEL_KEY)).           // don't take data label into account (step number)
+      filterNot(_.equals(TEL_P_KEY)).               // configs with different P offsets are considered as one config
+      filterNot(_.equals(TEL_Q_KEY)).               // dito for Q
+      filterNot(step.getItemValue(_) == null).      // occasionally we get null values..
+      map(step.getItemValue(_).hashCode()).
+      foldLeft(17)((acc, h) => 37*acc + h)
+
+  // Creates a text label based on the spans of steps covered by the steps.
+  // E.g. ((1,2,3),(10,11),(15)) is turned into "001-003, 010-011, 015"
+  private def labels(cs: Seq[Config]): String = {
+    val ls = cs.map(_.getItemValue(DATALABEL_KEY).toString.toInt).sorted
+    findSpans(ls).map {
+      case i :: Nil => i.toString
+      case i :: is => f"$i%03d-${is.last}%03d"
+    }.mkString(", ")
+  }
+
+  // Finds spans of int values that immediately follow each other.
+  // E.g. (1,2,3,10,11,15) is turned into ((1,2,3),(10,11),(15)).
+  // Note, this is done backwards, so we can always prepend the newest element.
+  private def findSpans(ns: Seq[Int]): Seq[Seq[Int]] = {
+    val e: Seq[Seq[Int]] = Seq()
+    ns.reverse.foldLeft(e) {
+      case (a, i) if a.isEmpty           => Seq(Seq(i))
+      case (a, i) if a.head.head == i+1  => (i +: a.head) +: a.tail
+      case (a, i)                        => Seq(i) +: a
+    }
+  }
+
+}


### PR DESCRIPTION
This PR addresses two steps for the ITC integration. 

It adds functionality in ```UniqueConfig``` that deals with extracting the "unique configurations" that are relevant for the ITC calculations, i.e. it groups all observes in the sequence according to their configurations (e.g. dispersers, filters etc). For each of those groups we will later have to trigger a call to the ITC service. (Note: I just noticed that there is already another ```UniqueConfig``` implementation in the pot bundle which seems to do some similar stuff. However since the UniqueConfig here is short and very specific to ITC I think I will leave it as is and not try to use the ```UniqueConfig``` from the pot bundle.)

It also adds UI elements to the Base Sequence Component node which display those unique configurations and - at a later stage - will display the results of the ITC service calls. There are separate panels for imaging and spectroscopy because those results are fundamentally different (e.g. spectroscopy results will also contain charts while imaging results don't). Unfortunately at least GMOS will also differ from the other instruments by displaying results for each of its CCDs separately, which results in a different table layout. Note that some instruments only support imaging or spectroscopy while others support both; depending on the instrument the panels are displayed or not.

Currently the ITC result panels are displayed for all instruments that support ITC calculations so we can check the unique configuration extraction and can play around with it. At a later stage we might only show the ones for which the ITC services have already been successfully connected to the OT.

As an example some unique spectroscopy configurations extracted from a sequence of 40 observes with iterators and offsets:

![image](https://cloud.githubusercontent.com/assets/7856060/6647437/484243ec-c972-11e4-9e37-8447984b791f.png)
