### PR TITLE
Google Services Ignore

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -235,6 +235,7 @@ def swalker(version: Version) = AppConfig(
     "edu.gemini.dataman.xfer.tempDir.base"       -> "/Users/swalker/dataman/base/.xfer",
     "edu.gemini.dataman.xfer.tempDir.gsa"        -> "/Users/swalker/dataman/gsa/.xfer",
     "edu.gemini.datasetfile.workDir"             -> "/Users/swalker/dataman/work",
+    "edu.gemini.services.server.start"           -> "false",
     "edu.gemini.smartgcal.host"                  -> "localhost",
     "edu.gemini.spdb.dir"                        -> "/Users/swalker/.spdb/",
     "edu.gemini.util.trpc.name"                  -> "Shane's ODB (Test)"

--- a/bundle/edu.gemini.services.server/src/main/scala/edu/gemini/services/server/osgi/Activator.scala
+++ b/bundle/edu.gemini.services.server/src/main/scala/edu/gemini/services/server/osgi/Activator.scala
@@ -13,6 +13,7 @@ import scala.concurrent.Future
 import scala.util.{Try, Success, Failure}
 
 object Activator {
+  val ServiceStart = "edu.gemini.services.server.start"
   val Log = Logger.getLogger(classOf[Activator].getName)
 }
 
@@ -25,12 +26,15 @@ class Activator extends BundleActivator {
   var telescopeScheduleService: Option[ServiceRegistration[TelescopeScheduleService]] = None
 
   def start(ctx: BundleContext): Unit = {
-
     val site = SiteProperty.get(ctx)
     Log.info(s"Starting services bundle for site $site.")
-    
-    // register the services..
-    registerTelescopeSchedule(ctx, site)
+
+    if (Option(ctx.getProperty(ServiceStart)).forall(_.toLowerCase == "true")) {
+      // register the services..
+      registerTelescopeSchedule(ctx, site)
+    } else {
+      Log.warning(s"Skipping services start.  Set '$ServiceStart' to 'true' in bundle properties to enable.")
+    }
 
   }
 
@@ -45,7 +49,7 @@ class Activator extends BundleActivator {
 
   /** Tries to register the telescope schedule service. */
   private def registerTelescopeSchedule(ctx: BundleContext, site: Site) {
-    
+
     // only try to create services if we know the site
     if (site != null) {
 


### PR DESCRIPTION
This is a tiny PR that adds a bundle property to the spdb app.  It's called `edu.gemini.services.server.start` and if not present it defaults to `true`.  You can define it and set it to `false` though and the spdb won't try to do the google services login.  I added that property to my own spdb configuration since I've never worked with anything that needs it.

In theory relinking the credentials files will make the login work, and it does for a time.  Eventually though it stops working and you have to relink.  Perhaps it is because the resources directory is missing, I'm not sure.  The end result though is that usually while trying to use the spdb command line during development it is spinning and writing out google services login exceptions.  Also, I'm often at home with a saturated 3G network and logging in to anything is problematic.  This update just allows anyone to turn the google services login and `TelescopeScheduleService` registration off.

I noticed a potential race condition in the `Activator`, by the way.  Since `start` kicks off a thread that retries the login, it seems like it could happen that you've stopped the bundle before the registration is complete.  I'm not going to touch that though since the goal is just to make it possible to turn off the login attempts.