### PR TITLE
OCSADV-256: restore TPE version of GMOS and F2 OI and science area

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -94,7 +94,8 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
           }
           val bestPerCtx = for {
             (c, soList) <- results
-            rating      <- brightestByQualityAndVignetting(soList, mt, c, v, params)
+//            rating      <- brightestByQualityAndVignetting(soList, mt, c, v, params)
+            rating      <- brightestByQuality(soList, mt, c, v, params)
           } yield (c, rating)
           bestPerCtx.reduceOption(vignettingCtxOrder.min).map {
             case (c, (_, _, _, st)) => AgsStrategy.Selection(c.getPositionAngle.toNewModel, List(AgsStrategy.Assignment(params.guideProbe, st)))
@@ -211,6 +212,17 @@ object SingleProbeStrategy {
     }
     // TODO: Temporary code to help Andy with debugging. Remove.
     println("--- Analysis complete ---")
+
+    candidates.reduceOption(vignettingOrder.min)
+  }
+
+  def brightestByQuality(lst: List[SiderealTarget], mt: MagnitudeTable, ctx: ObsContext,
+                         probe: ValidatableGuideProbe,
+                         params: SingleProbeStrategyParams): Option[(AgsGuideQuality, Double, Option[Magnitude], SiderealTarget)] = {
+    val candidates = for {
+      st       <- lst
+      analysis <- AgsAnalysis.analysis(ctx, mt, probe, st, params.probeBands)
+    } yield (analysis.quality, 0.0, params.referenceMagnitude(st), st)
 
     candidates.reduceOption(vignettingOrder.min)
   }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -83,6 +83,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
   def select(ctx: ObsContext, mt: MagnitudeTable, candidates: List[SiderealTarget]): Option[AgsStrategy.Selection] = {
     if (candidates.isEmpty) None
     else {
+/*
       params.guideProbe match {
         // If vignetting, filter according to the pos angle constraint, and then for each obs context, pick the best quality with
         // the least vignetting. Then pick the best quality with the least vignetting of the final result.
@@ -94,8 +95,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
           }
           val bestPerCtx = for {
             (c, soList) <- results
-//            rating      <- brightestByQualityAndVignetting(soList, mt, c, v, params)
-            rating      <- brightestByQuality(soList, mt, c, v, params)
+            rating      <- brightestByQualityAndVignetting(soList, mt, c, v, params)
           } yield (c, rating)
           bestPerCtx.reduceOption(vignettingCtxOrder.min).map {
             case (c, (_, _, _, st)) => AgsStrategy.Selection(c.getPositionAngle.toNewModel, List(AgsStrategy.Assignment(params.guideProbe, st)))
@@ -103,6 +103,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
 
         // Otherwise proceed as normal.
         case _ =>
+*/
           val results = ctx.getPosAngleConstraint match {
             case FIXED                         => selectBounded(List(ctx), mt, candidates)
             case FIXED_180 | PARALLACTIC_ANGLE => selectBounded(List(ctx, ctx180(ctx)), mt, candidates)
@@ -111,7 +112,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
           params.brightest(results)(_._2).map {
             case (angle, st) => AgsStrategy.Selection(angle, List(AgsStrategy.Assignment(params.guideProbe, st)))
           }
-      }
+//      }
     }
   }
 
@@ -212,17 +213,6 @@ object SingleProbeStrategy {
     }
     // TODO: Temporary code to help Andy with debugging. Remove.
     println("--- Analysis complete ---")
-
-    candidates.reduceOption(vignettingOrder.min)
-  }
-
-  def brightestByQuality(lst: List[SiderealTarget], mt: MagnitudeTable, ctx: ObsContext,
-                         probe: ValidatableGuideProbe,
-                         params: SingleProbeStrategyParams): Option[(AgsGuideQuality, Double, Option[Magnitude], SiderealTarget)] = {
-    val candidates = for {
-      st       <- lst
-      analysis <- AgsAnalysis.analysis(ctx, mt, probe, st, params.probeBands)
-    } yield (analysis.quality, 0.0, params.referenceMagnitude(st), st)
 
     candidates.reduceOption(vignettingOrder.min)
   }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -122,7 +122,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
-      verifyGuideStarSelection(strategy, ctx, selection, "288-000439", GmosOiwfsGuideProbe.instance)
+      verifyGuideStarSelection(strategy, ctx, selection, "288-000438", GmosOiwfsGuideProbe.instance)
     }
     "find a guide star for GMOS-N+PWFS2, OCSADV-255" in {
       // M1 target

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -21,7 +21,7 @@ import edu.gemini.spModel.target.env.TargetEnvironment
 import edu.gemini.spModel.telescope.{IssPortProvider, IssPort}
 
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Ignore, Test}
 
 import scala.collection.JavaConverters._
 import scala.util.Random
@@ -129,54 +129,54 @@ class VignettingTest {
     nextCandidate(Random.shuffle(candidates), expected)
   }
 
-  @Test def testSideLookingBasePosAngle0() = {
+  @Ignore @Test def testSideLookingBasePosAngle0() = {
     val expected   = List(GS3, GS2, GS1, GS4)
     executeTest(expected)
   }
 
-  @Test def testSideLookingBasePosAngle90() = {
+  @Ignore @Test def testSideLookingBasePosAngle90() = {
     val expected = List(GS7, GS6, GS1)
     executeTest(expected, posAngle = 90.0)
   }
 
-  @Test def testSideLookingBasePosAngle180() = {
+  @Ignore @Test def testSideLookingBasePosAngle180() = {
     val expected = List(GS8, GS10, GS9)
     executeTest(expected, posAngle = 180.0)
   }
 
-  @Test def testUpLookingBasePosAngle0() = {
+  @Ignore @Test def testUpLookingBasePosAngle0() = {
     val expected = List(GS1)
     executeTest(expected, config = GMOSSouthUpLookingWithOI)
   }
 
-  @Test def testUpLookingBasePosAngle90() = {
+  @Ignore @Test def testUpLookingBasePosAngle90() = {
     val expected = List(GS3, GS2, GS1, GS4)
     executeTest(expected, config = GMOSSouthUpLookingWithOI, posAngle = 90.0)
   }
 
-  @Test def testUpLookingBasePosAngle180() = {
+  @Ignore @Test def testUpLookingBasePosAngle180() = {
     val expected = List(GS7, GS6)
     executeTest(expected, config = GMOSSouthUpLookingWithOI, posAngle = 180.0)
   }
 
-  @Test def testSideLookingOneOffsetPosAngle0() = {
+  @Ignore @Test def testSideLookingOneOffsetPosAngle0() = {
     val expected = List(GS2, GS6)
     executeTest(expected, offsets = List(Offset(50.arcsecs[OffsetP], 50.arcsecs[OffsetQ])))
   }
 
-  @Test def testSideLookingOneOffset2PosAngle0() = {
+  @Ignore @Test def testSideLookingOneOffset2PosAngle0() = {
     // The vignetting exclusively on the offset would result in GS6 and then GS7, but the vignetting averaged across
     // the base position and the offset would result in GS7 and then GS6.
     val expected = List(GS7, GS6)
     executeTest(expected, offsets = List(Offset(200.arcsecs[OffsetP], 50.arcsecs[OffsetQ])))
   }
 
-  @Test def testSideLookingOneNegOffset2PosAngle0() = {
+  @Ignore @Test def testSideLookingOneNegOffset2PosAngle0() = {
     val expected = List(GS5, GS3, GS2)
     executeTest(expected, offsets = List(Offset(-50.arcsecs[OffsetP], -50.arcsecs[OffsetQ])))
   }
 
-  @Test def testAllNoVignetting() = {
+  @Ignore @Test def testAllNoVignetting() = {
     val expected = List(NVGS2, NVGS3, NVGS1, NVGS4, NVGS6, NVGS5, NVGS7)
     executeTest(expected, candidates = AllNV)
   }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_OIWFS_Feature.java
@@ -1,0 +1,382 @@
+/**
+ * $Id: Flamingos2_OIWFS_Feature.java 45719 2012-06-01 16:35:09Z swalker $
+ */
+
+package jsky.app.ot.gemini.flamingos2;
+
+import diva.util.java2d.Polygon2D;
+import edu.gemini.skycalc.Angle;
+import edu.gemini.skycalc.Offset;
+import edu.gemini.spModel.data.AbstractDataObject;
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2OiwfsGuideProbe;
+import edu.gemini.spModel.gemini.gems.Gems;
+import edu.gemini.spModel.guide.PatrolField;
+import edu.gemini.spModel.obs.context.ObsContext;
+import edu.gemini.spModel.obscomp.SPInstObsComp;
+import edu.gemini.spModel.telescope.IssPort;
+import jsky.app.ot.gemini.inst.OIWFS_FeatureBase;
+import jsky.app.ot.tpe.TpeImageInfo;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
+import java.awt.geom.Point2D;
+import java.util.Set;
+
+
+/**
+ * Draws the OIWFS overlay for Flamingos2.
+ */
+public class Flamingos2_OIWFS_Feature  extends OIWFS_FeatureBase  {
+
+    // OT-540:
+    // OIWFS FOV: a "lozenge" defined by two arcs with different radii and different centers.
+    // The first center is the base position, and radius from this center is 139.7mm.
+    // The second center is located in the +(?)p direction, at a distance of 170.25mm from the
+    // base position, and has radius 198.125mm.
+    // see file: OIWFS_Patrol_Area.jpg and Jeff's Sweep Path Model(1).jpg
+
+    // The color to use to draw the OIWFS probe arm
+    private static final Color PROBE_ARM_COLOR = Color.red;
+
+    // Used to draw dashed lines
+//    private static final Stroke DASHED_LINE_STROKE
+//            = new BasicStroke(2.0F,
+//                              BasicStroke.CAP_BUTT,
+//                              BasicStroke.JOIN_BEVEL,
+//                              0.0F,
+//                              new float[]{12.0F, 12.0F},
+//                              0.0F);
+
+    // The size of the OIWFS probe arm pickoff mirror in mm
+    private static final double PICKOFF_MIRROR_SIZE = 19.8;
+
+    private static final double PROBE_PICKOFF_ARM_TOTAL_LENGTH = 203.40;
+
+    private static final double PROBE_BASE_ARM_LENGTH = 109.63;
+    private static final double PROBE_PICKOFF_ARM_LENGTH = PROBE_PICKOFF_ARM_TOTAL_LENGTH - PICKOFF_MIRROR_SIZE/2;
+    private static final double PROBE_ARM_OFFSET = 256.87;
+
+
+    // The width of the tapered end of the probe arm in arcsec
+    private static final double PROBE_ARM_TAPERED_WIDTH = 15.;
+
+    // The length of the tapered end of the probe arm in arcsec
+    private static final double PROBE_ARM_TAPERED_LENGTH = 180.;
+
+
+    // Composite used for drawing items that block the view
+    private static final Composite BLOCKED = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.5F);
+
+
+    private Area _patrolField;
+
+    // Saved Flamingos2 port setting (side-looking or up-looking)
+    private IssPort _port;
+
+    // Saved Flamingos2 LyotWheel setting
+    private Flamingos2.LyotWheel _lyotWheel;
+
+    // from config file
+    private boolean _flip;
+    private double _fovRotation;//in radians
+    /**
+      * Construct the feature with its name and description.
+      */
+     public Flamingos2_OIWFS_Feature() {
+         super("Flamingos2 OIWFS", "Show the Flamingos2 OIWFS patrol field.");
+     }
+
+
+    /**
+     * Add the OIWFS patrol field to the list of figures to display.
+     *
+     * @param xc the X screen coordinate for the base position to use
+     * @param yc the Y screen coordinate for the base position to use
+     * @param plateScale plate scale in arcsec/mm
+     */
+    protected void _addPatrolField(double xc, double yc, double plateScale) {
+        for (ObsContext ctx : _iw.getMinimalObsContext()) {
+            // get scaled and offset f2 oiwfs patrol field
+            for (PatrolField patrolField : Flamingos2OiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+
+                // set patrol field for in Range check (this should probably be done using the inRange check provided by the guide probe)
+                _patrolField = patrolField.getArea();
+                _patrolField = transformToScreen(_patrolField);
+
+                // draw patrol field
+                addPatrolField(patrolField);
+            }
+        }
+    }
+
+
+    /**
+     * Add the OIWFS probe arm (without the pickoff mirror) to the display list.
+     *
+     * The probe arm is made of two fixed length components rotating about two axles.
+     *
+     *
+     * @param xc the X screen coordinate for the base position
+     * @param yc the Y screen coordinate for the base position
+     * @param xg the X screen coordinate position for the guide star
+     * @param yg the Y screen coordinate position for the guide star
+     * @param xt translate resulting figure by this amount of pixels in X
+     * @param yt translate resulting figure by this amount of pixels in Y
+     * @param plateScale plate scale in arcsec/mm
+     */
+    private void _addProbeArm(double xc, double yc, double xg, double yg, double xt, double yt, double plateScale) {
+        int sign = _flip ?  -1 : 1;
+
+        Point2D.Double tp = new Point2D.Double(xg, yg);
+        Point2D.Double tpOff = new Point2D.Double(xg + xt, yg + yt);
+        //Point2D.Double tpOff = new Point2D.Double(xc + xt, yc + yt);
+
+        if (_patrolField.contains(tpOff)) {
+            double scale = _pixelsPerArcsec * plateScale;
+            double length_base = PROBE_BASE_ARM_LENGTH * scale;
+            double length_pickoff = PROBE_PICKOFF_ARM_LENGTH * scale;
+            double base_arm_axis = PROBE_ARM_OFFSET * scale;
+
+            //We will compute the position of the rotation axis of probe arm. It's defined
+            //by the intersection point of the 2 circles defined by the 2 fixed length components
+            //The intersection of two circles can be calculated knowing the position of the
+            //two centers and the 2 radius.  We used the definitions from
+            //http://local.wasp.uwa.edu.au/~pbourke/geometry/2circle/
+
+            // position of the base arm, translated based on the position angle
+            double pa = -_posAngle - _fovRotation;
+            double x0 = xc + base_arm_axis * _flipRA * sign * Math.cos(pa);
+            double y0 = yc + base_arm_axis * _flipRA * sign * Math.sin(pa);
+
+            //The position of the OIWFS. Rotation of the PA doesn't affect this.
+            double x1 = xg + xt; // xt already takes _flipRA into account
+            double y1 = yg + yt;
+
+            //Distance between OIWFS and the position of the base arm (the center of the 2 circles)
+            double distance = Math.sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0));
+
+            if (distance > length_base + length_pickoff) {
+                distance = length_base + length_pickoff;
+            }
+
+            //a is the adjacent side of the rectangle triangle formed by the OIWFS position, the interesection of
+            //the 2 circles and the imaginary line that connects the OIWFS and the position of the base arm
+            double a = (length_base * length_base - length_pickoff * length_pickoff + distance * distance) / (2 * distance);
+            //h is the distance from a to the intersection point
+            //Note: OT-38: fix was to multiply by sign below to handle both orientations correctly.
+            double h = sign * Math.sqrt(length_base * length_base - a * a);
+            //(x2,y2) are the coordinates of the point located "a" from the OIWFS
+            double x2 = x0 + a * (x1 - x0) / distance;
+            double y2 = y0 + a * (y1 - y0) / distance;
+
+            //decide what solution to choose. Since we always want a /\ form, we should pick the one
+            //whose y is smaller than the other one
+            //We take the dot product to decide
+            double y3 = y2 - h * (x1 - x0) / distance;
+            double x3 = x2 + h * (y1 - y0) / distance;
+            if (_flipRA < 0) { // REL-299: Orientation bug: seems this is only needed in this case
+                if ((x3 * xc * _flipRA + y3 * yc) < 0 || (x3 * xc + y3 * yc * _flipRA) < 0) {
+                    y3 = y2 + h * (x1 - x0) / distance;
+                    x3 = x2 - h * (y1 - y0) / distance;
+                }
+            }
+
+//            // XXX debug
+//            _figureList.add(new OIWFSFigure(new Ellipse2D.Double(x0-5, y0-5, 10, 10), Color.pink, BLOCKED, OIWFS_STROKE));
+//            _figureList.add(new OIWFSFigure(new Ellipse2D.Double(x1-5, y1-5, 10, 10), Color.white, BLOCKED, OIWFS_STROKE));
+//            _figureList.add(new OIWFSFigure(new Ellipse2D.Double(x2-5, y2-5, 10, 10), Color.blue, BLOCKED, OIWFS_STROKE));
+//            _figureList.add(new OIWFSFigure(new Ellipse2D.Double(x3-5, y3-5, 10, 10), Color.green, BLOCKED, OIWFS_STROKE));
+
+            //Draw the fixed arm. Disabled for now.
+//            Polygon2D.Double arm = new Polygon2D.Double(x0, y0);
+//            arm.lineTo(x3, y3);
+//            _figureList.add(new OIWFSFigure(arm, PROBE_ARM_COLOR, BLOCKED, OIWFS_STROKE));
+
+
+            //Get the rotation angle of the probe.
+            double angle = Math.atan2(y3 - y1, x3 - x1);
+
+            //and build the transformation to apply to the arm and pickoff mirror
+            AffineTransform armTrans = new AffineTransform();
+            armTrans.translate(xt, yt);
+            armTrans.rotate(angle, x1, y1);
+
+            _addPickoffMirror(tp, armTrans, plateScale);
+            _addProbeArm(tp, armTrans, plateScale);
+        }
+    }
+
+    /**
+     * Add the OIWFS probe arm (without the pickoff mirror) to the display list.
+     *
+     * @param tp    the location of the OIWFS guide star in screen coords
+     * @param trans the transformation to apply to the figure
+     * @param plateScale plate scale in arcsec/mm
+     */
+    private void _addProbeArm(Point2D.Double tp, AffineTransform trans, double plateScale) {
+        double mirror = PICKOFF_MIRROR_SIZE * plateScale * _pixelsPerArcsec;
+        double length = PROBE_PICKOFF_ARM_LENGTH * plateScale * _pixelsPerArcsec;
+        double taperedWidth = PROBE_ARM_TAPERED_WIDTH * _pixelsPerArcsec;
+        double taperedLength = PROBE_ARM_TAPERED_LENGTH * _pixelsPerArcsec;
+        double hm = mirror / 2.;
+        double htw = taperedWidth / 2.;
+
+        double x0 = tp.x + hm;
+        double y0 = tp.y - htw;
+        Polygon2D.Double arm = new Polygon2D.Double(x0, y0);
+
+        double x1 = x0 + taperedLength;
+        double y1 = tp.y - hm;
+        arm.lineTo(x1, y1);
+
+        double x2 = x0 + length;
+        double y2 = y1;
+        arm.lineTo(x2, y2);
+
+        double x3 = x2;
+        double y3 = tp.y + hm;
+        arm.lineTo(x3, y3);
+
+        double x4 = x1;
+        double y4 = y3;
+        arm.lineTo(x4, y4);
+
+        double x5 = x0;
+        double y5 = tp.y + htw;
+        arm.lineTo(x5, y5);
+
+        arm.transform(trans);
+        _figureList.add(new Figure(arm, PROBE_ARM_COLOR, BLOCKED, OIWFS_STROKE));
+    }
+
+
+
+
+    /**
+     * Add the OIWFS probe arm pickoff mirror to the display list.
+     *
+     * @param tp the location of the OIWFS guide star in screen coords
+     * @param trans the transformation to apply to the figure
+     * @param plateScale plate scale in arcsec/mm
+     */
+    private void _addPickoffMirror(Point2D.Double tp, AffineTransform trans, double plateScale) {
+        double width = PICKOFF_MIRROR_SIZE * _pixelsPerArcsec * plateScale;
+        double d = width / 2.;
+        double x = tp.x - d;
+        double y = tp.y - d;
+        Polygon2D.Double pickoffMirror = new Polygon2D.Double(x, y);
+        pickoffMirror.lineTo(x + width, y);
+        pickoffMirror.lineTo(x + width, y + width);
+        pickoffMirror.lineTo(x, y + width);
+
+        // rotate by position angle
+        pickoffMirror.transform(trans);
+
+        _figureList.add(new Figure(pickoffMirror, PROBE_ARM_COLOR, BLOCKED, OIWFS_STROKE));
+    }
+
+
+    /**
+     * Update the list of figures to draw.
+     *
+     * @param guidePosX the X screen coordinate position for the OIWFS guide star
+     * @param guidePosY the Y screen coordinate position for the OIWFS guide star
+     * @param offsetPosX the X screen coordinate for the selected offset
+     * @param offsetPosY the X screen coordinate for the selected offset
+     * @param translateX translate resulting figure by this amount of pixels in X
+     * @param translateY translate resulting figure by this amount of pixels in Y
+     * @param basePosX the X screen coordinate for the base position (IGNORED)
+     * @param basePosY the Y screen coordinate for the base position (IGNORED)
+     * @param oiwfsDefined set to true if an OIWFS position is defined (otherwise
+     *                     the xg and yg parameters are ignored)
+     */
+    protected void _updateFigureList(double guidePosX, double guidePosY, double offsetPosX, double offsetPosY,
+                                     double translateX, double translateY, double basePosX, double basePosY, boolean oiwfsDefined) {
+        // need to flip the drawing about the X axis if the instrument is side-mounted
+        Flamingos2 inst = (Flamingos2) _iw.getInstObsComp();
+        _port = inst.getIssPort();
+        _lyotWheel = inst.getLyotWheel();
+
+        ObsContext ctx =  _iw.getObsContext().getOrNull();
+        if(ctx!=null){
+            AbstractDataObject aoComp = ctx.getAOComponent().getOrNull();
+            if(aoComp!=null){
+                _flip = inst.getFlipConfig(aoComp.getNarrowType().equals(Gems.SP_TYPE.narrowType));
+                _fovRotation = inst.getRotationConfig(aoComp.getNarrowType().equals(Gems.SP_TYPE.narrowType)).toRadians().getMagnitude();
+            }else{
+                _flip = inst.getFlipConfig(false);
+                _fovRotation = inst.getRotationConfig(false).toRadians().getMagnitude();
+            }
+        }else{
+            _flip = inst.getFlipConfig(false);
+            _fovRotation = inst.getRotationConfig(false).toRadians().getMagnitude();
+        }
+
+        double plateScale = inst.getLyotWheel().getPlateScale();
+
+        _figureList.clear();
+
+        _addPatrolField(offsetPosX + translateX, offsetPosY + translateY, plateScale);
+
+        addOffsetConstrainedPatrolField(basePosX, basePosY);
+
+        // rotate by position angle
+        AffineTransform trans = new AffineTransform();
+        trans.rotate(-_posAngle, offsetPosX, offsetPosY);
+
+        // If the OIWFS is defined for this observation, draw the probe arm.
+        if (oiwfsDefined)
+            _addProbeArm(offsetPosX, offsetPosY, guidePosX, guidePosY, translateX, translateY, plateScale);
+    }
+
+    private void addOffsetConstrainedPatrolField(double basePosX, double basePosY){
+        for (ObsContext ctx : _iw.getMinimalObsContext()) {
+            // get flipped and offset and scaled f2 oiwfs patrol field
+            for (PatrolField patrolField : Flamingos2OiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(basePosX, basePosY);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+
+                final Set<Offset> offsets = getContext().offsets().scienceOffsetsJava();
+                addOffsetConstrainedPatrolField(patrolField, offsets);
+            }
+        }
+    }
+
+
+    /** Return true if the display needs to be updated because values changed. */
+    protected boolean _needsUpdate(SPInstObsComp inst, TpeImageInfo tii) {
+        // This method in its original form DOES NOT WORK and always returns FALSE.
+        // This is likely because we are just comparing references below, which do not
+        // change. The result of this is that the OIWFS probe arm is never drawn unless
+        // explicitly forced by toggling the OIWFS checkbox in the Field of View section.
+        return true;
+
+        /*
+        System.err.println("*** In _needsUpdate");
+        if (super._needsUpdate(inst, tii)) {
+            System.err.println("\t TRUE");
+            return true;
+        }
+
+        Flamingos2 instFlamingos2 = (Flamingos2) inst;
+        if (_port != instFlamingos2.getIssPort()) {
+            System.err.println("\t TRUE");
+            return true;
+        }
+        if (_lyotWheel != instFlamingos2.getLyotWheel()) {
+            System.err.println("\t TRUE");
+            return true;
+        }
+        System.err.println("\t FALSE");
+        return false;
+        */
+    }
+}

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_SciAreaFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2_SciAreaFeature.java
@@ -4,14 +4,11 @@
 
 package jsky.app.ot.gemini.flamingos2;
 
-import edu.gemini.shared.util.immutable.ApplyOp;
-import edu.gemini.shared.util.immutable.ImList;
+import diva.util.java2d.Polygon2D;
 import edu.gemini.spModel.data.AbstractDataObject;
-import edu.gemini.spModel.gemini.flamingos2.F2ScienceAreaGeometry;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.FPUnit;
 import edu.gemini.spModel.gemini.gems.Gems;
-import edu.gemini.spModel.inst.FeatureGeometry$;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.util.Angle;
 import jsky.app.ot.gemini.inst.SciAreaFeatureBase;
@@ -24,6 +21,8 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 
 
@@ -31,6 +30,17 @@ import java.awt.geom.Point2D;
  * Draws the Science Area, the detector or slit (see OT-540).
  */
 public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
+
+    // The size of the imaging field of view in mm.
+    public static final double IMAGING_FOV_SIZE = 230.12;
+
+    // The width of the MOS field of view in mm
+    public static final double MOS_FOV_WIDTH = 75.16;
+
+    // The height of the long slit FOV in mm (the width is selected by the user)
+    public static final double LONG_SLIT_FOV_HEIGHT = 164.1; // SCT-297, LongSlit FOV doesn't run the full lenght of the MOS FOV
+    public static final double LONG_SLIT_FOV_SOUTH_POS = 112.0; // South position of slit when PA = 0
+    public static final double LONG_SLIT_FOV_NORTH_POS = 52.1; // North position of slit when PA = 0
 
     // OT-540:
     // Imaging field of view: 230.12mm diameter circle, centered on base position.
@@ -53,25 +63,101 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
     public Flamingos2_SciAreaFeature() {
     }
 
+
+    /**
+     * Add the imaging FOV to the list of figures to display.
+     * @param plateScale plate scale in arcsec/mm
+     */
+    private void _addImagingFOV(double plateScale) {
+        double size = IMAGING_FOV_SIZE * plateScale * _pixelsPerArcsec;
+        double radius = size/2.;
+        Ellipse2D.Double fig = new Ellipse2D.Double(_baseScreenPos.x - radius,
+                                                    _baseScreenPos.y - radius,
+                                                    size, size);
+        _figureList.add(fig);
+    }
+
+    /**
+     * Add the MOS field of view to the list of figures to display.
+     * @param plateScale plate scale in arcsec/mm
+     */
+    private void _addMOS_FOV(double plateScale) {
+
+        // Make the rectangle and circle and then take the intersection
+        double width = MOS_FOV_WIDTH * plateScale * _pixelsPerArcsec;
+        double height = IMAGING_FOV_SIZE * plateScale * _pixelsPerArcsec;
+
+        double radius = height /2.;
+        Ellipse2D.Double circle = new Ellipse2D.Double(_baseScreenPos.x - radius,
+                                                       _baseScreenPos.y - radius,
+                                                       height, height);
+
+        double x = _baseScreenPos.x - (width / 2);
+        double y = _baseScreenPos.y - radius;
+        Polygon2D.Double rect = new Polygon2D.Double(x, y);
+        rect.lineTo(x + width, y);
+        rect.lineTo(x + width, y + height);
+        rect.lineTo(x, y + height);
+
+        // rotate by position angle
+        rect.transform(_posAngleTrans);
+
+        // take the intersection
+        Area area = new Area(circle);
+        area.intersect(new Area(rect));
+
+        _figureList.add(area);
+    }
+
+    /**
+     * Add the long slit field of view to the list of figures to display.
+     * @param plateScale plate scale in arcsec/mm
+     */
+    private void _addLongSlitFOV(double plateScale) {
+        double slitWidth = _sciArea.getWidth();
+        double slitHeight = LONG_SLIT_FOV_HEIGHT * plateScale * _pixelsPerArcsec;
+
+        double slitSouth = LONG_SLIT_FOV_SOUTH_POS * plateScale * _pixelsPerArcsec;
+
+        double x = _baseScreenPos.x - (slitWidth / 2);
+        double y = _baseScreenPos.y + slitSouth;
+
+        Polygon2D.Double slit = new Polygon2D.Double(x, y);
+        slit.lineTo(x + slitWidth, y);
+        slit.lineTo(x + slitWidth, y - slitHeight);
+        slit.lineTo(x, y - slitHeight);
+
+        // rotate by position angle
+        slit.transform(_posAngleTrans);
+
+        _figureList.add(slit);
+    }
+
     /**
      * Update the list of FOV figures to draw.
      */
     protected void _updateFigureList() {
         _figureList.clear();
-        final Flamingos2 inst = getFlamingos2();
+
+        // OT-540:
+        // There should be different FOV drawings for imaging, MOS, longslit,
+        // MCAO imaging, MCAO MOS, and the OIWFS (for both non-AO and MCAO feeds).
+        // (OIWFS is handled elsewhere)
+        Flamingos2 inst = getFlamingos2();
         if (inst != null) {
-            final ObsContext ctx = _iw.getMinimalObsContext().getOrNull();
-            final ImList<Shape> shape = inst.getVignettableScienceArea().geometryAsJava();
-            final AffineTransform ptm = getPosAngleTransformModifier();
-            shape.foreach(new ApplyOp<Shape>() {
-                @Override
-                public void apply(final Shape s) {
-                    final Shape s2 = FeatureGeometry$.MODULE$.transformScienceAreaForContext(s, ctx);
-                    final Shape s3 = FeatureGeometry$.MODULE$.transformScienceAreaForScreen(s2, _pixelsPerArcsec, ctx, _baseScreenPos);
-                    final Shape s4 = ptm.createTransformedShape(s3);
-                    _figureList.add(s4);
-                }
-            });
+            double plateScale = inst.getLyotWheel().getPlateScale();
+            Flamingos2.FPUnit fpu = inst.getFpu();
+            switch (fpu) {
+                case FPU_NONE:
+                    _addImagingFOV(plateScale);
+                    break;
+                case CUSTOM_MASK:
+                    _addMOS_FOV(plateScale);
+                    break;
+                default:
+                    if (fpu.isLongslit()) _addLongSlitFOV(plateScale);
+                    break;
+            }
         }
     }
 
@@ -83,28 +169,30 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
      * Overriden to take into account fov rotation from config file
      */
     @Override
-    protected boolean _calc(final TpeImageInfo tii)  {
-        final Flamingos2 inst = getFlamingos2();
+    protected boolean _calc(TpeImageInfo tii)  {
+        Flamingos2 inst = getFlamingos2();
         if (inst == null) return false;
 
         _sciArea.update(inst, tii);
         _baseScreenPos = tii.getBaseScreenPos();
         _sciAreaPD = _sciArea.getPolygonDAt(_baseScreenPos.x, _baseScreenPos.y);
         _pixelsPerArcsec = tii.getPixelsPerArcsec();
-        final double posAngle = tii.getCorrectedPosAngleRadians();
+        double posAngle = tii.getCorrectedPosAngleRadians();
         _posAngleTrans.setToIdentity();
         _posAngleTrans.rotate(-posAngle, _baseScreenPos.x, _baseScreenPos.y);
 
 
-        final ObsContext ctx = _iw.getObsContext().getOrNull();
+        ObsContext ctx = _iw.getObsContext().getOrNull();
         if (ctx != null) {
-            final AbstractDataObject aoComp = ctx.getAOComponent().getOrNull();
+            AbstractDataObject aoComp = ctx.getAOComponent().getOrNull();
             if (aoComp != null) {
                 _fovRotation = inst.getRotationConfig(aoComp.getNarrowType().equals(Gems.SP_TYPE.narrowType)).toRadians().getMagnitude();
             } else {
                 _fovRotation = inst.getRotationConfig(false).toRadians().getMagnitude();
             }
         } else {
+// RCN: actually this is ok; it happens in template obs
+//            System.out.println("No ObsContext!!!");
             _fovRotation = inst.getRotationConfig(false).toRadians().getMagnitude();
         }
 
@@ -113,12 +201,12 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
 
         // Init the _tickMarkPD
         if (_tickMarkPD == null) {
-            final double[] xpoints = new double[4];
-            final double[] ypoints = new double[4];
+            double[] xpoints = new double[4];
+            double[] ypoints = new double[4];
             _tickMarkPD = new PolygonD(xpoints, ypoints, 4);
         }
 
-        final Point2D.Double tickOffset = _getTickMarkOffset();
+        Point2D.Double tickOffset = _getTickMarkOffset();
 
         _tickMarkPD.xpoints[0] = tickOffset.x;
         _tickMarkPD.ypoints[0] = tickOffset.y - MARKER_SIZE * 2;
@@ -132,8 +220,9 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
         _tickMarkPD.xpoints[3] = _tickMarkPD.xpoints[0];
         _tickMarkPD.ypoints[3] = _tickMarkPD.ypoints[0];
 
-        // Rotate tick mark
-        final double angle = tii.getCorrectedPosAngleRadians() + _fovRotation;
+        //_iw.skyRotate(_tickMarkPD);
+        //rotate tick mark
+        double angle = tii.getCorrectedPosAngleRadians() + _fovRotation;
 
         ScreenMath.rotateRadians(_tickMarkPD, angle, _baseScreenPos.x, _baseScreenPos.y);
         _updateFigureList();
@@ -144,17 +233,15 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
      * Draw the feature.
      */
     @Override
-    public void draw(final Graphics g, final TpeImageInfo tii) {
-        final Graphics2D g2d = (Graphics2D) g;
+    public void draw(Graphics g, TpeImageInfo tii) {
+        Graphics2D g2d = (Graphics2D) g;
 
         if (!_calc(tii)) return;
 
         g2d.setColor(FOV_COLOR);
 
-        // Draw the FOV
-        for (final Shape shape : _figureList)
-            g2d.draw(shape);
-
+        // draw the FOV
+        for (Shape shape : _figureList) g2d.draw(shape);
         drawDragItem(g2d);
     }
     /**
@@ -162,7 +249,7 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
       * Overridden to take into account fov rotation from config file.
       */
     @Override
-     public void drag(final TpeMouseEvent tme) {
+     public void drag(TpeMouseEvent tme) {
          if (_dragX == tme.xWidget && _dragY == tme.yWidget) {
              _iw.repaint();
              return;
@@ -172,8 +259,8 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
          _dragX = tme.xWidget;
          _dragY = tme.yWidget;
 
-         final double radians = _dragObject.getAngle(_dragX, _dragY) * _tii.flipRA() + _tii.getTheta();
-         final double degrees = Math.round(Angle.radiansToDegrees(radians-_fovRotation));
+         double radians = _dragObject.getAngle(_dragX, _dragY) * _tii.flipRA() + _tii.getTheta();
+         double degrees = Math.round(Angle.radiansToDegrees(radians-_fovRotation));
         _iw.setPosAngle(degrees);
         _iw.repaint();
      }
@@ -182,7 +269,7 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
      * Draw the science area at the given x,y (screen coordinate) offset position.
      */
     @Override
-    public void drawAtOffsetPos(final Graphics g, final TpeImageInfo tii, final double x, final double y) {
+    public void drawAtOffsetPos(Graphics g, TpeImageInfo tii, double x, double y) {
         if (!_calc(tii)) return;
 
         final Graphics2D g2d = (Graphics2D) g;
@@ -190,7 +277,7 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
             final AffineTransform saveAT = g2d.getTransform();
             try {
                 g2d.translate(x - _baseScreenPos.x, y - _baseScreenPos.y);
-                for (final Shape shape : _figureList) {
+                for (Shape shape : _figureList) {
                     g2d.draw(shape);
                 }
             } finally {
@@ -209,11 +296,11 @@ public class Flamingos2_SciAreaFeature  extends SciAreaFeatureBase {
         final Flamingos2 inst = getFlamingos2();
         final Point2D.Double offset;
         if (inst != null) {
-            final FPUnit fpu = inst.getFpu();
+            FPUnit fpu = inst.getFpu();
 
-            final double plateScale = inst.getLyotWheel().getPlateScale();
+            double plateScale = inst.getLyotWheel().getPlateScale();
             if (fpu.isLongslit()) {
-                final double slitNorth = F2ScienceAreaGeometry.LongSlitFOVNorthPos() * plateScale * _pixelsPerArcsec;
+                double slitNorth = LONG_SLIT_FOV_NORTH_POS * plateScale * _pixelsPerArcsec;
                 offset = new Point2D.Double(_baseScreenPos.x,
                                             _baseScreenPos.y - slitNorth);
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_OIWFS_Feature.java
@@ -1,0 +1,336 @@
+// Copyright 1997 Association for Universities for Research in Astronomy, Inc.,
+// Observatory Control System, Gemini Telescopes Project.
+// See the file COPYRIGHT for complete details.
+//
+// $Id: GMOS_OIWFS_Feature.java 45719 2012-06-01 16:35:09Z swalker $
+//
+package jsky.app.ot.gemini.gmos;
+
+import diva.util.java2d.Polygon2D;
+import edu.gemini.skycalc.Angle;
+import edu.gemini.skycalc.Offset;
+import edu.gemini.shared.util.immutable.None;
+import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.spModel.gemini.gmos.GmosCommonType;
+import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
+import edu.gemini.spModel.gemini.gmos.InstGmosCommon;
+import edu.gemini.spModel.guide.PatrolField;
+import edu.gemini.spModel.obs.context.ObsContext;
+import edu.gemini.spModel.obscomp.SPInstObsComp;
+import edu.gemini.spModel.target.offset.OffsetPosBase;
+import edu.gemini.spModel.telescope.IssPort;
+import jsky.app.ot.gemini.inst.OIWFS_FeatureBase;
+import jsky.app.ot.tpe.TpeContext;
+import jsky.app.ot.tpe.TpeImageInfo;
+import jsky.app.ot.tpe.TpeMessage;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+
+/**
+ * Draws the OIWFS overlay for GMOS.
+ */
+public class GMOS_OIWFS_Feature extends OIWFS_FeatureBase {
+    // The color to use to draw the OIWFS probe arm
+    private static final Color PROBE_ARM_COLOR = Color.red;
+
+    // Composite used for drawing items that block the view
+    private static final Composite BLOCKED = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.5F);
+
+//    // The offsets (from the base pos) and dimensions of the OIWFS patrol field (in arcsec)
+//    private static final Shape PATROL_FIELD = GmosOiwfsGuideProbe.instance.getPatrolField().getArea();
+
+    // The following values (in arcsec) are used to calculate the position of the OIWFS arm
+    // and are described in the paper "Opto-Mechanical Design of the Gemini Multi-Object
+    // Spectrograph On-Instrument Wavefront Sensor".
+    private static final double TX = -427.52;  // Location of base stage in arcsec
+    private static final double TZ = -101.84;
+
+    private static final double BX = 124.89;   // Length of stage arm in arcsec
+    private static final double MX = 358.46;   // Length of pick-off arm in arcsec
+
+
+    // The size of the OIWFS probe arm pickoff mirror in arcsec
+    private static final double PICKOFF_MIRROR_SIZE = 20.;
+
+    // The length of the OIWFS probe arm, starting at the pickoff mirror, in arcsec
+    private static final double PROBE_ARM_LENGTH = MX - PICKOFF_MIRROR_SIZE / 2.;
+
+    // The width of the tapered end of the probe arm in arcsec
+    private static final double PROBE_ARM_TAPERED_WIDTH = 15.;
+
+    // The length of the tapered end of the probe arm in arcsec
+    private static final double PROBE_ARM_TAPERED_LENGTH = 180.;
+
+    // Set to true if the offset constrained patrol field area is empty
+    private boolean offsetConstrainedPatrolFieldIsEmpty = false;
+
+    /**
+     * Construct the feature with its name and description.
+     */
+    public GMOS_OIWFS_Feature() {
+        super("GMOS OIWFS", "Show the GMOS OIWFS patrol field and arm.");
+        setFillObscuredArea(true);
+    }
+
+    protected void addPatrolField(double xc, double yc) {
+        // RCN: this won't work if there's no obs context
+        for (ObsContext ctx : _iw.getMinimalObsContext()) {
+            for (PatrolField patrolField : GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                // rotation, scaling and transformation to match screen coordinates
+                Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+
+                addPatrolField(patrolField);
+            }
+        }
+    }
+
+    /**
+     * Add the OIWFS patrol field to the list of figures to display.
+     *
+     * @param xc the X screen coordinate for the base position to use
+     * @param yc the Y screen coordinate for the base position to use
+     */
+    protected void addOffsetConstrainedPatrolField(final double xc, final double yc) {
+        final Set<Offset> offsets = _iw.getContext().offsets().scienceOffsetsJava();
+
+        for (ObsContext ctx : _iw.getMinimalObsContext()) {
+            for (PatrolField patrolField : GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx)) {
+                offsetConstrainedPatrolFieldIsEmpty = patrolField.outerLimitOffsetIntersection(offsets).isEmpty() ? true : false;
+                // rotation, scaling and transformation to match screen coordinates
+                final Angle rotation = new Angle(-_posAngle, Angle.Unit.RADIANS);
+                final Point2D.Double translation = new Point2D.Double(xc, yc);
+                setTransformationToScreen(rotation, _pixelsPerArcsec, translation);
+                addOffsetConstrainedPatrolField(patrolField, offsets);
+            }
+        }
+    }
+
+
+    /**
+     * Add the OIWFS probe arm pickoff mirror to the display list.
+     *
+     * @param tp the location of the OIWFS guide star in screen coords
+     * @param trans the transformation to apply to the figure
+     */
+    private void _addPickoffMirror(Point2D.Double tp, AffineTransform trans) {
+        double width = PICKOFF_MIRROR_SIZE * _pixelsPerArcsec;
+        double d = width / 2.;
+        double x = tp.x - d;
+        double y = tp.y - d;
+        Polygon2D.Double pickoffMirror = new Polygon2D.Double(x, y);
+        pickoffMirror.lineTo(x + width, y);
+        pickoffMirror.lineTo(x + width, y + width);
+        pickoffMirror.lineTo(x, y + width);
+
+        // rotate by position angle
+        pickoffMirror.transform(trans);
+
+        _figureList.add(new Figure(pickoffMirror, PROBE_ARM_COLOR, BLOCKED, OIWFS_STROKE));
+    }
+
+
+    /**
+     * Add the OIWFS probe arm (without the pickoff mirror) to the display list.
+     *
+     * @param tp the location of the OIWFS guide star in screen coords
+     * @param trans the transformation to apply to the figure
+     */
+    private void _addProbeArm(Point2D.Double tp, AffineTransform trans) {
+        double mirror = PICKOFF_MIRROR_SIZE * _pixelsPerArcsec;
+//        double width = PROBE_ARM_WIDTH * _pixelsPerArcsec;
+        double length = PROBE_ARM_LENGTH * _pixelsPerArcsec;
+        double taperedWidth = PROBE_ARM_TAPERED_WIDTH * _pixelsPerArcsec;
+        double taperedLength = PROBE_ARM_TAPERED_LENGTH * _pixelsPerArcsec;
+        double hm = mirror / 2.;
+        double htw = taperedWidth / 2.;
+
+        double x0 = tp.x + hm * _flipRA;
+        double y0 = tp.y - htw;
+        Polygon2D.Double arm = new Polygon2D.Double(x0, y0);
+
+        double x1 = x0 + taperedLength * _flipRA;
+        double y1 = tp.y - hm;
+        arm.lineTo(x1, y1);
+
+        double x2 = x0 + length * _flipRA;
+        double y2 = y1;
+        arm.lineTo(x2, y2);
+
+        double x3 = x2;
+        double y3 = tp.y + hm;
+        arm.lineTo(x3, y3);
+
+        double x4 = x1;
+        double y4 = y3;
+        arm.lineTo(x4, y4);
+
+        double x5 = x0;
+        double y5 = tp.y + htw;
+        arm.lineTo(x5, y5);
+
+        arm.transform(trans);
+        _figureList.add(new Figure(arm, PROBE_ARM_COLOR, BLOCKED, OIWFS_STROKE));
+    }
+
+    // Get the offset that should be used as the "base" for drawing the probe
+    // arm.  This is either the selected offset position (if any), otherwise
+    // whatever offset position is considered the default one (the first), or
+    // failing all else a 0 offset (which corresponds to the base)..
+    private Offset getProbeArmOffset() {
+        TpeContext ctx = _iw.getContext();
+        OffsetPosBase selOffset = ctx.offsets().selectedPosOrNull();
+
+        // TPE REFACTOR - default offset?
+//        if (selOffsetOpt.isEmpty()) selOffsetOpt = progData.getDefaultOffsetPos();
+
+        return (selOffset == null) ? Offset.ZERO_OFFSET : selOffset.toSkycalcOffset();
+    }
+
+    /**
+     * Add the OIWFS probe arm to the list of figures to display.
+     * Calculates the OIWFS arm position (see eq. 21 - 28 in GMOS paper).
+     *
+     * @param xg the X screen coordinate position for the guide star
+     * @param yg the Y screen coordinate position for the guide star
+     * @param xc the X screen coordinate for the base position
+     * @param yc the Y screen coordinate for the base position
+     * @param xt translate resulting figure by this amount of pixels in X
+     * @param yt translate resulting figure by this amount of pixels in Y
+     * @param flip if true, flip the probe arm about the base position X axis
+     */
+    protected void _addProbeArm(double xg, double yg, double xc, double yc, double xt, double yt, boolean flip) {
+        int sign = (flip ? -1 : 1);
+
+        //get the selected offset, or the default offset(first one) if none is selected
+        Option<ObsContext> obsCtxOpt=_iw.getMinimalObsContext();
+        ObsContext ctx = obsCtxOpt.getOrNull();
+        if(ctx==null)return;
+
+        //Draw probe arm if guide star is inside the selected offset patrol field.
+        Offset probeArmOffset = getProbeArmOffset();
+        if (!GmosOiwfsGuideProbe.instance.inRange(ctx, probeArmOffset)) return;
+
+        // get the additional (IFU) patrol field offset in screen coords, rotated by the position angle
+        Point2D.Double ifuOffset = new Point2D.Double(_getPatrolFieldXOffset((InstGmosCommon) _iw.getInstObsComp()), 0);
+        edu.gemini.spModel.util.Angle.rotatePoint(ifuOffset, _posAngle);
+        xc += ifuOffset.x * _flipRA;
+        yc += ifuOffset.y;
+
+        // get the GMOS constants in screen coords
+        Point2D.Double t = new Point2D.Double(TX * _pixelsPerArcsec * _flipRA,
+                                              TZ * _pixelsPerArcsec * sign);
+        edu.gemini.spModel.util.Angle.rotatePoint(t, _posAngle);
+        double tx = t.x;
+        double tz = t.y;
+
+        // get the location of the OIWFS guide star in screen coordinates
+        Point2D.Double tp = new Point2D.Double(xg, yg);
+
+        // get x and y based on offset of tp to base pos
+        double x = tx + tp.x - xc;
+        double y = tz + tp.y - yc;
+
+        double r = Math.sqrt(x * x + y * y);
+        double mxx = MX * _pixelsPerArcsec;
+        double mx = mxx * _flipRA;
+        double mx2 = mx * mx;
+        double bx = BX * _pixelsPerArcsec;
+        double bx2 = bx * bx;
+
+        // Calculate the relevant angles
+        @SuppressWarnings({"SuspiciousNameCombination"}) double alpha = Math.atan2(x, y);
+        double r2 = r * r;
+
+        // Grim hack to handle an edge case.
+        double acosArg = (r*r - (bx2 + mx2)) / (2 * bx * mx);
+        if (acosArg > 1.0) {
+            acosArg = 1.0;
+        } else if (acosArg < -1.0) {
+            acosArg = -1.0;
+        }
+        double phi = sign * Math.acos(acosArg);
+
+        double theta = Math.asin((mx / r) * Math.sin(phi));
+        if (mx2 > (r2 + bx2)) {
+            theta = Math.PI - theta;
+        }
+
+        // Set up the transformation to rotate by the angles calculated above
+        // (minus PI/2 to make up for the starting angle?)
+        AffineTransform armTrans = new AffineTransform();
+        double angle = phi - theta - alpha - Math.PI / 2.;
+        armTrans.translate(xt, yt);
+        armTrans.rotate(angle, tp.x, tp.y);
+
+        // add the figures to the display list
+        _addPickoffMirror(tp, armTrans);
+        _addProbeArm(tp, armTrans);
+    }
+
+
+    /** Return the X offset for the patrol field based on the selected FP unit (in arcsec) */
+    private double _getPatrolFieldXOffset(InstGmosCommon inst) {
+        return ((GmosCommonType.FPUnit)inst.getFPUnit()).getWFSOffset();
+    }
+
+
+    /**
+     * Update the list of figures to draw.
+     *
+     * @param guidePosX the X screen coordinate position for the OIWFS guide star
+     * @param guidePosY the Y screen coordinate position for the OIWFS guide star
+     * @param offsetPosX the X screen coordinate for the selected offset
+     * @param offsetPosY the X screen coordinate for the selected offset
+     * @param translateX translate resulting figure by this amount of pixels in X
+     * @param translateY translate resulting figure by this amount of pixels in Y
+     * @param basePosX the X screen coordinate for the base position
+     * @param basePosY the Y screen coordinate for the base position
+     * @param oiwfsDefined set to true if an OIWFS position is defined (otherwise
+     *                     the xg and yg parameters are ignored)
+     */
+    protected void _updateFigureList(double guidePosX, double guidePosY, double offsetPosX, double offsetPosY,
+                                     double translateX, double translateY, double basePosX, double basePosY, boolean oiwfsDefined) {
+
+        // need to flip the drawing about the X axis if the instrument is side-mounted
+        InstGmosCommon inst = (InstGmosCommon) _iw.getInstObsComp();
+        boolean flip = (inst.getIssPort() == IssPort.SIDE_LOOKING);
+
+        _figureList.clear();
+        addOffsetConstrainedPatrolField(basePosX, basePosY);
+        addPatrolField(offsetPosX + translateX, offsetPosY + translateY);
+        if (oiwfsDefined) {
+            _addProbeArm(guidePosX, guidePosY, offsetPosX, offsetPosY, translateX, translateY, flip);
+        }
+    }
+
+
+    /** Return true if the display needs to be updated because values changed. */
+    protected boolean _needsUpdate(SPInstObsComp inst, TpeImageInfo tii) {
+        // Needs to take into account offset position list updates to work
+        // as intended.  Unclear whether it is worth the effort to maintain
+        // the old offset lists when the calculation isn't that slow anyway.
+        return true;
+    }
+
+    private static final TpeMessage WARNING = TpeMessage.warningMessage(
+            "No valid OIWFS region.  Check offset positions.");
+
+    @Override
+    public Option<Collection<TpeMessage>> getMessages() {
+        if (offsetConstrainedPatrolFieldIsEmpty) {
+            return new Some<Collection<TpeMessage>>(Collections.singletonList(WARNING));
+        } else {
+            return None.instance();
+        }
+    }
+}
+

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_SciAreaFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/GMOS_SciAreaFeature.java
@@ -6,27 +6,30 @@
 //
 package jsky.app.ot.gemini.gmos;
 
-import edu.gemini.shared.util.immutable.*;
+import diva.util.java2d.Polygon2D;
 import edu.gemini.spModel.gemini.gmos.*;
-import edu.gemini.spModel.inst.FeatureGeometry$;
-import edu.gemini.spModel.obs.context.ObsContext;
 import jsky.app.ot.gemini.inst.SciAreaFeatureBase;
 import jsky.app.ot.tpe.TpeImageInfo;
 import jsky.app.ot.tpe.TpeImageWidget;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
-import java.awt.geom.Area;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 
-import java.util.*;
-import java.util.List;
+import java.util.Iterator;
 
 
 /**
  * Draws the Science Area, the detector or slit.
  */
 public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
+
+    // The size of the imaging field of view in arcsec
+    private static final double IMAGING_FOV_SIZE = 330.34;
+
+    // The size of the imaging FOV before the cut-off corners, in arcsec
+    private static final double IMAGING_FOV_INNER_SIZE = 131.33 * 2;
 
     // The size of the central imaging CCD, in arcsec
     private static final double IMAGING_CENTER_CCD_WIDTH = 2.76 * 60;
@@ -37,7 +40,67 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
     // The size of the gaps between imaging CCDs, in arcsec
     private static final double IMAGING_GAP_WIDTH = 3;
 
-    // Holds information needed to display CCD gaps, if applicable
+    // The size of the square MOS field of view in arcsec
+    // (slightly smaller than the imaging FOV)
+    private static final double MOS_FOV_SIZE = IMAGING_FOV_SIZE - 2 * 8.05;
+
+    // The size of the imaging FOV before the cut-off corners, in arcsec
+    private static final double MOS_FOV_INNER_SIZE = 139.38 * 2;
+
+
+    // The height of the long slit FOV in arcsec (the width is selected by the user)
+    private static final double LONG_SLIT_FOV_HEIGHT = 108.0;
+
+    // The height of a long slit FOV bridge in arcsec
+    // (There are one of these between each of the slits)
+    private static final double LONG_SLIT_FOV_BRIDGE_HEIGHT = 3.2;
+
+
+    // IFU visualisation in TPE
+    //
+    // Currently TPE shows the true focal plane geometry which has fixed IFU sub-fields
+    // offset either side of the base position. Whilst this is factually correct, what users
+    // will expect is that the larger of the two sub-fields be positioned on their target (as
+    // defined by the target component). This is the first case in which the instrument
+    // aperture is not symmetric about the pointing position (in this case it is offset by ~
+    // 30 arcsec from it).
+    //
+    // {Phil: proposed solution}
+    // The tricky aspect is that the base position displayed in TPE currently has two
+    // meanings (a) it shows the position of the target RA,dec and (b) it also shows the
+    // telescope pointing direction (essentially the direction in which the mount points) and
+    // is used as the origin for drawing the PWFS and OIWFS patrol fields. These need not be
+    // the same for an off-axis. (A similar case will occur with the bHROS fibre feed).
+    //
+    // There are several options, only one of which will avoid completely confusing the
+    // users. The proposed solution is: firstly, the larger IFU sub-aperture should be drawn
+    // at the base position. Secondly, the PWFS and OIWFS patrol fields must be offset (by
+    // the opposite amount that the IFU field is off-axis). This 'pseudo' base position (we
+    // would call it the pointing position) is the centre for drawing the PWFS and OIWFS
+    // patrol fields. (The pointing position need not be displayed in TPE).
+    //
+    // [source: bmiller e-mail 19Dec01 and 14Jan 02, generalised by ppuxley]**********
+    //
+    // Allan: Note: For GMOS-S it is the smaller rect that is centered on the base position
+    // (The display is reversed).
+    //
+    // The offset from the base position in arcsec
+    private static final double IFU_FOV_OFFSET = 30.;
+
+    // The offsets (from the base pos) and dimensions of the IFU FOV (in arcsec)
+    private static final Rectangle2D.Double[] IFU_FOV = new Rectangle2D.Double[]{
+        new Rectangle2D.Double(-30. - IFU_FOV_OFFSET, 0., 3.5, 5.),
+        new Rectangle2D.Double(30. - IFU_FOV_OFFSET, 0., 7., 5.)
+    };
+
+    // Indexes for above array
+    private static final int IFU_FOV_SMALLER_RECT_INDEX = 0;
+    private static final int IFU_FOV_LARGER_RECT_INDEX = 1;
+
+    // Set to true if the instrument is GMOS South
+    private boolean _isSouth;
+
+    // Holds infor needed to display CCD gaps, if applicable
     private ImagingGaps _gaps;
 
     /**
@@ -49,19 +112,182 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
     /**
      * Override reinit to note if this is for Gemini south or north
      */
-    public void reinit(final TpeImageWidget iw, final TpeImageInfo tii) {
+    public void reinit(TpeImageWidget iw, TpeImageInfo tii) {
         super.reinit(iw, tii);
+        _isSouth = iw.getContext().instrument().is(InstGmosSouth.SP_TYPE);
     }
 
     private InstGmosCommon getInst() {
-        final InstGmosCommon gmos = _iw.getContext().instrument().orNull(InstGmosNorth.SP_TYPE);
-        if (gmos != null) return gmos;
-        return _iw.getContext().instrument().orNull(InstGmosSouth.SP_TYPE);
+        InstGmosCommon gmos = _iw.getContext().instrument().orNull(InstGmosNorth.SP_TYPE);
+        if (gmos == null) gmos = _iw.getContext().instrument().orNull(InstGmosSouth.SP_TYPE);
+        return gmos;
     }
 
     private boolean isHamamatsu() {
         final InstGmosCommon inst = getInst();
-        return inst != null && GmosCommonType.DetectorManufacturer.HAMAMATSU.equals(inst.getDetectorManufacturer());
+        return (inst == null) ? false : GmosCommonType.DetectorManufacturer.HAMAMATSU.equals(inst.getDetectorManufacturer());
+    }
+
+    /**
+     * Add the FOV described by the arguments to the list of figures to display.
+     * The shape drawn here is a square with cut-off corners.
+     *
+     * @param size the basic size of a square, in arcsec, centered at the base pos
+     * @param innerSize the length of a side after cutting off the corners, in arcsec
+     */
+    private void _addFOV(double size, double innerSize) {
+        // draw a square with the corners cut off
+        double size1 = size * _pixelsPerArcsec;
+        double size2 = innerSize * _pixelsPerArcsec;
+        double d1 = size1 / 2;
+        double d2 = size2 / 2;
+        double cornerSize = d1 - d2;
+
+        double x0 = _baseScreenPos.x - d1 + cornerSize;
+        double y0 = _baseScreenPos.y - d1;
+        Polygon2D.Double fov = new Polygon2D.Double(x0, y0);
+
+        double x1 = x0 + size2;
+        double y1 = y0;
+        fov.lineTo(x1, y1);
+
+        double x2 = x1 + cornerSize;
+        double y2 = y1 + cornerSize;
+        fov.lineTo(x2, y2);
+
+        double x3 = x2;
+        double y3 = y2 + size2;
+        fov.lineTo(x3, y3);
+
+        double x4 = x3 - cornerSize;
+        double y4 = y3 + cornerSize;
+        fov.lineTo(x4, y4);
+
+        double x5 = x4 - size2;
+        double y5 = y4;
+        fov.lineTo(x5, y5);
+
+        double x6 = x5 - cornerSize;
+        double y6 = y5 - cornerSize;
+        fov.lineTo(x6, y6);
+
+        double x7 = x6;
+        double y7 = y6 - size2;
+        fov.lineTo(x7, y7);
+
+        // rotate by position angle
+        fov.transform(_posAngleTrans);
+
+        _figureList.add(fov);
+    }
+
+
+    /** Add the imaging FOV to the list of figures to display. */
+    private void _addImagingFOV() {
+        _addFOV(IMAGING_FOV_SIZE, IMAGING_FOV_INNER_SIZE);
+        _gaps = new ImagingGaps(IMAGING_FOV_SIZE);
+    }
+
+    /** Add the MOS field of view to the list of figures to display. */
+    private void _addMOS_FOV() {
+        _addFOV(MOS_FOV_SIZE, MOS_FOV_INNER_SIZE);
+        _gaps = new ImagingGaps(MOS_FOV_SIZE);
+    }
+
+    /** Add the long slit field of view to the list of figures to display. */
+    private void _addLongSlitFOV() {
+        double slitWidth = _sciArea.getWidth();
+        double slitHeight = LONG_SLIT_FOV_HEIGHT * _pixelsPerArcsec;
+        double bridgeHeight = LONG_SLIT_FOV_BRIDGE_HEIGHT * _pixelsPerArcsec;
+
+        // add the 3 slits along the y axis
+        double x = _baseScreenPos.x - (slitWidth / 2);
+        double d = slitHeight + bridgeHeight;
+        for (int i = -1; i <= 1; i++) {
+            double y = _baseScreenPos.y - (slitHeight / 2) + (i * d);
+            Polygon2D.Double slit = new Polygon2D.Double(x, y);
+            slit.lineTo(x + slitWidth, y);
+            slit.lineTo(x + slitWidth, y + slitHeight);
+            slit.lineTo(x, y + slitHeight);
+
+            // rotate by position angle
+            slit.transform(_posAngleTrans);
+
+            _figureList.add(slit);
+        }
+    }
+
+    /** Add the nod & shuffle field of view to the list of figures to display. */
+    private void _addNS_FOV() {
+        double slitWidth = _sciArea.getWidth();
+        double slitHeight = LONG_SLIT_FOV_HEIGHT * _pixelsPerArcsec;
+        //double bridgeHeight = LONG_SLIT_FOV_BRIDGE_HEIGHT * _pixelsPerArcsec;
+
+        // add the slit along the y axis
+        double x = _baseScreenPos.x - (slitWidth / 2);
+        double y = _baseScreenPos.y - (slitHeight / 2);
+        Polygon2D.Double slit = new Polygon2D.Double(x, y);
+        slit.lineTo(x + slitWidth, y);
+        slit.lineTo(x + slitWidth, y + slitHeight);
+        slit.lineTo(x, y + slitHeight);
+
+        // rotate by position angle
+        slit.transform(_posAngleTrans);
+
+        _figureList.add(slit);
+    }
+
+
+    // Add the IFU field of view to the list of figures to display.
+    private void _addIFU_FOV(GmosCommonType.FPUnit fpUnit) {
+        // The width values are different for these (see OT-419).
+        // In these cases we need to subtract 2 from the width.
+        int wx = 0;
+        if (fpUnit == GmosSouthType.FPUnitSouth.IFU_N || fpUnit == GmosSouthType.FPUnitSouth.IFU_N_B
+                || fpUnit == GmosSouthType.FPUnitSouth.IFU_N_R ) {
+            wx = 2;
+        }
+
+        // These are used to center the right rect on the base pos
+        double w = ((IFU_FOV[IFU_FOV_LARGER_RECT_INDEX].width - wx) * _pixelsPerArcsec) / 2.0;
+        double h = (IFU_FOV[IFU_FOV_LARGER_RECT_INDEX].height * _pixelsPerArcsec) / 2.0;
+
+        // Add the two slits
+        for (int i = 0; i < IFU_FOV.length; i++) {
+            if (wx != 0 && i != IFU_FOV_LARGER_RECT_INDEX) {
+                continue; // only display the larger one for these (see OT-419)
+            }
+            double width = (IFU_FOV[i].width - wx) * _pixelsPerArcsec;
+            double height = IFU_FOV[i].height * _pixelsPerArcsec;
+            double x = _baseScreenPos.x + (IFU_FOV[i].x * _pixelsPerArcsec) - w;
+            double y = _baseScreenPos.y + (IFU_FOV[i].y * _pixelsPerArcsec) - h;
+
+            if (fpUnit == GmosNorthType.FPUnitNorth.IFU_2 || fpUnit == GmosNorthType.FPUnitNorth.IFU_3 ||
+                fpUnit == GmosSouthType.FPUnitSouth.IFU_2 || fpUnit == GmosSouthType.FPUnitSouth.IFU_3 ||
+                    fpUnit == GmosSouthType.FPUnitSouth.IFU_N_B || fpUnit == GmosSouthType.FPUnitSouth.IFU_N_R) {
+                // left or right slit: show the left or right half of both slits, with the larger(north) or
+                // smaller(south) of the two centered about the base position
+                width /= 2.0;
+                x += (w / 2.0);
+            }
+
+            // allan: 11/13/03: For GMOS-S, flip along the X axis about the base position
+            // (OIWFS patrol field should be shifted as well: See JIRA log for #OT-10)
+            if (_isSouth && i == IFU_FOV_SMALLER_RECT_INDEX) {
+                x = _baseScreenPos.x + (_baseScreenPos.x - x) - width;
+            }
+
+            Polygon2D.Double fov = new Polygon2D.Double(x, y);
+            fov.lineTo(x + width, y);
+            fov.lineTo(x + width, y + height);
+            fov.lineTo(x, y + height);
+
+            // rotate by position angle
+            fov.transform(_posAngleTrans);
+
+            _figureList.add(fov);
+
+        }
     }
 
 
@@ -71,16 +297,17 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
      * offset depends on the selected FP unit mode.
      */
     protected Point2D.Double _getTickMarkOffset() {
-        final Point2D.Double offset = new Point2D.Double(_baseScreenPos.x, _baseScreenPos.y - _sciArea.getHeight() / 2.0);
+        Point2D.Double offset = new Point2D.Double(_baseScreenPos.x,
+                                                   _baseScreenPos.y - _sciArea.getHeight() / 2.0);
 
-        final InstGmosCommon instGMOS = getInst();
+        InstGmosCommon instGMOS = getInst();
         if (instGMOS != null) {
-            final GmosCommonType.FPUnitMode fpUnitMode = instGMOS.getFPUnitMode();
+            GmosCommonType.FPUnitMode fpUnitMode = instGMOS.getFPUnitMode();
             if (fpUnitMode == GmosCommonType.FPUnitMode.BUILTIN) {
                 if (instGMOS.isIFU()) {
-                    offset.y = _baseScreenPos.y - 30.0;
+                    offset.y = _baseScreenPos.y - 30;
                 } else if (instGMOS.isNS()) {
-                    offset.y = _baseScreenPos.y - GmosScienceAreaGeometry$.MODULE$.LongSlitFOVHeight() / 2.0 * _pixelsPerArcsec;
+                    offset.y = _baseScreenPos.y - LONG_SLIT_FOV_HEIGHT / 2. * _pixelsPerArcsec;
                 }
             }
         }
@@ -90,38 +317,30 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
     /**
      * Update the list of FOV figures to draw.
      */
-    @SuppressWarnings("unchecked")
     protected void _updateFigureList() {
         _figureList.clear();
         _gaps = null;
 
         InstGmosCommon instGMOS = getInst();
         if (instGMOS != null) {
-            final ObsContext ctx = _iw.getMinimalObsContext().getOrNull();
-            if (ctx != null) {
-                final ImList<Shape> shape = instGMOS.getVignettableScienceArea().geometryAsJava();
-                final AffineTransform ptm = getPosAngleTransformModifier();
-                shape.foreach(new ApplyOp<Shape>() {
-                    @Override
-                    public void apply(final Shape s) {
-                        final Shape s2 = FeatureGeometry$.MODULE$.transformScienceAreaForContext(s, ctx);
-                        final Shape s3 = FeatureGeometry$.MODULE$.transformScienceAreaForScreen(s2, _pixelsPerArcsec, ctx, _baseScreenPos);
-                        final Shape s4 = ptm.createTransformedShape(s3);
-                        _figureList.add(s4);
-                    }
-                });
-
-                // Create any necessary modifications.
-                final GmosCommonType.FPUnitMode fpUnitMode = instGMOS.getFPUnitMode();
-                if (fpUnitMode == GmosCommonType.FPUnitMode.BUILTIN && instGMOS.isImaging())
-                    _gaps = new ImagingGaps(GmosScienceAreaGeometry$.MODULE$.ImagingFOVSize());
-                else if (fpUnitMode == GmosCommonType.FPUnitMode.CUSTOM_MASK)
-                    _gaps = new ImagingGaps(GmosScienceAreaGeometry$.MODULE$.MOSFOVSize());
+            GmosCommonType.FPUnitMode fpUnitMode = instGMOS.getFPUnitMode();
+            if (fpUnitMode == GmosCommonType.FPUnitMode.BUILTIN) {
+                if (instGMOS.isImaging()) {
+                    _addImagingFOV();
+                } else if (instGMOS.isSpectroscopic()) {
+                    _addLongSlitFOV();
+                } else if (instGMOS.isIFU()) {
+                    _addIFU_FOV((GmosCommonType.FPUnit) instGMOS.getFPUnit());
+                } else if (instGMOS.isNS()) {
+                    _addNS_FOV();
+                }
+            } else if (fpUnitMode == GmosCommonType.FPUnitMode.CUSTOM_MASK) {
+                _addMOS_FOV();
             }
         }
     }
 
-    @Override protected boolean _calc(final TpeImageInfo tii) {
+    @Override protected boolean _calc(TpeImageInfo tii) {
         if (!super._calc(tii)) return false;
         _updateFigureList();
         return true;
@@ -130,32 +349,36 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
     /**
      * Draw the feature.
      */
-    public void draw(final Graphics g, final TpeImageInfo tii) {
+    public void draw(Graphics g, TpeImageInfo tii) {
         if (!_calc(tii)) return;
 
-        final Graphics2D g2d = (Graphics2D) g;
+        Graphics2D g2d = (Graphics2D) g;
         g2d.setColor(FOV_COLOR);
 
         // draw the FOV
-        for (final Shape s: _figureList)
-            g2d.draw(s);
-
-        if (_gaps != null)
+        Iterator it = _figureList.iterator();
+        while (it.hasNext()) {
+            g2d.draw((Shape) it.next());
+        }
+        if (_gaps != null) {
             _gaps.draw(g2d);
+        }
 
         // Draw the drag item
         g2d.fill(_tickMarkPD.getPolygon2D());
 
-        // Draw a string displaying the rotation angle
-        final InstGmosCommon inst = getInst();
-        if (_dragging && inst != null) {
-            g2d.setFont(POS_ANGLE_FONT);
-
+        if (_dragging) {
             // Draw a little above the mouse
-            final int baseX = _dragX;
-            final int baseY = _dragY - 10;
-            final String s = "position angle = " + inst.getPosAngleDegreesStr() + " deg";
-            g.drawString(s, baseX, baseY);
+            int baseX = _dragX;
+            int baseY = _dragY - 10;
+
+            // Draw a string displaying the rotation angle
+            g2d.setFont(POS_ANGLE_FONT);
+            InstGmosCommon inst = getInst();
+            if (inst != null) {
+                String s = "position angle = " + inst.getPosAngleDegreesStr() + " deg";
+                g.drawString(s, baseX, baseY);
+            }
         }
     }
 
@@ -164,18 +387,21 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
      * Draw the science area at the given x,y (screen coordinate) offset position.
      */
     @Override
-    public void drawAtOffsetPos(final Graphics g, final TpeImageInfo tii, double x, double y) {
+    public void drawAtOffsetPos(Graphics g, TpeImageInfo tii, double x, double y) {
         if (!_calc(tii)) return;
 
-        final Graphics2D g2d = (Graphics2D) g;
-        final AffineTransform saveAT = g2d.getTransform();
+        Graphics2D g2d = (Graphics2D) g;
+        AffineTransform saveAT = g2d.getTransform();
 
         try {
             g2d.translate(x - _baseScreenPos.x, y - _baseScreenPos.y);
-            for (final Shape s : _figureList)
-                g2d.draw(s);
-            if (_gaps != null)
+            Iterator it = _figureList.iterator();
+            while (it.hasNext()) {
+                g2d.draw((Shape) it.next());
+            }
+            if (_gaps != null) {
                 _gaps.draw(g2d);
+            }
         } finally {
             g2d.setTransform(saveAT);
         }
@@ -184,18 +410,18 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
     // Manages drawing the CCD gaps and associated labels
     private class ImagingGaps {
         // CCD gaps
-        final Shape gap1;
-        final Shape gap2;
+        Polygon2D.Double _gap1;
+        Polygon2D.Double _gap2;
 
         // label positions
-        final Point2D.Double posCCD1;
-        final Point2D.Double posCCD2;
-        final Point2D.Double posCCD3;
+        Point2D.Double _posCCD1;
+        Point2D.Double _posCCD2;
+        Point2D.Double _posCCD3;
 
         // label strings
-        final String nameCCD1;
-        final String nameCCD2;
-        final String nameCCD3;
+        String _nameCCD1;
+        String _nameCCD2;
+        String _nameCCD3;
 
         /**
          * Initialize CCD gap for FOV of the given size
@@ -203,69 +429,67 @@ public class GMOS_SciAreaFeature extends SciAreaFeatureBase {
          * @param size the basic size of the imaging square, in arcsec, centered at the base pos
          */
         ImagingGaps(double size) {
-            final double height = size * _pixelsPerArcsec;
-            final double width = IMAGING_CENTER_CCD_WIDTH * _pixelsPerArcsec;
-            final double h2 = height / 2;
-            final double w2 = width / 2;
-            final double gapWidth = IMAGING_GAP_WIDTH * _pixelsPerArcsec;
+            double height = size * _pixelsPerArcsec;
+            double width = IMAGING_CENTER_CCD_WIDTH * _pixelsPerArcsec;
+            double h2 = height / 2;
+            double w2 = width / 2;
+            double gapWidth = IMAGING_GAP_WIDTH * _pixelsPerArcsec;
 
             // XXX should the gaps be centered, inside or outside the center CCD?
-            final double x1 = _baseScreenPos.x - w2 - gapWidth/2.;
-            final double y1 = _baseScreenPos.y - h2;
-            gap1 = makeGap(x1, y1, gapWidth, height);
+            double x1 = _baseScreenPos.x - w2 - gapWidth/2.;
+            double y1 = _baseScreenPos.y - h2;
+            _gap1 = _makeGap(x1, y1, gapWidth, height);
 
-            final double x2 = _baseScreenPos.x + w2 - gapWidth/2.;
-            final double y2 = y1;
-            gap2 = makeGap(x2, y2, gapWidth, height);
+            double x2 = _baseScreenPos.x + w2 - gapWidth/2.;
+            double y2 = y1;
+            _gap2 = _makeGap(x2, y2, gapWidth, height);
 
-            final double lrWidth = IMAGING_LR_CCD_WIDTH * _pixelsPerArcsec;
-            final double w3 = lrWidth / 2;
-            final double y3 = y1 + height / 4;
+            double lrWidth = IMAGING_LR_CCD_WIDTH * _pixelsPerArcsec;
+            double w3 = lrWidth / 2;
+            double y3 = y1 + height / 4;
 
-            posCCD1 = new Point2D.Double(x1 - w3, y3);
-            posCCD2 = new Point2D.Double(_baseScreenPos.x, y3);
-            posCCD3 = new Point2D.Double(x2 + w3, y3);
-            _posAngleTrans.transform(posCCD1, posCCD1);
-            _posAngleTrans.transform(posCCD2, posCCD2);
-            _posAngleTrans.transform(posCCD3, posCCD3);
+            _posCCD1 = new Point2D.Double(x1 - w3, y3);
+            _posCCD2 = new Point2D.Double(_baseScreenPos.x, y3);
+            _posCCD3 = new Point2D.Double(x2 + w3, y3);
+            _posAngleTrans.transform(_posCCD1, _posCCD1);
+            _posAngleTrans.transform(_posCCD2, _posCCD2);
+            _posAngleTrans.transform(_posCCD3, _posCCD3);
 
             if (isHamamatsu()) {
-                nameCCD1 = "CCDr";
-                nameCCD2 = "CCDg";
-                nameCCD3 = "CCDb";
+                _nameCCD1 = "CCDr";
+                _nameCCD2 = "CCDg";
+                _nameCCD3 = "CCDb";
             } else {
-                nameCCD1 = "CCD1";
-                nameCCD2 = "CCD2";
-                nameCCD3 = "CCD3";
+                _nameCCD1 = "CCD1";
+                _nameCCD2 = "CCD2";
+                _nameCCD3 = "CCD3";
             }
         }
 
         // Returns a polygon for a gap with the given x,y origin, width and height (all in screen pixels)
-        private Shape makeGap(double x, double y, double width, double height) {
-            final List<Pair<Double,Double>> points = new ArrayList<>();
-            points.add(new Pair<>(x        , y));
-            points.add(new Pair<>(x + width, y));
-            points.add(new Pair<>(x + width, y + height));
-            points.add(new Pair<>(x        , y + height));
+        private Polygon2D.Double _makeGap(double x, double y, double width, double height) {
+            Polygon2D.Double p = new Polygon2D.Double(x, y);
+            p.lineTo(x + width, y);
+            p.lineTo(x + width, y + height);
+            p.lineTo(x, y + height);
+            p.closePath();
 
-            // Create the polygon and rotate it by the PA.
-            final ImPolygon p = ImPolygon$.MODULE$.apply(points);
-            final Area a = new Area(p);
-            a.transform(_posAngleTrans);
-            return a;
+            // rotate by position angle
+            p.transform(_posAngleTrans);
+            return p;
         }
 
         // Draw the CCD gaps and associated labels
         void draw(Graphics2D g2d) {
-            g2d.fill(gap1);
-            g2d.fill(gap2);
+            g2d.fill(_gap1);
+            g2d.fill(_gap2);
 
             g2d.setFont(POS_ANGLE_FONT);
             FontMetrics fm = g2d.getFontMetrics();
             int w = fm.stringWidth("CCDx") / 2;
-            g2d.drawString(nameCCD1, (int) posCCD1.x - w, (int) posCCD1.y);
-            g2d.drawString(nameCCD2, (int) posCCD2.x - w, (int) posCCD2.y);
-            g2d.drawString(nameCCD3, (int) posCCD3.x - w, (int) posCCD3.y);
+            g2d.drawString(_nameCCD1, (int) _posCCD1.x - w, (int) _posCCD1.y);
+            g2d.drawString(_nameCCD2, (int) _posCCD2.x - w, (int) _posCCD2.y);
+            g2d.drawString(_nameCCD3, (int) _posCCD3.x - w, (int) _posCCD3.y);
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/inst/OIWFS_Feature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/inst/OIWFS_Feature.java
@@ -16,6 +16,8 @@ import edu.gemini.spModel.gemini.gnirs.InstGNIRS;
 import edu.gemini.spModel.gemini.nifs.InstNIFS;
 import edu.gemini.spModel.gemini.niri.InstNIRI;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
+import jsky.app.ot.gemini.flamingos2.Flamingos2_OIWFS_Feature;
+import jsky.app.ot.gemini.gmos.GMOS_OIWFS_Feature;
 import jsky.app.ot.gemini.gnirs.GNIRS_OIWFS_Feature;
 import jsky.app.ot.gemini.nifs.NIFS_OIWFS_Feature;
 import jsky.app.ot.gemini.niri.NIRI_OIWFS_Feature;
@@ -38,6 +40,8 @@ public class OIWFS_Feature extends TpeImageFeature {
     private TpeImageFeature _feat;
 
     // The instrument specific subclasses
+    private TpeImageFeature _gmosFeat;
+    private TpeImageFeature _f2Feat;
     private TpeImageFeature _niriFeat;
     private TpeImageFeature _gnirsFeat;
     private TpeImageFeature _nifsFeat;
@@ -77,18 +81,19 @@ public class OIWFS_Feature extends TpeImageFeature {
         if (inst instanceof InstNIRI) {
             if (_niriFeat == null) _niriFeat = new NIRI_OIWFS_Feature();
             _feat = _niriFeat;
-        } else if (inst instanceof InstGmosNorth)
-            _feat = GmosNorthOIWFSFeature.instance();
-        else if (inst instanceof InstGmosSouth || inst instanceof InstBHROS)
-            _feat = GmosSouthOIWFSFeature.instance();
-        else if (inst instanceof InstGNIRS) {
+        } else if ((inst instanceof InstGmosNorth) || (inst instanceof InstGmosSouth) || (inst instanceof InstBHROS)) {
+            if (_gmosFeat == null) _gmosFeat = new GMOS_OIWFS_Feature();
+            _feat = _gmosFeat;
+        } else if (inst instanceof InstGNIRS) {
             if (_gnirsFeat == null) _gnirsFeat = new GNIRS_OIWFS_Feature();
             _feat = _gnirsFeat;
         } else if (inst instanceof InstNIFS) {
             if (_nifsFeat == null) _nifsFeat = new NIFS_OIWFS_Feature();
             _feat = _nifsFeat;
-        } else if (inst instanceof Flamingos2)
-            _feat = Flamingos2OIWFSFeature.instance();
+        } else if (inst instanceof Flamingos2) {
+            if (_f2Feat == null) _f2Feat = new Flamingos2_OIWFS_Feature();
+            _feat = _f2Feat;
+        }
 
         if (_feat != null)
             _feat.reinit(iw, tii);


### PR DESCRIPTION
There is an issue with the new vignetting calculations and the new GMOS and F2 science area and probe arm models.  This PR restores the old OT/TPE definitions of GMOS/F2 features and disables the vignetting calculation while leaving all the code for the new work in place but unused.  This accomplishes a few goals:

* Allows us to put together a test release for the other OT work for 2015B
* Provides a fallback for the 2015B release if we cannot sort the problems out in time
* Gives us a quick reference to the old implementation to help work on the issue with the new model

Note that the GMOS/F2 classes `Flamingos2_OIWFS_Feature`, `Flamingos2_SciAreaFeature`, `GMOS_OIWFS_Feature`, and `GMOS_SciAreaFeature` are all simply restored from the repository and are intended to be temporary.  No effort was placed in modernizing them since that has already been done in the new model.