### PR TITLE
OCSADV-303:Ignore bogus magnitude values on UCAC4

### DIFF
--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsCatalogResultsSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsCatalogResultsSpec.scala
@@ -115,7 +115,7 @@ class GemsCatalogResultsSpec extends MascotProgress with Specification with NoTi
       }
 
       System.out.println("gems results: size = " + gemsGuideStars.size)
-      gemsGuideStars should have size 41
+      gemsGuideStars should have size 25
 
       val result = gemsGuideStars.head
       result.getPa.toDegrees should beCloseTo(0, 0.0001)
@@ -135,13 +135,13 @@ class GemsCatalogResultsSpec extends MascotProgress with Specification with NoTi
       val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget
       val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget
       val odgw2 = group.get(GsaoiOdgw.odgw2).getValue.getPrimary.getValue.getTarget
-      cwfs1.getName must beEqualTo("104-014547")
-      cwfs2.getName must beEqualTo("104-014564")
+      cwfs1.getName must beEqualTo("104-014597")
+      cwfs2.getName must beEqualTo("104-014547")
       cwfs3.getName must beEqualTo("104-014608")
       odgw2.getName must beEqualTo("104-014556")
 
-      val cwfs1x = Coordinates.create("05:35:18.423", "-69:16:30.67")
-      val cwfs2x = Coordinates.create("05:35:24.994", "-69:16:04.77")
+      val cwfs1x = Coordinates.create("05:35:32.630", "-69:15:48.64")
+      val cwfs2x = Coordinates.create("05:35:18.423", "-69:16:30.67")
       val cwfs3x = Coordinates.create("05:35:36.409", "-69:16:24.17")
       val odgw2x = Coordinates.create("05:35:23.887", "-69:16:18.20")
 
@@ -154,10 +154,10 @@ class GemsCatalogResultsSpec extends MascotProgress with Specification with NoTi
       (Angle.fromDegrees(odgw2x.getRaDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getRaDeg)) should beTrue
       (Angle.fromDegrees(odgw2x.getDecDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getDecDeg)) should beTrue
 
-      val cwfs1Mag = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget.getMagnitude(Magnitude.Band.r).getValue.getBrightness
+      val cwfs1Mag = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget.getMagnitude(Magnitude.Band.UC).getValue.getBrightness
       val cwfs2Mag = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget.getMagnitude(Magnitude.Band.UC).getValue.getBrightness
       val cwfs3Mag = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget.getMagnitude(Magnitude.Band.UC).getValue.getBrightness
-      cwfs1Mag < cwfs2Mag && cwfs3Mag < cwfs2Mag should beTrue
+      cwfs2Mag < cwfs3Mag && cwfs2Mag < cwfs1Mag should beTrue
     }
     "support Gsaoi Search on M6" in {
       val base = new WorldCoords("17:40:20.000", "-32:15:12.00")
@@ -176,7 +176,7 @@ class GemsCatalogResultsSpec extends MascotProgress with Specification with NoTi
       }
 
       System.out.println("gems results: size = " + gemsGuideStars.size)
-      gemsGuideStars should have size 59
+      gemsGuideStars should have size 51
 
       val result = gemsGuideStars.head
       result.getPa.toDegrees should beCloseTo(0, 0.0001)
@@ -192,28 +192,33 @@ class GemsCatalogResultsSpec extends MascotProgress with Specification with NoTi
       set.contains(GsaoiOdgw.odgw3) should beFalse
       set.contains(GsaoiOdgw.odgw4) should beFalse
 
-      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget.getSkycalcCoordinates
-      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget.getSkycalcCoordinates
-      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget.getSkycalcCoordinates
-      val odgw2 = group.get(GsaoiOdgw.odgw2).getValue.getPrimary.getValue.getTarget.getSkycalcCoordinates
-      val cwfs1x = Coordinates.create("17:40:22.572", "-32:14:43.58")
-      val cwfs2x = Coordinates.create("17:40:15.912", "-32:15:06.01")
-      val cwfs3x = Coordinates.create("17:40:19.713", "-32:15:56.77")
+      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget
+      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget
+      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget
+      val odgw2 = group.get(GsaoiOdgw.odgw2).getValue.getPrimary.getValue.getTarget
+      cwfs1.getName must beEqualTo("289-128878")
+      cwfs2.getName must beEqualTo("289-128908")
+      cwfs3.getName must beEqualTo("289-128891")
+      odgw2.getName must beEqualTo("289-128878")
+
+      val cwfs1x = Coordinates.create("17:40:16.855", "-32:15:55.83")
+      val cwfs2x = Coordinates.create("17:40:21.594", "-32:15:50.38")
+      val cwfs3x = Coordinates.create("17:40:19.295", "-32:14:58.34")
       val odgw2x = Coordinates.create("17:40:16.855", "-32:15:55.83")
 
-      (Angle.fromDegrees(cwfs1x.getRaDeg) ~= Angle.fromDegrees(cwfs1.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getRaDeg) ~= Angle.fromDegrees(cwfs2.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getRaDeg) ~= Angle.fromDegrees(cwfs3.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getDecDeg)) should beTrue
-      (Angle.fromDegrees(odgw2x.getRaDeg) ~= Angle.fromDegrees(odgw2.getRaDeg)) should beTrue
-      (Angle.fromDegrees(odgw2x.getDecDeg) ~= Angle.fromDegrees(odgw2.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getRaDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getRaDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getRaDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getDecDeg)) should beTrue
+      (Angle.fromDegrees(odgw2x.getRaDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getRaDeg)) should beTrue
+      (Angle.fromDegrees(odgw2x.getDecDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getDecDeg)) should beTrue
 
       val cwfs1Mag = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget.getMagnitude(Magnitude.Band.UC).getValue.getBrightness
       val cwfs2Mag = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget.getMagnitude(Magnitude.Band.UC).getValue.getBrightness
       val cwfs3Mag = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget.getMagnitude(Magnitude.Band.UC).getValue.getBrightness
-      cwfs1Mag < cwfs2Mag && cwfs3Mag < cwfs2Mag should beTrue
+      cwfs2Mag < cwfs1Mag && cwfs2Mag < cwfs3Mag should beTrue
     }
     "support Gsaoi Search on BPM 37093" in {
       val base = new WorldCoords("12:38:49.820", "-49:48:00.20")

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -98,8 +98,8 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       results.head.criterion should beEqualTo(GemsCatalogSearchCriterion(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, Wfs.Group.instance), CatalogSearchCriterion("Canopus Wave Front Sensor tiptilt", MagnitudeBand.R, MagnitudeRange(FaintnessConstraint(15.0), scala.Option(SaturationConstraint(7.5))), RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01666666666665151)), scala.Option(Offset(0.0014984027777700248.degrees[OffsetP], 0.0014984027777700248.degrees[OffsetQ])), scala.Some(Angle.zero))))
       results(1).criterion.key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.flexure, GsaoiOdgw.Group.instance))
       results(1).criterion should beEqualTo(GemsCatalogSearchCriterion(GemsCatalogSearchKey(GemsGuideStarType.flexure, GsaoiOdgw.Group.instance), CatalogSearchCriterion("On-detector Guide Window flexure", MagnitudeBand.H, MagnitudeRange(FaintnessConstraint(17.0), scala.Option(SaturationConstraint(8.0))), RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01666666666665151)), scala.Option(Offset(0.0014984027777700248.degrees[OffsetP], 0.0014984027777700248.degrees[OffsetQ])), scala.Some(Angle.zero))))
-      results.head.results should be size 7
-      results(1).results should be size 12
+      results.head.results should be size 5
+      results(1).results should be size 9
 
       val selection = Await.result(TestGemsStrategy("/gems_sn1987A.xml").select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.zero)
@@ -114,14 +114,14 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val cwfs3 = assignments.find(_.guideProbe == Canopus.Wfs.cwfs3).map(_.guideStar)
       val gp4 = assignments.find(_.guideProbe == GsaoiOdgw.odgw2).map(_.guideProbe)
       val odgw2 = assignments.find(_.guideProbe == GsaoiOdgw.odgw2).map(_.guideStar)
-      cwfs1.map(_.name) should beSome("104-014547")
-      cwfs2.map(_.name) should beSome("104-014564")
+      cwfs1.map(_.name) should beSome("104-014597")
+      cwfs2.map(_.name) should beSome("104-014547")
       cwfs3.map(_.name) should beSome("104-014608")
       odgw2.map(_.name) should beSome("104-014556")
 
-      val cwfs1x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(5, 35, 18.423).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(69, 16, 30.67).getOrElse(Angle.zero)).getOrElse(Declination.zero))
+      val cwfs1x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(5, 35, 32.630).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(69, 15, 48.64).getOrElse(Angle.zero)).getOrElse(Declination.zero))
       cwfs1.map(_.coordinates ~= cwfs1x) should beSome(true)
-      val cwfs2x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(5, 35, 24.994).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(69, 16, 04.77).getOrElse(Angle.zero)).getOrElse(Declination.zero))
+      val cwfs2x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(5, 35, 18.423).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(69, 16, 30.67).getOrElse(Angle.zero)).getOrElse(Declination.zero))
       cwfs2.map(_.coordinates ~= cwfs2x) should beSome(true)
       val cwfs3x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(5, 35, 36.409).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(69, 16, 24.17).getOrElse(Angle.zero)).getOrElse(Declination.zero))
       cwfs3.map(_.coordinates ~= cwfs3x) should beSome(true)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -62,8 +62,8 @@ case object UCAC4Filter extends MagnitudesFilter {
 
   // UCAC4 ignores A-mags
   override def ignoredMagnitudeField(v: FieldId) = v.id === "amag" || v.id === "e_amag"
-  // Magnitudes with value 20 and error over 0.9 are invalid
-  override def validMagnitude(m: Magnitude) = m.value =/= ucac4BadMagnitude || m.error.map(math.abs) < ucac4BadMagnitudeError
+  // Magnitudes with value 20 or error over or equal to 0.9 are invalid
+  override def validMagnitude(m: Magnitude) = m.value =/= ucac4BadMagnitude && m.error.map(math.abs) <= ucac4BadMagnitudeError
 
   override def findBand(id: FieldId, band: String): Option[MagnitudeBand] = (id.id, id.ucd) match {
     case ("gmag" | "e_gmag", ucd) if ucd.includes(UcdWord("em.opt.r")) => Some(MagnitudeBand._g)

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
@@ -21,21 +21,21 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
     "be able to filter targets inside the requested range limit" in {
       val qc = CatalogQuery.catalogQuery(c, RadiusConstraint.between(Angle.zero, coneSearch), Some(noMagnitudeConstraint))
       // Filtering on search radius should give all back
-      unfiltered.filter(qc).targets.rows should be size 12
+      unfiltered.filter(qc).targets.rows should be size 11
     }
     "be able to filter targets to a specific ring" in {
       val qc = CatalogQuery.catalogQuery(c, RadiusConstraint.between(Angle.fromDegrees(0.05), coneSearch), Some(noMagnitudeConstraint))
       val filtered = unfiltered.filter(qc)
 
       // Filtering on search radius filters out 4 targets
-      filtered.targets.rows should be size 8
+      filtered.targets.rows should be size 7
     }
     "be able to filter by band" in {
       val qc = CatalogQuery.catalogQuery(c, RadiusConstraint.between(Angle.fromDegrees(0.05), coneSearch), Some(noMagnitudeConstraint))
       val filtered = unfiltered.filter(qc)
 
       // Filtering on search radius filters out 4 targets
-      filtered.targets.rows should be size 8
+      filtered.targets.rows should be size 7
     }
     "be able to filter by faintness on band j" in {
       val m = MagnitudeConstraints(MagnitudeBand.J, FaintnessConstraint(15.0), None)


### PR DESCRIPTION
The UCAC4 catalog sometimes includes magnitudes that should be ignored, this PR updates those rules to discard magnitudes with value 20 OR with error >= 0.9
Before, magnitudes were discarded if both conditions were true