### PR TITLE
OCSADV-196: TPE science area drawing bugfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2015A", false, 1, 1, 2)
+ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2015B", false, 2, 1, 0)
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -150,4 +150,9 @@ class VignettingTest {
     val expected   = List(GS7, GS6)
     executeTest(GMOSSouthSideLookingWithOI, 0.0, List(Offset(Angle.fromArcsecs(200.0), Angle.fromArcsecs(50.0))), All, expected)
   }
+
+  @Test def testSideLookingOneNegOffset2PosAngle0() = {
+    val expected   = List(GS5, GS3, GS2)
+    executeTest(GMOSSouthSideLookingWithOI, 0.0, List(Offset(Angle.fromArcsecs(-50.0), Angle.fromArcsecs(-50.0))), All, expected)
+  }
 }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -109,32 +109,32 @@ class VignettingTest {
     nextCandidate(candidates, expected)
   }
 
-  @Ignore @Test def testSideLookingBasePosAngle0() = {
+  @Test def testSideLookingBasePosAngle0() = {
     val expected   = List(GS3, GS2, GS1, GS4)
     executeTest(GMOSSouthSideLookingWithOI, 0.0, Nil, All, expected)
   }
 
-  @Ignore @Test def testSideLookingBasePosAngle90() = {
+  @Test def testSideLookingBasePosAngle90() = {
     val expected = List(GS7, GS6, GS1)
     executeTest(GMOSSouthSideLookingWithOI, 90.0, Nil, All, expected)
   }
 
-  @Ignore @Test def testSideLookingBasePosAngle180() = {
+  @Test def testSideLookingBasePosAngle180() = {
     val expected = List(GS8, GS10, GS9)
     executeTest(GMOSSouthSideLookingWithOI, 180.0, Nil, All, expected)
   }
 
-  @Ignore @Test def testUpLookingBasePosAngle0() = {
+  @Test def testUpLookingBasePosAngle0() = {
     val expected = List(GS1)
     executeTest(GMOSSouthUpLookingWithOI, 0.0, Nil, All, expected)
   }
 
-  @Ignore @Test def testUpLookingBasePosAngle90() = {
+  @Test def testUpLookingBasePosAngle90() = {
     val expected = List(GS3, GS2, GS1, GS4)
     executeTest(GMOSSouthUpLookingWithOI, 90.0, Nil, All, expected)
   }
 
-  @Ignore @Test def testUpLookingBasePosAngle180() = {
+  @Test def testUpLookingBasePosAngle180() = {
     val expected = List(GS7, GS6)
     executeTest(GMOSSouthUpLookingWithOI, 180.0, Nil, All, expected)
   }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -33,10 +33,8 @@ object ModelConverters {
   private val maxArcsecs = 60 * maxArcmins
   implicit class AngleNormalizer(val angle: Angle) extends AnyVal {
     private def normalize(value: Double, maxValue: Double): Double = {
-      val half = maxValue / 2.0
-      val pos = value % maxValue
-      val neg = pos - maxValue
-      if (math.abs(pos) < math.abs(neg)) pos else neg
+      val neg = value - maxValue
+      if (value < math.abs(neg)) value else neg
     }
 
     def toNormalizedRadians:    Double = normalize(angle.toRadians, maxRadians)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -26,6 +26,25 @@ object ModelConverters {
     def toOldModel: skycalc.Angle = skycalc.Angle.degrees(angle.toDegrees)
   }
 
+  // We need a way to convert angles from [0,maxValOfUnit) to [-maxValOfUnit/2,maxValOfUnit/2) for a number of purposes.
+  private val maxRadians = 2 * math.Pi
+  private val maxDegrees = 360
+  private val maxArcmins = 60 * maxDegrees
+  private val maxArcsecs = 60 * maxArcmins
+  implicit class AngleNormalizer(val angle: Angle) extends AnyVal {
+    private def normalize(value: Double, maxValue: Double): Double = {
+      val half = maxValue / 2.0
+      val pos = value % maxValue
+      val neg = pos - maxValue
+      if (math.abs(pos) < math.abs(neg)) pos else neg
+    }
+
+    def toNormalizedRadians:    Double = normalize(angle.toRadians, maxRadians)
+    def toNormalizedDegrees:    Double = normalize(angle.toDegrees, maxDegrees)
+    def toNormalizedArcmins:    Double = normalize(angle.toArcmins, maxArcmins)
+    def toNormalizedArcseconds: Double = normalize(angle.toArcsecs, maxArcsecs)
+  }
+
   implicit class OldOffset2New(val offset: skycalc.Offset) extends AnyVal {
     def toNewModel: Offset = Offset(offset.p().toNewModel, offset.q().toNewModel)
   }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
@@ -90,7 +90,7 @@ object GmosOiwfsProbeArm extends ProbeArmGeometry {
                        posAngle:  Double,
                        guideStar: Point2D,
                        offset:    Point2D,
-                       flip:      Int): Double = {
+                       flip:      Int): Angle = {
     val p  = {
       val posAngleRot = AffineTransform.getRotateInstance(-posAngle)
 
@@ -124,7 +124,7 @@ object GmosOiwfsProbeArm extends ProbeArmGeometry {
       if (MX2 > (r2 + BX2)) math.Pi - thetaP else thetaP
     }
 
-    phi - theta - alpha - math.Pi / 2.0
+    Angle.fromRadians(phi - theta - alpha - math.Pi / 2.0)
   }
 
   // Various measurements in arcsec.

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/ScalaGuideProbeUtil.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/ScalaGuideProbeUtil.scala
@@ -2,6 +2,7 @@ package edu.gemini.spModel.guide
 
 import java.awt.geom.{AffineTransform, Area}
 
+import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.core.Coordinates
 import edu.gemini.spModel.inst.{FeatureGeometry, ProbeArmGeometry, ScienceAreaGeometry}
 import edu.gemini.spModel.obs.context.ObsContext
@@ -34,8 +35,10 @@ object ScalaGuideProbeUtil {
           // If an adjustment exists, calculate the vignetting for this offset.
           val vignetting = probeArmGeometry.armAdjustment(ctx, coordinates, offset).map { armAdjustment =>
             // Adjust the science area for the current offset.
-            val x = -offset.p.toArcsecs.getMagnitude
-            val y = -offset.q.toArcsecs.getMagnitude * flip
+//            val x = -offset.p.toArcsecs.getMagnitude
+//            val y = -offset.q.toArcsecs.getMagnitude * flip
+            val x = -(offset.p.toNewModel.toNormalizedArcseconds)
+            val y = -(offset.q.toNewModel.toNormalizedArcseconds * flip)
             val trans = AffineTransform.getTranslateInstance(x, y)
             val adjScienceArea = scienceArea.transform(trans)
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/ScalaGuideProbeUtil.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/ScalaGuideProbeUtil.scala
@@ -32,7 +32,7 @@ object ScalaGuideProbeUtil {
         case (currentSum,offset) =>
           // Find the probe arm adjustment, which consists of the arm angle and guide star location in arcsec.
           // If an adjustment exists, calculate the vignetting for this offset.
-          val vignetting = probeArmGeometry.armAdjustment(ctx, coordinates, offset).map { adj =>
+          val vignetting = probeArmGeometry.armAdjustment(ctx, coordinates, offset).map { armAdjustment =>
             // Adjust the science area for the current offset.
             val x = -offset.p.toArcsecs.getMagnitude
             val y = -offset.q.toArcsecs.getMagnitude * flip
@@ -41,7 +41,7 @@ object ScalaGuideProbeUtil {
 
             val probeArmArea = probeArmShapes.foldLeft(new Area){
               case (area,s) =>
-                val sp = FeatureGeometry.transformProbeArmForContext(s, adj.angle, adj.guideStarCoords)
+                val sp = FeatureGeometry.transformProbeArmForContext(s, armAdjustment)
                 area.add(new Area(sp))
                 area
             }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/FeatureGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/FeatureGeometry.scala
@@ -81,14 +81,15 @@ object FeatureGeometry {
   /**
    * Given a list of shapes representing a guide probe arm, an angle for the probe arm, and the position of the guide
    * star, execute transformations on the shapes to get the adjusted probe arm.
-   * @param shapes    the list of shapes to transform
-   * @param armAngle  the angle at which the probe arm will be situated
-   * @param guideStar the position of the guide star in arcseconds
-   * @return          the transformed shapes
+   * @param shapes         the list of shapes to transform
+   * @param armAdjustment  the adjustment information for the probe arm, consisting of an angle and guide star location
+   * @return               the transformed shapes
    */
-  def transformProbeArmForContext(shapes: List[Shape], armAngle: Double, guideStar: Point2D): List[Shape] = {
+  def transformProbeArmForContext(shapes: List[Shape], armAdjustment: ArmAdjustment): List[Shape] = {
     // For the guide star, we want to use the point closest to zero in terms of arcsec as a normalization.
-    val armTrans = AffineTransform.getRotateInstance(armAngle, guideStar.getX, guideStar.getY)
+    val armAngle  = armAdjustment.angle
+    val guideStar = armAdjustment.guideStarCoords
+    val armTrans  = AffineTransform.getRotateInstance(armAngle.toRadians, guideStar.getX, guideStar.getY)
     armTrans.concatenate(AffineTransform.getTranslateInstance(guideStar.getX, guideStar.getY))
     shapes.map { armTrans.createTransformedShape }
   }
@@ -96,13 +97,12 @@ object FeatureGeometry {
   /**
    * Given a shape representing a guide probe arm or segment, an angle for the probe arm, and the position of the guide
    * star, execute transformations on the shape to get the adjusted probe arm.
-   * @param shape     the shape to transform
-   * @param armAngle  the angle at which the probe arm will be situated
-   * @param guideStar the position of the guide star in arcsec
-   * @return          the transformed shapes
+   * @param shape          the shape to transform
+   * @param armAdjustment  the adjustment information for the probe arm, consisting of an angle and guide star location
+   * @return               the transformed shapes
    */
-  def transformProbeArmForContext(shape: Shape, armAngle: Double, guideStar: Point2D): Shape =
-    transformProbeArmForContext(List(shape), armAngle, guideStar).head
+  def transformProbeArmForContext(shape: Shape, armAdjustment: ArmAdjustment): Shape =
+    transformProbeArmForContext(List(shape), armAdjustment).head
 
   /**
    * Given a list of geometry shapes, transform them as needed for display on the screen.
@@ -129,3 +129,10 @@ object FeatureGeometry {
   def transformProbeArmForScreen(shape: Shape, pixelsPerArcsec: Double, flipRA: Double, screenPos: Point2D): Shape =
     transformProbeArmForScreen(List(shape), pixelsPerArcsec, flipRA, screenPos).head
 }
+
+/**
+ * A representation of the adjustment made to the default list of shapes when using a specified guide star.
+ * @param angle           the angle which will be used by the probe arm
+ * @param guideStarCoords the coordinates (in arcsec) where the probe arm will be placed
+ */
+case class ArmAdjustment(angle: Angle, guideStarCoords: Point2D)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ProbeArmGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ProbeArmGeometry.scala
@@ -101,10 +101,3 @@ object ProbeArmGeometry {
       new Point2D.Double(p.getX.toCanonicalArcsec, p.getY.toCanonicalArcsec)
   }
 }
-
-/**
- * A representation of the adjustment made to the default list of shapes when using a specified guide star.
- * @param angle           the angle which will be used by the probe arm
- * @param guideStarCoords the coordinates (in arcsec) where the probe arm will be placed
- */
-case class ArmAdjustment(angle: Double, guideStarCoords: Point2D)

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_OIWFS_Feature.java
@@ -122,15 +122,12 @@ public class GMOS_OIWFS_Feature extends OIWFS_FeatureBase {
             final Option<ArmAdjustment> adj = GmosOiwfsProbeArm.armAdjustmentAsJava(ctx, offset);
             adj.foreach(new ApplyOp<ArmAdjustment>() {
                 @Override
-                public void apply(final ArmAdjustment armAdj) {
-                    //final edu.gemini.spModel.core.Angle armAngle = armAdj.angle();
-                    final double armAngle                        = armAdj.angle();
-                    final Point2D guideStar                      = armAdj.guideStarCoords();
+                public void apply(final ArmAdjustment armAdjustment) {
                     final ImList<Shape> shapes                   = GmosOiwfsProbeArm.geometryAsJava();
                     shapes.foreach(new ApplyOp<Shape>() {
                         @Override
                         public void apply(final Shape s) {
-                            final Shape sContext = FeatureGeometry$.MODULE$.transformProbeArmForContext(s, armAngle, guideStar);
+                            final Shape sContext = FeatureGeometry$.MODULE$.transformProbeArmForContext(s, armAdjustment);
                             final Shape sScreen  = FeatureGeometry$.MODULE$.transformProbeArmForScreen(sContext, _pixelsPerArcsec, _flipRA, screenPos);
                             _figureList.add(new Figure(sScreen, PROBE_ARM_COLOR, BLOCKED, OIWFS_STROKE));
                         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_SciAreaFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_SciAreaFeature.java
@@ -99,16 +99,13 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
         if (instGMOS != null) {
             final ObsContext ctx = _iw.getMinimalObsContext().getOrNull();
             if (ctx != null) {
-                final AffineTransform trans = AffineTransform.getTranslateInstance(_baseScreenPos.getX(), _baseScreenPos.getY());
-
                 final ImList<Shape> shape = new GmosScienceAreaGeometry().geometryAsJava(instGMOS);
                 shape.foreach(new ApplyOp<Shape>() {
                     @Override
                     public void apply(final Shape s) {
                         final Shape s2 = FeatureGeometry$.MODULE$.transformScienceAreaForContext(s, ctx);
-                        final Shape s3 = FeatureGeometry$.MODULE$.transformScienceAreaForScreen(s2, _pixelsPerArcsec);
-                        final Shape s4 = trans.createTransformedShape(s3);
-                        _figureList.add(s4);
+                        final Shape s3 = FeatureGeometry$.MODULE$.transformScienceAreaForScreen(s2, _pixelsPerArcsec, ctx, _baseScreenPos);
+                        _figureList.add(s3);
                     }
                 });
 


### PR DESCRIPTION
TPE would previously draw the science area in the wrong place if the base was not (0,0). This has been fixed.