### PR TITLE
OCSADV-300: shell seqexec client

### DIFF
--- a/app/all-bundles/build.sbt
+++ b/app/all-bundles/build.sbt
@@ -35,6 +35,8 @@ ocsAppManifest := {
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_qpt_server).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_qpt_server).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_qpt_shared).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_qpt_shared).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_qv_plugin).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_qv_plugin).value)),
+    BundleSpec((sbt.Keys.name in bundle_edu_gemini_seqexec_client).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_seqexec_client).value)),
+    BundleSpec((sbt.Keys.name in bundle_edu_gemini_seqexec_shared).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_seqexec_shared).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_services_client).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_services_client).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_services_server).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_services_server).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_shared_ca).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_shared_ca).value)),

--- a/app/seqexec/build.sbt
+++ b/app/seqexec/build.sbt
@@ -1,0 +1,118 @@
+
+import OcsKeys._
+import edu.gemini.osgi.tools.Version
+import edu.gemini.osgi.tools.app.{ Configuration => AppConfig, _ }
+import edu.gemini.osgi.tools.app.Configuration.Distribution.{ Test => TestDistro, _ }
+import OcsCredentials.Qpt._
+
+ocsAppSettings
+
+// Application project for Queue Planning Tool
+ocsAppManifest := {
+  val v = ocsVersion.value.toBundleVersion
+  Application(
+    id = "seqexec",
+    name = "SeqExec",
+    version = ocsVersion.value.toString,
+    configs = List(
+      common(v),
+        development(v),
+        with_test_dbs(v),
+          mac_test(v),
+          linux64_test(v),
+        with_production_dbs(v),
+          mac(v),
+          linux64(v)
+      )
+    )
+}
+
+// COMMON
+def common(version: Version) = AppConfig(
+  id = "common",
+  vmargs = List(
+    "-Xmx1024M"
+  ),
+  props = Map(
+    "org.osgi.framework.storage.clean"                 -> "onFirstInit",
+    "edu.gemini.spdb.mode"                             -> "api",
+    "org.osgi.framework.startlevel.beginning"          -> "100",
+    "edu.gemini.util.security.auth.ui.showDatabaseTab" -> "true",
+    "org.osgi.framework.bootdelegation"                -> "*"
+  ),
+  log = Some("%a/log/seqexec.%u.%g.log"),
+  bundles = List(
+    BundleSpec("edu.gemini.ags",               version),
+    BundleSpec("edu.gemini.osgi.main",         Version(4, 2, 1)),
+    BundleSpec("edu.gemini.seqexec.client",    version),
+    BundleSpec("edu.gemini.shared.gui",        version),
+    BundleSpec("edu.gemini.spModel.io",        version),
+    BundleSpec("edu.gemini.spModel.smartgcal", version),
+    BundleSpec("org.scala-lang.scala-reflect", Version(2, 10, 1)),
+    BundleSpec("org.scala-lang.scala-swing",   Version(2, 0, 0)),
+    BundleSpec("slf4j.api",                    Version(1, 6, 4)),
+    BundleSpec("slf4j.jdk14",                  Version(1, 6, 4)),
+    BundleSpec("org.apache.commons.logging",   Version(1, 1, 0))
+  )
+) extending List(common_credentials(version))
+
+// WITH-TEST-DBS
+def with_test_dbs(version: Version) = AppConfig(
+  id = "with-test-dbs",
+  props = Map(
+    "edu.gemini.util.trpc.peer.GN" -> "gnodbtest2.gemini.edu:8443:Gemini North ODB (Test)",
+    "edu.gemini.util.trpc.peer.GS" -> "gsodbtest2.gemini.edu:8443:Gemini South ODB (Test)"
+  )
+) extending List(common(version))
+
+// WITH-PRODUCTION-DBS
+def with_production_dbs(version: Version) = AppConfig(
+  id = "with-production-dbs",
+  props = Map(
+    "edu.gemini.util.trpc.peer.GN" -> "gnodb.gemini.edu:8443:Gemini North ODB (Test)",
+    "edu.gemini.util.trpc.peer.GS" -> "gsodb.gemini.edu:8443:Gemini South ODB (Test)"
+  )
+) extending List(common(version))
+
+// MAC-TEST
+def mac_test(version: Version) = AppConfig(
+  id = "mac-test",
+  distribution = List(MacOS),
+  log = Some("%h/Library/Logs/edu.gemini.seqexec/seqexec.%u.%g.log")
+) extending List(with_test_dbs(version))
+
+// MAC
+def mac(version: Version) = AppConfig(
+  id = "mac",
+  distribution = List(MacOS),
+  log = Some("%h/Library/Logs/edu.gemini.seqexec/seqexec.%u.%g.log")
+) extending List(with_production_dbs(version))
+
+// LINUX64-TEST
+def linux64_test(version: Version) = AppConfig(
+  id = "linux64-test",
+  distribution = List(Linux64)
+) extending List(with_test_dbs(version))
+
+// LINUX64
+def linux64(version: Version) = AppConfig(
+  id = "linux64",
+  distribution = List(Linux64)
+) extending List(with_production_dbs(version))
+
+// DEVELOPMENT
+def development(version: Version) = AppConfig(
+  id = "development",
+  distribution = List(TestDistro),
+  props = Map(
+    "edu.gemini.util.trpc.peer.GN" -> "localhost:8443:Gemini North ODB (Local)",
+    "edu.gemini.util.trpc.peer.GS" -> "localhost:8443:Gemini South ODB (Local)"
+  ),
+  bundles = List(
+    BundleSpec(99, "org.apache.felix.gogo.runtime", Version(0, 10, 0)),
+    BundleSpec(99, "org.apache.felix.gogo.command", Version(0, 12, 0)),
+    BundleSpec(99, "org.apache.felix.gogo.shell",   Version(0, 10, 0))
+  )
+) extending List(common(version))
+
+

--- a/app/seqexec/conf/logging.properties
+++ b/app/seqexec/conf/logging.properties
@@ -1,0 +1,10 @@
+handlers = java.util.logging.FileHandler java.util.logging.ConsoleHandler
+
+.level = INFO
+
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+java.util.logging.FileHandler.limit = 10000000
+java.util.logging.FileHandler.count = 10
+

--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -112,6 +112,7 @@ def common(version: Version) = AppConfig(
     BundleSpec("edu.gemini.phase2.skeleton.servlet",     version),
     BundleSpec("edu.gemini.qpt.shared",                  version),
     BundleSpec("edu.gemini.services.server",             version),
+    BundleSpec("edu.gemini.seqexec.shared",              version),
     BundleSpec("edu.gemini.smartgcal.odbinit",           version),
     BundleSpec("edu.gemini.smartgcal.servlet",           version),
     BundleSpec("edu.gemini.sp.vcs.tui",                  version),

--- a/bundle/edu.gemini.seqexec.client/README.md
+++ b/bundle/edu.gemini.seqexec.client/README.md
@@ -1,0 +1,5 @@
+
+## edu.gemini.seqexec.client
+
+Seqexec client bundle.
+

--- a/bundle/edu.gemini.seqexec.client/build.sbt
+++ b/bundle/edu.gemini.seqexec.client/build.sbt
@@ -1,0 +1,23 @@
+import OcsKeys._
+
+// note: inter-project dependencies are declared at the top, in projects.sbt
+
+name := "edu.gemini.seqexec.client"
+
+// version set in ThisBuild
+
+unmanagedJars in Compile ++= Seq(
+  new File(baseDirectory.value, "../../lib/bundle/org.scala-lang.scala-library_2.10.1.v20130302-092018-VFINAL-33e32179fd.jar"),
+  new File(baseDirectory.value, "../../lib/bundle/scalaz-core_2.10-7.0.5.jar"))
+
+osgiSettings
+
+ocsBundleSettings
+
+OsgiKeys.bundleActivator := Some("edu.gemini.seqexec.client.osgi.Activator")
+
+OsgiKeys.bundleSymbolicName := name.value
+
+OsgiKeys.dynamicImportPackage := Seq("")
+
+OsgiKeys.exportPackage := Seq()

--- a/bundle/edu.gemini.seqexec.client/src/main/scala/edu/gemini/seqexec/client/osgi/Activator.scala
+++ b/bundle/edu.gemini.seqexec.client/src/main/scala/edu/gemini/seqexec/client/osgi/Activator.scala
@@ -1,0 +1,29 @@
+package edu.gemini.seqexec.client.osgi
+
+import org.osgi.framework.{ServiceRegistration, BundleContext, BundleActivator}
+
+object Activator {
+  val CommandScope    = "osgi.command.scope"
+  val CommandFunction = "osgi.command.function"
+}
+
+class Activator extends BundleActivator {
+  import Activator._
+
+  private var reg: Option[ServiceRegistration[Commands]] = None
+
+  override def start(ctx: BundleContext): Unit = {
+    println("edu.gemini.seqexec.client start")
+
+    val dict = new java.util.Hashtable[String, Object]()
+    dict.put(CommandScope, "seq")
+    dict.put(CommandFunction, Array("seq"))
+    reg = Some(ctx.registerService(classOf[Commands], Commands(), dict))
+  }
+
+  override def stop(ctx: BundleContext): Unit = {
+    println("edu.gemini.seqexec.client stop")
+    reg.foreach(_.unregister())
+    reg = None
+  }
+}

--- a/bundle/edu.gemini.seqexec.client/src/main/scala/edu/gemini/seqexec/client/osgi/Commands.scala
+++ b/bundle/edu.gemini.seqexec.client/src/main/scala/edu/gemini/seqexec/client/osgi/Commands.scala
@@ -1,0 +1,147 @@
+package edu.gemini.seqexec.client.osgi
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.shared.{SeqFailure, SeqExecService}
+import edu.gemini.spModel.`type`.{LoggableSpType, SequenceableSpType, DisplayableSpType}
+import edu.gemini.spModel.config2.{ItemKey, ConfigSequence}
+import edu.gemini.spModel.core.Peer
+
+import scalaz._
+import Scalaz._
+
+sealed trait Commands {
+  def seq(cmd: String, args: Array[String]): String
+}
+
+object Commands {
+  def parseId(s: String): String \/ SPObservationID =
+    \/.fromTryCatch {
+      new SPObservationID(s)
+    }.leftMap(_ => s"Sorry, '$s' isn't a valid observation id.")
+
+  def parseLoc(s: String): String \/ Peer =
+    Option(Peer.tryParse(s)) \/> s"Sorry, expecting host:port not '$s'."
+
+  def fetch(oid: SPObservationID, loc: Peer): String \/ ConfigSequence =
+    SeqExecService.client(loc).sequence(oid).leftMap(SeqFailure.explain)
+
+  // a better version of this available in the latest scalaz
+  implicit class MergeOp[A](d: A \/ A) {
+    def merge: A = d.fold(identity, identity)
+  }
+
+  implicit object KeyOrdering extends scala.Ordering[ItemKey] {
+    override def compare(x: ItemKey, y: ItemKey) = x.compareTo(y)
+  }
+
+  val Usage =
+    "Usage: seq host [host:port] | show obsId count|static|dynamic"
+
+  val ShowUsage =
+    """Usage:
+      |  seq show obsId count
+      |  seq show obsId static [calibration|instrument|telescope ...]
+      |  seq show obsId dynamic step# [calibration|instrument|telescope ...]
+      |
+      |  Example
+      |    seq show GS-2014B-Q-2-355 static
+      |    -> shows all static values for observation 355
+      |
+      |    seq show GS-2014B-Q-2-355 static instrument
+      |    -> shows all static instrument values for observation 355
+      |
+      |    seq show GS-2014B-Q-2-355 dynamic 4 instrument
+      |    -> shows dynamic instrument values for dataset 4 of obs 355
+    """.stripMargin
+
+  def apply(): Commands = new Commands {
+    var loc = new Peer("localhost", 8443, null)
+
+    def host(): String =
+      s"Default seq host set to ${loc.host} ${loc.port}"
+
+    def host(loc0: Peer): String = {
+      loc = loc0
+      host()
+    }
+
+    def show(oid: SPObservationID, cs: ConfigSequence, args: List[String]): String = {
+      def seqValue(o: Object): String = o match {
+        case s: SequenceableSpType => s.sequenceValue()
+        case d: DisplayableSpType  => d.displayValue()
+        case l: LoggableSpType     => l.logValue()
+        case _                     => o.toString
+      }
+
+      def width(ks: Array[ItemKey]): Int = ks match {
+        case Array() => 0
+        case _       => ks.maxBy(_.toString.length).toString.length
+      }
+
+      def showKeys(title: String, step: Int, ks: Array[ItemKey]): String = {
+        val pad = width(ks)
+        ks.sorted.map { k =>
+          val paddedKey = s"%-${pad}s".format(k.toString)
+          s"$paddedKey -> ${seqValue(cs.getItemValue(step, k))}"
+        }.mkString(s"$title\n", "\n", "")
+      }
+
+      def sysFilter(system: String): ItemKey => Boolean =
+        _.splitPath().get(0) == system
+
+      def ifStepValid(step: String)(body: Int => String): String =
+        \/.fromTryCatch(step.toInt - 1).fold(
+          _ => s"Specify an integer step, not '$step'.", {
+          case i if i < 0          => "Specify a positive step number."
+          case i if i >= cs.size() => s"$oid only has ${cs.size} steps."
+          case i                   => body(i)
+        })
+
+
+      args match {
+        case List("count")                 =>
+          s"$oid sequence has ${cs.size()} steps."
+
+        case List("static")                =>
+          showKeys(s"$oid Static Values", 0, cs.getStaticKeys)
+
+        case List("static", system)        =>
+          val ks = cs.getStaticKeys.filter(sysFilter(system))
+          showKeys(s"$oid Static Values ($system only)", 0, ks)
+
+        case List("dynamic", step)         =>
+          ifStepValid(step) { s =>
+            showKeys(s"$oid Dynamic Values (Step ${s+1})", s, cs.getIteratedKeys)
+          }
+
+        case List("dynamic", step, system) =>
+          ifStepValid(step) { s =>
+            val ks = cs.getIteratedKeys.filter(sysFilter(system))
+            showKeys(s"$oid Dynamic Values (Step ${s+1}, $system only)", s, ks)
+          }
+
+        case _              =>
+          ShowUsage
+      }
+    }
+
+
+    def seq(cmd: String, args: Array[String]): String =
+      cmd :: args.toList match {
+        case List("host")                =>
+          host()
+
+        case List("host", peer)          =>
+          parseLoc(peer).map(host).merge
+
+        case "show" :: obsId :: showArgs =>
+          (for {
+            oid <- parseId(obsId)
+            seq <- fetch(oid, loc)
+          } yield show(oid, seq, showArgs)).merge
+
+        case _                           =>
+          Usage
+      }
+  }
+}

--- a/bundle/edu.gemini.seqexec.shared/README.md
+++ b/bundle/edu.gemini.seqexec.shared/README.md
@@ -1,0 +1,5 @@
+
+## edu.gemini.seqexec.shared
+
+Shared ODB and seqexec API.
+

--- a/bundle/edu.gemini.seqexec.shared/build.sbt
+++ b/bundle/edu.gemini.seqexec.shared/build.sbt
@@ -1,0 +1,24 @@
+import OcsKeys._
+
+// note: inter-project dependencies are declared at the top, in projects.sbt
+
+name := "edu.gemini.seqexec.shared"
+
+// version set in ThisBuild
+
+unmanagedJars in Compile ++= Seq(
+  new File(baseDirectory.value, "../../lib/bundle/org.scala-lang.scala-library_2.10.1.v20130302-092018-VFINAL-33e32179fd.jar"),
+  new File(baseDirectory.value, "../../lib/bundle/scalaz-core_2.10-7.0.5.jar"))
+
+osgiSettings
+
+ocsBundleSettings
+
+OsgiKeys.bundleActivator := Some("edu.gemini.seqexec.shared.osgi.Activator")
+
+OsgiKeys.bundleSymbolicName := name.value
+
+OsgiKeys.dynamicImportPackage := Seq("")
+
+OsgiKeys.exportPackage := Seq(
+  "edu.gemini.seqexec.shared")

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecServer.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecServer.scala
@@ -1,0 +1,23 @@
+package edu.gemini.seqexec.shared
+
+import edu.gemini.pot.sp.{ISPObservation, SPObservationID}
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.seqexec.shared.SeqFailure.MissingObservation
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
+import edu.gemini.spModel.config2.ConfigSequence
+
+import scalaz._
+import Scalaz._
+
+/** Sequence Executor service server-side implementation. */
+final class SeqExecServer(odb: IDBDatabaseService) extends SeqExecService {
+  def lookup(oid: SPObservationID): TrySeq[ISPObservation] =
+    Option(odb.lookupObservationByID(oid)) \/> MissingObservation(oid)
+
+  override def sequence(oid: SPObservationID): TrySeq[ConfigSequence] =
+    lookup(oid).map { obs =>
+      ConfigBridge.extractSequence(obs, null, IDENTITY_MAP, true)
+    }
+
+}

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecService.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecService.scala
@@ -1,0 +1,34 @@
+package edu.gemini.seqexec.shared
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.shared.SeqFailure.SeqException
+
+
+import edu.gemini.spModel.config2.ConfigSequence
+import edu.gemini.spModel.core.Peer
+import edu.gemini.util.trpc.client.TrpcClient
+
+import scalaz._
+import Scalaz._
+
+/**
+ * Sequence Executor Service API.
+ */
+trait SeqExecService {
+
+  /** Fetches the sequence associated with the given observation id, if it
+    * exists. */
+  def sequence(oid: SPObservationID): TrySeq[ConfigSequence]
+}
+
+object SeqExecService {
+  def client(peer: Peer): SeqExecService = new SeqExecService {
+    val trpc = TrpcClient(peer).withoutKeys
+
+    private def call[A](op: SeqExecService => TrySeq[A]): TrySeq[A] =
+      trpc { remote => op(remote[SeqExecService]) }.valueOr(ex => SeqException(ex).left)
+
+    override def sequence(oid: SPObservationID): TrySeq[ConfigSequence] =
+      call(_.sequence(oid))
+  }
+}

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqFailure.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqFailure.scala
@@ -1,0 +1,19 @@
+package edu.gemini.seqexec.shared
+
+import edu.gemini.pot.sp.SPObservationID
+
+sealed trait SeqFailure
+
+object SeqFailure {
+  case class MissingObservation(oid: SPObservationID) extends SeqFailure
+  case class SeqException(ex: Throwable) extends SeqFailure
+
+  def explain(sf: SeqFailure): String = sf match {
+    case MissingObservation(oid) =>
+      s"The database doesn't have observation $oid"
+
+    case SeqException(ex)        =>
+      s"Exception: ${ex.getMessage}"
+  }
+}
+

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/osgi/Activator.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/osgi/Activator.scala
@@ -1,0 +1,38 @@
+package edu.gemini.seqexec.shared.osgi
+
+import java.util
+
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.seqexec.shared.{SeqExecService, SeqExecServer}
+import org.osgi.framework.{ServiceRegistration, BundleContext, BundleActivator}
+
+import edu.gemini.util.osgi.Tracker._
+import org.osgi.util.tracker.ServiceTracker
+
+
+object Activator {
+  val PublishTrpc = "trpc"
+}
+
+class Activator extends BundleActivator {
+  private var tracker: Option[ServiceTracker[_,_]] = None
+
+  override def start(ctx: BundleContext): Unit = {
+    import Activator._
+
+    tracker = Some(track[IDBDatabaseService, ServiceRegistration[_]](ctx) { (odb) =>
+      val seqServer = new SeqExecServer(odb)
+
+      val props = new util.Hashtable[String, Object]()
+      props.put(PublishTrpc, "true")
+      ctx.registerService(classOf[SeqExecService], seqServer, props)
+    } { _.unregister() })
+
+    tracker.foreach(_.open())
+  }
+
+  override  def stop(ctx: BundleContext): Unit = {
+    tracker.foreach(_.close())
+    tracker = None
+  }
+}

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/package.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/package.scala
@@ -1,0 +1,7 @@
+package edu.gemini.seqexec
+
+import scalaz._
+
+package object shared {
+  type TrySeq[A] = SeqFailure \/ A
+}

--- a/project/OcsApp.scala
+++ b/project/OcsApp.scala
@@ -72,6 +72,10 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_itc
   )
 
+  lazy val app_seqexec = project.in(file("app/seqexec")).dependsOn(
+    bundle_edu_gemini_seqexec_client
+  )
+
   lazy val app_weather = project.in(file("app/weather")).dependsOn(
     bundle_edu_gemini_shared_ca,
     bundle_edu_gemini_spdb_reports_collection

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -236,6 +236,29 @@ trait OcsBundle {
       bundle_jsky_elevation_plot
     )
 
+  lazy val bundle_edu_gemini_seqexec_client = 
+    project.in(file("bundle/edu.gemini.seqexec.client")).dependsOn(
+      bundle_edu_gemini_pot,
+      bundle_edu_gemini_seqexec_shared,
+      bundle_edu_gemini_shared_util,
+      bundle_edu_gemini_spModel_core,
+      bundle_edu_gemini_spModel_pio,
+      bundle_edu_gemini_util_trpc,
+      bundle_jsky_coords,
+      bundle_jsky_util
+    )
+
+  lazy val bundle_edu_gemini_seqexec_shared = 
+    project.in(file("bundle/edu.gemini.seqexec.shared")).dependsOn(
+      bundle_edu_gemini_pot,
+      bundle_edu_gemini_shared_util,
+      bundle_edu_gemini_spModel_core,
+      bundle_edu_gemini_spModel_pio,
+      bundle_edu_gemini_util_trpc,
+      bundle_jsky_coords,
+      bundle_jsky_util
+    )
+
   lazy val bundle_edu_gemini_services_client = 
     project.in(file("bundle/edu.gemini.services.client")).dependsOn(
       bundle_edu_gemini_pot,


### PR DESCRIPTION
This PR creates a skeleton seqexec command line client and a shared server bundle.  It is meant to be used as an example and starting point for building the seqexec, and accordingly adds a new "seqexec" application to the build.

The client bundle offers Felix shell extensions with simple commands to view observation sequences.  These are clearly primitive but may serve as an example:

* Set the database from which sequences may be fetched:
```
g! seq host localhost:8443
Default seq host set to localhost 8443
```

* View the database from which sequences will be fetched:
```
g! seq host
Default seq host set to localhost 8443
```

* Get the number of datasets that will be produced by an observation:
```
g! seq show GS-2014B-Q-2-355 count
GS-2014B-Q-2-355 sequence has 24 steps.
```
* Show all static (unchanging) settings for an observation sequence:
```
g! seq show GS-2014B-Q-2-355 static
GS-2014B-Q-2-355 Static Values
calibration:basecalDay             -> true
calibration:basecalNight           -> false
calibration:coadds                 -> 1
calibration:diffuser               -> IR
calibration:exposureTime           -> 60.0
calibration:filter                 -> ND4-5
calibration:lamp                   -> [IR grey body - high]
instrument:decker                  -> IMAGING
instrument:disperser               -> NONE
instrument:exposureTime            -> 85.0
instrument:filter                  -> J
instrument:fpu                     -> FPU_NONE
instrument:instrument              -> Flamingos2
...
```
* Show all static (unchanging) settings for a particular subsystem of an observation sequence:
```
g! seq show GS-2014B-Q-2-355 static instrument
GS-2014B-Q-2-355 Static Values (instrument only)
instrument:decker                  -> IMAGING
instrument:disperser               -> NONE
instrument:exposureTime            -> 85.0
instrument:filter                  -> J
instrument:fpu                     -> FPU_NONE
instrument:instrument              -> Flamingos2
instrument:issPort                 -> Side-looking
instrument:lyotWheel               -> OPEN
instrument:mosPreimaging           -> No
instrument:observingWavelength     -> 1.25
instrument:posAngle                -> 0.0
instrument:readMode                -> BRIGHT_OBJECT_SPEC
instrument:useElectronicOffsetting -> false
instrument:version                 -> 2009A-1
```
* Show dynamic (iterated) values for a particular step of an observation:
```
g! seq show GS-2014B-Q-2-355 dynamic 10
GS-2014B-Q-2-355 Dynamic Values (Step 10)
calibration:shutter  -> Closed
observe:dataLabel    -> GS-2014B-Q-2-355-010
observe:exposureTime -> 60.0
observe:object       -> GCALflat
observe:observeType  -> FLAT
```
* Show dynamic (iterated) values for a particular step and subsystem:
```
g! seq show GS-2014B-Q-2-355 dynamic 10 calibration
GS-2014B-Q-2-355 Dynamic Values (Step 10, calibration only)
calibration:shutter -> Closed
```