### PR TITLE
OCSADV-200-O: template numbering correction

### DIFF
--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ProgramGen.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ProgramGen.scala
@@ -99,7 +99,7 @@ object ProgramGen {
       val tf  = ftf(f, p)
       val tgs = ftg.sequenceU.apply(f, p).zipWithIndex.map { case (tg, i) =>
         val dob = tg.getDataObject.asInstanceOf[TemplateGroup]
-        dob.setVersionToken(VersionToken.apply(Array(i), 1))
+        dob.setVersionToken(VersionToken.apply(Array(i+1), 1))
         tg.setDataObject(dob)
         tg
       }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ProgramGen.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ProgramGen.scala
@@ -5,7 +5,7 @@ import edu.gemini.pot.sp.validator.{Validator, NodeCardinality, NodeType}
 import edu.gemini.spModel.core.ProgramIdGen
 import edu.gemini.spModel.obs.{SPObservation, ObsPhase2Status}
 import edu.gemini.spModel.rich.pot.sp._
-import edu.gemini.spModel.template.{TemplateGroup, TemplateParameters}
+import edu.gemini.spModel.template.{SplitFunctor, TemplateGroup, TemplateParameters}
 import edu.gemini.spModel.util.VersionToken
 
 import org.scalacheck._
@@ -139,7 +139,12 @@ object ProgramGen {
   val pickNode: Gen[ISPProgram => ISPNode] = pickOne(_.nel)
 
   val maybePickObservation: Gen[ISPProgram => Option[ISPObservation]] =
-    maybePickOne(_.getProgram.getAllObservations.asScala)
+    maybePickOne(n => new ObservationIterator(n.getProgram).asScala.toList)
+
+  val maybePickTemplateGroup: Gen[ISPProgram => Option[ISPTemplateGroup]] =
+    maybePickOne(n => Option(n.getProgram.getTemplateFolder).toList.flatMap { tf =>
+      tf.getTemplateGroups.asScala.toList
+    })
 
   def collectOne[T](pf: PartialFunction[ISPNode, T]): Gen[ISPProgram => Option[T]] =
     maybePickOne(_.toStream.collect(pf))
@@ -159,6 +164,17 @@ object ProgramGen {
     } yield { (_: ISPFactory, p: ISPProgram) =>
       val n = fn(p)
       n.title = decorativeTitle(n, title)
+    }
+
+  val genEditSplitTemplateGroup: Gen[ProgEdit] =
+    for {
+      tgf <- maybePickTemplateGroup
+    } yield { (f: ISPFactory, p: ISPProgram) =>
+      tgf(p).foreach { tg =>
+        val sf    = new SplitFunctor(tg)
+        val newTg = sf.split(f)
+        tg.getParent.asInstanceOf[ISPTemplateFolder].addTemplateGroup(newTg)
+      }
     }
 
   val genEditObsPhase2Status: Gen[ProgEdit] =
@@ -260,7 +276,7 @@ object ProgramGen {
 
   val genEdit: Gen[ProgEdit] =
     oneOf(
-      frequency(7 -> genEditDataObject, 3 -> genEditObsPhase2Status),
+      frequency(6 -> genEditDataObject, 3 -> genEditObsPhase2Status, 1 -> genEditSplitTemplateGroup),
       genEditReorderChildren,
       genEditAddChild,
       genEditDeleteChild,

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ProgramGen.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ProgramGen.scala
@@ -5,7 +5,8 @@ import edu.gemini.pot.sp.validator.{Validator, NodeCardinality, NodeType}
 import edu.gemini.spModel.core.ProgramIdGen
 import edu.gemini.spModel.obs.{SPObservation, ObsPhase2Status}
 import edu.gemini.spModel.rich.pot.sp._
-import edu.gemini.spModel.template.TemplateParameters
+import edu.gemini.spModel.template.{TemplateGroup, TemplateParameters}
+import edu.gemini.spModel.util.VersionToken
 
 import org.scalacheck._
 import org.scalacheck.Gen._
@@ -85,15 +86,39 @@ object ProgramGen {
     }
   }
 
+  val genTemplateGroup: Gen[ProgFun[ISPTemplateGroup]] =
+    genNode(_.createTemplateGroup(_, null)).map { ftg => {
+      (f: ISPFactory, p: ISPProgram) => ftg.apply(f, p) }
+    }
+
+  val genTemplateFolder: Gen[ProgFun[ISPTemplateFolder]] = sized { size =>
+    for {
+      ftf <- genNode(_.createTemplateFolder(_, null))
+      ftg <- listOfN(size min 3, genTemplateGroup)
+    } yield { (f: ISPFactory, p: ISPProgram) =>
+      val tf  = ftf(f, p)
+      val tgs = ftg.sequenceU.apply(f, p).zipWithIndex.map { case (tg, i) =>
+        val dob = tg.getDataObject.asInstanceOf[TemplateGroup]
+        dob.setVersionToken(VersionToken.apply(Array(i), 1))
+        tg.setDataObject(dob)
+        tg
+      }
+      tf.children = tgs
+      tf
+    }
+  }
+
   val genProg: Gen[ISPFactory => ISPProgram] = sized { size =>
     for {
       id <- ProgramIdGen.genSomeId
       ns <- genNotes
+      tf <- listOfN(size % 2,   genTemplateFolder)
       os <- listOfN(size min 3, genObs)
       gs <- listOfN(size min 5, genGroup)
     } yield { (fact: ISPFactory) =>
       val p = fact.createProgram(null, id)
-      p.children = ns.sequenceU.apply(fact, p) ++ os.sequenceU.apply(fact, p) ++ gs.sequenceU.apply(fact, p)
+      p.children = ns.sequenceU.apply(fact, p) ++ tf.sequenceU.apply(fact, p) ++
+                   os.sequenceU.apply(fact, p) ++ gs.sequenceU.apply(fact, p)
       p
     }
   }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergeCorrection.scala
@@ -19,7 +19,8 @@ object MergeCorrection {
       for {
         prm <- ObsPermissionCorrection(mc)(mp, hasPermission)
         on  <- ObsNumberCorrection(mc)(prm).liftVcs
-        v   <- ValidityCorrection(mc)(on).liftVcs
+        tn  <- TemplateNumberingCorrection(mc)(on).liftVcs
+        v   <- ValidityCorrection(mc)(tn).liftVcs
         sof <- StaffOnlyFieldCorrection(mc)(v, hasPermission)
       } yield sof
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsEdit.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsEdit.scala
@@ -63,7 +63,7 @@ object ObsEdit {
    * the local program.
    */
   def all(local: ISPProgram, diff: ProgramDiff): TryVcs[List[ObsEdit]] = {
-    val localObsMap = local.getAllObservations.asScala.map { o => o.key -> o }.toMap
+    val localObsMap = new ObservationIterator(local).asScala.map { o => o.key -> o }.toMap
 
     def localObs(k: SPNodeKey): Obs = {
       val lo = localObsMap(k)

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ProgramDiff.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ProgramDiff.scala
@@ -1,7 +1,7 @@
 package edu.gemini.sp.vcs.diff
 
 import edu.gemini.pot.sp.version._
-import edu.gemini.pot.sp.{ISPNode, ISPObservation, ISPProgram, SPNodeKey}
+import edu.gemini.pot.sp._
 import edu.gemini.sp.vcs.diff.MergeNode._
 import edu.gemini.spModel.obs.ObservationStatus
 import edu.gemini.spModel.rich.pot.sp._
@@ -155,7 +155,7 @@ object ProgramDiff {
     val (update, pairs) = presentDiffs(p, Nil)
     val plan            = MergePlan(update, missingDiffs(vmOnlyKeys ++ deletedKeys))
 
-    val allObs          = p.getAllObservations.asScala
+    val allObs          = new ObservationIterator(p).asScala
     val maxObs          = if (allObs.isEmpty) none else some(allObs.maxBy(_.getObservationNumber).getObservationNumber)
 
     ProgramDiff(plan, pairs, maxObs)

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/TemplateNumberingCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/TemplateNumberingCorrection.scala
@@ -1,0 +1,88 @@
+package edu.gemini.sp.vcs.diff
+
+import edu.gemini.pot.sp.{ISPNode, SPNodeKey}
+import edu.gemini.pot.sp.version._
+import edu.gemini.sp.vcs.diff.MergeCorrection.CorrectionFunction
+import edu.gemini.spModel.template.{TemplateGroup, TemplateFolder}
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.util.{VersionToken, VersionTokenUtil}
+
+
+import scalaz._
+import Scalaz._
+
+/** A Merge correction function for duplicate template group numbers. Template
+  * groups that are split locally can have `VersionToken`s that clash with
+  * groups that were split remotely.  This correction function renumbers them
+  * as appropriate so that they are unique. */
+class TemplateNumberingCorrection(lifespanId: LifespanId, nodeMap: Map[SPNodeKey, ISPNode], isKnownRemote: SPNodeKey => Boolean) extends CorrectionFunction {
+
+  def apply(mp: MergePlan): TryVcs[MergePlan] = {
+    def correct(tokens: List[(VersionToken, SPNodeKey)]): TryVcs[MergePlan] = {
+      def updateToken(tgLoc: TreeLoc[MergeNode], vt: VersionToken): TryVcs[TreeLoc[MergeNode]] =
+        tgLoc.getLabel match {
+          case m@Modified(_, _, tg: TemplateGroup, _) => TryVcs(tgLoc.modifyLabel(_ => m.copy(dob = tg.copy <| (_.setVersionToken(vt)))))
+          case _                                      => TryVcs.fail(s"Expected a TemplateGroup for node ${tgLoc.key}")
+        }
+
+      (TryVcs(mp)/:tokens) { case (mp0, (vt, k)) =>
+          for {
+            mp  <- mp0
+            tg0 <- mp.update.loc.find(_.key === k).toTryVcs(s"Missing template group $k")
+            tg1 <- tg0.asModified(nodeMap)
+            tg2 <- updateToken(tg1, vt)
+            tg3 <- tg2.incr(lifespanId)
+          } yield mp.copy(update = tg3.toTree)
+      }
+    }
+
+    versionTokens(mp).flatMap { lst =>
+      val (oldTokens, newTokens) = lst.partition { case (_, k) => isKnownRemote(k) }
+      import VersionTokenUtil._
+      correct(merge(normalize(oldTokens), normalize(newTokens)))
+    }
+  }
+
+  /** Extracts all the `VersionToken`s from the `MergePlan`, assuming one or
+    * more template groups have been modified.  Otherwise, produces an empty
+    * list. */
+  def versionTokens(mp: MergePlan): TryVcs[List[(VersionToken, SPNodeKey)]] = {
+
+    // Find the template folder, if modified.  Otherwise, there's nothing to
+    // renumber.
+    val tf = mp.update.subForest.find(_.rootLabel match {
+      case Modified(_, _, tf: TemplateFolder, _) => true
+      case _                                     => false
+    })
+
+    // Get all the surviving template group keys and their version tokens,
+    // looking up the unmodified values in the provided node map.
+    tf.toList.flatMap { _.subForest.toList.map { _.rootLabel match {
+      case Modified(k, _, tg: TemplateGroup, _) =>
+        (tg.getVersionToken -> k).right
+
+      case Unmodified(k)                        =>
+        for {
+          n <- nodeMap.get(k).toTryVcs(s"Missing unmodified node $k")
+          p <- n.getDataObject match {
+                 case tg: TemplateGroup => (tg.getVersionToken -> k).right
+                 case _                 => TryVcs.fail(s"Expected a TemplateGroup for node $k")
+               }
+        } yield p
+
+      case mn                                    =>
+        TryVcs.fail(s"Expected a Template group for node ${mn.key}")
+
+    }}}.sequenceU
+  }
+
+}
+
+
+object TemplateNumberingCorrection {
+  def apply(mc: MergeContext): TemplateNumberingCorrection = {
+    val isKnown = (k: SPNodeKey) => nodeVersions(mc.remote.remoteVm, k) =/= EmptyNodeVersions
+
+    new TemplateNumberingCorrection(mc.local.prog.getLifespanId, mc.local.nodeMap, isKnown)
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMerge.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/TestMerge.scala
@@ -504,9 +504,9 @@ class TestMerge {
       }).toList
 
     val actual: List[(String, Int)] =
-      (pc.sp.getAllObservations.asScala map {
+      new ObservationIterator(pc.sp).asScala.map {
         obs => pc.getTitle(obs.getNodeKey) -> obs.getObservationNumber
-      }).toList
+      }.toList
 
     assertEquals(expected, actual)
   }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeCorrectionSpec.scala
@@ -2,6 +2,7 @@ package edu.gemini.sp.vcs.diff
 
 import edu.gemini.pot.sp.SPNodeKey
 import edu.gemini.pot.sp.version._
+import edu.gemini.sp.vcs.diff.ProgramLocation.{Remote, Local}
 import edu.gemini.spModel.conflict.ConflictFolder
 import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth
@@ -10,7 +11,8 @@ import edu.gemini.spModel.obs.SPObservation
 import edu.gemini.spModel.obslog.{ObsQaLog, ObsExecLog}
 import edu.gemini.spModel.seqcomp.SeqBase
 import edu.gemini.spModel.target.obsComp.TargetObsComp
-import edu.gemini.spModel.template.TemplateFolder
+import edu.gemini.spModel.template.{TemplateGroup, TemplateFolder}
+import edu.gemini.spModel.util.VersionToken
 import org.specs2.matcher.{MatchResult, Expectable, Matcher}
 
 import org.specs2.mutable.Specification
@@ -20,6 +22,10 @@ import Scalaz._
 
 class MergeCorrectionSpec extends Specification {
   import NodeDetail._
+
+  val LocalOnly: Set[ProgramLocation]  = Set(Local)
+  val RemoteOnly: Set[ProgramLocation] = Set(Remote)
+  val Both: Set[ProgramLocation]       = Set(Local, Remote)
 
   val lifespanId: LifespanId = LifespanId.random
 
@@ -37,6 +43,9 @@ class MergeCorrectionSpec extends Specification {
   def prog: MergeNode = nonObs(new SPProgram)
 
   def templateFolder: MergeNode = nonObs(new TemplateFolder)
+
+  def templateGroup(vt: VersionToken): MergeNode =
+    new TemplateGroup() <| (_.setVersionToken(vt)) |> (tg => nonObs(tg))
 
   def obs(num: Int): MergeNode = mergeNode(new SPObservation, Some(num))
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/MergeTest.scala
@@ -14,6 +14,7 @@ import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.template.TemplateGroup
 
 import org.junit.Test
 import org.scalatest.junit.JUnitSuite
@@ -606,6 +607,18 @@ class MergeTest extends JUnitSuite {
             }
           case _ => true
         }
+      }
+    ),
+
+    ("All template groups have unique version tokens",
+      (start, local, remote, pc) => {
+        pc.updatedLocalProgram.exists { ulp =>
+          val tgs = Option(ulp.getTemplateFolder).toList.flatMap { tf =>
+            tf.getTemplateGroups.asScala.toList
+          }
+          val vts = tgs.map(_.getDataObject.asInstanceOf[TemplateGroup].getVersionToken)
+          vts.size == vts.toSet.size
+        }.run
       }
     )
   )

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
@@ -12,9 +12,6 @@ import scalaz._
 import Scalaz._
 
 class ObsNumberCorrectionSpec extends MergeCorrectionSpec {
-  val LocalOnly: Set[ProgramLocation]  = Set(Local)
-  val RemoteOnly: Set[ProgramLocation] = Set(Remote)
-  val Both: Set[ProgramLocation]       = Set(Local, Remote)
 
   def test(expected: List[Int], merged: (Int, Set[ProgramLocation])*): Boolean = {
     val obsList = merged.map { case (i,_) => obs(i).leaf }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffTest.scala
@@ -1,6 +1,6 @@
 package edu.gemini.sp.vcs.diff
 
-import edu.gemini.pot.sp.{ISPFactory, SPNodeKey, ISPProgram}
+import edu.gemini.pot.sp.{ObservationIterator, ISPFactory, SPNodeKey, ISPProgram}
 import edu.gemini.pot.sp.version._
 import edu.gemini.sp.vcs.diff.NodeDetail.Obs
 import edu.gemini.spModel.obs.ObservationStatus
@@ -42,7 +42,7 @@ class ProgramDiffTest extends JUnitSuite {
     ("if a node in an observation appears in the diff list, the entire observation appears",
       (start, local, remote, pd) => {
         val modKeys    = modifiedKeys(pd.plan)
-        val allObsKeys = remote.getAllObservations.asScala.map(o => o.fold(Set.empty[SPNodeKey])(_ + _.key))
+        val allObsKeys = new ObservationIterator(remote).asScala.map(o => o.fold(Set.empty[SPNodeKey])(_ + _.key))
 
         allObsKeys.forall { obsKeys =>
           val sd = obsKeys &~ modKeys
@@ -121,7 +121,7 @@ class ProgramDiffTest extends JUnitSuite {
 
     ("obs status list should correspond to remote program",
       (start, local, remote, pd) => {
-        val remoteMap = (Map.empty[SPNodeKey, ObservationStatus]/:remote.getAllObservations.asScala) { (m,o) =>
+        val remoteMap = (Map.empty[SPNodeKey, ObservationStatus]/:new ObservationIterator(remote).asScala) { (m,o) =>
           m + (o.key -> ObservationStatus.computeFor(o))
         }
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/TemplateNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/TemplateNumberCorrectionSpec.scala
@@ -74,6 +74,14 @@ class TemplateNumberCorrectionSpec extends MergeCorrectionSpec {
       )
     }
 
+    "renumber sub-groups with the same number as remote groups" in {
+      test(List(vt1(1,2), vt1(1,1), vt(1)(3)),
+        (vt1(1, 1), LocalOnly),
+        (vt1(1, 1), RemoteOnly),
+        (vt(1)(2),  Both)
+      )
+    }
+
     // Here 1, 1.1, and 1.2 clash with the remote group 1 so we renumber them
     // to 2, 2.1, and 2.2.
     "renumber all derived local groups with the same base number as a remote group" in {

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/TemplateNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/TemplateNumberCorrectionSpec.scala
@@ -1,0 +1,91 @@
+package edu.gemini.sp.vcs.diff
+
+
+import edu.gemini.sp.vcs.diff.ProgramLocation.Remote
+import edu.gemini.spModel.template.{TemplateGroup, TemplateFolder}
+import edu.gemini.spModel.util.VersionToken
+
+import scalaz._
+import Scalaz._
+
+class TemplateNumberCorrectionSpec extends MergeCorrectionSpec {
+  def vt1(segs: Int*): VersionToken = vt(segs: _*)(1)
+
+  def vt(segs: Int*)(next: Int): VersionToken =
+    VersionToken.apply(segs.toArray, next)
+
+  def test(expected: List[VersionToken], merged: (VersionToken, Set[ProgramLocation])*): Boolean = {
+    val tgList = merged.map { case (tok,_) => templateGroup(tok).leaf }
+
+    val mergeTree = prog.node(Tree.node(templateFolder, tgList.toStream))
+
+    val known = merged.unzip._2.zip(tgList.map(_.key)).collect {
+      case (locs, key) if locs.contains(Remote) => key
+    }.toSet
+
+    def tgNumbers(t: Tree[MergeNode]): List[VersionToken] = {
+      val tf = t.subForest.find(_.rootLabel match {
+        case Modified(_, _, _: TemplateFolder, _) => true
+        case _                                    => false
+      })
+
+      tf.toList.flatMap { _.subForest.toList.map { _.rootLabel } }.collect {
+        case Modified(_, _, tg: TemplateGroup, _) => tg.getVersionToken
+      }
+    }
+
+    val plan = MergePlan(mergeTree, Set.empty)
+    val tnc  = new TemplateNumberingCorrection(lifespanId, Map.empty, known.contains)
+    tnc(plan).map(mp => tgNumbers(mp.update)) shouldEqual \/-(expected)
+  }
+
+  "TemplateNumberingCorrection" should {
+    "handle the no template group case without exception" in {
+      test(Nil)
+    }
+
+    "not change remote only template group numbers" in {
+      test(List(vt1(1), vt1(2), vt1(3)),
+        (vt1(1), RemoteOnly),
+        (vt1(2), RemoteOnly),
+        (vt1(3), RemoteOnly)
+      )
+    }
+
+    "not renumber new local-only groups if there are no remote groups" in {
+      test(List(vt1(1), vt1(2)),
+        (vt1(1), LocalOnly),
+        (vt1(2), LocalOnly)
+      )
+    }
+
+    "not renumber new local-only groups if they come after the last remote group" in {
+      test(List(vt1(2), vt1(1), vt1(3)),
+        (vt1(2), LocalOnly),
+        (vt1(1), Both),
+        (vt1(3), LocalOnly)
+      )
+    }
+
+    "renumber a local group with the same number as a remote group" in {
+      test(List(vt1(2), vt1(1)),
+        (vt1(1), LocalOnly),
+        (vt1(1), RemoteOnly)
+      )
+    }
+
+    // Here 1, 1.1, and 1.2 clash with the remote group 1 so we renumber them
+    // to 2, 2.1, and 2.2.
+    "renumber all derived local groups with the same base number as a remote group" in {
+      test(List(vt(2)(3), vt1(2, 1), vt1(2, 2), vt1(1)),
+        (vt(1)(3),  LocalOnly),
+        (vt1(1, 1), LocalOnly),
+        (vt1(1, 2), LocalOnly),
+        (vt1(1),    RemoteOnly)
+      )
+    }
+
+    // VersionTokenUtilTest already tests the underlying renumbering algorithm.
+    // See that test case for more involved examples.
+  }
+}


### PR DESCRIPTION
This merge installment introduces the last expected `MergePlan` correction.  It makes use of the existing `VersionTokenUtil` class to renumber template groups that are split both locally and remotely.  For example, if template group "1" is split remotely and committed to the database, we end up with groups "1" and "1.1".  If the same happens locally we have the same template groups, "1" and "1.1" but the two new "1.1" template groups are different objects with different keys. In this case the local "1.1" is renumbered to "1.2".

This correction builds on `VersionTokenUtil` to manipulate the `MergePlan` in order to guarantee that all template groups are uniquely numbered.  See `TemplateNumberingCorrection`.   It also fixes a bug in which template observations were not being considered in the observation numbering correction.
