### PR TITLE
OCSADV-200-P: merge conflict notes

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflict.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflict.java
@@ -12,7 +12,7 @@ public final class Conflict {
      * Note added to {@link Conflicts} to warn the user of a conflict.
      */
     public static abstract class Note implements Serializable {
-        private final SPNodeKey nodeKey;
+        public final SPNodeKey nodeKey;
 
         Note(SPNodeKey nodeKey) {
             if (nodeKey == null) throw new IllegalArgumentException("nodeKey == null");
@@ -25,11 +25,9 @@ public final class Conflict {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            Note that = (Note) o;
+            final Note that = (Note) o;
+            return nodeKey.equals(that.nodeKey);
 
-            if (!nodeKey.equals(that.nodeKey)) return false;
-
-            return true;
         }
 
         @Override public int hashCode() {
@@ -61,7 +59,7 @@ public final class Conflict {
      * note is added to the parent where the node was in the existing program.
      */
     public static final class Moved extends Note {
-        private final SPNodeKey to;
+        public final SPNodeKey to;
 
         public Moved(SPNodeKey node, SPNodeKey to) {
             super(node);
@@ -78,8 +76,7 @@ public final class Conflict {
             if (!super.equals(o)) return false;
 
             Moved that = (Moved) o;
-            if (!to.equals(that.to)) return false;
-            return true;
+            return to.equals(that.to);
         }
 
         @Override public int hashCode() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflicts.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflicts.java
@@ -37,7 +37,7 @@ public final class Conflicts implements Serializable {
     }
 
     public Conflicts withDataObjectConflict(DataObjectConflict doc) {
-        return apply(new Some<DataObjectConflict>(doc), notes);
+        return apply(new Some<>(doc), notes);
     }
 
     public Conflicts withConflictNote(final Conflict.Note note) {
@@ -49,11 +49,7 @@ public final class Conflicts implements Serializable {
     }
 
     public Conflicts resolveConflictNote(final Conflict.Note note) {
-        ImList<Conflict.Note> lst = notes.filter(new PredicateOp<Conflict.Note>() {
-            @Override public Boolean apply(Conflict.Note conflictNote) {
-                return !conflictNote.equals(note);
-            }
-        });
+        final ImList<Conflict.Note> lst = notes.filter(cn -> !cn.equals(note));
         return (lst.size() == notes.size()) ? this : apply(dataObjectConflict, lst);
     }
 
@@ -67,16 +63,10 @@ public final class Conflicts implements Serializable {
 
         final Option<DataObjectConflict> mergedDoc = that.dataObjectConflict.orElse(dataObjectConflict);
 
-        final Set<SPNodeKey> newKeys = new HashSet<SPNodeKey>();
-        that.notes.foreach(new ApplyOp<Conflict.Note>() {
-            @Override public void apply(Conflict.Note cn) { newKeys.add(cn.getNodeKey()); }
-        });
+        final Set<SPNodeKey> newKeys = new HashSet<>();
+        that.notes.foreach(cn -> newKeys.add(cn.getNodeKey()));
 
-        final ImList<Conflict.Note> oldNotes = notes.filter(new PredicateOp<Conflict.Note>() {
-            @Override public Boolean apply(Conflict.Note cn) {
-                return !newKeys.contains(cn.getNodeKey());
-            }
-        });
+        final ImList<Conflict.Note> oldNotes = notes.filter(cn -> !newKeys.contains(cn.getNodeKey()));
 
         final ImList<Conflict.Note> mergedNotes = oldNotes.append(that.notes);
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/MergePlan.scala
@@ -66,6 +66,15 @@ case class MergePlan(update: Tree[MergeNode], delete: Set[Missing]) {
     up |+| del
   }
 
+  /** True if this plan contains non-empty `Conflicts`, false otherwise.
+   */
+  def hasConflicts: Boolean =
+    update.sFoldRight(false) { (mn, b) =>
+      b || (mn match {
+        case Modified(_, _, _, _, con) => !con.isEmpty
+        case _                         => false
+      })
+    }
 
   /** Accepts a program and edits it according to this merge plan. */
   def merge(f: ISPFactory, p: ISPProgram): VcsAction[Unit] = {

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrection.scala
@@ -32,9 +32,9 @@ class ObsNumberCorrection(lifespanId: LifespanId, isKnown: (ProgramLocation, SPN
       if (obsMap.isEmpty) mp // usually empty so we might as well check and save a traversal in that case
       else
         mp.copy(update = mp.update.map {
-          case m@Modified(k, nv, dob, Obs(n)) =>
+          case m@Modified(k, nv, dob, Obs(n), con) =>
             val newNum = obsMap.getOrElse(k, n)
-            if (newNum == n) m else m.copy(k, nv.incr(lifespanId), dob, Obs(newNum))
+            if (newNum == n) m else m.copy(k, nv.incr(lifespanId), dob, Obs(newNum), con)
           case lab => lab
         })
     }
@@ -44,8 +44,8 @@ class ObsNumberCorrection(lifespanId: LifespanId, isKnown: (ProgramLocation, SPN
   private def renumberedObs(mp: MergePlan): TryVcs[Map[SPNodeKey, Int]] = {
     def isExecuted(children: Stream[Tree[MergeNode]]): Boolean =
       children.toList.exists { _.rootLabel match {
-        case Modified(_, _, log: ObsExecLog, _) => !log.isEmpty
-        case _                                  => false
+        case Modified(_, _, log: ObsExecLog, _, _) => !log.isEmpty
+        case _                                     => false
       }}
 
     val localOnly0 = mp.update.foldObservations(List.empty[(SPNodeKey, Int, Boolean)]) { (mod, i, children, lst) =>

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/PreliminaryMerge.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/PreliminaryMerge.scala
@@ -1,29 +1,31 @@
 package edu.gemini.sp.vcs.diff
 
-import edu.gemini.pot.sp.{ISPNode, SPNodeKey}
+import edu.gemini.pot.sp.Conflict.{Moved, ResurrectedLocalDelete, ReplacedRemoteDelete}
+import edu.gemini.pot.sp.{Conflict, DataObjectBlob, ISPNode, SPNodeKey}
 import edu.gemini.shared.util.VersionComparison._
 import edu.gemini.sp.vcs.diff.MergeNode._
 import edu.gemini.spModel.rich.pot.sp._
 
 import scalaz.\&/.{Both, This, That}
 import scalaz._
+import Scalaz._
 
 /** Produces a preliminary [[MergePlan]]. Before using it to complete a merge
   * however, various special case corrections (e.g., observation renumbering)
   * must be applied to the plan. */
 object PreliminaryMerge {
 
-  def merge(mc: MergeContext): MergePlan = {
-    val t = tree(mc)
-    val mergedKeys  = t.foldRight(Set.empty[SPNodeKey]) { (mn,s) => s + mn.key }
-    val allKeys     = mc.remote.diffMap.keySet ++ mc.remote.plan.delete.map(_.key)
-    val deletedKeys = allKeys &~ mergedKeys
-    val allMissing  = deletedKeys.map { k => Missing(k, mc.local.version(k).sync(mc.remote.version(k))) }
+  def merge(mc: MergeContext): TryVcs[MergePlan] =
+    tree(mc).map { t =>
+      val mergedKeys  = t.foldRight(Set.empty[SPNodeKey]) { (mn, s) => s + mn.key }
+      val allKeys     = mc.remote.diffMap.keySet ++ mc.remote.plan.delete.map(_.key)
+      val deletedKeys = allKeys &~ mergedKeys
+      val allMissing  = deletedKeys.map { k => Missing(k, mc.local.version(k).sync(mc.remote.version(k))) }
 
-    MergePlan(t, allMissing)
-  }
+      MergePlan(t, allMissing)
+    }
 
-  def tree(mc: MergeContext): Tree[MergeNode] = {
+  def tree(mc: MergeContext): TryVcs[Tree[MergeNode]] = {
 
     def isUpdated(k: SPNodeKey, pc0: ProgContext, pc1: ProgContext): Boolean =
       pc0.version(k).compare(pc1.version(k)) match {
@@ -156,6 +158,110 @@ object PreliminaryMerge {
         }
       }
 
-    go(Both(mc.local.prog, mc.remote.plan.update))
+    def addDataObjectConflicts(in: Tree[MergeNode]): TryVcs[Tree[MergeNode]] = {
+      val commonKeys = mc.remote.diffMap.keySet & mc.local.nodeMap.keySet
+
+      def dobConflicts(k: SPNodeKey): Boolean = {
+        lazy val local  = mc.local.nodeMap(k).getDataObject
+        lazy val remote = mc.remote.diffMap(k).rootLabel match {
+          case Modified(_, _, dob, _, _) => Some(dob)
+          case Unmodified(_)             => None
+        }
+        mc.local.version(k).compare(mc.remote.version(k)) === Conflicting &&
+        remote.exists(dob => !DataObjectBlob.same(local, dob))
+      }
+
+      val conflicts = commonKeys.collect { case k if dobConflicts(k) =>
+        k -> mc.local.nodeMap(k).getDataObject
+      }
+
+      (TryVcs(in)/:conflicts) { case(tryTree,(k,dob)) =>
+        for {
+          t  <- tryTree
+          n0 <- t.loc.findNode(k)
+          n1 <- n0.addDataObjectConflict(dob)
+        } yield n1.toTree
+      }
+    }
+
+    // Given the root of the tree and the set of keys that have been replaced or
+    // resurrected, find the roots of subtrees with the conflict issue and just
+    // add the note to the roots. For example, if an observation is replaced we
+    // don't want to see conflict notes on every node in the observation, but
+    // rather just on the observation node itself.
+    def addNotes(in: Tree[MergeNode], ks: Set[SPNodeKey], nf: SPNodeKey => Conflict.Note): TryVcs[Tree[MergeNode]] = {
+      def goAdd(r: Tree[MergeNode]): TryVcs[Tree[MergeNode]] =
+        if (ks.contains(r.key))
+          for {
+            t0 <- r.mModifyLabel(_.withConflictNote(nf(r.key)))
+            t1 <- visitChildren(t0, goSkip)
+          } yield t1
+        else
+          visitChildren(r, goAdd)
+
+      // If this node is in the set, we skip the note we would otherwise have
+      // added.  If not, from that point down we will go back to adding the note
+      def goSkip(r: Tree[MergeNode]): TryVcs[Tree[MergeNode]] =
+        visitChildren(r, if (ks.contains(r.key)) goSkip else goAdd)
+
+      def visitChildren(t: Tree[MergeNode], fun: Tree[MergeNode] => TryVcs[Tree[MergeNode]]): TryVcs[Tree[MergeNode]] =
+        t.subForest.map(fun).sequenceU.map(children => Tree.node(t.rootLabel, children))
+
+      goAdd(in)
+    }
+
+    def addReplacedRemoteDelete(in: Tree[MergeNode]): TryVcs[Tree[MergeNode]] = {
+      val mergeSurvivors = in.keySet
+      val remoteDeleted  = mc.remote.diff.plan.delete.collect {
+        case Missing(k, _) if mc.remote.isKnown(k) => k
+      }
+      val replaced = mergeSurvivors & remoteDeleted
+
+      // check for empty to avoid an unnecessary traversal.  would work anyway
+      if (replaced.isEmpty) TryVcs(in)
+      else addNotes(in, replaced, new ReplacedRemoteDelete(_))
+    }
+
+    def addResurrectedLocalDelete(in: Tree[MergeNode]): TryVcs[Tree[MergeNode]] = {
+      val mergeSurvivors = in.keySet
+      val localDeleted   = mc.remote.diff.plan.update.keySet.filter(mc.local.isDeleted)
+      val resurrected    = mergeSurvivors & localDeleted
+
+      // check for empty to avoid an unnecessary traversal.  would work anyway
+      if (resurrected.isEmpty) TryVcs(in)
+      else addNotes(in, resurrected, new ResurrectedLocalDelete(_))
+    }
+
+    def addMoved(in: Tree[MergeNode]): TryVcs[Tree[MergeNode]] = {
+      // moved = List: (old parent, child, new parent)
+      val moved = in.foldTree(List.empty[(SPNodeKey, SPNodeKey, SPNodeKey)]) { (newParent, lst) =>
+        (lst/:newParent.subForest) { (lst0, child) =>
+          mc.local.parent(child.key).fold(lst0) { oldParentKey =>
+            val isMoved = (oldParentKey =/= newParent.key) &&
+                            isUpdated(oldParentKey, mc.local, mc.remote)
+            if (isMoved) (oldParentKey, child.key, newParent.key) :: lst0
+            else lst0
+          }
+        }
+      }
+
+      (TryVcs(in)/:moved) { case (tryTree, (oldParent, child, newParent)) =>
+        for {
+          t  <- tryTree
+          n0 <- t.loc.findNode(oldParent)
+          n1 <- n0.addConflictNote(new Moved(child, newParent))
+        } yield n1.toTree
+      }
+    }
+
+    def addConflicts(in: Tree[MergeNode]): TryVcs[Tree[MergeNode]] =
+      for {
+        t0 <- addDataObjectConflicts(in)
+        t1 <- addReplacedRemoteDelete(t0)
+        t2 <- addResurrectedLocalDelete(t1)
+        t3 <- addMoved(t2)
+      } yield t3
+
+    addConflicts(go(Both(mc.local.prog, mc.remote.plan.update)))
   }
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/StaffOnlyFieldCorrection.scala
@@ -39,7 +39,7 @@ class StaffOnlyFieldCorrection(lifespanId: LifespanId, key: SPNodeKey, pid: SPPr
 
     def correctedNode(mn: MergeNode): MergeNode =
       mn match {
-        case m@Modified(k, nv, dob: StaffProtected, _) =>
+        case m@Modified(k, nv, dob: StaffProtected, _, _) =>
           remote(k).fold(correctedNew(m, dob)) { remoteMod =>
             nv.compare(remoteMod.nv) match {
               case Newer => correctedExisting(m, dob, remoteMod.dob)
@@ -72,8 +72,8 @@ object StaffOnlyFieldCorrection {
     def contact(sp: SPProgram) = Option(sp.getContactPerson).map(_.trim.toLowerCase)
 
     mn match {
-      case Modified(_, _, sp: SPProgram, _) => contact(sp)
-      case _                                => none
+      case Modified(_, _, sp: SPProgram, _, _) => contact(sp)
+      case _                                   => none
     }
   }
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Vcs.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs/diff/Vcs.scala
@@ -55,11 +55,11 @@ class Vcs(user: VcsAction[Set[Principal]], server: VcsServer, service: Peer => V
 
     def evaluate(p: ISPProgram): VcsAction[MergeEval] =
       for {
-        diffs <- client.fetchDiffs(id, DiffState(p))
-        _     <- validateProgKey(p, diffs.plan)
-        mc     = MergeContext(p, diffs)
-        prelim = PreliminaryMerge.merge(mc)
-        plan  <- MergeCorrection(mc)(prelim, hasPermission)
+        diffs  <- client.fetchDiffs(id, DiffState(p))
+        _      <- validateProgKey(p, diffs.plan)
+        mc      = MergeContext(p, diffs)
+        prelim <- PreliminaryMerge.merge(mc).liftVcs
+        plan   <- MergeCorrection(mc)(prelim, hasPermission)
       } yield MergeEval(plan, p, mc.remote.vm)
 
     // Only do the merge if the merge plan has something new to offer.

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsEditValidatorTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsEditValidatorTest.scala
@@ -1,6 +1,6 @@
 package edu.gemini.sp.vcs.diff
 
-import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.pot.sp.{Conflicts, SPNodeKey}
 import edu.gemini.pot.sp.version._
 import edu.gemini.shared.util.VersionComparison
 import edu.gemini.shared.util.VersionComparison._
@@ -36,7 +36,7 @@ object ObsEditValidatorTest {
 
   val Key           = new SPNodeKey()
   val DataObject    = new SPObservation()
-  val ObsTree       = MergeNode.modified(Key, EmptyNodeVersions, DataObject, NodeDetail.Obs(1)).node()
+  val ObsTree       = MergeNode.modified(Key, EmptyNodeVersions, DataObject, NodeDetail.Obs(1), Conflicts.EMPTY).node()
   val AllUrps       = Set(PI, NGO, STAFF)
   val AllToo        = TooType.values.toSet[TooType]
   val AllStat       = ObservationStatus.values.toSet[ObservationStatus]

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsNumberCorrectionSpec.scala
@@ -24,8 +24,8 @@ class ObsNumberCorrectionSpec extends MergeCorrectionSpec {
 
     def obsNumbers(t: Tree[MergeNode]): List[Int] =
       t.subForest.map(_.rootLabel match {
-        case Modified(_, _, _, Obs(i)) => i
-        case _                         => -1
+        case Modified(_, _, _, Obs(i), _) => i
+        case _                            => -1
       }).toList
 
     val plan = MergePlan(mergeTree, Set.empty)

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsPermissionCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ObsPermissionCorrectionSpec.scala
@@ -159,7 +159,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
     "allow a staff person to advance the status of a remotely deleted observation" in withVcs { env =>
       env.remote.delete(ObsKey)
       env.local.setObsPhase2Status(ObsKey, PHASE_2_COMPLETE)
-      afterSync(env, StaffUserPrincipal) { bothAre(PHASE_2_COMPLETE, ObsKey, env) }
+      afterPull(env, StaffUserPrincipal) { localIs(PHASE_2_COMPLETE, ObsKey, env) }
     }
 
     "move inappropriately edited observations to a conflict folder" in withVcs { env =>
@@ -199,7 +199,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
 
       // now we expect that the note is not duplicated in the new observation
       // that is created and that it has version information from both sides
-      afterSync(env, PiUserPrincipal) {
+      afterPull(env, PiUserPrincipal) {
         env.local.nodeVersions(noteKey) must_== rVersions.sync(lVersions)
       }
     }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ProgramDiffTest.scala
@@ -108,8 +108,8 @@ class ProgramDiffTest extends JUnitSuite {
       (start, local, remote, pd) => {
         val obsKeys = pd.plan.update.sFoldRight(Set.empty[SPNodeKey]) { (mn, s) =>
           mn match {
-            case Modified(k, _, _, Obs(_)) => s + k
-            case _                         => s
+            case Modified(k, _, _, Obs(_), _) => s + k
+            case _                            => s
           }
         }
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/TemplateNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/TemplateNumberCorrectionSpec.scala
@@ -25,12 +25,12 @@ class TemplateNumberCorrectionSpec extends MergeCorrectionSpec {
 
     def tgNumbers(t: Tree[MergeNode]): List[VersionToken] = {
       val tf = t.subForest.find(_.rootLabel match {
-        case Modified(_, _, _: TemplateFolder, _) => true
-        case _                                    => false
+        case Modified(_, _, _: TemplateFolder, _, _) => true
+        case _                                       => false
       })
 
       tf.toList.flatMap { _.subForest.toList.map { _.rootLabel } }.collect {
-        case Modified(_, _, tg: TemplateGroup, _) => tg.getVersionToken
+        case Modified(_, _, tg: TemplateGroup, _, _) => tg.getVersionToken
       }
     }
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ValidityCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/ValidityCorrectionSpec.scala
@@ -1,5 +1,6 @@
 package edu.gemini.sp.vcs.diff
 
+import edu.gemini.pot.sp.Conflict.ConstraintViolation
 import edu.gemini.pot.sp.SPNodeKey
 import edu.gemini.pot.spdb.DBLocalDatabase
 import edu.gemini.sp.vcs.diff.VcsFailure.Unmergeable
@@ -17,7 +18,7 @@ class ValidityCorrectionSpec extends MergeCorrectionSpec {
       case \/-(mp)               => mp.update must correspondTo(expected)
     }
 
-  "MergeValidityCorrection" should {
+  "ValidityCorrection" should {
     "not modify an already valid program" in {
       val start = prog.node(obsTree(1))
       test(start, start)
@@ -30,7 +31,7 @@ class ValidityCorrectionSpec extends MergeCorrectionSpec {
 
       val start    = p.node(tf1.leaf, tf2.leaf)
       val expected = incr(incr(p)).node(
-        incr(incr(conflictFolder)).node(tf2.leaf),
+        incr(incr(conflictFolder)).node(addConflictNote(incr(tf2), new ConstraintViolation(_)).leaf),
         tf1.leaf
       )
 
@@ -53,7 +54,7 @@ class ValidityCorrectionSpec extends MergeCorrectionSpec {
 
         val start    = p.node(un.leaf, tf2.leaf)
         val expected = incr(incr(p)).node(
-          incr(incr(conflictFolder)).node(tf2.leaf),
+          incr(incr(conflictFolder)).node(addConflictNote(incr(tf2), new ConstraintViolation(_)).leaf),
           un.leaf
         )
 
@@ -71,7 +72,9 @@ class ValidityCorrectionSpec extends MergeCorrectionSpec {
 
       val start    = p.node(tf1.leaf, tf2.leaf, tf3.leaf)
       val expected = incr(incr(incr(p))).node(
-        incr(incr(incr(conflictFolder))).node(tf2.leaf, tf3.leaf),
+        incr(incr(incr(conflictFolder))).node(
+          addConflictNote(incr(tf2), new ConstraintViolation(_)).leaf,
+          addConflictNote(incr(tf3), new ConstraintViolation(_)).leaf),
         tf1.leaf
       )
 
@@ -95,7 +98,7 @@ class ValidityCorrectionSpec extends MergeCorrectionSpec {
 
         val start    = p.node(un.leaf, tf1.leaf, tf2.leaf)
         val expected = incr(p).node(
-          incr(MergeNode.modified(cfn)).node(tf2.leaf),
+          incr(MergeNode.modified(cfn)).node(addConflictNote(incr(tf2), new ConstraintViolation(_)).leaf),
           tf1.leaf
         )
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsServerSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs/diff/VcsServerSpec.scala
@@ -1,7 +1,7 @@
 package edu.gemini.sp.vcs.diff
 
 
-import edu.gemini.pot.sp.{DataObjectBlob, ISPFactory, ISPProgram, SPNodeKey}
+import edu.gemini.pot.sp._
 import edu.gemini.pot.sp.version._
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.sp.vcs.diff.VcsAction._
@@ -163,7 +163,7 @@ class VcsServerSpec extends VcsSpecification {
         case \/-(pdt) =>
           val mp = pdt.decode.plan
           mp.update.rootLabel match {
-            case Modified(k, n, dob, NodeDetail.Empty) =>
+            case Modified(k, n, dob, NodeDetail.Empty, Conflicts.EMPTY) =>
               (k must_== Key) and
                 (n must_== nv) and
                 (DataObjectBlob.same(dob, env.local.prog.getDataObject) must beTrue)
@@ -193,7 +193,7 @@ class VcsServerSpec extends VcsSpecification {
 
       // create a merge plan with an updated title for the program node
       val dob    = new SPProgram <| (_.setTitle("The Myth of Sisyphus"))
-      val update = MergeNode.modified(Key, nv2, dob, NodeDetail.Empty).node()
+      val update = MergeNode.modified(Key, nv2, dob, NodeDetail.Empty, Conflicts.EMPTY).node()
       val mp     = MergePlan(update, Set.empty)
 
       val svs = new env.local.server.SecureVcsService(StaffUser)


### PR DESCRIPTION
This installment adds merge conflict notes as appropriate.  Conflict notes are issues that must be brought to the attention of the user.  The already exist in the program model and are already handled by the OT.  The user is forced to acknowledge all conflicts before they can send changes to the server.

This code updates the `Modified` `MergeNode` with a field for `Conflicts` from the existing program model and augments the merge algorithm to add the appropriate notes.  It also updates `VcsServer` to reject attempts to store differences that contain conflict notes.