### PR TITLE
OCSADV-297: All guide star quality icons change when switching stars

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -122,7 +122,7 @@ object AgsAnalysis {
       } yield gStar
 
     selection(ctx, guideProbe).fold(Some(NoGuideStarForProbe(guideProbe, bands)): Option[AgsAnalysis]) { guideStar =>
-      AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, bands)
+      AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar.toNewModel, bands)
     }
   }
 
@@ -130,9 +130,11 @@ object AgsAnalysis {
    * Analysis of the given guide star in the given context, regardless of which
    * guide star is actually selected in the target environment.
    */
-  protected [ags] def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget, bands: List[MagnitudeBand]): Option[AgsAnalysis] =
-    if (!guideProbe.validate(guideStar, ctx)) Some(NotReachable(guideProbe, guideStar.toNewModel, bands))
-    else magnitudeAnalysis(ctx, mt, guideProbe, guideStar.toNewModel, bands)
+  protected [ags] def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget, bands: List[MagnitudeBand]): Option[AgsAnalysis] = {
+    val spTarget = new SPTarget(guideStar.coordinates.ra.toAngle.toDegrees, guideStar.coordinates.dec.toDegrees)
+    if (!guideProbe.validate(spTarget, ctx)) Some(NotReachable(guideProbe, guideStar, bands))
+    else magnitudeAnalysis(ctx, mt, guideProbe, guideStar, bands)
+  }
 
   private def magnitudeAnalysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget, bands: List[MagnitudeBand]): Option[AgsAnalysis] = {
     import GuideSpeed._

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsRegistrar.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsRegistrar.scala
@@ -12,6 +12,9 @@ import scala.collection.JavaConverters._
  * Methods for finding strategies.
  */
 object AgsRegistrar {
+  // For Java usage
+  val instance = this
+
   def lookup(key: AgsStrategyKey): Option[AgsStrategy] = Strategy.fromKey(key)
 
   /**

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -9,6 +9,7 @@ import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
+import edu.gemini.shared.util.immutable.{Option => JOption, Some => JSome}
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.{OptionsList, GuideProbeTargets, TargetEnvironment}
 import edu.gemini.spModel.target.system.HmsDegTarget
@@ -23,10 +24,11 @@ trait AgsStrategy {
 
   def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis]
 
-  def analyzeForJava(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): java.util.List[AgsAnalysis] = {
-    import scala.collection.JavaConverters._
-    if (!guideProbe.validate(guideStar, ctx)) List[AgsAnalysis](NotReachable(guideProbe, guideStar.toNewModel, probeBands)).asJava
-    else analyze(ctx, mt).asJava
+  protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis]
+
+  def analyzeForJava(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): JOption[AgsAnalysis] = {
+    if (!guideProbe.validate(guideStar, ctx)) new JSome(NotReachable(guideProbe, guideStar.toNewModel, probeBands))
+    else analyze(ctx, mt, guideProbe, guideStar).asGeminiOpt
   }
 
   def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]]

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -24,10 +24,11 @@ trait AgsStrategy {
 
   def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis]
 
-  protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis]
+  protected [ags] def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis]
 
-  def analyzeForJava(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): JOption[AgsAnalysis] = {
-    if (!guideProbe.validate(guideStar, ctx)) new JSome(NotReachable(guideProbe, guideStar.toNewModel, probeBands))
+  def analyzeForJava(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): JOption[AgsAnalysis] = {
+    val spTarget = new SPTarget(guideStar.coordinates.ra.toAngle.toDegrees, guideStar.coordinates.dec.toDegrees)
+    if (!guideProbe.validate(spTarget, ctx)) new JSome(NotReachable(guideProbe, guideStar, probeBands))
     else analyze(ctx, mt, guideProbe, guideStar).asGeminiOpt
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -18,7 +18,6 @@ import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw
 import edu.gemini.spModel.gems.{GemsTipTiltMode, GemsGuideProbeGroup, GemsGuideStarType}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
-import edu.gemini.spModel.target.SPTarget
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
@@ -107,7 +106,7 @@ trait GemsStrategy extends AgsStrategy {
   }
 
   // TODO Implement for GEMS
-  override protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] = None
+  override protected [ags] def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] = None
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] = {
     import AgsAnalysis._

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -18,12 +18,13 @@ import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw
 import edu.gemini.spModel.gems.{GemsTipTiltMode, GemsGuideProbeGroup, GemsGuideStarType}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
+import edu.gemini.spModel.target.SPTarget
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
 import scala.concurrent._
 import edu.gemini.ags.api.AgsMagnitude.{MagnitudeCalc, MagnitudeTable}
-import edu.gemini.spModel.guide.{GuideProbeGroup, GuideProbe}
+import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbeGroup, GuideProbe}
 import edu.gemini.spModel.core.{Angle, MagnitudeBand}
 
 import scalaz._
@@ -104,6 +105,9 @@ trait GemsStrategy extends AgsStrategy {
     val odgw = GsaoiOdgw.values().map { odgw => mt(ctx, odgw).map(odgw -> _) }.toList.flatten
     cans ++ odgw
   }
+
+  // TODO Implement for GEMS
+  override protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] = None
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] = {
     import AgsAnalysis._

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -8,6 +8,7 @@ import edu.gemini.spModel.core.MagnitudeBand
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.target.SPTarget
 
 import scala.concurrent.Future
 
@@ -16,6 +17,9 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
   // Since the science target is the used as the guide star, success is always guaranteed.
   override def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
     Future.successful(AgsStrategy.Estimate.GuaranteedSuccess)
+
+  override protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] =
+    AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, probeBands).toList

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -8,7 +8,6 @@ import edu.gemini.spModel.core.MagnitudeBand
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
-import edu.gemini.spModel.target.SPTarget
 
 import scala.concurrent.Future
 
@@ -18,7 +17,7 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
   override def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
     Future.successful(AgsStrategy.Estimate.GuaranteedSuccess)
 
-  override protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] =
+  override protected [ags] def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -12,7 +12,6 @@ import edu.gemini.spModel.core.{Magnitude, MagnitudeBand, Coordinates, Angle}
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, VignettingGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
-import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.CoordinateParam.Units
 import edu.gemini.spModel.target.system.HmsDegTarget
 import edu.gemini.spModel.telescope.PosAngleConstraint._
@@ -40,7 +39,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, params.guideProbe, probeBands).toList
 
-  override protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] =
+  override protected [ags] def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
 
   private def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): Option[CatalogQuery] =
@@ -198,8 +197,7 @@ object SingleProbeStrategy {
 
     val candidates = for {
       st <- lst
-      spTarget = new SPTarget(HmsDegTarget.fromSkyObject(st.toOldModel))
-      analysis <- AgsAnalysis.analysis(ctx, mt, probe, spTarget, params.probeBands)
+      analysis <- AgsAnalysis.analysis(ctx, mt, probe, st, params.probeBands)
     } yield {
       val vig = probe.calculateVignetting(ctx, st.coordinates)
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -1,6 +1,5 @@
 package edu.gemini.ags.impl
 
-import edu.gemini.ags.api.AgsAnalysis.Usable
 import edu.gemini.ags.api._
 import edu.gemini.ags.api.AgsMagnitude._
 import edu.gemini.catalog.api.CatalogQuery
@@ -82,7 +81,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
     catalogResult(ctx, mt).map(select(ctx, mt, _))
 
   def select(ctx: ObsContext, mt: MagnitudeTable, candidates: List[SiderealTarget]): Option[AgsStrategy.Selection] = {
-    if (candidates.size == 0) None
+    if (candidates.isEmpty) None
     else {
       params.guideProbe match {
         // If vignetting, filter according to the pos angle constraint, and then for each obs context, pick the best quality with
@@ -196,7 +195,7 @@ object SingleProbeStrategy {
     val df = new DecimalFormat("0.####")
 
     val candidates = for {
-      st <- lst
+      st       <- lst
       analysis <- AgsAnalysis.analysis(ctx, mt, probe, st, params.probeBands)
     } yield {
       val vig = probe.calculateVignetting(ctx, st.coordinates)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -37,8 +37,11 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
   override def magnitudes(ctx: ObsContext, mt: MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =
     params.magnitudeCalc(ctx, mt).toList.map(params.guideProbe -> _)
 
-  def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
+  override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, params.guideProbe, probeBands).toList
+
+  override protected def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SPTarget): Option[AgsAnalysis] =
+    AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
 
   private def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): Option[CatalogQuery] =
     params.catalogQueries(ctx, mt)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -52,14 +52,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(AltairAowfsGuider.instance)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(AltairAowfsGuider.instance)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("553-036128")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, AltairAowfsGuider.instance, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for NIRI+LGS, OCSADV-245" in {
       // Pal 12 target
@@ -77,14 +81,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(AltairAowfsGuider.instance)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(AltairAowfsGuider.instance)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("344-198748")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, AltairAowfsGuider.instance, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for NIRI+PWFS1, OCSADV-255" in {
       // HIP 1000 target
@@ -104,14 +112,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs1)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs1)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("340-000202")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs1, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for NIRI+PWFS2, OCSADV-255" in {
       // HIP 1024 target
@@ -131,14 +143,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs2)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs2)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("458-000297")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs2, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for GMOS-N+OIWFS, OCSADV-255" in {
       // NGC 101 target
@@ -158,14 +174,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(GmosOiwfsGuideProbe.instance)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(GmosOiwfsGuideProbe.instance)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("288-000439")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, GmosOiwfsGuideProbe.instance, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for GMOS-N+PWFS2, OCSADV-255" in {
       // M1 target
@@ -185,14 +205,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs2)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs2)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("560-017530")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs2, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for Flamingos2+OIWFS, OCSADV-255" in {
       // RMC 136 target
@@ -212,14 +236,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(Flamingos2OiwfsGuideProbe.instance)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(Flamingos2OiwfsGuideProbe.instance)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("105-014127")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, Flamingos2OiwfsGuideProbe.instance, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for Flamingos2+PWFS2, OCSADV-255" in {
       // RMC 136 target
@@ -239,14 +267,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs2)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs2)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("105-014476")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs2, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for Flamingos2+PWFS2, OCSADV-255" in {
       // RMC 136 target
@@ -266,14 +298,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs2)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs2)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("105-014476")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs2, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for GMOS-S+OIWFS, OCSADV-255" in {
       // LMC 1 target
@@ -293,14 +329,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(GmosOiwfsGuideProbe.instance)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(GmosOiwfsGuideProbe.instance)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("138-005574")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, GmosOiwfsGuideProbe.instance, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for GMOS-S+PWFS2, OCSADV-255" in {
       // Blanco 1 target
@@ -320,14 +360,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs2)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs2)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("302-000084")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs2, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for GNIRS, OCSADV-255" in {
       // Pleiades target
@@ -347,14 +391,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs2)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs2)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("571-008701")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs2, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
     "find a guide star for GNIRS Part II, OCSADV-255" in {
       // Orion target
@@ -374,14 +422,18 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       // One guide star found
       selection.map(_.assignments.size) should beSome(1)
-      selection.map(_.assignments.headOption.map(_.guideProbe)).flatten should beSome(PwfsGuideProbe.pwfs2)
-      val guideStar = selection.map(_.assignments.headOption.map(_.guideStar)).flatten
+      selection.flatMap(_.assignments.headOption.map(_.guideProbe)) should beSome(PwfsGuideProbe.pwfs2)
+      val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
       guideStar.map(_.name) should beSome("424-010170")
       // Add GS to targets
       val newCtx = selection.map(applySelection(ctx, _))
       val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
       analyzedSelection should be size 1
       analyzedSelection.headOption.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
+
+      // Analyze Single Guide Star
+      val analyzedGS = (newCtx |@| guideStar){ strategy.analyze(_, magTable, PwfsGuideProbe.pwfs2, _) }.flatten
+      analyzedGS.map(_.quality) should beSome(AgsGuideQuality.DeliversRequestedIq)
     }
 
   }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/WatchablePos.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/WatchablePos.java
@@ -9,7 +9,7 @@ public class WatchablePos implements Cloneable, Serializable {
 
     public final synchronized void addWatcher(final TelescopePosWatcher tpw) {
         if (_watchers == null) {
-            _watchers = new Vector<TelescopePosWatcher>();
+            _watchers = new Vector<>();
         } else if (_watchers.contains(tpw)) {
             return;
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -229,7 +229,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
         Set<GuideProbe> cur = genv.getActiveGuiders();
         if (cur.contains(guider)) return this;
 
-        Set<GuideProbe> active = new HashSet<GuideProbe>(cur);
+        Set<GuideProbe> active = new HashSet<>(cur);
         active.add(guider);
         return setGuideEnvironment(genv.setActiveGuiders(active));
     }
@@ -273,7 +273,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
         // Doesn't exist yet/anymore so initialize it.
         if (res == null) {
             res = initAllTargets();
-            allTargets = new SoftReference<ImList<SPTarget>>(res);
+            allTargets = new SoftReference<>(res);
         }
         return res;
     }
@@ -323,7 +323,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      */
     @Override
     public TargetEnvironment cloneTargets() {
-        SPTarget clonedBase = (SPTarget) base.clone();
+        SPTarget clonedBase = base.clone();
         GuideEnvironment clonedGuide = guide.cloneTargets();
         ImList<SPTarget> clonedUser  = user.map(new Function1<SPTarget, SPTarget>() {
             public SPTarget apply(final SPTarget target) {
@@ -414,8 +414,8 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
         }
 
         // Parse the old pre-2010B information into a GuideEnvironment
-        Set<GuideProbe> active = new HashSet<GuideProbe>();
-        List<GuideProbeTargets> lst = new ArrayList<GuideProbeTargets>();
+        Set<GuideProbe> active = new HashSet<>();
+        List<GuideProbeTargets> lst = new ArrayList<>();
         for (ParamSet ps : guideProbeTargets) {
             GuideProbeTargets gpt = GuideProbeTargets.fromParamSet(ps);
             if (gpt == null) continue;
@@ -441,7 +441,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
         GuideEnvironment guide = parseGuideEnvironment(parent);
 
         // Get the user targets.
-        List<SPTarget> userTargets = new ArrayList<SPTarget>();
+        List<SPTarget> userTargets = new ArrayList<>();
         ParamSet userPset = parent.getParamSet("userTargets");
         if (userPset != null) {
             for (ParamSet ps : userPset.getParamSets()) {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -22,6 +22,8 @@ object ModelConverters {
 
   def toCoordinates(coords: skycalc.Coordinates): Coordinates = coords.toNewModel
 
+  def toSideralTarget(spTarget: SPTarget):SiderealTarget = spTarget.toNewModel
+
   implicit class OldAngle2New(val angle: skycalc.Angle) extends AnyVal{
     def toNewModel: Angle = Angle.fromDegrees(angle.toDegrees.getMagnitude)
   }
@@ -166,7 +168,7 @@ object ModelConverters {
       val dec         = Angle.fromDegrees(coords.getDecDeg)
       val coordinates = Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))
 
-            // Only HmsDegTargets have a proper motion and the values are in milli arcsecs/year
+      // Only HmsDegTargets have a proper motion and the values are in milli arcsecs/year
       val pm          = sp.getTarget match {
         case t:HmsDegTarget => Some(ProperMotion(RightAscensionAngularVelocity(AngularVelocity(t.getPropMotionRA)), DeclinationAngularVelocity(AngularVelocity(t.getPropMotionDec))))
         case _              => None

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -241,16 +241,12 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 @Override public Option<AgsGuideQuality> apply(final Tuple2<ObsContext, AgsMagnitude.MagnitudeTable> tup) {
                     if (guideProbe instanceof ValidatableGuideProbe) {
                         final ValidatableGuideProbe vgp = (ValidatableGuideProbe) guideProbe;
-
                         return AgsRegistrar$.MODULE$.currentStrategyForJava(tup._1()).map(new Function1<AgsStrategy, Option<AgsGuideQuality>>() {
                             @Override
                             public Option<AgsGuideQuality> apply(AgsStrategy strategy) {
-                                final List<AgsAnalysis> agsAnalysises = strategy.analyzeForJava(tup._1(), tup._2(), vgp, guideStar);
-                                if (!agsAnalysises.isEmpty()) {
-                                    return new Some<>(agsAnalysises.get(0).quality());
-                                } else {
-                                    return None.instance();
-                                }
+
+                                final Option<AgsAnalysis> agsAnalysis = strategy.analyzeForJava(tup._1(), tup._2(), vgp, guideStar);
+                                return agsAnalysis.map(g -> g.quality());
                             }
                         }).getOrElse(None.<AgsGuideQuality>instance());
                     } else {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -7,6 +7,7 @@
 package jsky.app.ot.gemini.editor.targetComponent;
 
 import edu.gemini.ags.api.*;
+import edu.gemini.pot.ModelConverters;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
@@ -240,7 +241,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 if (guideProbe instanceof ValidatableGuideProbe) {
                     final ValidatableGuideProbe vgp = (ValidatableGuideProbe) guideProbe;
                     return AgsRegistrar$.MODULE$.currentStrategyForJava(tup._1()).map(strategy -> {
-                        final Option<AgsAnalysis> agsAnalysis = strategy.analyzeForJava(tup._1(), tup._2(), vgp, guideStar);
+                        final Option<AgsAnalysis> agsAnalysis = strategy.analyzeForJava(tup._1(), tup._2(), vgp, ModelConverters.toSideralTarget(guideStar));
                         return agsAnalysis.map(AgsAnalysis::quality);
                     }).getOrElse(None.<AgsGuideQuality>instance());
                 } else {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -240,7 +240,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             return ags.flatMap(tup -> {
                 if (guideProbe instanceof ValidatableGuideProbe) {
                     final ValidatableGuideProbe vgp = (ValidatableGuideProbe) guideProbe;
-                    return AgsRegistrar$.MODULE$.currentStrategyForJava(tup._1()).map(strategy -> {
+                    return AgsRegistrar.instance().currentStrategyForJava(tup._1()).map(strategy -> {
                         final Option<AgsAnalysis> agsAnalysis = strategy.analyzeForJava(tup._1(), tup._2(), vgp, ModelConverters.toSideralTarget(guideStar));
                         return agsAnalysis.map(AgsAnalysis::quality);
                     }).getOrElse(None.<AgsGuideQuality>instance());

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
@@ -4,12 +4,10 @@ import edu.gemini.ags.api.AgsAnalysis.{NoGuideStarForProbe, NoGuideStarForGroup}
 import edu.gemini.ags.api._
 import edu.gemini.ags.api.AgsGuideQuality._
 import edu.gemini.ags.api.AgsMagnitude.{MagnitudeCalc, MagnitudeTable}
-import edu.gemini.shared.skyobject.Magnitude
 import edu.gemini.spModel.core.MagnitudeBand
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideSpeed, GuideProbe}
 import edu.gemini.spModel.guide.GuideSpeed._
 import edu.gemini.spModel.obs.context.ObsContext
-import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.TargetEnvironment
 import jsky.app.ot.util.OtColor

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
@@ -48,7 +48,7 @@ object GuidingFeedback {
       s"${lim(sat)} $le FAST $le ${lim(fast)} < MEDIUM $le ${lim(medium)} < SLOW $le ${lim(slow)}"
   }
 
-  class Row(analysis: AgsAnalysis, probeLimits: Option[ProbeLimits], includeProbeName: Boolean) extends GridBagPanel {
+  case class Row(analysis: AgsAnalysis, probeLimits: Option[ProbeLimits], includeProbeName: Boolean) extends GridBagPanel {
     val bg = analysis.quality match {
       case DeliversRequestedIq   => HONEY_DEW
       case PossibleIqDegradation => BANANA
@@ -136,7 +136,7 @@ object GuidingFeedback {
         gp <- AgsAnalysis.guideProbe(a)
         pl <- probeLimitsMap.get(gp).flatten
       } yield pl
-      new Row(a, plo, includeProbeName = true)
+      Row(a, plo, includeProbeName = true)
     }
   }
 
@@ -167,13 +167,13 @@ object GuidingFeedback {
         case NoGuideStarForGroup(_, _) => true
         case NoGuideStarForProbe(_, _) => true
         case _                         => false
-      }.map { a => new Row(a, None, includeProbeName = true) }
+      }.map { a => Row(a, None, includeProbeName = true) }
     }
 
   // GuidingFeedback.Row related to the given guide star itself.
   def guideStarAnalysis(ctx: ObsContext, mt: MagnitudeTable, gp: ValidatableGuideProbe, target: SPTarget): Option[Row] =
-    AgsRegistrar.currentStrategy(ctx).map(_.analyze(ctx, mt).headOption.map { a =>
+    AgsRegistrar.currentStrategy(ctx).flatMap(_.analyze(ctx, mt).headOption.map { a =>
       val plo = mt(ctx, gp).flatMap(ProbeLimits(a.probeBands, ctx, _))
-      new Row(a, plo, includeProbeName = false)
-    }).flatten
+      Row(a, plo, includeProbeName = false)
+    })
 }


### PR DESCRIPTION
This bug originates from the lack of a capability to to analyze a single guide star on `AgsStrategy` interface. This new method has been added on this PR, plus tests and refactorings in a few places
 