### PR TITLE
OCSADV-253: End-to-end implementation of ITC service for GMOS imaging

### DIFF
--- a/app/ot/build.sbt
+++ b/app/ot/build.sbt
@@ -54,6 +54,7 @@ def common(version: Version) = AppConfig(
     BundleSpec("edu.gemini.util.log.extras",   version),
     BundleSpec("edu.gemini.sp.vcs.tui",        version),
     BundleSpec("edu.gemini.qpt.shared",        version),
+    BundleSpec("edu.gemini.itc.shared",        version),
     BundleSpec("edu.gemini.qv.plugin",         version),
     BundleSpec("edu.gemini.services.client",   version),
     BundleSpec("slf4j.api",                    Version(1, 6, 4)),

--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -99,6 +99,7 @@ def common(version: Version) = AppConfig(
     BundleSpec("edu.gemini.ags.servlet",                 version),
     BundleSpec("edu.gemini.dataman.app",                 version),
     BundleSpec("edu.gemini.horizons.server",             version),
+    BundleSpec("edu.gemini.itc",                         version),
     BundleSpec("edu.gemini.lchquery.servlet",            version),
     BundleSpec("edu.gemini.obslog",                      version),
     BundleSpec("edu.gemini.oodb.auth.servlet",           version),

--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -100,6 +100,8 @@ def common(version: Version) = AppConfig(
     BundleSpec("edu.gemini.dataman.app",                 version),
     BundleSpec("edu.gemini.horizons.server",             version),
     BundleSpec("edu.gemini.itc",                         version),
+    BundleSpec("edu.gemini.itc.shared",                  version),
+    BundleSpec("edu.gemini.itc.web",                     version),
     BundleSpec("edu.gemini.lchquery.servlet",            version),
     BundleSpec("edu.gemini.obslog",                      version),
     BundleSpec("edu.gemini.oodb.auth.servlet",           version),

--- a/bundle/edu.gemini.itc.shared/build.sbt
+++ b/bundle/edu.gemini.itc.shared/build.sbt
@@ -21,7 +21,8 @@ OsgiKeys.bundleActivator := Some("edu.gemini.itc.shared.osgi.Activator")
 OsgiKeys.bundleSymbolicName := name.value
 
 OsgiKeys.exportPackage := Seq(
-  "edu.gemini.itc.service"
+  "edu.gemini.itc.service",
+  "edu.gemini.itc.shared"
 )
 
 OsgiKeys.importPackage := Seq(

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/BrightnessUnit.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/BrightnessUnit.java
@@ -1,0 +1,25 @@
+package edu.gemini.itc.shared;
+
+import edu.gemini.spModel.type.DisplayableSpType;
+
+public enum BrightnessUnit implements DisplayableSpType {
+    // TODO: The "displayable" units are pretty ugly, but we have to keep them for
+    // TODO: now in order to be backwards compatible for regression testing.
+    MAG                 ("mag"),
+    ABMAG               ("ABmag"),
+    JY                  ("Jy"),
+    WATTS               ("watts_fd_wavelength"),
+    ERGS_WAVELENGTH     ("ergs_fd_wavelength"),
+    ERGS_FREQUENCY      ("ergs_fd_frequency"),
+    // -- TODO: same in blue but per area, can we unify those two sets of values?
+    MAG_PSA             ("mag_per_sq_arcsec"),
+    ABMAG_PSA           ("ABmag_per_sq_arcsec"),
+    JY_PSA              ("jy_per_sq_arcsec"),
+    WATTS_PSA           ("watts_fd_wavelength_per_sq_arcsec"),
+    ERGS_WAVELENGTH_PSA ("ergs_fd_wavelength_per_sq_arcsec"),
+    ERGS_FREQUENCY_PSA  ("ergs_fd_frequency_per_sq_arcsec")
+    ;
+    private final String displayValue;
+    private BrightnessUnit(final String displayName) { this.displayValue = displayName; }
+    public String displayValue() {return displayValue;}
+}

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservationDetails.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservationDetails.java
@@ -1,9 +1,13 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
+
+import edu.gemini.itc.shared.*;
+
+import java.io.Serializable;
 
 /**
  * Container for observation detail parameters.
  */
-public final class ObservationDetails {
+public final class ObservationDetails implements Serializable {
 
     private final CalculationMethod calculationMethod;
     private final AnalysisMethod analysisMethod;

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservingConditions.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/ObservingConditions.java
@@ -1,14 +1,16 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.ImageQuality;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.SkyBackground;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.WaterVapor;
 
+import java.io.Serializable;
+
 /**
  * Container for observing condition parameters.
  */
-public final class ObservingConditions {
+public final class ObservingConditions implements Serializable {
 
     private final ImageQuality  iq;
     private final CloudCover    cc;

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/PlottingDetails.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/PlottingDetails.java
@@ -1,9 +1,11 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
+
+import java.io.Serializable;
 
 /**
  * Container for plotting detail parameters.
  */
-public final class PlottingDetails {
+public final class PlottingDetails implements Serializable {
 
     public static enum PlotLimits {
         AUTO,

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/SourceDefinition.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/SourceDefinition.java
@@ -1,33 +1,11 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
-import edu.gemini.spModel.type.DisplayableSpType;
+import java.io.Serializable;
 
 /**
  * Container for source definition parameters.
  */
-public final class SourceDefinition {
-
-    public static enum BrightnessUnit implements DisplayableSpType {
-        // TODO: The "displayable" units are pretty ugly, but we have to keep them for
-        // TODO: now in order to be backwards compatible for regression testing.
-        MAG                 ("mag"),
-        ABMAG               ("ABmag"),
-        JY                  ("Jy"),
-        WATTS               ("watts_fd_wavelength"),
-        ERGS_WAVELENGTH     ("ergs_fd_wavelength"),
-        ERGS_FREQUENCY      ("ergs_fd_frequency"),
-        // -- TODO: same in blue but per area, can we unify those two sets of values?
-        MAG_PSA             ("mag_per_sq_arcsec"),
-        ABMAG_PSA           ("ABmag_per_sq_arcsec"),
-        JY_PSA              ("jy_per_sq_arcsec"),
-        WATTS_PSA           ("watts_fd_wavelength_per_sq_arcsec"),
-        ERGS_WAVELENGTH_PSA ("ergs_fd_wavelength_per_sq_arcsec"),
-        ERGS_FREQUENCY_PSA  ("ergs_fd_frequency_per_sq_arcsec")
-        ;
-        private final String displayValue;
-        private BrightnessUnit(final String displayName) { this.displayValue = displayName; }
-        public String displayValue() {return displayValue;}
-    }
+public final class SourceDefinition implements Serializable {
 
     public static enum Recession {
         REDSHIFT,

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/TelescopeDetails.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/TelescopeDetails.java
@@ -1,12 +1,14 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
 import edu.gemini.spModel.telescope.IssPort;
 import edu.gemini.spModel.type.DisplayableSpType;
 
+import java.io.Serializable;
+
 /**
  * Container for telescope parameters.
  */
-public final class TelescopeDetails {
+public final class TelescopeDetails implements Serializable {
 
     public static enum Coating implements DisplayableSpType {
         ALUMINIUM("aluminium"),

--- a/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/WavebandDefinition.java
+++ b/bundle/edu.gemini.itc.shared/src/main/Java/edu/gemini/itc/shared/WavebandDefinition.java
@@ -1,4 +1,4 @@
-package edu.gemini.itc.service;
+package edu.gemini.itc.shared;
 
 /**
  * This class represents the definition of standard "wavebands",

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
@@ -1,4 +1,4 @@
-package edu.gemini.itc.service
+package edu.gemini.itc.shared
 
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.{DetectorManufacturer, FPUnit, Disperser, Filter}

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -1,5 +1,11 @@
-package edu.gemini.itc.service
+package edu.gemini.itc.shared
 
+import edu.gemini.spModel.core.Peer
+import edu.gemini.util.security.auth.keychain.KeyChain
+import edu.gemini.util.trpc.client.TrpcClient
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scalaz.{Failure, Success, Validation}
 
 /**
@@ -16,7 +22,7 @@ final case class ItcSpectroscopyResult(/*TODO*/) extends ItcCalcResult
  * return one result (either because they don't have more than one CCD or because all different CCDs are assumed to
  * have the same characteristics).
  */
-sealed trait ItcResult {
+sealed trait ItcResult extends Serializable {
   /** Returns the results for all CCDs. */
   def ccds: Array[ItcCalcResult]
 
@@ -26,7 +32,7 @@ sealed trait ItcResult {
 
 object ItcResult {
 
-  import ItcService._
+  import edu.gemini.itc.shared.ItcService._
 
   /** Creates an ITC result in case of an error. */
   def forException(e: Throwable): Result = Failure(List(e.getMessage))
@@ -43,7 +49,7 @@ object ItcResult {
  */
 trait ItcService {
 
-  import ItcService._
+  import edu.gemini.itc.shared.ItcService._
 
   def calculate(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Result
 
@@ -52,5 +58,11 @@ trait ItcService {
 object ItcService {
 
   type Result = Validation[List[String], ItcResult]
+
+  /** Performs an ITC call on the given host. */
+  def calculate(kc: KeyChain, peer: Peer, source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Future[Result] =
+    TrpcClient(peer).withKeyChain(kc) future { r =>
+      r[ItcService].calculate(source, obs, cond, tele, ins)
+    }
 
 }

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -60,8 +60,8 @@ object ItcService {
   type Result = Validation[List[String], ItcResult]
 
   /** Performs an ITC call on the given host. */
-  def calculate(kc: KeyChain, peer: Peer, source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Future[Result] =
-    TrpcClient(peer).withKeyChain(kc) future { r =>
+  def calculate(peer: Peer, source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Future[Result] =
+    TrpcClient(peer).withoutKeys future { r =>
       r[ItcService].calculate(source, obs, cond, tele, ins)
     }
 

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -1,6 +1,4 @@
-package edu.gemini.itc.service
-
-import edu.gemini.itc.service.SourceDefinition.BrightnessUnit
+package edu.gemini.itc.shared
 
 // ==== Source spatial profile
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
@@ -1,10 +1,10 @@
 package edu.gemini.itc.acqcam;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.SourceDefinition;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcquisitionCamParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcquisitionCamParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.acqcam;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Parameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Parameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.flamingos2;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.flamingos2;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gems;
 
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.AOSystem;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.SampledSpectrumVisitor;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -1,10 +1,10 @@
 package edu.gemini.itc.gmos;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.GmosParameters;
-import edu.gemini.itc.service.IfuRadial;
-import edu.gemini.itc.service.IfuSingle;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.GmosParameters;
+import edu.gemini.itc.shared.IfuRadial;
+import edu.gemini.itc.shared.IfuSingle;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.gemini.gmos.GmosCommonType;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.gmos;
 
-import edu.gemini.itc.service.GmosParameters;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.GmosParameters;
+import edu.gemini.itc.shared.ObservationDetails;
 
 /**
  * Gmos specification class

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.gmos;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;
@@ -318,7 +317,7 @@ public final class GmosRecipe extends RecipeBase {
 
     // Calculation results
     // TEMPORARY, these will probably turn into Scala case classes
-    interface GmosResult {}
+    public interface GmosResult {}
     public static final class GmosImagingResult implements GmosResult {
         public final SourceFraction SFcalc;
         public final double peak_pixel_count;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosSouth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosSouth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.gmos;
 
-import edu.gemini.itc.service.GmosParameters;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.GmosParameters;
+import edu.gemini.itc.shared.ObservationDetails;
 
 /**
  * Gmos specification class

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gnirs;
 
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsNorth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.gnirs;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 
 public final class GnirsNorth extends Gnirs {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gnirs;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.gnirs;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gsaoi;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.gsaoi;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
@@ -2,10 +2,10 @@ package edu.gemini.itc.gsaoi;
 
 import edu.gemini.itc.gems.*;
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.SourceDefinition;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/Michelle.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/Michelle.java
@@ -1,8 +1,8 @@
 package edu.gemini.itc.michelle;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.michelle;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.michelle;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.nifs;
 
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsNorth.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.nifs;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.*;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.nifs;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -4,7 +4,6 @@ import edu.gemini.itc.altair.*;
 import edu.gemini.itc.operation.ImageQualityCalculatable;
 import edu.gemini.itc.operation.ImageQualityCalculationFactory;
 import edu.gemini.itc.operation.SpecS2NLargeSlitVisitor;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.niri;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 
 import java.util.Iterator;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.niri;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -2,7 +2,6 @@ package edu.gemini.itc.niri;
 
 import edu.gemini.itc.altair.*;
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculation.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.ArraySpectrum;
 import edu.gemini.itc.shared.DefaultArraySpectrum;
 import edu.gemini.itc.shared.FormatStringWriter;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculationFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculationFactory.java
@@ -1,8 +1,8 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.SourceDefinition;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.Instrument;
 
 public final class ImageQualityCalculationFactory {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.Instrument;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculation.java
@@ -2,7 +2,7 @@ package edu.gemini.itc.operation;
 
 import edu.gemini.itc.gsaoi.Gsaoi;
 import edu.gemini.itc.niri.Niri;
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.BinningProvider;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.Instrument;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculationFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculationFactory.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.Instrument;
 
 public final class ImagingS2NCalculationFactory {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NMethodACalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NMethodACalculation.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
+import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.FormatStringWriter;
 import edu.gemini.itc.shared.Instrument;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/NormalizeVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/NormalizeVisitor.java
@@ -1,9 +1,9 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.BrightnessUnit;
+import edu.gemini.itc.shared.WavebandDefinition;
 import edu.gemini.itc.shared.SampledSpectrum;
 import edu.gemini.itc.shared.SampledSpectrumVisitor;
-import edu.gemini.itc.service.WavebandDefinition;
 import edu.gemini.itc.shared.ZeroMagnitudeStar;
 
 /**
@@ -15,7 +15,7 @@ import edu.gemini.itc.shared.ZeroMagnitudeStar;
 public class NormalizeVisitor implements SampledSpectrumVisitor {
     private final WavebandDefinition _band; // String description of waveband (A, B, R, etc.)
     private final double _user_norm; // Brightness of the object (flux) as an average
-    private final SourceDefinition.BrightnessUnit _units;  // mag, abmag, ...
+    private final BrightnessUnit _units;  // mag, abmag, ...
 
     /**
      * Constructs a Normalizer
@@ -24,7 +24,7 @@ public class NormalizeVisitor implements SampledSpectrumVisitor {
      * @param user_norm The average flux in the waveband
      * @param units     The code for the units chosen by user
      */
-    public NormalizeVisitor(final WavebandDefinition waveband, final double user_norm, final SourceDefinition.BrightnessUnit units) {
+    public NormalizeVisitor(final WavebandDefinition waveband, final double user_norm, final BrightnessUnit units) {
         _band = waveband;
         _user_norm = user_norm;
         _units = units;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/PeakPixelFlux.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/PeakPixelFlux.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.DatFile;
 import edu.gemini.itc.shared.ITCConstants;
 import edu.gemini.itc.shared.Instrument;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/SourceFractionFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/SourceFractionFactory.java
@@ -1,7 +1,7 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.Instrument;
 
 public final class SourceFractionFactory {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeBackgroundVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeBackgroundVisitor.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.core.Site;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeTransmissionVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/TelescopeTransmissionVisitor.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.operation;
 
-import edu.gemini.itc.service.TelescopeDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
 import edu.gemini.itc.shared.ITCConstants;
 import edu.gemini.itc.shared.TransmissionElement;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/BlackBodySpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/BlackBodySpectrum.java
@@ -1,8 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.WavebandDefinition;
-
 /**
  * This class creates a black body spectrum over the interval defined by the
  * blocking filter.  The code comes from Inger Jorgensen and Tom Geballe's
@@ -17,7 +14,7 @@ public class BlackBodySpectrum implements VisitableSampledSpectrum {
         _spectrum = spectrum;
     }
 
-    public BlackBodySpectrum(double temp, double interval, double flux, SourceDefinition.BrightnessUnit units, WavebandDefinition band, double z) {
+    public BlackBodySpectrum(double temp, double interval, double flux, BrightnessUnit units, WavebandDefinition band, double z) {
 
         //rescale the start and end depending on the redshift
         final double start = 300 / (1 + z);
@@ -69,7 +66,7 @@ public class BlackBodySpectrum implements VisitableSampledSpectrum {
     }
 
 
-    private double _convertToMag(final double flux, final SourceDefinition.BrightnessUnit units, final WavebandDefinition band) {
+    private double _convertToMag(final double flux, final BrightnessUnit units, final WavebandDefinition band) {
         //THis method should convert the flux into units of magnitude.
         //same code as in NormalizeVisitor.java.  Eventually should come out
         // into a genral purpose conversion class if needs to be used again.

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/EmissionLineSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/EmissionLineSpectrum.java
@@ -1,7 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.SourceDefinition;
-
 /**
  * This class creates a EmissionLine spectrum over the interval defined by the
  * blocking filter.  The code comes from PPuxley's Mathcad Demo

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ITCChart.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ITCChart.java
@@ -1,6 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.PlottingDetails;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/MultipartTestServlet.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/MultipartTestServlet.java
@@ -1,10 +1,6 @@
 package edu.gemini.itc.shared;
 
 import edu.gemini.itc.acqcam.AcquisitionCamParameters;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.SourceDefinition;
-import edu.gemini.itc.service.TelescopeDetails;
 import edu.gemini.itc.web.ITCRequest;
 
 import javax.servlet.ServletConfig;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/SEDFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/SEDFactory.java
@@ -5,7 +5,6 @@ import edu.gemini.itc.gsaoi.Gsaoi;
 import edu.gemini.itc.nifs.Nifs;
 import edu.gemini.itc.niri.Niri;
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.spModel.core.Site;
 import scala.Option;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ZeroMagnitudeStar.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/shared/ZeroMagnitudeStar.java
@@ -1,7 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.service.WavebandDefinition;
-
 /**
  * This class encapsulates the photon flux density (in photons/s/m^2/nm)
  * for a zero-magnitude star.

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecs.java
@@ -1,8 +1,8 @@
 package edu.gemini.itc.trecs;
 
 import edu.gemini.itc.operation.DetectorsTransmissionVisitor;
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.CalculationMethod;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.*;
 import scala.Option;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsParameters.java
@@ -1,6 +1,6 @@
 package edu.gemini.itc.trecs;
 
-import edu.gemini.itc.service.InstrumentDetails;
+import edu.gemini.itc.shared.InstrumentDetails;
 import edu.gemini.itc.shared.ITCMultiPartParser;
 import edu.gemini.itc.shared.ITCParameters;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
@@ -1,7 +1,6 @@
 package edu.gemini.itc.trecs;
 
 import edu.gemini.itc.operation.*;
-import edu.gemini.itc.service.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.itc.web.HtmlPrinter;
 import edu.gemini.itc.web.ITCRequest;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/web/HtmlPrinter.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/web/HtmlPrinter.java
@@ -1,12 +1,12 @@
 package edu.gemini.itc.web;
 
-import edu.gemini.itc.service.ObservationDetails;
-import edu.gemini.itc.service.ObservingConditions;
-import edu.gemini.itc.service.PlottingDetails;
-import edu.gemini.itc.service.TelescopeDetails;
-import edu.gemini.itc.service.SourceDefinition;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.ObservingConditions;
+import edu.gemini.itc.shared.PlottingDetails;
+import edu.gemini.itc.shared.TelescopeDetails;
+import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.FormatStringWriter;
-import edu.gemini.itc.service.Library;
+import edu.gemini.itc.shared.Library;
 import edu.gemini.spModel.telescope.IssPort;
 
 /**

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/osgi/Activator.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/osgi/Activator.scala
@@ -4,7 +4,8 @@ import java.util.logging.Level._
 import java.util.logging.Logger
 
 import edu.gemini.itc.osgi.Activator._
-import edu.gemini.itc.service.{ItcService, ItcServiceImpl}
+import edu.gemini.itc.service.ItcServiceImpl
+import edu.gemini.itc.shared.ItcService
 import org.osgi.framework.{BundleActivator, BundleContext, ServiceRegistration}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -29,7 +30,8 @@ class Activator extends BundleActivator {
     // register the services..
     Future {
 
-      val properties = new java.util.Hashtable[String, Object]() {{ put("trpc", "")}}
+     val properties = new java.util.Hashtable[String, Object]()
+      properties.put("trpc", "")
       val service    = new ItcServiceImpl()
       ctx.registerService(classOf[ItcService], service, properties)
 

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -23,7 +23,6 @@ class ItcServiceImpl extends ItcService {
   } catch {
     // TODO: for now in most cases where a validation problem should be reported to the user the ITC code throws an exception instead
     case e: Throwable =>
-      e.printStackTrace()
       ItcResult.forException(e)
   }
 

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -2,6 +2,7 @@ package edu.gemini.itc.service
 
 import edu.gemini.itc.gmos.GmosRecipe
 import edu.gemini.itc.operation.ImagingS2NMethodACalculation
+import edu.gemini.itc.shared._
 
 /**
  * The ITC service implementation.
@@ -21,7 +22,9 @@ class ItcServiceImpl extends ItcService {
     }
   } catch {
     // TODO: for now in most cases where a validation problem should be reported to the user the ITC code throws an exception instead
-    case e: Throwable => ItcResult.forException(e)
+    case e: Throwable =>
+      e.printStackTrace()
+      ItcResult.forException(e)
   }
 
   private def calculateGmos(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: GmosParameters): Result = {

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -3,7 +3,8 @@ package edu.gemini.itc.web
 import javax.servlet.http.HttpServletRequest
 
 import edu.gemini.itc.altair.AltairParameters
-import edu.gemini.itc.service.SourceDefinition._
+import edu.gemini.itc.shared._
+import SourceDefinition._
 import edu.gemini.itc.service._
 import edu.gemini.itc.shared._
 import edu.gemini.spModel.core.Site
@@ -160,7 +161,7 @@ object ITCRequest {
     val pc = ITCRequest.from(r)
 
     // Get the source geometry and type
-    import edu.gemini.itc.service.SourceDefinition.Profile._
+    import SourceDefinition.Profile._
     val spatialProfile = pc.enumParameter(classOf[Profile]) match {
       case POINT    =>
         val norm  = pc.doubleParameter("psSourceNorm")
@@ -181,7 +182,7 @@ object ITCRequest {
     val normBand = pc.enumParameter(classOf[WavebandDefinition])
 
     // Get Spectrum Resource
-    import edu.gemini.itc.service.SourceDefinition.Distribution._
+    import SourceDefinition.Distribution._
     val sourceSpec = pc.enumParameter(classOf[Distribution])
     val sourceDefinition = sourceSpec match {
       case BBODY =>             BlackBody(pc.doubleParameter("BBTemp"))
@@ -200,7 +201,7 @@ object ITCRequest {
     }
 
     //Get Redshift
-    import edu.gemini.itc.service.SourceDefinition.Recession._
+    import SourceDefinition.Recession._
     val recession = pc.enumParameter(classOf[Recession])
     val redshift = recession match {
       case REDSHIFT => pc.doubleParameter("z")

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineAllSpec.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineAllSpec.scala
@@ -9,7 +9,7 @@ import edu.gemini.itc.gsaoi.GsaoiParameters
 import edu.gemini.itc.michelle.MichelleParameters
 import edu.gemini.itc.nifs.NifsParameters
 import edu.gemini.itc.niri.NiriParameters
-import edu.gemini.itc.service.GmosParameters
+import edu.gemini.itc.shared.GmosParameters
 import edu.gemini.itc.trecs.TRecsParameters
 import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
@@ -3,7 +3,7 @@ package edu.gemini.itc.baseline
 import edu.gemini.itc.baseline.util.Baseline._
 import edu.gemini.itc.baseline.util._
 import edu.gemini.itc.gmos.GmosRecipe
-import edu.gemini.itc.service.{GmosParameters, IfuRadial, IfuSingle}
+import edu.gemini.itc.shared.{GmosParameters, IfuRadial, IfuSingle}
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.DetectorManufacturer
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.{DisperserNorth, FPUnitNorth, FilterNorth}

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Baseline.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Baseline.scala
@@ -1,9 +1,7 @@
 package edu.gemini.itc.baseline.util
 
 import java.io.{ByteArrayOutputStream, File, PrintWriter}
-
-import edu.gemini.itc.service.InstrumentDetails
-import edu.gemini.itc.shared.{ITCImageFileIO, Recipe}
+import edu.gemini.itc.shared.{InstrumentDetails, ITCImageFileIO, Recipe}
 
 import scala.io.Source
 

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/BaselineTest.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/BaselineTest.scala
@@ -1,7 +1,7 @@
 package edu.gemini.itc.baseline.util
 
 import edu.gemini.itc.baseline._
-import edu.gemini.itc.service.InstrumentDetails
+import edu.gemini.itc.shared.InstrumentDetails
 import org.junit.Assert._
 import org.junit.{Ignore, Test}
 

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
@@ -2,9 +2,7 @@ package edu.gemini.itc.baseline.util
 
 import edu.gemini.itc.altair.AltairParameters
 import edu.gemini.itc.gems.GemsParameters
-import edu.gemini.itc.service.SourceDefinition.BrightnessUnit
-import edu.gemini.itc.service.TelescopeDetails.{Coating, Wfs}
-import edu.gemini.itc.service._
+import edu.gemini.itc.shared.TelescopeDetails.{Coating, Wfs}
 import edu.gemini.itc.shared._
 import edu.gemini.spModel.gemini.altair.AltairParams.{FieldLens, GuideStarType}
 import edu.gemini.spModel.telescope.IssPort

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
@@ -10,6 +10,7 @@ import edu.gemini.itc.michelle.MichelleParameters
 import edu.gemini.itc.nifs.NifsParameters
 import edu.gemini.itc.niri.NiriParameters
 import edu.gemini.itc.service._
+import edu.gemini.itc.shared._
 import edu.gemini.itc.trecs.TRecsParameters
 
 // TEMPORARY helper

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/OtItemEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/OtItemEditor.java
@@ -10,6 +10,7 @@ import edu.gemini.pot.sp.*;
 import edu.gemini.shared.gui.calendar.JCalendarPopup;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
@@ -273,6 +274,16 @@ public abstract class OtItemEditor<N extends ISPNode, T extends ISPDataObject> {
             for (ISPObsComponent c : o.getObsComponents())
                 if (c.getType() == SPComponentType.TELESCOPE_TARGETENV)
                     return c;
+        }
+        return null;
+    }
+
+    public SPSiteQuality getContextSiteQuality() {
+        final ISPObservation o = getContextObservation();
+        if (o != null) {
+            for (ISPObsComponent c : o.getObsComponents())
+                if (c.getType() == SPComponentType.SCHEDULING_CONDITIONS)
+                    return (SPSiteQuality) c.getDataObject();
         }
         return null;
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -9,7 +9,7 @@ import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
 import edu.gemini.spModel.config2.{ConfigSequence, ItemKey}
-import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.core.{Peer, Site}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType
 import jsky.app.ot.OT
 import jsky.app.ot.userprefs.observer.ObservingPeer
@@ -18,6 +18,8 @@ import jsky.app.ot.util.OtColor
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.swing.{Swing, Table}
+
+import scalaz.Scalaz._
 
 /**
  * A table to display ITC calculation results to users.
@@ -64,39 +66,39 @@ trait ItcTable extends Table {
     ConfigBridge.extractSequence(_, null, ConfigValMapInstances.IDENTITY_MAP, true)
   }
 
-  protected def callService(c: ItcUniqueConfig): Future[ItcService.Result] = {
+  protected def calculateSpectroscopy(c: ItcUniqueConfig, peer: Peer): Future[ItcService.Result] =
+    Future {
+      List("Not Implemented Yet").fail
+    }
 
-    ObservingPeer.get.map { peer =>
-      val port = owner.getContextIssPort
-      //val wfs  = ??? TODO
-      val src  = new SourceDefinition(PointSource(20.0, BrightnessUnit.MAG), LibraryStar("A0V"), WavebandDefinition.R, 0.0)
-      val obs  = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
-      val tele = new TelescopeDetails(TelescopeDetails.Coating.SILVER, port, Wfs.OIWFS)
+  protected def calculateImaging(c: ItcUniqueConfig, peer: Peer): Future[ItcService.Result] = {
+    val port = owner.getContextIssPort
+    //val wfs  = ??? TODO
+    val src  = new SourceDefinition(PointSource(20.0, BrightnessUnit.MAG), LibraryStar("A0V"), WavebandDefinition.R, 0.0)
+    val obs  = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
+    val tele = new TelescopeDetails(TelescopeDetails.Coating.SILVER, port, Wfs.OIWFS)
 
-      val qual = owner.getContextSiteQuality
-      val cond = new ObservingConditions(qual.getImageQuality, qual.getCloudCover, qual.getWaterVapor, qual.getSkyBackground, 1.5)
+    val qual = owner.getContextSiteQuality
+    val cond = new ObservingConditions(qual.getImageQuality, qual.getCloudCover, qual.getWaterVapor, qual.getSkyBackground, 1.5)
 
-      // get the instrument configuration
-      val filter    = c.config.getItemValue(new ItemKey("instrument:filter")).asInstanceOf[GmosCommonType.Filter]
-      val grating   = c.config.getItemValue(new ItemKey("instrument:disperser")).asInstanceOf[GmosCommonType.Disperser]
-      val wavelen   = 500.0 // ??? TODO
-      val fpmask    = c.config.getItemValue(new ItemKey("instrument:fpu")).asInstanceOf[GmosCommonType.FPUnit]
-      val spatBin   = c.config.getItemValue(new ItemKey("instrument:ccdXBinning")).asInstanceOf[GmosCommonType.Binning]
-      val specBin   = c.config.getItemValue(new ItemKey("instrument:ccdYBinning")).asInstanceOf[GmosCommonType.Binning]
-      val ccdType   = c.config.getItemValue(new ItemKey("instrument:detectorManufacturer")).asInstanceOf[GmosCommonType.DetectorManufacturer]
-      val ifuMethod = None
-      val site      = if (c.config.getItemValue(new ItemKey("instrument:instrument")).equals("GMOS-N")) Site.GN else Site.GS
-      val ins       = GmosParameters(filter, grating, wavelen, fpmask, spatBin.getValue, specBin.getValue, ifuMethod, ccdType, site)
+    // get the instrument configuration
+    val filter    = c.config.getItemValue(new ItemKey("instrument:filter")).asInstanceOf[GmosCommonType.Filter]
+    val grating   = c.config.getItemValue(new ItemKey("instrument:disperser")).asInstanceOf[GmosCommonType.Disperser]
+    val wavelen   = 500.0 // ??? TODO
+    val fpmask    = c.config.getItemValue(new ItemKey("instrument:fpu")).asInstanceOf[GmosCommonType.FPUnit]
+    val spatBin   = c.config.getItemValue(new ItemKey("instrument:ccdXBinning")).asInstanceOf[GmosCommonType.Binning]
+    val specBin   = c.config.getItemValue(new ItemKey("instrument:ccdYBinning")).asInstanceOf[GmosCommonType.Binning]
+    val ccdType   = c.config.getItemValue(new ItemKey("instrument:detectorManufacturer")).asInstanceOf[GmosCommonType.DetectorManufacturer]
+    val ifuMethod = None
+    val site      = if (c.config.getItemValue(new ItemKey("instrument:instrument")).equals("GMOS-N")) Site.GN else Site.GS
+    val ins       = GmosParameters(filter, grating, wavelen, fpmask, spatBin.getValue, specBin.getValue, ifuMethod, ccdType, site)
 
-      // Do the service call
-      ItcService.calculate(OT.getKeyChain, peer, src, obs, cond, tele, ins).
-      // whenever service call is finished notify table to update its contents
-      andThen {
-        case _ => Swing.onEDT(this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged())
-      }
-
-    }.get  // TODO: what to do if no peer is present?
-
+    // Do the service call
+    ItcService.calculate(OT.getKeyChain, peer, src, obs, cond, tele, ins).
+    // whenever service call is finished notify table to update its contents
+    andThen {
+      case _ => Swing.onEDT(this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged())
+    }
   }
 
 }
@@ -104,27 +106,32 @@ trait ItcTable extends Table {
 class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
   private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(Seq(), Seq(), Seq())
 
-  /**
-   * Creates a new table model for the current context (instrument) and config sequence.
-   * Note that GMOS has a different table model with separate columns for its three CCDs.
-   */
+  /** Creates a new table model for the current context (instrument) and config sequence.
+    * Note that GMOS has a different table model with separate columns for its three CCDs. */
   def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel = {
-    val uniqConfigs = ItcUniqueConfig.imagingConfigs(seq)
-    val results     = uniqConfigs.map(callService)
-    Option(owner.getContextInstrument).fold(emptyTable) {
-      _.getType match {
-        case SPComponentType.INSTRUMENT_GMOS      => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
-        case SPComponentType.INSTRUMENT_GMOSSOUTH => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
-        case _                                    => new ItcGenericImagingTableModel(keys, uniqConfigs, results)
+    ObservingPeer.getOrPrompt.fold(emptyTable) { peer =>
+      val uniqConfigs = ItcUniqueConfig.imagingConfigs(seq)
+      val results     = uniqConfigs.map(calculateImaging(_, peer))
+      Option(owner.getContextInstrument).map(_.getType) match {
+        case None                                       => emptyTable // just in case; context instrument should always be present (?)
+        case Some(SPComponentType.INSTRUMENT_GMOS)      => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case Some(SPComponentType.INSTRUMENT_GMOSSOUTH) => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case _                                          => new ItcGenericImagingTableModel(keys, uniqConfigs, results)
       }
     }
   }
 }
 
 class ItcSpectroscopyTable(val owner: EdIteratorFolder) extends ItcTable {
+  private val emptyTable: ItcGenericSpectroscopyTableModel = new ItcGenericSpectroscopyTableModel(Seq(), Seq(), Seq())
 
   /** Creates a new table model for the current context and config sequence. */
-  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, ItcUniqueConfig.spectroscopyConfigs(seq), Seq())
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) =
+    ObservingPeer.getOrPrompt.fold(emptyTable) { peer =>
+      val uniqueConfigs = ItcUniqueConfig.spectroscopyConfigs(seq)
+      val results       = uniqueConfigs.map(calculateSpectroscopy(_, peer))
+      new ItcGenericSpectroscopyTableModel(keys, uniqueConfigs, results)
+  }
 
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -1,14 +1,23 @@
 package jsky.app.ot.editor.seq
 
 import java.awt.Color
+import javax.swing.table.AbstractTableModel
 
+import edu.gemini.itc.shared.TelescopeDetails.Wfs
+import edu.gemini.itc.shared._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
 import edu.gemini.spModel.config2.{ConfigSequence, ItemKey}
+import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.gemini.gmos.GmosCommonType
+import jsky.app.ot.OT
+import jsky.app.ot.userprefs.observer.ObservingPeer
 import jsky.app.ot.util.OtColor
 
-import scala.swing.Table
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.swing.{Swing, Table}
 
 /**
  * A table to display ITC calculation results to users.
@@ -55,21 +64,59 @@ trait ItcTable extends Table {
     ConfigBridge.extractSequence(_, null, ConfigValMapInstances.IDENTITY_MAP, true)
   }
 
+  protected def callService(c: ItcUniqueConfig): Future[ItcService.Result] = {
+
+    ObservingPeer.get.map { peer =>
+      val port = owner.getContextIssPort
+      //val wfs  = ??? TODO
+      val src  = new SourceDefinition(PointSource(20.0, BrightnessUnit.MAG), LibraryStar("A0V"), WavebandDefinition.R, 0.0)
+      val obs  = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
+      val tele = new TelescopeDetails(TelescopeDetails.Coating.SILVER, port, Wfs.OIWFS)
+
+      val qual = owner.getContextSiteQuality
+      val cond = new ObservingConditions(qual.getImageQuality, qual.getCloudCover, qual.getWaterVapor, qual.getSkyBackground, 1.5)
+
+      // get the instrument configuration
+      val filter    = c.config.getItemValue(new ItemKey("instrument:filter")).asInstanceOf[GmosCommonType.Filter]
+      val grating   = c.config.getItemValue(new ItemKey("instrument:disperser")).asInstanceOf[GmosCommonType.Disperser]
+      val wavelen   = 500.0 // ??? TODO
+      val fpmask    = c.config.getItemValue(new ItemKey("instrument:fpu")).asInstanceOf[GmosCommonType.FPUnit]
+      val spatBin   = c.config.getItemValue(new ItemKey("instrument:ccdXBinning")).asInstanceOf[GmosCommonType.Binning]
+      val specBin   = c.config.getItemValue(new ItemKey("instrument:ccdYBinning")).asInstanceOf[GmosCommonType.Binning]
+      val ccdType   = c.config.getItemValue(new ItemKey("instrument:detectorManufacturer")).asInstanceOf[GmosCommonType.DetectorManufacturer]
+      val ifuMethod = None
+      val site      = if (c.config.getItemValue(new ItemKey("instrument:instrument")).equals("GMOS-N")) Site.GN else Site.GS
+      val ins       = GmosParameters(filter, grating, wavelen, fpmask, spatBin.getValue, specBin.getValue, ifuMethod, ccdType, site)
+
+      // Do the service call
+      ItcService.calculate(OT.getKeyChain, peer, src, obs, cond, tele, ins).
+      // whenever service call is finished notify table to update its contents
+      andThen {
+        case _ => Swing.onEDT(this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged())
+      }
+
+    }.get  // TODO: what to do if no peer is present?
+
+  }
+
 }
 
 class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
-  private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(Seq(), Seq())
+  private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(Seq(), Seq(), Seq())
 
   /**
    * Creates a new table model for the current context (instrument) and config sequence.
    * Note that GMOS has a different table model with separate columns for its three CCDs.
    */
-  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel =
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcImagingTableModel = {
+    val uniqConfigs = ItcUniqueConfig.imagingConfigs(seq)
+    val results     = uniqConfigs.map(callService)
     Option(owner.getContextInstrument).fold(emptyTable) {
-    _.getType match {
-      case SPComponentType.INSTRUMENT_GMOS        => new ItcGmosImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
-      case SPComponentType.INSTRUMENT_GMOSSOUTH   => new ItcGmosImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
-      case _                                      => new ItcGenericImagingTableModel(keys, ItcUniqueConfig.imagingConfigs(seq))
+      _.getType match {
+        case SPComponentType.INSTRUMENT_GMOS      => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case SPComponentType.INSTRUMENT_GMOSSOUTH => new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+        case _                                    => new ItcGenericImagingTableModel(keys, uniqConfigs, results)
+      }
     }
   }
 }
@@ -77,7 +124,7 @@ class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {
 class ItcSpectroscopyTable(val owner: EdIteratorFolder) extends ItcTable {
 
   /** Creates a new table model for the current context and config sequence. */
-  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, ItcUniqueConfig.spectroscopyConfigs(seq))
+  def tableModel(keys: Seq[ItemKey], seq: ConfigSequence) = new ItcGenericSpectroscopyTableModel(keys, ItcUniqueConfig.spectroscopyConfigs(seq), Seq())
 
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -101,7 +101,7 @@ trait ItcTable extends Table {
     val ins       = GmosParameters(filter, grating, wavelen, fpmask, spatBin.getValue, specBin.getValue, ifuMethod, ccdType, site)
 
     // Do the service call
-    ItcService.calculate(OT.getKeyChain, peer, src, obs, cond, tele, ins).
+    ItcService.calculate(peer, src, obs, cond, tele, ins).
     // whenever service call is finished notify table to update its contents
     andThen {
       case _ => Swing.onEDT(this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged())

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -7,7 +7,9 @@ import edu.gemini.shared.util.StringUtil
 import edu.gemini.spModel.config2.ItemKey
 
 import scala.concurrent.Future
-import scala.util.Failure
+import scala.util.{Success, Failure}
+
+import scalaz.Scalaz._
 
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
 case class Column(label: String, value: (ItcUniqueConfig, Future[ItcService.Result]) => Object)
@@ -36,25 +38,26 @@ sealed trait ItcTableModel extends AbstractTableModel {
   val uniqueSteps: Seq[ItcUniqueConfig]
   val res: Seq[Future[ItcService.Result]]
 
-  def getRowCount: Int = uniqueSteps.size
+  override def getRowCount: Int = uniqueSteps.size
 
-  def getColumnCount: Int = headers.size + keys.size + results.size
+  override def getColumnCount: Int = headers.size + keys.size + results.size
 
-  def getKeyAt(col: Int): Option[ItemKey] = col match {
-    case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
-    case _ => None
-  }
-
-  def getValueAt(row: Int, col: Int): Object = col match {
-    case c if c < headers.size => header(col).value(uniqueSteps(row), res(row))
+  override def getValueAt(row: Int, col: Int): Object = col match {
+    case c if c <  headers.size             => header(col).value(uniqueSteps(row), res(row))
     case c if c >= headers.size + keys.size => result(col).value(uniqueSteps(row), res(row))
-    case c => uniqueSteps(row).config.getItemValue(key(col))
+    case c                                  => uniqueSteps(row).config.getItemValue(key(col))
   }
 
   override def getColumnName(col: Int): String = col match {
-    case c if c < headers.size => header(col).label
+    case c if c <  headers.size             => header(col).label
     case c if c >= headers.size + keys.size => result(col).label
-    case c => StringUtil.toDisplayName(key(col).getName)
+    case c                                  => StringUtil.toDisplayName(key(col).getName)
+  }
+
+  // Gets the ItemKey of a column (if any), this is used by the table to color code the columns.
+  def getKeyAt(col: Int): Option[ItemKey] = col match {
+    case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
+    case _                                                      => None
   }
 
   // Translate overall column index into the corresponding header, column or key value.
@@ -64,67 +67,78 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   private def result(col: Int) = results(col - headers.size - keys.size)
 
-  // Gets the imaging result from the service result future (if present)
-  protected def imagingResult(f: Future[ItcService.Result]): Option[ItcImagingResult] =
+  // Gets the result from the service result future (if present)
+  protected def imagingCalcResult(f: Future[ItcService.Result]): Option[ItcResult] =
+    for {
+      futureResult  <- f.value                // unwrap future
+      serviceResult <- futureResult.toOption  // unwrap try
+      calcResult    <- serviceResult.toOption // unwrap validation
+    } yield calcResult
+
+  // TODO: display errors/validation messages in an appropriate way in the UI, for now also print them to console
+  protected def messages(f: Future[ItcService.Result]): String =
+    f.value.fold("Calculating...") {
+      case Failure(t) => t <| (_.printStackTrace()) |> (_.getMessage)  // "Look mummy, there's a spaceship up in the sky!"
+      case Success(s) => s match {
+        case scalaz.Failure(errs) => errs.mkString(", ") <| System.out.println
+        case scalaz.Success(_)    => "OK"
+      }
+    }
+}
+
+
+/** Generic ITC imaging tables model. */
+sealed trait ItcImagingTableModel extends ItcTableModel {
+
+  // Gets the imaging result from the service result future (if present).
+  // Note that in most cases (except for GMOS) there is only one CCD in the result, but for GMOS there can be
+  // 1 or 3 CCDs depending on the selected CCD manufacturer.
+  protected def imagingResult(f: Future[ItcService.Result], n: Int = 0): Option[ItcImagingResult] =
     imagingCalcResult(f).flatMap { r =>
-      r.ccd match {
+      // For GMOS ITC returns 1 or 3 different CCD results depending on the manufacturer, the simplest way to deal
+      // with this is by just using n % #CCDs here, which means that if there is only one result it is repeated three
+      // times, and if there are 3 results, they are shown individually as expected. All instruments other than GMOS
+      // use this method with ccd index = 0.
+      r.ccds(n % r.ccds.length) match {
         case img: ItcImagingResult => Some(img)
         case _                     => None
       }
     }
 
-  // Gets the result from the service result future (if present)
-  protected def imagingCalcResult(f: Future[ItcService.Result]): Option[ItcResult] =
-    for {
-      futureResult  <- f.value                // unwrap future
-      serviceResult <- futureResult.toOption  // unwrap try (as option)
-      calcResult    <- serviceResult.toOption // unwrap validation (as option)
-    } yield calcResult
+  protected def peakPixelFlux(f: Future[ItcService.Result], n: Int = 0) = prettyPrint(f, n, r => r.peakPixelFlux)
 
-  // TODO: display errors/validation messages in an appropriate way in the UI, for now just print them
-  protected def messages(f: Future[ItcService.Result]): String =
-    if (!f.isCompleted) "Calculating..."
-    else if (f.value.get.isFailure) {
-      val msg = "Error Service Call: " + (f.value.get match { case Failure(t) => t.printStackTrace(); t.getMessage})
-      System.out.println(msg)
-      msg
-    }
-    else if (f.value.get.get.isFailure) {
-      f.value.get.get match {case scalaz.Failure(s) => s.foreach(msg => System.out.println("Validation failed: " + msg))}
-      "Error Validation"
-    }
-    else "OK"
+  protected def singleSNRatio(f: Future[ItcService.Result], n: Int = 0) = prettyPrint(f, n, r => r.singleSNRatio)
+
+  protected def totalSNRatio (f: Future[ItcService.Result], n: Int = 0) = prettyPrint(f, n, r => r.totalSNRatio)
+
+  private def prettyPrint(f: Future[ItcService.Result], n: Int, v: ItcImagingResult => Double) =
+    imagingResult(f, n).fold("")(x => f"${v(x)}%.2f")
+
 }
-
-
-/** Generic ITC imaging tables model. */
-sealed trait ItcImagingTableModel extends ItcTableModel
 
 class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("PPF",             (c, r) => imagingResult(r).fold("")(_.peakPixelFlux.toString)),
-    Column("S/N Single",      (c, r) => imagingResult(r).fold("")(_.singleSNRatio.toString)),
-    Column("S/N Total",       (c, r) => imagingResult(r).fold("")(_.totalSNRatio.toString)),
+    Column("PPF",             (c, r) => peakPixelFlux(r)),
+    Column("S/N Single",      (c, r) => singleSNRatio(r)),
+    Column("S/N Total",       (c, r) => totalSNRatio (r)),
     Column("Messages",        (c, r) => messages(r))
   )
-
-
 }
 
 /** GMOS specific ITC imaging table model. */
 class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("CCD1 PPF",        (c, r) => imagingResult(r).fold("")(x => f"${x.peakPixelFlux}%.2f")),
-    Column("CCD1 S/N Single", (c, r) => imagingResult(r).fold("")(x => f"${x.singleSNRatio}%.2f")),
-    Column("CCD1 S/N Total",  (c, r) => imagingResult(r).fold("")(x => f"${x.totalSNRatio}%.2f")),
-    Column("CCD2 PPF",        (c, r) => ""),
-    Column("CCD2 S/N Single", (c, r) => ""),
-    Column("CCD2 S/N Total",  (c, r) => ""),
-    Column("CCD3 PPF",        (c, r) => ""),
-    Column("CCD3 S/N Single", (c, r) => ""),
-    Column("CCD3 S/N Total",  (c, r) => ""),
+    Column("CCD1 PPF",        (c, r) => peakPixelFlux(r, 0)),
+    Column("CCD1 S/N Single", (c, r) => singleSNRatio(r, 0)),
+    Column("CCD1 S/N Total",  (c, r) => totalSNRatio (r, 0)),
+    Column("CCD2 PPF",        (c, r) => peakPixelFlux(r, 1)),
+    Column("CCD2 S/N Single", (c, r) => singleSNRatio(r, 1)),
+    Column("CCD2 S/N Total",  (c, r) => totalSNRatio (r, 1)),
+    Column("CCD3 PPF",        (c, r) => peakPixelFlux(r, 2)),
+    Column("CCD3 S/N Single", (c, r) => singleSNRatio(r, 2)),
+    Column("CCD3 S/N Total",  (c, r) => totalSNRatio (r, 2)),
     Column("Messages",        (c, r) => messages(r))
   )
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -2,19 +2,23 @@ package jsky.app.ot.editor.seq
 
 import javax.swing.table.AbstractTableModel
 
+import edu.gemini.itc.shared.{ItcImagingResult, ItcResult, ItcService}
 import edu.gemini.shared.util.StringUtil
 import edu.gemini.spModel.config2.ItemKey
 
+import scala.concurrent.Future
+import scala.util.Failure
+
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
-case class Column(label: String, value: ItcUniqueConfig => Object)
+case class Column(label: String, value: (ItcUniqueConfig, Future[ItcService.Result]) => Object)
 
 object ItcTableModel {
   /** Defines a set of header columns for all tables. */
   val headers = Seq(
-    Column("Data Labels",     c => c.labels),
-    Column("Images",          c => new java.lang.Integer(c.count)),             // must be an object for JTable
-    Column("Exposure Time",   c => new java.lang.Double(c.singleExposureTime)), // must be an object for JTable
-    Column("Total Exp. Time", c => new java.lang.Double(c.totalExposureTime))   // must be an object for JTable
+    Column("Data Labels",     (c, r) => c.labels),
+    Column("Images",          (c, r) => new java.lang.Integer(c.count)),             // must be an object for JTable
+    Column("Exposure Time",   (c, r) => new java.lang.Double(c.singleExposureTime)), // must be an object for JTable
+    Column("Total Exp. Time", (c, r) => new java.lang.Double(c.totalExposureTime))   // must be an object for JTable
   )
 }
 
@@ -26,9 +30,11 @@ object ItcTableModel {
 sealed trait ItcTableModel extends AbstractTableModel {
 
   val headers: Seq[Column]
-  val keys:    Seq[ItemKey]
+  val keys: Seq[ItemKey]
   val results: Seq[Column]
+
   val uniqueSteps: Seq[ItcUniqueConfig]
+  val res: Seq[Future[ItcService.Result]]
 
   def getRowCount: Int = uniqueSteps.size
 
@@ -36,55 +42,90 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   def getKeyAt(col: Int): Option[ItemKey] = col match {
     case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
-    case _                                                      => None
+    case _ => None
   }
 
   def getValueAt(row: Int, col: Int): Object = col match {
-    case c if c <  headers.size               => header(col).value(uniqueSteps(row))
-    case c if c >= headers.size + keys.size   => result(col).value(uniqueSteps(row))
-    case c                                    => uniqueSteps(row).config.getItemValue(key(col))
+    case c if c < headers.size => header(col).value(uniqueSteps(row), res(row))
+    case c if c >= headers.size + keys.size => result(col).value(uniqueSteps(row), res(row))
+    case c => uniqueSteps(row).config.getItemValue(key(col))
   }
 
   override def getColumnName(col: Int): String = col match {
-    case c if c <  headers.size               => header(col).label
-    case c if c >= headers.size + keys.size   => result(col).label
-    case c                                    => StringUtil.toDisplayName(key(col).getName)
+    case c if c < headers.size => header(col).label
+    case c if c >= headers.size + keys.size => result(col).label
+    case c => StringUtil.toDisplayName(key(col).getName)
   }
 
   // Translate overall column index into the corresponding header, column or key value.
   private def header(col: Int) = headers(col)
-  private def key   (col: Int) = keys   (col - headers.size)
+
+  private def key(col: Int) = keys(col - headers.size)
+
   private def result(col: Int) = results(col - headers.size - keys.size)
 
- }
+  // Gets the imaging result from the service result future (if present)
+  protected def imagingResult(f: Future[ItcService.Result]): Option[ItcImagingResult] =
+    imagingCalcResult(f).flatMap { r =>
+      r.ccd match {
+        case img: ItcImagingResult => Some(img)
+        case _                     => None
+      }
+    }
+
+  // Gets the result from the service result future (if present)
+  protected def imagingCalcResult(f: Future[ItcService.Result]): Option[ItcResult] =
+    for {
+      futureResult  <- f.value                // unwrap future
+      serviceResult <- futureResult.toOption  // unwrap try (as option)
+      calcResult    <- serviceResult.toOption // unwrap validation (as option)
+    } yield calcResult
+
+  // TODO: display errors/validation messages in an appropriate way in the UI, for now just print them
+  protected def messages(f: Future[ItcService.Result]): String =
+    if (!f.isCompleted) "Calculating..."
+    else if (f.value.get.isFailure) {
+      val msg = "Error Service Call: " + (f.value.get match { case Failure(t) => t.printStackTrace(); t.getMessage})
+      System.out.println(msg)
+      msg
+    }
+    else if (f.value.get.get.isFailure) {
+      f.value.get.get match {case scalaz.Failure(s) => s.foreach(msg => System.out.println("Validation failed: " + msg))}
+      "Error Validation"
+    }
+    else "OK"
+}
+
 
 /** Generic ITC imaging tables model. */
 sealed trait ItcImagingTableModel extends ItcTableModel
 
-class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcImagingTableModel {
+class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("PPF",             c => ""),
-    Column("S/N Single",      c => ""),
-    Column("S/N Total",       c => ""),
-    Column("Messages",        c => "OK")
+    Column("PPF",             (c, r) => imagingResult(r).fold("")(_.peakPixelFlux.toString)),
+    Column("S/N Single",      (c, r) => imagingResult(r).fold("")(_.singleSNRatio.toString)),
+    Column("S/N Total",       (c, r) => imagingResult(r).fold("")(_.totalSNRatio.toString)),
+    Column("Messages",        (c, r) => messages(r))
   )
+
+
 }
 
 /** GMOS specific ITC imaging table model. */
-class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcImagingTableModel {
+class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("CCD1 PPF",        c => ""),
-    Column("CCD1 S/N Single", c => ""),
-    Column("CCD1 S/N Total",  c => ""),
-    Column("CCD2 PPF",        c => ""),
-    Column("CCD2 S/N Single", c => ""),
-    Column("CCD2 S/N Total",  c => ""),
-    Column("CCD3 PPF",        c => ""),
-    Column("CCD3 S/N Single", c => ""),
-    Column("CCD3 S/N Total",  c => ""),
-    Column("Messages",        c => "OK")
+    Column("CCD1 PPF",        (c, r) => imagingResult(r).fold("")(x => f"${x.peakPixelFlux}%.2f")),
+    Column("CCD1 S/N Single", (c, r) => imagingResult(r).fold("")(x => f"${x.singleSNRatio}%.2f")),
+    Column("CCD1 S/N Total",  (c, r) => imagingResult(r).fold("")(x => f"${x.totalSNRatio}%.2f")),
+    Column("CCD2 PPF",        (c, r) => ""),
+    Column("CCD2 S/N Single", (c, r) => ""),
+    Column("CCD2 S/N Total",  (c, r) => ""),
+    Column("CCD3 PPF",        (c, r) => ""),
+    Column("CCD3 S/N Single", (c, r) => ""),
+    Column("CCD3 S/N Total",  (c, r) => ""),
+    Column("Messages",        (c, r) => messages(r))
   )
 }
 
@@ -92,10 +133,10 @@ class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcU
 /** Generic ITC spectroscopy table model. */
 sealed trait ItcSpectroscopyTableModel extends ItcTableModel
 
-class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig]) extends ItcSpectroscopyTableModel {
+class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcSpectroscopyTableModel {
   val headers = ItcTableModel.headers
   val results = Seq(
-    Column("Messages",        c => "OK")
+    Column("Messages",        (c, r) => messages(r))
   )
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -45,13 +45,13 @@ sealed trait ItcTableModel extends AbstractTableModel {
   override def getValueAt(row: Int, col: Int): Object = col match {
     case c if c <  headers.size             => header(col).value(uniqueSteps(row), res(row))
     case c if c >= headers.size + keys.size => result(col).value(uniqueSteps(row), res(row))
-    case c                                  => uniqueSteps(row).config.getItemValue(key(col))
+    case _                                  => uniqueSteps(row).config.getItemValue(key(col))
   }
 
   override def getColumnName(col: Int): String = col match {
     case c if c <  headers.size             => header(col).label
     case c if c >= headers.size + keys.size => result(col).label
-    case c                                  => StringUtil.toDisplayName(key(col).getName)
+    case _                                  => StringUtil.toDisplayName(key(col).getName)
   }
 
   // Gets the ItemKey of a column (if any), this is used by the table to color code the columns.

--- a/project/OcsApp.scala
+++ b/project/OcsApp.scala
@@ -68,7 +68,8 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_wdba_xmlrpc_server,
     bundle_edu_gemini_obslog,
     bundle_edu_gemini_services_server,
-    bundle_edu_gemini_smartgcal_servlet
+    bundle_edu_gemini_smartgcal_servlet,
+    bundle_edu_gemini_itc
   )
 
   lazy val app_weather = project.in(file("app/weather")).dependsOn(

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -59,9 +59,11 @@ trait OcsBundle {
 
   lazy val bundle_edu_gemini_itc_shared = 
     project.in(file("bundle/edu.gemini.itc.shared")).dependsOn(
-      bundle_edu_gemini_util_osgi,
+      bundle_edu_gemini_pot,
       bundle_edu_gemini_shared_util,
-      bundle_edu_gemini_pot
+      bundle_edu_gemini_util_osgi,
+      bundle_edu_gemini_util_security,
+      bundle_edu_gemini_util_trpc
     )
 
   lazy val bundle_edu_gemini_itc = 
@@ -540,6 +542,7 @@ trait OcsBundle {
       bundle_edu_gemini_shared_skyobject,
       bundle_edu_gemini_ags,
       bundle_edu_gemini_horizons_api,
+      bundle_edu_gemini_itc_shared,
       bundle_edu_gemini_p2checker,
       bundle_edu_gemini_phase2_core,
       bundle_edu_gemini_pot,


### PR DESCRIPTION
This PR provides a basic but working end-to-end implementation of the ITC service for GMOS (imaging only) without any bells and whistles. Improvements like client-side caching of calculation results etc. are planned for upcoming PRs.

Unfortunately this PR is a bit biggish because I had to rename/refactor a few things to get the TRCP service to work which rippled through to a lot of the files.

Main relevant changes are the inclusion of the ITC bundles into the spdb application and additions to the ```ItcTable``` and ```ItcTableModel``` classes to perform service calls and handle the results. Future refinements will probably see some of the ITC services related tasks (like creation of input parameter objects) being extracted to some utility classes.

Here it would also be nice to know if there is a way we can already anticipate the usage of ITC in PIT? However since PIT uses its own model I am afraid that the translation of instrument configurations into ITC parameter objects would have to be entirely PIT specific(?).

I also have two questions:

* Do we want to set the Serial Version UIDs for service objects manually?
* Is it correct to use the peer obtained by ```ObservingPeer``` for the service calls?