### PR TITLE
OCSADV-200: fix old vcs service registration

### DIFF
--- a/bundle/edu.gemini.sp.vcs/build.sbt
+++ b/bundle/edu.gemini.sp.vcs/build.sbt
@@ -25,6 +25,5 @@ OsgiKeys.bundleSymbolicName := name.value
 OsgiKeys.dynamicImportPackage := Seq("")
 
 OsgiKeys.exportPackage := Seq(
-  "edu.gemini.sp.vcs.*;-noimport:=true",
-  "edu.gemini.sp.vcs.diff",
-  "edu.gemini.sp.vcs.diff.osgi")
+  "edu.gemini.sp.vcs;-noimport:=true",
+  "edu.gemini.sp.vcs.diff")


### PR DESCRIPTION
This is a quick fix for a bug with the old VCS service, which wasn't being started in some cases because the `edu.gemini.sp.vcs.tui` bundle could not find a required service, whose service class, `edu.gemini.vcs.log.VcsLog`, shares the same package root of a package exported by `edu.gemini.vcs`.

Ultimately the `edu.gemini.vcs` bundle, which houses the old VCS code, will be retired and the who-provides-what questions will become clearer.