### PR TITLE
OCSADV-200-K: increment version when correcting observation numbers

### DIFF
--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeCorrectionSpec.scala
@@ -21,6 +21,8 @@ import Scalaz._
 class MergeCorrectionSpec extends Specification {
   import NodeDetail._
 
+  val lifespanId: LifespanId = LifespanId.random
+
   def mergeNode(dob: ISPDataObject, obsNum: Option[Int]): MergeNode = Modified(
     new SPNodeKey(),
     EmptyNodeVersions,
@@ -37,6 +39,12 @@ class MergeCorrectionSpec extends Specification {
   def templateFolder: MergeNode = nonObs(new TemplateFolder)
 
   def obs(num: Int): MergeNode = mergeNode(new SPObservation, Some(num))
+
+  def incr(mn: MergeNode): MergeNode =
+    mn match {
+      case m: Modified => m.copy(nv = m.nv.incr(lifespanId))
+      case _           => failure("trying to increment unmodified node")
+    }
 
   def obsTree(num: Int): Tree[MergeNode] =
     obs(num).node(

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ValidityCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ValidityCorrectionSpec.scala
@@ -1,7 +1,6 @@
 package edu.gemini.sp.vcs.diff
 
 import edu.gemini.pot.sp.SPNodeKey
-import edu.gemini.pot.sp.version.LifespanId
 import edu.gemini.pot.spdb.DBLocalDatabase
 import edu.gemini.sp.vcs.diff.VcsFailure.Unmergeable
 import org.specs2.matcher.MatchResult
@@ -10,14 +9,7 @@ import scalaz._
 import Scalaz._
 
 class ValidityCorrectionSpec extends MergeCorrectionSpec {
-  val lifespanId         = LifespanId.random
   val validityCorrection = new ValidityCorrection(lifespanId, Map.empty)
-
-  def incr(mn: MergeNode): MergeNode =
-    mn match {
-      case m: Modified => m.copy(nv = m.nv.incr(lifespanId))
-      case _           => failure("trying to increment unmodified node")
-    }
 
   private def test(start: Tree[MergeNode], expected: Tree[MergeNode], vc: ValidityCorrection = validityCorrection): MatchResult[Tree[MergeNode]] =
     vc.apply(plan(start)) match {


### PR DESCRIPTION
This is a small update to observation number corrections.  It simply increments node version information when adjusting the observation number.  This is mostly to be consistent with other corrections.  The idea is that any adjustment to the merge plan should be reflected as a local edit.  We compare the version information of the final merge plan to the original program to know whether any updates need to be made locally before sending changes to the database.