### PR TITLE
OCSADV-200: bugfix for ancient test cases

### DIFF
--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/CBNestedSeqCompCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/CBNestedSeqCompCase.java
@@ -68,6 +68,7 @@ public class CBNestedSeqCompCase extends CBSeqCompTestBase {
 
         TestDataObject dataObj = (TestDataObject) testSeqComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testSeqComp.setDataObject(dataObj);
 
 
         // Create the one expected configuration.
@@ -106,6 +107,7 @@ public class CBNestedSeqCompCase extends CBSeqCompTestBase {
 
         TestDataObject dataObj = (TestDataObject) testSeqComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testSeqComp.setDataObject(dataObj);
 
 
         // Create the one expected configurations.
@@ -174,7 +176,7 @@ public class CBNestedSeqCompCase extends CBSeqCompTestBase {
 
         TestDataObject dataObj = (TestDataObject) testSeqComp.getDataObject();
         dataObj.setSysConfig(sc);
-
+        testSeqComp.setDataObject(dataObj);
 
 
         // Create the one expected configurations.

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/CBObsCompCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/CBObsCompCase.java
@@ -72,6 +72,7 @@ public class CBObsCompCase extends CBTestBase {
 
         TestDataObject dataObj = (TestDataObject) testObsComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testObsComp.setDataObject(dataObj);
 
         IConfig expected = new DefaultConfig();
         _putConfigParameterValue(expected, "set0", "param0", "value0");
@@ -91,6 +92,7 @@ public class CBObsCompCase extends CBTestBase {
 
         TestDataObject dataObj = (TestDataObject) testObsComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testObsComp.setDataObject(dataObj);
 
         IConfig expected = new DefaultConfig();
         _putConfigParameterValue(expected, "set0", "param0", "value0");
@@ -116,6 +118,7 @@ public class CBObsCompCase extends CBTestBase {
 
         TestDataObject dataObj = (TestDataObject) testObsComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testObsComp.setDataObject(dataObj);
 
         IConfig expected = new DefaultConfig();
         _putConfigParameterValue(expected, "set0", "param0", "value0");

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/CBSeqCompCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/config/test/CBSeqCompCase.java
@@ -66,6 +66,7 @@ public class CBSeqCompCase extends CBSeqCompTestBase {
 
         TestDataObject dataObj = (TestDataObject) testSeqComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testSeqComp.setDataObject(dataObj);
 
         // Create the one expected configuration.
         IConfig conf = new DefaultConfig();
@@ -92,6 +93,7 @@ public class CBSeqCompCase extends CBSeqCompTestBase {
 
         TestDataObject dataObj = (TestDataObject) testSeqComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testSeqComp.setDataObject(dataObj);
 
 
         // Create the one expected configurations.
@@ -130,7 +132,7 @@ public class CBSeqCompCase extends CBSeqCompTestBase {
 
         TestDataObject dataObj = (TestDataObject) testSeqComp.getDataObject();
         dataObj.setSysConfig(sc);
-
+        testSeqComp.setDataObject(dataObj);
 
         // Create the one expected configurations.
         IConfig conf0 = new DefaultConfig();
@@ -168,6 +170,7 @@ public class CBSeqCompCase extends CBSeqCompTestBase {
 
         TestDataObject dataObj = (TestDataObject) testSeqComp.getDataObject();
         dataObj.setSysConfig(sc);
+        testSeqComp.setDataObject(dataObj);
 
 
         // Create the one expected configurations.


### PR DESCRIPTION
The change to make all data objects cloneable broke some old test cases.  The behavior of these old test cases relied upon having a reference to a test data object returned when requested from the program node instead of being copied.  This update fixes those test cases by making them work like the real data objects.  They are copied when requested and have to be replaced after modifying them.