### PR TITLE
Added Java runtime version check to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,20 @@ version in ThisBuild := ocsVersion.value.toOsgiVersion
 scalaVersion in ThisBuild := "2.10.4"
 
 // Note that this is not a standard setting; it's used for building IDEA modules.
-javaVersion in ThisBuild := "1.7" 
+javaVersion in ThisBuild := {
+  val expected = "1.7" 
+  val actual   = sys.props("java.version")
+  if (!actual.startsWith(expected))
+    println(s"""
+      |***
+      |***                   INCORRECT JAVA RUNTIME VERSION 
+      |***
+      |***  The build expexts version $expected, but you are running $actual.
+      |***  Change the VM you're using to run sbt to avoid confusion and strange behavior.
+      |***
+    """.stripMargin)
+  expected
+}
 
 scalacOptions in ThisBuild ++= Seq(
   // "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ javaVersion in ThisBuild := {
       |***
       |***                   INCORRECT JAVA RUNTIME VERSION 
       |***
-      |***  The build expexts version $expected, but you are running $actual.
+      |***  The build expects version $expected, but you are running $actual.
       |***  Change the VM you're using to run sbt to avoid confusion and strange behavior.
       |***
     """.stripMargin)


### PR DESCRIPTION
This adds a check to the build that ensures the Java runtime agrees with the `javaVersion` setting. If there is a mismatch you see this:

```
ocs (java-version)$ sbt
[info] Loading project definition from /Users/rnorris/Scala/ocs/project

***
***                   INCORRECT JAVA RUNTIME VERSION 
***
***  The build expects version 1.8, but you are running 1.7.0_67.
***  Change the VM you're using to run sbt to avoid confusion and strange behavior.
***
    
[info] Set current project to ocs (in build file:/Users/rnorris/Scala/ocs/)
> 
```