### PR TITLE
OCSADV-295: UI improvements

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -1,7 +1,6 @@
 package edu.gemini.itc.shared
 
 import edu.gemini.spModel.core.Peer
-import edu.gemini.util.security.auth.keychain.KeyChain
 import edu.gemini.util.trpc.client.TrpcClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -13,7 +12,7 @@ import scalaz.{Failure, Success, Validation}
  * Depending on the observation type (imaging vs. spectroscopy) and calculation method different results are returned.
  */
 sealed trait ItcCalcResult
-final case class ItcImagingResult(singleSNRatio: Double, totalSNRatio: Double, peakPixelFlux: Double) extends ItcCalcResult
+final case class ItcImagingResult(source: SourceDefinition, singleSNRatio: Double, totalSNRatio: Double, peakPixelFlux: Double) extends ItcCalcResult
 final case class ItcSpectroscopyResult(/*TODO*/) extends ItcCalcResult
 
 /**

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -55,7 +55,7 @@ class ItcServiceImpl extends ItcService {
     ItcResult.forCcds(recipe.calculateImaging().map(imgResult))
 
   private def imgResult(result: ImagingResult): ItcCalcResult = result.is2nCalc match {
-    case i: ImagingS2NMethodACalculation  => ItcImagingResult(i.singleSNRatio(), i.totalSNRatio(), result.peakPixelCount)
+    case i: ImagingS2NMethodACalculation  => ItcImagingResult(result.source, i.singleSNRatio(), i.totalSNRatio(), result.peakPixelCount)
     case _                                => throw new NotImplementedError
   }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/EdIteratorFolder.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/EdIteratorFolder.java
@@ -94,14 +94,16 @@ public final class EdIteratorFolder
             obs.addCompositeChangeListener(obslogUpdater);
         }
 
-        // show/hide ITC result panels depending on instrument
+        // show/hide ITC result panels depending on instrument, if applicable also re-establish selected panel
         final ISPObsComponent instrument = getContextInstrument();
+        final int activePanel = _w.tabbedPane.getSelectedIndex();
         _w.tabbedPane.remove(itcImagingPanel.peer());
         _w.tabbedPane.remove(itcSpectroscopyPanel.peer());
         if (instrument != null) {
             final SPComponentType type = instrument.getType();
             if (itcImagingPanel.visibleFor(type))      _w.tabbedPane.add("ITC Imaging",      itcImagingPanel.peer());
             if (itcSpectroscopyPanel.visibleFor(type)) _w.tabbedPane.add("ITC Spectroscopy", itcSpectroscopyPanel.peer());
+            if (_w.tabbedPane.getTabCount() > activePanel) _w.tabbedPane.setSelectedIndex(activePanel);
         }
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -32,17 +32,17 @@ object ItcTable {
   abstract sealed class Renderer[A](alignment: Alignment.Value, f: A => (Icon, String)) extends LabelRenderer[A](f)  {
     override def componentFor(table : Table, isSelected : Boolean, hasFocus : Boolean, a : A, row : Int, column : Int) : Component = {
       val c = super.componentFor(table, isSelected, hasFocus, a, row, column)
-      val l = c.asInstanceOf[Label]
       val model = table.model.asInstanceOf[ItcTableModel]
       // Cell renderer based on the sequence cell renderer used for other sequence tables. This gives us coherent
       // formatting and color coding throughout the different tables in the sequence node.
       val bg = model.getKeyAt(column).map(SequenceCellRenderer.lookupColor)
       val tt = model.tooltip(column)
       // set horizontal alignment, bg color and tooltip as needed
-      l <|
-        (_.horizontalAlignment  = alignment)                  <|
-        (_.background           = bg.getOrElse(l.background)) <|
-        (_.tooltip              = tt)
+      c.asInstanceOf[Label] <| { l =>
+        l.horizontalAlignment = alignment
+        l.background = bg.getOrElse(l.background)
+        l.tooltip = tt
+      }
     }
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -7,18 +7,22 @@ import edu.gemini.ags.api.AgsRegistrar
 import edu.gemini.itc.shared._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.pot.sp.SPComponentType._
+import edu.gemini.shared.skyobject.Magnitude
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
-import edu.gemini.spModel.config2.{ConfigSequence, ItemKey}
+import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
 import edu.gemini.spModel.core.Peer
 import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable.asScalaOpt
 import edu.gemini.spModel.target.env.TargetEnvironment
+import edu.gemini.spModel.target.system.ITarget
 import edu.gemini.spModel.telescope.IssPort
+import jsky.app.ot.editor.seq.ItcTable.{AnyRenderer, DoubleRenderer, IntRenderer}
 import jsky.app.ot.userprefs.observer.ObservingPeer
 import jsky.app.ot.util.OtColor
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.swing.Table.LabelRenderer
@@ -33,11 +37,11 @@ object ItcTable {
     override def componentFor(table : Table, isSelected : Boolean, hasFocus : Boolean, a : A, row : Int, column : Int) : Component = {
       val c = super.componentFor(table, isSelected, hasFocus, a, row, column)
       val model = table.model.asInstanceOf[ItcTableModel]
-      // Cell renderer based on the sequence cell renderer used for other sequence tables. This gives us coherent
-      // formatting and color coding throughout the different tables in the sequence node.
-      val bg = model.getKeyAt(column).map(SequenceCellRenderer.lookupColor)
+      // Use SequenceCellRenderer based background color. This gives us coherent color coding throughout
+      // the different tables in the sequence node.
+      val bg = model.key(column).map(SequenceCellRenderer.lookupColor)
       val tt = model.tooltip(column)
-      // set horizontal alignment, bg color and tooltip as needed
+      // set label horizontal alignment, bg color and tooltip as needed
       c.asInstanceOf[Label] <| { l =>
         l.horizontalAlignment = alignment
         l.background = bg.getOrElse(l.background)
@@ -46,20 +50,19 @@ object ItcTable {
     }
   }
 
-  // Render anything by turning it into a string
-  case object AnyRenderer extends Renderer(Alignment.Left, (o: AnyRef) => (null, o.toString))
-
-  // Render an optional double value as int (rounded)
-  case object IntRenderer extends Renderer(Alignment.Right, (o: AnyRef) => (null, o match {
+  // Render anything by turning it into a string (or ignore it if empty)
+  case object AnyRenderer extends Renderer(Alignment.Left, (o: AnyRef) => (null, o match {
+    case null             => ""
     case None             => ""
-    case Some(d: Double)  => f"$d%.0f"
+    case Some(s)          => s.toString
+    case x                => x.toString
   }))
 
-  // Render an optional double value with two decimal digits
-  case object DoubleRenderer extends Renderer(Alignment.Right, (o: AnyRef) => (null, o match {
-    case None             => ""
-    case Some(d: Double)  => f"$d%.2f"
-  }))
+  // Render an int value
+  case object IntRenderer extends Renderer[Int](Alignment.Right, i => (null, i.toString))
+
+  // Render a double value with two decimal digits
+  case object DoubleRenderer extends Renderer[Double](Alignment.Right, d => (null, f"$d%.2f"))
 
 }
 
@@ -70,28 +73,29 @@ trait ItcTable extends Table {
 
 
   val owner: EdIteratorFolder
+
   def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcTableModel
 
   import jsky.app.ot.editor.seq.Keys._
 
   // set this to the same values as in SequenceTableUI
   autoResizeMode = Table.AutoResizeMode.Off
-  background     = OtColor.VERY_LIGHT_GREY
-  focusable      = false
+  background = OtColor.VERY_LIGHT_GREY
+  focusable = false
   peer.setRowSelectionAllowed(false)
   peer.setColumnSelectionAllowed(false)
   peer.getTableHeader.setReorderingAllowed(false)
 
   def update() = {
-    val seq       = sequence()
-    val allKeys   = seq.getStaticKeys.toSeq ++ seq.getIteratedKeys.toSeq
-    val showKeys  = seq.getIteratedKeys.toSeq.
-      filterNot(_.equals(DATALABEL_KEY)).       // don't show the original data label (step number)
-      filterNot(_.equals(OBS_TYPE_KEY)).        // don't show the type (science vs. calibration)
-      filterNot(_.equals(OBS_EXP_TIME_KEY)).    // don't show observe exp time
-      filterNot(_.equals(INST_EXP_TIME_KEY)).   // don't show instrument exp time
-      filterNot(_.equals(TEL_P_KEY)).           // don't show offsets
-      filterNot(_.equals(TEL_Q_KEY)).           // don't show offsets
+    val seq = sequence()
+    val allKeys = seq.getStaticKeys.toSeq ++ seq.getIteratedKeys.toSeq
+    val showKeys = seq.getIteratedKeys.toSeq.
+      filterNot(_.equals(DATALABEL_KEY)). // don't show the original data label (step number)
+      filterNot(_.equals(OBS_TYPE_KEY)). // don't show the type (science vs. calibration)
+      filterNot(_.equals(OBS_EXP_TIME_KEY)). // don't show observe exp time
+      filterNot(_.equals(INST_EXP_TIME_KEY)). // don't show instrument exp time
+      filterNot(_.equals(TEL_P_KEY)). // don't show offsets
+      filterNot(_.equals(TEL_Q_KEY)). // don't show offsets
       filterNot(_.getParent().equals(CALIBRATION_KEY)). // calibration settings are not relevant
       sortBy(_.getPath)
 
@@ -100,8 +104,11 @@ trait ItcTable extends Table {
   }
 
   override def rendererComponent(sel: Boolean, foc: Boolean, row: Int, col: Int) = {
-    val value = model.getValueAt(row, col)
-    model.asInstanceOf[ItcTableModel].renderer(col).componentFor(this, sel, foc, value, row, col)
+    model.getValueAt(row, col) match {
+      case Some(i: Int)    => IntRenderer.componentFor(this, sel, foc, i, row, col)
+      case Some(d: Double) => DoubleRenderer.componentFor(this, sel, foc, d, row, col)
+      case v               => AnyRenderer.componentFor(this, sel, foc, v, row, col)
+    }
   }
 
   private def sequence() = Option(owner.getContextObservation).fold(new ConfigSequence) {
@@ -115,33 +122,35 @@ trait ItcTable extends Table {
 
   protected def calculateImaging(peer: Peer, instrument: SPComponentType, c: ItcUniqueConfig): Future[ItcService.Result] = {
     val s = for {
-      port        <- extractPort()
-      targetEnv   <- extractTargetEnv()
-      probe       <- extractGuideProbe()
-      tele        <- ConfigExtractor.extractTelescope(port, probe, targetEnv, c.config)
-      ins         <- ConfigExtractor.extractInstrumentDetails(instrument, probe, targetEnv, c.config)
+      port      <- extractPort()
+      targetEnv <- extractTargetEnv()
+      probe     <- extractGuideProbe()
+      src       <- extractSource(targetEnv.getBase.getTarget, c)
+      tele      <- ConfigExtractor.extractTelescope(port, probe, targetEnv, c.config)
+      ins       <- ConfigExtractor.extractInstrumentDetails(instrument, probe, targetEnv, c.config)
     } yield {
-      calculateImaging(peer, c, ins, tele)
-    }
+        calculateImaging(peer, c, src, ins, tele)
+      }
 
     s match {
-      case -\/(l) => Future { List(l).fail }
+      case -\/(l) => Future {
+        List(l).fail
+      }
       case \/-(r) => r
     }
 
   }
 
-  protected def calculateImaging(peer: Peer, c: ItcUniqueConfig, ins: InstrumentDetails, tele: TelescopeDetails): Future[ItcService.Result] = {
-    val src  = new SourceDefinition(PointSource(20.0, BrightnessUnit.MAG), LibraryStar("A0V"), WavebandDefinition.R, 0.0)
-    val obs  = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
+  protected def calculateImaging(peer: Peer, c: ItcUniqueConfig, src: SourceDefinition, ins: InstrumentDetails, tele: TelescopeDetails): Future[ItcService.Result] = {
+    val obs = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), AutoAperture(5.0))
     val qual = owner.getContextSiteQuality
     val cond = new ObservingConditions(qual.getImageQuality, qual.getCloudCover, qual.getWaterVapor, qual.getSkyBackground, 1.5)
 
     // Do the service call
     ItcService.calculate(peer, src, obs, cond, tele, ins).
 
-    // whenever service call is finished notify table to update its contents
-    andThen {
+      // whenever service call is finished notify table to update its contents
+      andThen {
       case _ => Swing.onEDT {
         this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged()
         // make all columns as wide as needed
@@ -159,9 +168,9 @@ trait ItcTable extends Table {
 
   private def extractGuideProbe(): String \/ GuideProbe = {
     val o = for {
-      observation         <- Option(owner.getContextObservation)
-      obsContext          <- ObsContext.create(observation).asScalaOpt
-      agsStrategy         <- AgsRegistrar.currentStrategy(obsContext)
+      observation <- Option(owner.getContextObservation)
+      obsContext  <- ObsContext.create(observation).asScalaOpt
+      agsStrategy <- AgsRegistrar.currentStrategy(obsContext)
 
     // Except for Gems we have only one guider, so in order to decide the "type" (AOWFS, OIWFS, PWFS)
     // we take a shortcut here and just look at the first guider we get from the strategy.
@@ -170,6 +179,62 @@ trait ItcTable extends Table {
     o.flatten.fold("Could not identify ags strategy or guide probe type".left[GuideProbe])(_.right)
   }
 
+  private def extractSource(target: ITarget, c: ItcUniqueConfig): String \/ SourceDefinition = {
+    for {
+      (mag, band) <- extractSourceMagnitude(target, c.config)
+    } yield {
+      // TODO: definition of spectral profile and redshift
+      new SourceDefinition(PointSource(mag, BrightnessUnit.MAG), /*TODO*/LibraryStar("A0V"), band, /*TODO*/0.0)
+    }
+  }
+
+  private def extractSourceMagnitude(target: ITarget, c: Config): String \/ (Double, WavebandDefinition) = {
+
+    def closestBand(bands: List[Magnitude], wl: Double) =
+      bands.minBy(m => Math.abs(m.getBand.getWavelengthMidPoint.getValue.toDouble - wl))
+
+    def mags(wl: Double): String \/ Magnitude = {
+      val bands = target.getMagnitudes.toList.asScala.toList.
+        filter(_.getBand.getWavelengthMidPoint.isDefined).// ignore bands with unknown wavelengths (currently AP only)
+        filterNot(_.getBand == Magnitude.Band.UC).        // ignore UC magnitudes
+        filterNot(_.getBand == Magnitude.Band.AP)         // ignore AP magnitudes
+      if (bands.isEmpty) "No standard magnitudes for target defined; ITC can not use UC and AP magnitudes.".left[Magnitude]
+      else closestBand(bands, wl).right[String]
+    }
+
+    for {
+      wl  <- ConfigExtractor.extractObservingWavelength(c)
+      mag <- mags(wl*1000) // convert wavelength from micrometer [um] to nanometer [nm]
+    } yield {
+      val b = mag.getBrightness
+      mag.getBand match {
+        // TODO: unify band definitions from spModel core and itc shared so that we don't need this translation anymore
+        case Magnitude.Band.u  => (b, WavebandDefinition.U)
+        case Magnitude.Band.g  => (b, WavebandDefinition.g)
+        case Magnitude.Band.r  => (b, WavebandDefinition.r)
+        case Magnitude.Band.i  => (b, WavebandDefinition.i)
+        case Magnitude.Band.z  => (b, WavebandDefinition.z)
+
+        case Magnitude.Band.U  => (b, WavebandDefinition.U)
+        case Magnitude.Band.B  => (b, WavebandDefinition.B)
+        case Magnitude.Band.V  => (b, WavebandDefinition.V)
+        case Magnitude.Band.R  => (b, WavebandDefinition.R)
+        case Magnitude.Band.I  => (b, WavebandDefinition.I)
+        case Magnitude.Band.Y  => (b, WavebandDefinition.z)
+        case Magnitude.Band.J  => (b, WavebandDefinition.J)
+        case Magnitude.Band.H  => (b, WavebandDefinition.H)
+        case Magnitude.Band.K  => (b, WavebandDefinition.K)
+        case Magnitude.Band.L  => (b, WavebandDefinition.L)
+        case Magnitude.Band.M  => (b, WavebandDefinition.M)
+        case Magnitude.Band.N  => (b, WavebandDefinition.N)
+        case Magnitude.Band.Q  => (b, WavebandDefinition.Q)
+
+        // UC and AP are not taken into account for ITC calculations
+        //case Magnitude.Band.UC => (b, WavebandDefinition.R)
+        //case Magnitude.Band.AP => (b, WavebandDefinition.V)
+      }
+    }
+  }
 }
 
 class ItcImagingTable(val owner: EdIteratorFolder) extends ItcTable {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -92,11 +92,6 @@ sealed trait ItcTableModel extends AbstractTableModel {
     case None    => StringUtil.toDisplayName(toKey(col).getName) // create column name for key columns
   }
 
-//  def renderer(col: Int): LabelRenderer[_] = column(col) match {
-//    case Some(c) => c.renderer
-//    case None    => ItcTable.AnyRenderer  // use "any" renderer for key columns
-//  }
-
   def tooltip(col: Int): String = column(col) match {
     case Some(c) => c.tooltip
     case None    => ""                    // no tooltip for key columns
@@ -127,7 +122,7 @@ sealed trait ItcTableModel extends AbstractTableModel {
     f.value.fold("Calculating...") {
       case Failure(t) => t <| (_.printStackTrace()) |> (_.getMessage)  // "Look mummy, there's a spaceship up in the sky!"
       case Success(s) => s match {
-        case scalaz.Failure(errs) => errs.mkString(", ") <| System.out.println
+        case scalaz.Failure(errs) => errs.mkString(", ")
         case scalaz.Success(_)    => "OK"
       }
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -7,79 +7,39 @@ import edu.gemini.shared.util.StringUtil
 import edu.gemini.spModel.config2.ItemKey
 
 import scala.concurrent.Future
-import scala.swing.Table.LabelRenderer
 import scala.util.{Failure, Success}
 import scalaz.Scalaz._
 
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
-case class Column[A](label: String, value: (ItcUniqueConfig, Future[ItcService.Result]) => Object, renderer: LabelRenderer[AnyRef] = ItcTable.AnyRenderer, tooltip: String = "")
+case class Column(label: String, value: (ItcUniqueConfig, Future[ItcService.Result]) => AnyRef, tooltip: String = "")
 
 object ItcTableModel {
-  val PeakPixelTooltip = "Peak pixel value = signal + background [ADU]"
+  val PeakPixelTooltip = "Peak pixel value = signal + background"
+}
+
+/** ITC tables have three types of columns: a series of header columns, then all the values that change and are
+  * relevant for the different unique configs (denoted by their {{{ItemKey}}} values) and finally the ITC calculation
+  * results. The static columns (headers and results) are represented by a {{{Column}}} object.
+  */
+sealed trait ItcTableModel extends AbstractTableModel {
 
   /** Defines a set of header columns for all tables. */
   val Headers = Seq(
     Column("Data Labels",     (c, r) => c.labels),
     Column("Images",          (c, r) => new java.lang.Integer(c.count),             tooltip = "Number of exposures used in S/N calculation"),
     Column("Exposure Time",   (c, r) => new java.lang.Double(c.singleExposureTime), tooltip = "Exposure time of each image [s]"),
-    Column("Total Exp. Time", (c, r) => new java.lang.Double(c.totalExposureTime),  tooltip = "Total exposure time [s]")
+    Column("Total Exp. Time", (c, r) => new java.lang.Double(c.totalExposureTime),  tooltip = "Total exposure time [s]"),
+    Column("Source Mag",      (c, r) => sourceMag(r),                               tooltip = "Source magnitude [mag]"),
+    Column("Source Band",     (c, r) => sourceBand(r),                              tooltip = "Source band")
   )
-}
 
-/**
- * ITC tables have three types of columns: a series of header columns, then all the values that change and are
- * relevant for the different unique configs (denoted by their ItemKey values) and finally the ITC calculation
- * results.
- */
-sealed trait ItcTableModel extends AbstractTableModel {
+  val headers:      Seq[Column]  = Headers  // override this in case different header columns are needed..
+  val keys:         Seq[ItemKey]
+  val results:      Seq[Column]
 
-  val headers: Seq[Column[_]]
-  val keys: Seq[ItemKey]
-  val results: Seq[Column[_]]
+  val uniqueSteps:  Seq[ItcUniqueConfig]
+  val res:          Seq[Future[ItcService.Result]]
 
-  val uniqueSteps: Seq[ItcUniqueConfig]
-  val res: Seq[Future[ItcService.Result]]
-
-  override def getRowCount: Int = uniqueSteps.size
-
-  override def getColumnCount: Int = headers.size + keys.size + results.size
-
-  override def getValueAt(row: Int, col: Int): Object = col match {
-    case c if c <  headers.size             => header(col).value(uniqueSteps(row), res(row))
-    case c if c >= headers.size + keys.size => result(col).value(uniqueSteps(row), res(row))
-    case _                                  => uniqueSteps(row).config.getItemValue(key(col))
-  }
-
-  override def getColumnName(col: Int): String = col match {
-    case c if c <  headers.size             => header(col).label
-    case c if c >= headers.size + keys.size => result(col).label
-    case _                                  => StringUtil.toDisplayName(key(col).getName)
-  }
-
-  def renderer(col: Int): LabelRenderer[AnyRef] = col match {
-    case c if c <  headers.size             => header(col).renderer
-    case c if c >= headers.size + keys.size => result(col).renderer
-    case _                                  => ItcTable.AnyRenderer
-  }
-
-  def tooltip(col: Int): String = col match {
-    case c if c <  headers.size             => header(col).tooltip
-    case c if c >= headers.size + keys.size => result(col).tooltip
-    case _                                  => key(col).getPath
-  }
-
-  // Gets the ItemKey of a column (if any), this is used by the table to color code the columns.
-  def getKeyAt(col: Int): Option[ItemKey] = col match {
-    case c if c >= headers.size && c < headers.size + keys.size => Some(key(col))
-    case _                                                      => None
-  }
-
-  // Translate overall column index into the corresponding header, column or key value.
-  private def header(col: Int) = headers(col)
-
-  private def key(col: Int) = keys(col - headers.size)
-
-  private def result(col: Int) = results(col - headers.size - keys.size)
 
   // Gets the result from the service result future (if present)
   protected def imagingCalcResult(f: Future[ItcService.Result]): Option[ItcResult] =
@@ -88,21 +48,6 @@ sealed trait ItcTableModel extends AbstractTableModel {
       serviceResult <- futureResult.toOption  // unwrap try
       calcResult    <- serviceResult.toOption // unwrap validation
     } yield calcResult
-
-  // TODO: display errors/validation messages in an appropriate way in the UI, for now also print them to console
-  protected def messages(f: Future[ItcService.Result]): String =
-    f.value.fold("Calculating...") {
-      case Failure(t) => t <| (_.printStackTrace()) |> (_.getMessage)  // "Look mummy, there's a spaceship up in the sky!"
-      case Success(s) => s match {
-        case scalaz.Failure(errs) => errs.mkString(", ") <| System.out.println
-        case scalaz.Success(_)    => "OK"
-      }
-    }
-}
-
-
-/** Generic ITC imaging tables model. */
-sealed trait ItcImagingTableModel extends ItcTableModel {
 
   // Gets the imaging result from the service result future (if present).
   // Note that in most cases (except for GMOS) there is only one CCD in the result, but for GMOS there can be
@@ -119,37 +64,100 @@ sealed trait ItcImagingTableModel extends ItcTableModel {
       }
     }
 
-  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int = 0) = imagingResult(result, ccd).map(_.peakPixelFlux)
+  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int = 0) = imagingResult(result, ccd).map(_.peakPixelFlux.toInt)
 
   protected def singleSNRatio(result: Future[ItcService.Result], ccd: Int = 0) = imagingResult(result, ccd).map(_.singleSNRatio)
 
   protected def totalSNRatio (result: Future[ItcService.Result], ccd: Int = 0) = imagingResult(result, ccd).map(_.totalSNRatio)
-  
+
+  // the source is the same for all CCDs, so we just always take the first one
+  protected def sourceMag    (result: Future[ItcService.Result]) = imagingResult(result, 0).map(_.source.profile.norm)
+
+  // the source is the same for all CCDs, so we just always take the first one
+  protected def sourceBand   (result: Future[ItcService.Result]) = imagingResult(result, 0).map(_.source.getNormBand.name)
+
+  // ===
+
+  override def getRowCount: Int = uniqueSteps.size
+
+  override def getColumnCount: Int = headers.size + keys.size + results.size
+
+  override def getValueAt(row: Int, col: Int): Object = column(col) match {
+    case Some(c) => c.value(uniqueSteps(row), res(row))
+    case None    => uniqueSteps(row).config.getItemValue(toKey(col))
+  }
+
+  override def getColumnName(col: Int): String = column(col) match {
+    case Some(c) => c.label
+    case None    => StringUtil.toDisplayName(toKey(col).getName) // create column name for key columns
+  }
+
+//  def renderer(col: Int): LabelRenderer[_] = column(col) match {
+//    case Some(c) => c.renderer
+//    case None    => ItcTable.AnyRenderer  // use "any" renderer for key columns
+//  }
+
+  def tooltip(col: Int): String = column(col) match {
+    case Some(c) => c.tooltip
+    case None    => ""                    // no tooltip for key columns
+  }
+
+  /** Gets the column description for the given {{{col}}} index. Returns {{{None}}} for dynamic key columns. */
+  def column(col: Int): Option[Column] = col match {
+    case c if c <  headers.size             => Some(toHeader(col))
+    case c if c >= headers.size + keys.size => Some(toResult(col))
+    case _                                  => None
+  }
+
+  /** Gets the ItemKey of a column (if any), this is used by the table to color code the columns. */
+  def key(col: Int): Option[ItemKey] = col match {
+    case c if c >= headers.size && c < headers.size + keys.size => Some(toKey(col))
+    case _                                                      => None
+  }
+
+  // Translate overall column index into the corresponding header, column or key value.
+  private def toHeader(col: Int) = headers(col)
+
+  private def toKey   (col: Int) = keys(col - headers.size)
+
+  private def toResult(col: Int) = results(col - headers.size - keys.size)
+
+  // TODO: display errors/validation messages in an appropriate way in the UI, for now also print them to console
+  protected def messages(f: Future[ItcService.Result]): String =
+    f.value.fold("Calculating...") {
+      case Failure(t) => t <| (_.printStackTrace()) |> (_.getMessage)  // "Look mummy, there's a spaceship up in the sky!"
+      case Success(s) => s match {
+        case scalaz.Failure(errs) => errs.mkString(", ") <| System.out.println
+        case scalaz.Success(_)    => "OK"
+      }
+    }
 }
 
+
+/** Generic ITC imaging tables model. */
+sealed trait ItcImagingTableModel extends ItcTableModel
+
 class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
-  val headers = ItcTableModel.Headers
   val results = Seq(
-    Column("Peak",            (c, r) => peakPixelFlux(r),         ItcTable.IntRenderer,       tooltip = ItcTableModel.PeakPixelTooltip),
-    Column("S/N Single",      (c, r) => singleSNRatio(r),         ItcTable.DoubleRenderer),
-    Column("S/N Total",       (c, r) => totalSNRatio (r),         ItcTable.DoubleRenderer),
+    Column("Peak",            (c, r) => peakPixelFlux(r),         tooltip = ItcTableModel.PeakPixelTooltip),
+    Column("S/N Single",      (c, r) => singleSNRatio(r)),
+    Column("S/N Total",       (c, r) => totalSNRatio (r)),
     Column("Messages",        (c, r) => messages(r))
   )
 }
 
 /** GMOS specific ITC imaging table model. */
 class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
-  val headers = ItcTableModel.Headers
   val results = Seq(
-    Column("CCD1 Peak",       (c, r) => peakPixelFlux(r, ccd=0),   ItcTable.IntRenderer,      tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 1"),
-    Column("CCD1 S/N Single", (c, r) => singleSNRatio(r, ccd=0),   ItcTable.DoubleRenderer),
-    Column("CCD1 S/N Total",  (c, r) => totalSNRatio (r, ccd=0),   ItcTable.DoubleRenderer),
-    Column("CCD2 Peak",       (c, r) => peakPixelFlux(r, ccd=1),   ItcTable.IntRenderer,      tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 2"),
-    Column("CCD2 S/N Single", (c, r) => singleSNRatio(r, ccd=1),   ItcTable.DoubleRenderer),
-    Column("CCD2 S/N Total",  (c, r) => totalSNRatio (r, ccd=1),   ItcTable.DoubleRenderer),
-    Column("CCD3 Peak",       (c, r) => peakPixelFlux(r, ccd=2),   ItcTable.IntRenderer,      tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 3"),
-    Column("CCD3 S/N Single", (c, r) => singleSNRatio(r, ccd=2),   ItcTable.DoubleRenderer),
-    Column("CCD3 S/N Total",  (c, r) => totalSNRatio (r, ccd=2),   ItcTable.DoubleRenderer),
+    Column("CCD1 Peak",       (c, r) => peakPixelFlux(r, ccd=0),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 1"),
+    Column("CCD1 S/N Single", (c, r) => singleSNRatio(r, ccd=0)),
+    Column("CCD1 S/N Total",  (c, r) => totalSNRatio (r, ccd=0)),
+    Column("CCD2 Peak",       (c, r) => peakPixelFlux(r, ccd=1),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 2"),
+    Column("CCD2 S/N Single", (c, r) => singleSNRatio(r, ccd=1)),
+    Column("CCD2 S/N Total",  (c, r) => totalSNRatio (r, ccd=1)),
+    Column("CCD3 Peak",       (c, r) => peakPixelFlux(r, ccd=2),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 3"),
+    Column("CCD3 S/N Single", (c, r) => singleSNRatio(r, ccd=2)),
+    Column("CCD3 S/N Total",  (c, r) => totalSNRatio (r, ccd=2)),
     Column("Messages",        (c, r) => messages(r))
   )
 }
@@ -159,7 +167,6 @@ class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcU
 sealed trait ItcSpectroscopyTableModel extends ItcTableModel
 
 class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcSpectroscopyTableModel {
-  val headers = ItcTableModel.Headers
   val results = Seq(
     Column("Messages",        (c, r) => messages(r))
   )

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -94,8 +94,8 @@ object ItcUniqueConfig {
   private def labels(cs: Seq[Config]): String = {
     val ls = cs.map(labelIndex).sorted
     findSpans(ls).map {
-      case i :: Nil => i.toString
-      case i :: is => f"$i%03d-${is.last}%03d"
+      case i :: Nil => f"$i%03d"
+      case i :: is  => f"$i%03d-${is.last}%03d"
     }.mkString(", ")
   }
 


### PR DESCRIPTION
This PR incorporates a collection of suggestions and improvements from Andy after he played around with the ITC integration for a bit. It's mostly improvements in the ITC tables (tooltips, alignment etc).

Furthermore, the source magnitude and band are now extracted from the science target depending on the instrument configuration, i.e. the magnitude of the band is taken that corresponds most closely to the observing wavelength of the instrument configuration. Unifying the bands from spModel and ITC is planned as a future task, currently there's a mapping between the two. The source mag and band that's been selected for each instrument configuration is now displayed in the results table.

Converting the peak pixel flux to ADU has been left out for now, because currently there is no general knowledge of the gain for each instrument. This may or may not be added in a future PR.