### PR TITLE
OCSADV-200-J: Staff-only field corrections

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/AbstractDataObject.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/AbstractDataObject.java
@@ -95,6 +95,12 @@ public class AbstractDataObject implements ISPCloneable, ISPDataObject, Serializ
         return result;
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public <A extends ISPDataObject> A clone(A a) {
+        return (A) a.clone();
+    }
+
     /**
      * Get the item's type.  SpType is like an enumerated type in C++.  Each
      * type is mapped one-to-one with its own object.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/ISPDataObject.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/data/ISPDataObject.java
@@ -7,6 +7,7 @@
 //
 package edu.gemini.spModel.data;
 
+import edu.gemini.pot.sp.ISPCloneable;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
@@ -32,7 +33,7 @@ import java.io.Serializable;
  * (and other formats).  A property list is expected upon export and
  * passed to a constructor when creating the data object.
  */
-public interface ISPDataObject extends Serializable {
+public interface ISPDataObject extends ISPCloneable, Serializable {
 
     /**
      * Names the version property of all data objects.
@@ -137,4 +138,11 @@ public interface ISPDataObject extends Serializable {
      * type is mapped one-to-one with its own object.
      */
     SPComponentType getType();
+
+    /**
+     * A clone method that is callable from Scala and that hides the cast to the
+     * desired type.
+     * https://issues.scala-lang.org/browse/SI-6760
+     */
+    <A extends ISPDataObject> A clone(A a);
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
@@ -2,6 +2,7 @@ package edu.gemini.spModel.rich.pot
 
 import edu.gemini.pot.sp._
 import edu.gemini.spModel.core.{RichSpProgramId, SPProgramID}
+import edu.gemini.spModel.data.ISPDataObject
 
 import scalaz._
 import Scalaz._
@@ -41,4 +42,8 @@ package object sp {
   }
 
   implicit def SpNodeKeyEqual: Equal[SPNodeKey] = Equal.equalA
+
+  implicit class RichDataObject[A <: ISPDataObject](dob: A) {
+    def copy: A = dob.clone(dob)
+  }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/pot/spdb/test/TriggerCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/pot/spdb/test/TriggerCase.java
@@ -9,7 +9,6 @@ import edu.gemini.pot.spdb.IDBTriggerCondition;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,10 +34,25 @@ public class TriggerCase extends SpdbBaseTestCase {
     private static final SPComponentType TRIGGER_TYPE = SPComponentType.INSTRUMENT_FLAMINGOS2; // SPComponentType.getInstance("trigger", "trigger", "trigger");
 
     public static final class ProgramDataObject implements ISPDataObject {
-        private List _triggerList = new ArrayList();
+        private List<String> _triggerList = new ArrayList<>();
+
+        public Object clone() {
+            try {
+                return super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new InternalError();
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <A extends ISPDataObject> A clone(A a) {
+            return (A) a.clone();
+        }
+
 
         public String[] getTriggerMessages() {
-            return (String[]) _triggerList.toArray(new String[0]);
+            return _triggerList.toArray(new String[_triggerList.size()]);
         }
 
         public void addTriggerMessage(String message) {
@@ -92,6 +106,19 @@ public class TriggerCase extends SpdbBaseTestCase {
 
     public static final class TriggerDataObject implements ISPDataObject, Serializable {
         private String _triggerMessage;
+
+        public Object clone() {
+            try {
+                return super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new InternalError();
+            }
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <A extends ISPDataObject> A clone(A a) {
+            return (A) a.clone();
+        }
 
         public String getTriggerMessage() {
             return _triggerMessage;
@@ -207,7 +234,6 @@ public class TriggerCase extends SpdbBaseTestCase {
     private ISPProgram _prog;
     private ISPObsComponent _triggerComp;
     private ISPObsComponent _nonTriggerComp;
-    private List _leaseList = new ArrayList();
 
     @Before
     public void setUp() throws Exception {
@@ -218,23 +244,10 @@ public class TriggerCase extends SpdbBaseTestCase {
         _triggerComp    = _createObsComponent(_prog, TRIGGER_TYPE);
         _nonTriggerComp = _createObsComponent(_prog, NON_TRIGGER_TYPE);
 
-        List obsCompList = new ArrayList();
+        List<ISPObsComponent> obsCompList = new ArrayList<>();
         obsCompList.add(_triggerComp);
         obsCompList.add(_nonTriggerComp);
         _prog.setObsComponents(obsCompList);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-
-//        for (Iterator it=_leaseList.iterator(); it.hasNext(); ) {
-//            Lease lease = (Lease) it.next();
-//            try {
-//                lease.cancel();
-//            } catch (Exception ex) {
-//            }
-//        }
     }
 
     private ISPObsComponent _createObsComponent(ISPProgram prog, SPComponentType type)

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/TestDataObject.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/TestDataObject.java
@@ -19,13 +19,26 @@ import java.beans.PropertyChangeListener;
 import java.io.Serializable;
 
 
-
 public class TestDataObject implements Serializable, IConfigProvider, ISPDataObject {
 
     private ISysConfig _sysConfig;
 
 
     public TestDataObject() {
+    }
+
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new InternalError();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <A extends ISPDataObject> A clone(A a) {
+        return (A) a.clone();
     }
 
     public ISysConfig getSysConfig() {

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrection.scala
@@ -1,0 +1,108 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.version.LifespanId
+import edu.gemini.pot.sp.{ISPStaffOnlyFieldProtected, SPNodeKey}
+import edu.gemini.shared.util.VersionComparison.Newer
+import edu.gemini.sp.vcs.diff.MergeCorrection._
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.data.ISPDataObject
+import edu.gemini.spModel.gemini.obscomp.SPProgram
+import edu.gemini.spModel.rich.pot.sp._
+
+import java.security.Permission
+
+import edu.gemini.util.security.permission.{VisitorPermission, StaffPermission}
+
+import scalaz._
+import Scalaz._
+
+/** Corrections required to reset any data object fields to which the user does
+  * not have permission.  Some data, for example time accounting information or
+  * private notes, may only be edited by staff members. If the user manages to
+  * edit these fields either via an OT bug or malicious editing of an exported
+  * program, they must be reset when synchronized with the remote database. */
+class StaffOnlyFieldCorrection(lifespanId: LifespanId, key: SPNodeKey, pid: SPProgramID, remote: SPNodeKey => Option[Modified]) extends CorrectionAction {
+
+  import StaffOnlyFieldCorrection._
+
+  private def resetFields(mp: MergePlan): MergePlan = {
+    def corrected(m: Modified, dob: StaffProtected, correct: StaffProtected => Unit): MergeNode =
+      m.copy(nv = m.nv.incr(lifespanId), dob = dob.copy <| correct)
+
+    def correctedNew(m: Modified, dob: StaffProtected): MergeNode =
+      if (dob.staffOnlyFieldsDefaulted()) m
+      else corrected(m, dob, _.resetStaffOnlyFieldsToDefaults())
+
+    def correctedExisting(m: Modified, dob: StaffProtected, existing: ISPDataObject): MergeNode =
+      if (dob.staffOnlyFieldsEqual(existing)) m
+      else corrected(m, dob, _.setStaffOnlyFieldsFrom(existing))
+
+    def correctedNode(mn: MergeNode): MergeNode =
+      mn match {
+        case m@Modified(k, nv, dob: StaffProtected, _) =>
+          remote(k).fold(correctedNew(m, dob)) { remoteMod =>
+            nv.compare(remoteMod.nv) match {
+              case Newer => correctedExisting(m, dob, remoteMod.dob)
+              case _     => mn
+            }
+          }
+
+        case _ => mn
+      }
+
+    mp.copy(update = mp.update.map(correctedNode))
+  }
+
+  def apply(mp: MergePlan, hasPermission: PermissionCheck): VcsAction[MergePlan] = {
+    // Regular staff permission is determined by program contact information. To
+    // prevent changing the contact and gaining staff permission we have to check
+    // that contacts aren't edited unless you have super-staff permission.
+    val contactsMatch = contact(mp.update.rootLabel) == remote(key).flatMap(contact)
+
+    canSetStaffFields(pid, contactsMatch, hasPermission).map { canSet =>
+      if (canSet) mp else resetFields(mp)
+    }
+  }
+}
+
+object StaffOnlyFieldCorrection {
+  type StaffProtected = ISPDataObject with ISPStaffOnlyFieldProtected
+
+  private def contact(mn: MergeNode): Option[String] = {
+    def contact(sp: SPProgram) = Option(sp.getContactPerson).map(_.trim.toLowerCase)
+
+    mn match {
+      case Modified(_, _, sp: SPProgram, _) => contact(sp)
+      case _                                => none
+    }
+  }
+
+  private def canSetStaffFields(pid: SPProgramID, contactsMatch: Boolean, hasPermission: PermissionCheck): VcsAction[Boolean] = {
+    def eitherPermission(p0: Permission, p1: Permission): VcsAction[Boolean] =
+      for {
+        b0 <- hasPermission(p0)
+        b1 <- hasPermission(p1)
+      } yield b0 || b1
+
+    val isStaff = eitherPermission(new StaffPermission(pid), new VisitorPermission(pid))
+    val isSuper = eitherPermission(new StaffPermission(), new VisitorPermission())
+
+    for {
+      sup   <- isSuper
+      staff <- isStaff
+    } yield sup || (contactsMatch && staff)
+  }
+
+  def apply(mc: MergeContext): StaffOnlyFieldCorrection = {
+    val remote = (key: SPNodeKey) => {
+      mc.remote.get(key).flatMap { t =>
+        t.rootLabel match {
+          case m: Modified => Some(m)
+          case _           => None
+        }
+      }
+    }
+
+    new StaffOnlyFieldCorrection(mc.local.prog.getLifespanId, mc.local.prog.key, mc.local.prog.getProgramID, remote)
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrectionSpec.scala
@@ -1,0 +1,115 @@
+package edu.gemini.sp.vcs.diff
+
+import java.security.Principal
+
+import edu.gemini.spModel.obs.ObsQaState
+import edu.gemini.util.security.principal.{StaffPrincipal, VisitorPrincipal}
+import org.specs2.matcher.MatchResult
+
+import scalaz._
+
+class StaffOnlyFieldCorrectionSpec extends VcsSpecification {
+
+  import TestEnv._
+
+  def afterSync(env: TestEnv, p: Principal)(mr: => MatchResult[Any]): MatchResult[_] = {
+    expect(env.local.vcs(p).sync(Q1, DummyPeer)) {
+      case \/-(_) => mr
+    }
+  }
+
+  "staff only field correction" should {
+    "allow super-staff to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      (env.remote.rollover should beFalse) and afterSync(env, StaffPrincipal.Gemini) {
+        env.remote.rollover should beTrue
+      }
+    }
+
+    "allow visitor to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      (env.remote.rollover should beFalse) and afterSync(env, new VisitorPrincipal(Q1)) {
+        env.remote.rollover should beTrue
+      }
+    }
+
+    "allow normal staff to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      (env.remote.rollover should beFalse) and afterSync(env, StaffUserPrincipal) {
+        env.remote.rollover should beTrue
+      }
+    }
+
+    "not allow non-staff to change rollover status" in withVcs { env =>
+      env.local.rollover = true
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.rollover should beFalse) and (env.remote.rollover should beFalse)
+      }
+    }
+
+    "not allow non-staff to sneak a change to staff contact" in withVcs { env =>
+      env.local.rollover = true
+      env.local.contact  = PiEmail
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.rollover should beFalse) and
+          (env.remote.rollover should beFalse) and
+          (env.local.contact must_== StaffEmail) and
+          (env.remote.contact must_== StaffEmail)
+      }
+    }
+
+    "keep non-staff changes to non-protected fields" in withVcs { env =>
+      env.local.rollover  = true
+      env.local.progTitle = "The Plague"
+
+      afterSync(env, PiUserPrincipal) {
+        (env.remote.progTitle must_== "The Plague") and
+          (env.remote.rollover should beFalse) and
+          (env.local.rollover should beFalse)
+      }
+    }
+
+    "allow staff to change QA state" in withVcs { env =>
+      env.local.setQaState(ObsKey, ObsQaState.PASS)
+
+      afterSync(env, StaffUserPrincipal) {
+        env.remote.getQaState(ObsKey) must_== ObsQaState.PASS
+      }
+    }
+
+    "not allow non-staff to change QA state" in withVcs { env =>
+      env.local.setQaState(ObsKey, ObsQaState.PASS)
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.getQaState(ObsKey) must_== ObsQaState.UNDEFINED) and
+        (env.remote.getQaState(ObsKey) must_== ObsQaState.UNDEFINED)
+      }
+    }
+
+    "allow staff to create new observations with non-default QA state" in withVcs { env =>
+      val obsKey = env.local.addObservation()
+      env.local.setQaState(obsKey, ObsQaState.PASS)
+
+      afterSync(env, StaffUserPrincipal) {
+        env.remote.getQaState(obsKey) must_== ObsQaState.PASS
+      }
+    }
+
+    "not allow non-staff to create new observations with non-default QA state" in withVcs { env =>
+      val obsKey = env.local.addObservation()
+      env.local.setQaState(obsKey, ObsQaState.PASS)
+
+      afterSync(env, PiUserPrincipal) {
+        (env.local.getQaState(obsKey) must_== ObsQaState.UNDEFINED) and
+        (env.remote.getQaState(obsKey) must_== ObsQaState.UNDEFINED)
+      }
+    }
+  }
+
+
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsServerSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsServerSpec.scala
@@ -8,7 +8,7 @@ import edu.gemini.sp.vcs.diff.VcsAction._
 import edu.gemini.sp.vcs.diff.VcsFailure._
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.gemini.obscomp.SPProgram
-import edu.gemini.util.security.principal.StaffPrincipal
+import edu.gemini.util.security.principal.{ProgramPrincipal, StaffPrincipal}
 
 import java.security.Principal
 
@@ -27,7 +27,7 @@ class VcsServerSpec extends VcsSpecification {
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
-      forbidden(env.local.server.read(Q1, progPrincipal(Q2)) { identity })
+      forbidden(env.local.server.read(Q1, Set(ProgramPrincipal(Q2))) { identity })
     }
 
     "handle any exceptions that happen" in withVcs { env =>
@@ -53,7 +53,7 @@ class VcsServerSpec extends VcsSpecification {
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
-      forbidden(dummyWrite(env, Q1, progPrincipal(Q2)))
+      forbidden(dummyWrite(env, Q1, Set(ProgramPrincipal(Q2))))
     }
 
     "handle any exceptions that happen in evaluate" in withVcs { env =>
@@ -115,7 +115,7 @@ class VcsServerSpec extends VcsSpecification {
 
   "add" should {
     "fail if the user doesn't have access to the program" in withVcs { env =>
-      val user    = progPrincipal(Q3)
+      val user    = Set(ProgramPrincipal(Q3): Principal)
       val newProg = env.local.newProgram(Q2)
       forbidden(env.local.server.add(newProg, user))
     }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsSpec.scala
@@ -16,7 +16,7 @@ class VcsSpec extends VcsSpecification {
 
   "checkout" should {
     "fail if the indicated program doesn't exist remotely" in withVcs { env =>
-      notFound(env.local.staffVcs.checkout(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.checkout(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -29,7 +29,7 @@ class VcsSpec extends VcsSpecification {
       val remoteQ2 = env.remote.addNewProgram(Q2)
 
       // run checkout on the local peer
-      env.local.staffVcs.checkout(Q2, DummyPeer).unsafeRun
+      env.local.superStaffVcs.checkout(Q2, DummyPeer).unsafeRun
 
       val localQ2 = env.local.odb.lookupProgramByID(Q2)
 
@@ -39,7 +39,7 @@ class VcsSpec extends VcsSpecification {
 
   "add" should {
     "fail if the indicated program doesn't exist locally" in withVcs { env =>
-      notFound(env.local.staffVcs.add(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.add(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -52,7 +52,7 @@ class VcsSpec extends VcsSpecification {
       val localQ2 = env.local.addNewProgram(Q2)
 
       // run add to send it to the remote peer
-      env.local.staffVcs.add(Q2, DummyPeer).unsafeRun
+      env.local.superStaffVcs.add(Q2, DummyPeer).unsafeRun
 
       val remoteQ2 = env.remote.odb.lookupProgramByID(Q2)
 
@@ -63,12 +63,12 @@ class VcsSpec extends VcsSpecification {
   "pull" should {
     "fail if the indicated program doesn't exist locally" in withVcs { env =>
       env.remote.addNewProgram(Q2)
-      notFound(env.local.staffVcs.pull(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.pull(Q2, DummyPeer), Q2)
     }
 
     "fail if the indicated program doesn't exist remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
-      notFound(env.local.staffVcs.pull(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.pull(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -78,11 +78,11 @@ class VcsSpec extends VcsSpecification {
     "fail if the indicated program has different keys locally vs remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
       env.remote.addNewProgram(Q2)
-      idClash(env.local.staffVcs.pull(Q2, DummyPeer), Q2)
+      idClash(env.local.superStaffVcs.pull(Q2, DummyPeer), Q2)
     }
 
     "do nothing if the local version is the same" in withVcs { env =>
-      expect(env.local.staffVcs.pull(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.pull(Q1, DummyPeer)) {
         case \/-(false) => ok("")
       }
     }
@@ -90,7 +90,7 @@ class VcsSpec extends VcsSpecification {
     "do nothing if the local version is newer" in withVcs { env =>
       env.local.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.pull(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.pull(Q1, DummyPeer)) {
         case \/-(false) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
@@ -98,7 +98,7 @@ class VcsSpec extends VcsSpecification {
     "merge the updates if the remote version is newer" in withVcs { env =>
       env.remote.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.pull(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.pull(Q1, DummyPeer)) {
         case \/-(true) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
@@ -107,12 +107,12 @@ class VcsSpec extends VcsSpecification {
   "push" should {
     "fail if the indicated program doesn't exist locally" in withVcs { env =>
       env.remote.addNewProgram(Q2)
-      notFound(env.local.staffVcs.push(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.push(Q2, DummyPeer), Q2)
     }
 
     "fail if the indicated program doesn't exist remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
-      notFound(env.local.staffVcs.push(Q2, DummyPeer), Q2)
+      notFound(env.local.superStaffVcs.push(Q2, DummyPeer), Q2)
     }
 
     "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -122,11 +122,11 @@ class VcsSpec extends VcsSpecification {
     "fail if the indicated program has different keys locally vs remotely" in withVcs { env =>
       env.local.addNewProgram(Q2)
       env.remote.addNewProgram(Q2)
-      idClash(env.local.staffVcs.push(Q2, DummyPeer), Q2)
+      idClash(env.local.superStaffVcs.push(Q2, DummyPeer), Q2)
     }
 
     "do nothing if the local version is the same" in withVcs { env =>
-      expect(env.local.staffVcs.push(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.push(Q1, DummyPeer)) {
         case \/-(false) => ok("")
       }
     }
@@ -134,7 +134,7 @@ class VcsSpec extends VcsSpecification {
     "fail with NeedsUpdate if the local version is older" in withVcs { env =>
       env.remote.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.push(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.push(Q1, DummyPeer)) {
         case -\/(NeedsUpdate) => ok("")
       } and (env.local.progTitle must_== Title)
     }
@@ -142,7 +142,7 @@ class VcsSpec extends VcsSpecification {
     "merge the updates if the local version is newer" in withVcs { env =>
       env.local.progTitle = "The Myth of Sisyphus"
 
-      expect(env.local.staffVcs.push(Q1, DummyPeer)) {
+      expect(env.local.superStaffVcs.push(Q1, DummyPeer)) {
         case \/-(true) => ok("")
       } and (env.remote.progTitle must_== "The Myth of Sisyphus")
     }
@@ -154,12 +154,12 @@ class VcsSpec extends VcsSpecification {
     name should {
       "fail if the indicated program doesn't exist locally" in withVcs { env =>
         env.remote.addNewProgram(Q2)
-        notFound(syncMethod(env.local.staffVcs, Q2), Q2)
+        notFound(syncMethod(env.local.superStaffVcs, Q2), Q2)
       }
 
       "fail if the indicated program doesn't exist remotely" in withVcs { env =>
         env.local.addNewProgram(Q2)
-        notFound(syncMethod(env.local.staffVcs, Q2), Q2)
+        notFound(syncMethod(env.local.superStaffVcs, Q2), Q2)
       }
 
       "fail if the user doesn't have access to the program" in withVcs { env =>
@@ -169,11 +169,11 @@ class VcsSpec extends VcsSpecification {
       "fail if the indicated program has different keys locally vs remotely" in withVcs { env =>
         env.local.addNewProgram(Q2)
         env.remote.addNewProgram(Q2)
-        idClash(syncMethod(env.local.staffVcs, Q2), Q2)
+        idClash(syncMethod(env.local.superStaffVcs, Q2), Q2)
       }
 
       "do nothing if both versions are the same" in withVcs { env =>
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.Neither) => ok("")
         }
       }
@@ -181,7 +181,7 @@ class VcsSpec extends VcsSpecification {
       "merge the remote updates if the remote version is newer" in withVcs { env =>
         env.remote.progTitle = "The Myth of Sisyphus"
 
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.LocalOnly) => ok("")
         } and (env.local.progTitle must_== "The Myth of Sisyphus")
       }
@@ -189,7 +189,7 @@ class VcsSpec extends VcsSpecification {
       "send the local updates if the local version is newer" in withVcs { env =>
         env.local.progTitle = "The Myth of Sisyphus"
 
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.RemoteOnly) => ok("")
         } and (env.remote.progTitle must_== "The Myth of Sisyphus")
       }
@@ -201,7 +201,7 @@ class VcsSpec extends VcsSpecification {
         val note = env.remote.odb.getFactory.createObsComponent(env.remote.prog, SPNote.SP_TYPE, null)
         env.remote.prog.addObsComponent(note)
 
-        expect(syncMethod(env.local.staffVcs, Q1)) {
+        expect(syncMethod(env.local.superStaffVcs, Q1)) {
           case \/-(ProgramLocation.Both) => ok("")
         } and (env.remote.prog.getGroups.get(0).getNodeKey must_== group.getNodeKey) and
           (env.local.prog.getObsComponents.get(0).getNodeKey must_== note.getNodeKey)


### PR DESCRIPTION
This installment introduces staff-only field corrections.  Some program nodes contain data that may only be edited by users with a staff key.  In particular, the root node itself, observations, and program notes (i.e., "pink" notes).  Examples of staff-only fields are the rollover status of the program or the QA state of an observation.  The merge correction algorithm has been updated to reset staff-only field edits to the appropriate values if a non-staff user should edit them, say via importing edited XML or an OT-bug.

To make this possible, a `copy` syntax function was added to `ISPDataObject` instances.  This permits duplicating a random data object `x` with `x.copy`.  The copy function is covered in the [first commit](https://github.com/gemini-hlsw/ocs/commit/3ccd7ba93ceb1507aaf27a2a21ca042403d3198d).  We use it in the [second commit](https://github.com/gemini-hlsw/ocs/commit/57574e8e068748023cbdf1bcf8e811eff63cf536) to edit any `MergePlan` that contains edits to staff-only fields.  The existing `ISPStaffOnlyFieldProtected` data object interface is used in this process.