### PR TITLE
OCSADV-294: Support Manual GS Search for GEMS and UCAC4

### DIFF
--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
@@ -132,10 +132,6 @@ public class GemsGuideStarSearchOptions {
         return instrument;
     }
 
-    public GemsTipTiltMode getTipTiltMode() {
-        return tipTiltMode;
-    }
-
     /**
      * @param nirBand      optional NIR magnitude band (default is H)
      * @return all relevant CatalogSearchCriterion instances

--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
@@ -26,12 +26,13 @@ public class GemsGuideStarSearchOptions {
         PPMXL_CADC("PPMXL@CADC", "PPMXL at CADC"),
         UCAC3_CDS("UCAC3@CDS", "UCAC3 at CDS"),
         UCAC3_CADC("UCAC3@CADC", "UCAC3 at CADC"),
+        UCAC4_GEMINI("UCAC4", "UCAC4 at Gemini"),
         NOMAD1_CDS("NOMAD1@CDS", "NOMAD1 at CDS"),
         NOMAD1_CADC("NOMAD1@CADC", "NOMAD1 at CADC"),
         USER_CATALOG("user", "User Catalog"),
         ;
 
-        public static CatalogChoice DEFAULT = UCAC3_CDS;
+        public static CatalogChoice DEFAULT = UCAC4_GEMINI;
 
         private String _displayValue;
         private String _catalogName;

--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
@@ -23,12 +23,9 @@ public class GemsGuideStarSearchOptions {
 
     public enum CatalogChoice {
         PPMXL_CDS("PPMXL@CDS", "PPMXL at CDS"),
-        PPMXL_CADC("PPMXL@CADC", "PPMXL at CADC"),
         UCAC3_CDS("UCAC3@CDS", "UCAC3 at CDS"),
-        UCAC3_CADC("UCAC3@CADC", "UCAC3 at CADC"),
         UCAC4_GEMINI("UCAC4", "UCAC4 at Gemini"),
         NOMAD1_CDS("NOMAD1@CDS", "NOMAD1 at CDS"),
-        NOMAD1_CADC("NOMAD1@CADC", "NOMAD1 at CADC"),
         USER_CATALOG("user", "User Catalog"),
         ;
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
@@ -32,7 +32,7 @@ object GemsUtils4Java {
    */
   def uniqueTargets(list: java.util.List[GemsCatalogSearchResults]): java.util.List[Target.SiderealTarget] = {
     import collection.breakOut
-    new java.util.ArrayList(list.asScala.map(_.results).flatten.groupBy(_.name).map(_._2.head)(breakOut).asJava)
+    new java.util.ArrayList(list.asScala.flatMap(_.results).groupBy(_.name).map(_._2.head)(breakOut).asJava)
   }
 
   def toOldBand(band: MagnitudeBand): skyobject.Magnitude.Band = band.toOldModel

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
@@ -2,12 +2,17 @@ package edu.gemini.ags.gems
 
 import edu.gemini.catalog.api.MagnitudeConstraints
 import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.ags.api.defaultProbeBands
+import edu.gemini.shared.skyobject.Magnitude
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
+import edu.gemini.spModel.gemini.gems.Canopus
+import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.shared.skyobject
 import edu.gemini.skycalc
-import edu.gemini.spModel.target.system.HmsDegTarget
+import edu.gemini.spModel.target.system.{ITarget, HmsDegTarget}
 import scala.collection.JavaConverters._
 
 import scalaz._
@@ -33,6 +38,20 @@ object GemsUtils4Java {
   def uniqueTargets(list: java.util.List[GemsCatalogSearchResults]): java.util.List[Target.SiderealTarget] = {
     import collection.breakOut
     new java.util.ArrayList(list.asScala.flatMap(_.results).groupBy(_.name).map(_._2.head)(breakOut).asJava)
+  }
+
+  /**
+   * Outputs the target magnitudes used by the Asterism table on the Manual Search for GEMS
+   */
+  def probeMagnitudeInUse(guideProbe: GuideProbe, referenceBand: Magnitude.Band, target: ITarget): String = {
+    val availableMagnitudes = target.getMagnitudes.asScalaList.map(_.toNewModel)
+    val probeBand = if (Canopus.Wfs.Group.instance.getMembers.contains(guideProbe)) {
+        MagnitudeBand.R
+      } else {
+        referenceBand.toNewModel
+      }
+    val r = defaultProbeBands(probeBand).flatMap {b => availableMagnitudes.find(_.band === b)}.headOption
+    ~r.map(m => s"${m.value} (${m.band.name})")
   }
 
   def toOldBand(band: MagnitudeBand): skyobject.Magnitude.Band = band.toOldModel

--- a/bundle/edu.gemini.catalog/src/main/java/edu/gemini/catalog/skycat/binding/skyobj/GemsSkyObjectFactory.java
+++ b/bundle/edu.gemini.catalog/src/main/java/edu/gemini/catalog/skycat/binding/skyobj/GemsSkyObjectFactory.java
@@ -28,19 +28,21 @@ public enum GemsSkyObjectFactory implements SkyObjectFactory {
     public static final String RA_COL  = "RA";
     public static final String DEC_COL = "Dec";
 
-    public static final CatalogValueExtractor.MagnitudeDescriptor J_MAG, H_MAG, K_MAG, R_MAG;
+    public static final CatalogValueExtractor.MagnitudeDescriptor UC_MAG, J_MAG, H_MAG, K_MAG, R_MAG, r_MAG;
     static {
+        UC_MAG = new CatalogValueExtractor.MagnitudeDescriptor(UC, "UC");
         J_MAG = new CatalogValueExtractor.MagnitudeDescriptor(J, "J");
         H_MAG = new CatalogValueExtractor.MagnitudeDescriptor(H, "H");
         K_MAG = new CatalogValueExtractor.MagnitudeDescriptor(K, "K");
         R_MAG = new CatalogValueExtractor.MagnitudeDescriptor(R, "R");
+        r_MAG = new CatalogValueExtractor.MagnitudeDescriptor(r, "r'");
     }
 
     private static final FactorySupport sup =
-            new FactorySupport.Builder(ID_COL, RA_COL, DEC_COL).add(J_MAG, H_MAG, K_MAG, R_MAG).build();
+            new FactorySupport.Builder(ID_COL, RA_COL, DEC_COL).add(UC_MAG, J_MAG, H_MAG, K_MAG, R_MAG, r_MAG).build();
 
     public static final Set<Magnitude.Band> BANDS = Collections.unmodifiableSet(
-            new HashSet<Magnitude.Band>(Arrays.asList(J, H, K, R)));
+            new HashSet<>(Arrays.asList(UC, J, H, K, R, r)));
 
     @Override
     public Set<Magnitude.Band> bands() { return BANDS; }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -137,6 +137,8 @@ trait CachedBackend extends VoTableBackend {
 }
 
 case object RemoteBackend extends CachedBackend {
+  val instance = this
+
   val Log = Logger.getLogger(getClass.getName)
 
   private val timeout = 30 * 1000 // Max time to wait

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -5,7 +5,6 @@ import edu.gemini.ags.gems.mascot.Strehl;
 import edu.gemini.ags.gems.mascot.MascotProgress;
 import edu.gemini.catalog.votable.CatalogException;
 import edu.gemini.catalog.votable.RemoteBackend;
-import edu.gemini.catalog.votable.RemoteBackend$;
 import edu.gemini.pot.ModelConverters;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
@@ -27,9 +26,6 @@ import jsky.util.gui.SwingWorker;
 import jsky.util.gui.DialogUtil;
 import jsky.util.gui.ProgressPanel;
 import jsky.util.gui.StatusLogger;
-
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 import java.util.*;
 import java.util.concurrent.CancellationException;
@@ -68,12 +64,7 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
     public GemsGuideStarWorker() {
         ProgressPanel progressPanel = ProgressPanel.makeProgressPanel("GeMS Strehl Calculations",
                 TpeManager.create().getImageWidget());
-        progressPanel.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                interrupted = true;
-            }
-        });
+        progressPanel.addActionListener(e -> interrupted = true);
         init(progressPanel);
     }
 
@@ -200,11 +191,8 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
      * @param obsContext used to getthe current pos angle
      */
     private Set<edu.gemini.spModel.core.Angle> getPosAngles(ObsContext obsContext) {
-        Set<edu.gemini.spModel.core.Angle> posAngles = new TreeSet<>(new Comparator<edu.gemini.spModel.core.Angle>() {
-            @Override
-            public int compare(edu.gemini.spModel.core.Angle a1, edu.gemini.spModel.core.Angle a2) {
-                return Double.compare(a1.toDegrees(), a2.toDegrees());
-            }
+        Set<edu.gemini.spModel.core.Angle> posAngles = new TreeSet<>((a1, a2) -> {
+            return Double.compare(a1.toDegrees(), a2.toDegrees());
         });
 
         posAngles.add(GemsUtils4Java.toNewAngle(obsContext.getPositionAngle()));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -4,6 +4,7 @@ import edu.gemini.ags.gems.*;
 import edu.gemini.ags.gems.mascot.Strehl;
 import edu.gemini.ags.gems.mascot.MascotProgress;
 import edu.gemini.catalog.votable.CatalogException;
+import edu.gemini.catalog.votable.RemoteBackend;
 import edu.gemini.catalog.votable.RemoteBackend$;
 import edu.gemini.pot.ModelConverters;
 import edu.gemini.skycalc.Angle;
@@ -235,7 +236,7 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
             GemsInstrument instrument = inst instanceof Flamingos2 ? GemsInstrument.flamingos2 : GemsInstrument.gsaoi;
             GemsGuideStarSearchOptions options = new GemsGuideStarSearchOptions(instrument, tipTiltMode, posAngles);
 
-            List<GemsCatalogSearchResults> results = new GemsVoTableCatalog(RemoteBackend$.MODULE$).search4Java(obsContext, ModelConverters.toCoordinates(base), options, nirBand, statusLogger, 10);
+            List<GemsCatalogSearchResults> results = new GemsVoTableCatalog(RemoteBackend.instance()).search4Java(obsContext, ModelConverters.toCoordinates(base), options, nirBand, statusLogger, 30);
             if (interrupted) {
                 throw new CancellationException("Canceled");
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeGuideStarDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeGuideStarDialog.java
@@ -63,7 +63,6 @@ public class TpeGuideStarDialog extends TpeGuideStarDialogForm
     private static final String AOWFS_LGS = "AOWFS LGS";
 
     private static final String CATALOG_2MASS = "2MASS";
-    private static final String CATALOG_UCAC3 = "UCAC3";
     private static final String CATALOG_UCAC4 = "UCAC4";
 
     private static final String OPTICAL_DEFAULT_CATALOG = CATALOG_UCAC4;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -10,7 +10,6 @@ import edu.gemini.ags.gems.GemsStrehl;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
-import org.jdesktop.swingx.JXTreeTable;
 import org.jdesktop.swingx.treetable.AbstractTreeTableModel;
 
 import java.util.ArrayList;
@@ -241,22 +240,20 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         }
     }
 
-    // Should be final, a bug seems to prevent it
-//    private ImList<Row> _rows;
     private final ImList<String> _columnHeaders;
 
     CandidateAsterismsTreeTableModel() {
         _columnHeaders = computeColumnHeaders();
     }
 
-    CandidateAsterismsTreeTableModel(List<GemsGuideStars> gemsGuideStarsList, JXTreeTable treeTable, Magnitude.Band band) {
+    CandidateAsterismsTreeTableModel(List<GemsGuideStars> gemsGuideStarsList, Magnitude.Band band) {
         super(new ArrayList<Row>());
         _columnHeaders = computeColumnHeaders();
 
-        final List<Row> tmp = (List<Row>)getRoot();
+        final List<Row> tmp = getRows();
 
         for(GemsGuideStars gemsGuideStars : gemsGuideStarsList) {
-            final List<Row> rowList = new ArrayList<Row>();
+            final List<Row> rowList = new ArrayList<>();
             for (GuideProbeTargets guideProbeTargets : gemsGuideStars.getGuideGroup().getAll()) {
                 rowList.add(new Row(gemsGuideStars, guideProbeTargets, band));
             }
@@ -271,7 +268,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     }
 
     private static ImList<String> computeColumnHeaders() {
-        List<String> hdr = new ArrayList<String>();
+        List<String> hdr = new ArrayList<>();
         for (Col c : Col.values()) hdr.add(c.displayName());
         return DefaultImList.create(hdr);
     }
@@ -306,7 +303,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
                 ((Row)node)._primary = (getPrimaryIndex(-1) == -1); // true if no others are marked primary
             } else {
                 ((Row)node)._primary = null;
-                List<Row> rowList = (List<Row>) getRoot();
+                List<Row> rowList = getRows();
                 for (Row row : rowList) {
                     if (row.isCheckBoxSelected()) {
                         row.setPrimary(true);
@@ -317,12 +314,10 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         } else if (column == Col.PRIMARY.ordinal() && node instanceof Row && value instanceof Boolean) {
             ((Row)node)._primary = (Boolean)value;
         }
-        // else {
-            // other columns are read-only
-        // }
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Object getChild(Object parent, int index) {
         if (parent instanceof List) {
             List<Row> rowList = (List<Row>)parent;
@@ -340,6 +335,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public int getChildCount(Object parent) {
         if (parent instanceof List) {
             List<Row> rowList = (List<Row>)parent;
@@ -355,6 +351,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public int getIndexOfChild(Object parent, Object child) {
         List<Row> rowList = null;
         if (parent instanceof List) {
@@ -392,9 +389,9 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
      * Returns a list of GemsGuideStars for the checked asterisms
      */
     public List<GemsGuideStars> getCheckedAsterisms() {
-        List<GemsGuideStars> result = new ArrayList<GemsGuideStars>();
+        List<GemsGuideStars> result = new ArrayList<>();
         if (getRoot() != null) {
-            List<Row> rowList = (List<Row>) getRoot();
+            List<Row> rowList = getRows();
             for (Row row : rowList) {
                 if (row.isCheckBoxSelected()) {
                     result.add(row.getGemsGuideStars());
@@ -410,7 +407,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     public int getPrimaryIndex(int defaultIndex) {
         if (getRoot() != null) {
             int i = 0;
-            List<Row> rowList = (List<Row>) getRoot();
+            List<Row> rowList = getRows();
             for (Row row : rowList) {
                 if (row.isCheckBoxSelected()) {
                     if (row.getPrimary() != null && row.getPrimary()) {
@@ -426,13 +423,18 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
     void clearPrimary() {
         if (getRoot() != null) {
-            List<Row> rowList = (List<Row>) getRoot();
+            List<Row> rowList = getRows();
             for (Row row : rowList) {
                 if (row.getPrimary() != null && row.getPrimary()) {
                     row.setPrimary(false);
                 }
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Row> getRows() {
+        return (List<Row>) getRoot();
     }
 
     void setPrimary(Row row) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -1,10 +1,9 @@
 package jsky.app.ot.tpe.gems;
 
+import edu.gemini.ags.gems.GemsUtils4Java;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.DefaultImList;
 import edu.gemini.shared.util.immutable.ImList;
-import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.gemini.gems.Canopus;
 import edu.gemini.ags.gems.GemsGuideStars;
 import edu.gemini.ags.gems.GemsStrehl;
 import edu.gemini.spModel.guide.GuideProbe;
@@ -179,14 +178,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
             if (_guideProbeTargets != null) {
                 if (!_guideProbeTargets.getPrimary().isEmpty()) {
                     GuideProbe guideProbe = _guideProbeTargets.getGuider();
-                    Magnitude.Band band = _band;
-                    if (Canopus.Wfs.Group.instance.getMembers().contains(guideProbe)) {
-                        band = Magnitude.Band.R;
-                    }
-                    Option<Magnitude> magOpt = _guideProbeTargets.getPrimary().getValue().getTarget().getMagnitude(band);
-                    if (!magOpt.isEmpty()) {
-                        return magOpt.getValue().getBrightness() + " (" + band.name() + ")";
-                    }
+                    return GemsUtils4Java.probeMagnitudeInUse(guideProbe, _band, _guideProbeTargets.getPrimary().getValue().getTarget());
                 }
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.getStrehl();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -25,7 +25,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     // The NIR band is selected in the UI, the others are listed afterwards (UNUSED_BAND*).
     // Always including them in the table makes the SkyObjectFactory code easier later on.
     enum Cols {
-        CHECK, ID, R, NIR_BAND, RA, DEC, UNUSED_BAND1, UNUSED_BAND2
+        CHECK, ID, _r, R, UC, NIR_BAND, RA, DEC, UNUSED_BAND1, UNUSED_BAND2
     }
 
     // User interface model
@@ -55,7 +55,9 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
         Vector<String> columnNames = new Vector<>();
         columnNames.add(""); // checkbox column
         columnNames.add("Id");
+        columnNames.add("r'");
         columnNames.add("R");
+        columnNames.add("UC");
         columnNames.add(_nirBand);
         columnNames.add("RA");
         columnNames.add("Dec");
@@ -100,7 +102,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
             return Boolean.class;
         if (columnIndex == Cols.ID.ordinal())
             return Object.class;
-        if (columnIndex == Cols.R.ordinal() || columnIndex == Cols.NIR_BAND.ordinal()
+        if (columnIndex == Cols.R.ordinal() || columnIndex == Cols._r.ordinal() || columnIndex == Cols.UC.ordinal() || columnIndex == Cols.NIR_BAND.ordinal()
                 || columnIndex == Cols.UNUSED_BAND1.ordinal() || columnIndex == Cols.UNUSED_BAND2.ordinal())
             return Double.class;
         return String.class;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
@@ -2,12 +2,10 @@ package jsky.app.ot.tpe.gems;
 
 import edu.gemini.ags.gems.GemsUtils4Java;
 import edu.gemini.skycalc.Angle;
-import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.core.MagnitudeBand;
 import edu.gemini.spModel.core.Target;
 import edu.gemini.spModel.gems.GemsTipTiltMode;
 import edu.gemini.ags.gems.GemsCatalogSearchResults;
-import edu.gemini.ags.gems.GemsGuideStarSearchOptions;
 import edu.gemini.ags.gems.GemsGuideStars;
 import edu.gemini.spModel.obs.context.ObsContext;
 import jsky.app.ot.tpe.GemsGuideStarWorker;
@@ -64,7 +62,7 @@ class GemsGuideStarSearchController {
             _dialog.setState(GemsGuideStarSearchDialog.State.PRE_QUERY);
         }
 
-        if (_model.isReviewCanditatesBeforeSearch()) {
+        if (_model.isReviewCandidatesBeforeSearch()) {
             _model.setGemsCatalogSearchResults(results);
         } else {
             _model.setGemsCatalogSearchResults(results);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -1,7 +1,6 @@
 package jsky.app.ot.tpe.gems;
 
 import edu.gemini.ags.gems.GemsUtils4Java;
-import edu.gemini.shared.skyobject.SkyObject;
 import edu.gemini.ags.gems.GemsGuideStarSearchOptions.*;
 import edu.gemini.ags.gems.GemsGuideStars;
 import edu.gemini.spModel.core.Target;
@@ -34,10 +33,6 @@ import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
-import javax.swing.event.TableModelEvent;
-import javax.swing.event.TableModelListener;
-import javax.swing.event.TreeSelectionEvent;
-import javax.swing.event.TreeSelectionListener;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -158,16 +153,15 @@ public class GemsGuideStarSearchDialog extends JFrame {
     // Context dependent message (title)
     private JLabel _actionLabel;
 
-    private JComboBox _catalogComboBox;
-    private JComboBox _userCatalogComboBox;
-    private Set<String> _userCatalogSet = new TreeSet<String>();
-    private JComboBox _nirBandComboBox;
+    private JComboBox<CatalogChoice> _catalogComboBox;
+    private JComboBox<String> _userCatalogComboBox;
+    private Set<String> _userCatalogSet = new TreeSet<>();
+    private JComboBox<NirBandChoice> _nirBandComboBox;
     private JCheckBox _reviewCandidatesCheckBox;
-    private JComboBox _analyseComboBox;
+    private JComboBox<AnalyseChoice> _analyseComboBox;
     private JCheckBox _allowPosAngleChangesCheckBox;
     private JTabbedPane _tabbedPane;
     private JPanel _candidateGuideStarsPanel;
-    private JPanel _candidateAsterismsPanel;
 
     // reuse file chooser widget for opening user catalogs
     private static JFileChooser _fileChooser;
@@ -245,14 +239,14 @@ public class GemsGuideStarSearchDialog extends JFrame {
         }});
 
         JPanel catalogPanel = new JPanel();
-        _catalogComboBox = new JComboBox(CatalogChoice.values());
-        _userCatalogComboBox = new JComboBox();
+        _catalogComboBox = new JComboBox<>(CatalogChoice.values());
+        _userCatalogComboBox = new JComboBox<>();
         _userCatalogComboBox.addItem("Open...");
         _userCatalogComboBox.setToolTipText("Select a local catalog file to use.");
         _userCatalogComboBox.setVisible(false);
         _userCatalogComboBox.setRenderer(new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(JList list, Object value, int index,
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
                                                           boolean isSelected, boolean cellHasFocus) {
                 if (index == 0)
                     return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
@@ -276,7 +270,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
             anchor = EAST;
         }});
 
-        _nirBandComboBox = new JComboBox(NirBandChoice.values());
+        _nirBandComboBox = new JComboBox<>(NirBandChoice.values());
         panel.add(_nirBandComboBox, new GridBagConstraints() {{
             gridx = 3;
             gridy = 1;
@@ -300,7 +294,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
             anchor = EAST;
         }});
 
-        _analyseComboBox = new JComboBox(AnalyseChoice.values());
+        _analyseComboBox = new JComboBox<>(AnalyseChoice.values());
         panel.add(_analyseComboBox, new GridBagConstraints() {{
             gridx = 1;
             gridy = 4;
@@ -319,7 +313,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
 
         _tabbedPane = new JTabbedPane();
         _tabbedPane.add(_candidateGuideStarsPanel = makeCandidateGuideStarsPanel());
-        _tabbedPane.add(_candidateAsterismsPanel = makeCandidateAsterismsPanel());
+        _tabbedPane.add(makeCandidateAsterismsPanel());
         panel.add(_tabbedPane, new GridBagConstraints() {{
             gridx = 0;
             gridy = 6;
@@ -356,7 +350,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         // If the user edits catalog search options, the tool throws away its results and moves back
         // to Pre-Query. On the other hand, if he changes Asterism parameters or changes candidate
         // guide stars, the tool moves back to Pre-Analyze.
-        final List<JComponent> searchParams = new ArrayList<JComponent>();
+        final List<JComponent> searchParams = new ArrayList<>();
         searchParams.add(_catalogComboBox);
         searchParams.add(_nirBandComboBox);
         searchParams.add(_reviewCandidatesCheckBox);
@@ -365,20 +359,17 @@ public class GemsGuideStarSearchDialog extends JFrame {
         searchParams.add(_analyseComboBox);
         searchParams.add(_allowPosAngleChangesCheckBox);
 
-        ActionListener a = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                _useDefaultsAction.setEnabled(!usingDefaults());
-                if (_state == State.PRE_ANALYZE) {
-                    if (searchParams.contains(e.getSource())) {
-                        setState(State.PRE_QUERY);
-                    }
-                } else if (_state == State.SELECTION) {
-                    if (searchParams.contains(e.getSource())) {
-                        setState(State.PRE_QUERY);
-                    } else {
-                        setState(State.PRE_ANALYZE);
-                    }
+        ActionListener a = e -> {
+            _useDefaultsAction.setEnabled(!usingDefaults());
+            if (_state == State.PRE_ANALYZE) {
+                if (searchParams.contains(e.getSource())) {
+                    setState(State.PRE_QUERY);
+                }
+            } else if (_state == State.SELECTION) {
+                if (searchParams.contains(e.getSource())) {
+                    setState(State.PRE_QUERY);
+                } else {
+                    setState(State.PRE_ANALYZE);
                 }
             }
         };
@@ -389,63 +380,50 @@ public class GemsGuideStarSearchDialog extends JFrame {
         _allowPosAngleChangesCheckBox.addActionListener(a);
 
         // REL-560: User catalog support
-        _catalogComboBox.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (_catalogComboBox.getSelectedItem() == CatalogChoice.USER_CATALOG) {
-                    _userCatalogComboBox.setVisible(true);
-                    if (_userCatalogComboBox.getItemCount() == 1) {
-                        loadUserCatalog();
-                    }
-                } else {
-                    _userCatalogFileName = null;
-                    _userCatalog = null;
-                    _userCatalogComboBox.setSelectedIndex(0);
-                    _userCatalogComboBox.setVisible(false);
+        _catalogComboBox.addActionListener(e -> {
+            if (_catalogComboBox.getSelectedItem() == CatalogChoice.USER_CATALOG) {
+                _userCatalogComboBox.setVisible(true);
+                if (_userCatalogComboBox.getItemCount() == 1) {
+                    loadUserCatalog();
                 }
-
+            } else {
+                _userCatalogFileName = null;
+                _userCatalog = null;
+                _userCatalogComboBox.setSelectedIndex(0);
+                _userCatalogComboBox.setVisible(false);
             }
+
         });
 
-        _userCatalogComboBox.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (_userCatalogComboBox.getSelectedIndex() == 0) {
-                    if (_catalogComboBox.getSelectedItem() == CatalogChoice.USER_CATALOG) {
-                        loadUserCatalog();
-                    }
-                } else {
-                    selectUserCatalog((String) _userCatalogComboBox.getSelectedItem());
+        _userCatalogComboBox.addActionListener(e -> {
+            if (_userCatalogComboBox.getSelectedIndex() == 0) {
+                if (_catalogComboBox.getSelectedItem() == CatalogChoice.USER_CATALOG) {
+                    loadUserCatalog();
                 }
-                setState(State.PRE_QUERY);
+            } else {
+                selectUserCatalog((String) _userCatalogComboBox.getSelectedItem());
             }
+            setState(State.PRE_QUERY);
         });
 
 
         // If unchecked, the “Candidate Guide Stars” tab should be removed.
-        _reviewCandidatesCheckBox.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (_reviewCandidatesCheckBox.isSelected()) {
-                    _tabbedPane.add(_candidateGuideStarsPanel, 0);
-                } else {
-                    _tabbedPane.remove(_candidateGuideStarsPanel);
-                }
+        _reviewCandidatesCheckBox.addActionListener(e -> {
+            if (_reviewCandidatesCheckBox.isSelected()) {
+                _tabbedPane.add(_candidateGuideStarsPanel, 0);
+            } else {
+                _tabbedPane.remove(_candidateGuideStarsPanel);
             }
         });
 
         // Selecting a group will cause it to be shown in the TPE
-        _candidateAsterismsTreeTable.getTreeSelectionModel().addTreeSelectionListener(new TreeSelectionListener() {
-            @Override
-            public void valueChanged(TreeSelectionEvent e) {
-                if (!_ignoreSelection) {
-                    _ignoreSelection = true;
-                    try {
-                        _candidateAsterismsTreeTable.selectRelatedRows();
-//                        _controller.add(_candidateAsterismsTreeTable.getSelectedGemsGuideStars());
-                    } finally {
-                        _ignoreSelection = false;
-                    }
+        _candidateAsterismsTreeTable.getTreeSelectionModel().addTreeSelectionListener(e -> {
+            if (!_ignoreSelection) {
+                _ignoreSelection = true;
+                try {
+                    _candidateAsterismsTreeTable.selectRelatedRows();
+                } finally {
+                    _ignoreSelection = false;
                 }
             }
         });
@@ -644,7 +622,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         }
         _model.setBand((NirBandChoice) _nirBandComboBox.getSelectedItem());
         _model.setAnalyseChoice((AnalyseChoice) _analyseComboBox.getSelectedItem());
-        _model.setReviewCanditatesBeforeSearch(_reviewCandidatesCheckBox.isSelected());
+        _model.setReviewCandidatesBeforeSearch(_reviewCandidatesCheckBox.isSelected());
         _model.setAllowPosAngleAdjustments(_allowPosAngleChangesCheckBox.isSelected());
         _model.setGemsCatalogSearchResults(null);
         _model.setGemsGuideStars(null);
@@ -698,15 +676,10 @@ public class GemsGuideStarSearchDialog extends JFrame {
             setState(State.PRE_QUERY);
         } else {
             _candidateGuideStarsTable.resize(); // fix column widths
-            if (_model.isReviewCanditatesBeforeSearch()) {
+            if (_model.isReviewCandidatesBeforeSearch()) {
                 setState(State.PRE_ANALYZE);
                 // Any changes in the checked candidates causes the state to change to PRE_ANALYZE
-                _candidateGuideStarsTable.getTable().getModel().addTableModelListener(new TableModelListener() {
-                    @Override
-                    public void tableChanged(TableModelEvent e) {
-                        setState(State.PRE_ANALYZE);
-                    }
-                });
+                _candidateGuideStarsTable.getTable().getModel().addTableModelListener(e -> setState(State.PRE_ANALYZE));
             } else {
                 analyzeDone();
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -728,7 +728,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
 
     private void analyzeDone() {
         CandidateAsterismsTreeTableModel treeTableModel = new CandidateAsterismsTreeTableModel(
-                _model.getGemsGuideStars(), _candidateAsterismsTreeTable, GemsUtils4Java.toOldBand(_model.getBand().getBand()));
+                _model.getGemsGuideStars(), GemsUtils4Java.toOldBand(_model.getBand().getBand()));
         _candidateAsterismsTreeTable.setTreeTableModel(treeTableModel);
         _candidateAsterismsTreeTable.expandAll();
         _candidateAsterismsTreeTable.packAll();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchModel.java
@@ -22,7 +22,7 @@ class GemsGuideStarSearchModel {
 
     private NirBandChoice _band;
     private AnalyseChoice _analyseChoice;
-    private boolean _reviewCanditatesBeforeSearch;
+    private boolean _reviewCandidatesBeforeSearch;
     private boolean _allowPosAngleAdjustments;
     private List<GemsCatalogSearchResults> _gemsCatalogSearchResults;
     private List<GemsGuideStars> _gemsGuideStars;
@@ -33,10 +33,6 @@ class GemsGuideStarSearchModel {
 
     public void setCatalog(CatalogChoice catalog) {
         _catalog = catalog;
-    }
-
-    public String getUserCatalogFileName() {
-        return _userCatalogFileName;
     }
 
     public void setUserCatalogFileName(String userCatalogFileName) {
@@ -67,12 +63,12 @@ class GemsGuideStarSearchModel {
         _analyseChoice = analyseChoice;
     }
 
-    public void setReviewCanditatesBeforeSearch(boolean reviewCanditatesBeforeSearch) {
-        _reviewCanditatesBeforeSearch = reviewCanditatesBeforeSearch;
+    public void setReviewCandidatesBeforeSearch(boolean reviewCanditatesBeforeSearch) {
+        _reviewCandidatesBeforeSearch = reviewCanditatesBeforeSearch;
     }
 
-    public boolean isReviewCanditatesBeforeSearch() {
-        return _reviewCanditatesBeforeSearch;
+    public boolean isReviewCandidatesBeforeSearch() {
+        return _reviewCandidatesBeforeSearch;
     }
 
     public void setAllowPosAngleAdjustments(boolean allowPosAngleAdjustments) {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/gems/CatalogUtils4Java.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/gems/CatalogUtils4Java.scala
@@ -13,13 +13,15 @@ object CatalogUtils4Java {
    */
   def makeRow(siderealTarget: Target.SiderealTarget, nirBand: String, unusedBands: Array[String]): java.util.Vector[AnyRef] = {
     new java.util.Vector[AnyRef](Vector[AnyRef](
-      Boolean.box(true),
+      Boolean.box(x = true),
       siderealTarget.name,
-      siderealTarget.magnitudeIn(MagnitudeBand.R).orNull,
-      MagnitudeBand.all.find(_.name == nirBand).map(siderealTarget.magnitudeIn).flatten.orNull,
+      siderealTarget.magnitudeIn(MagnitudeBand._r).map(v => Double.box(v.value)).orNull,
+      siderealTarget.magnitudeIn(MagnitudeBand.R).map(v => Double.box(v.value)).orNull,
+      siderealTarget.magnitudeIn(MagnitudeBand.UC).map(v => Double.box(v.value)).orNull,
+      MagnitudeBand.all.find(_.name == nirBand).flatMap(siderealTarget.magnitudeIn).map(v => Double.box(v.value)).orNull,
       new HMS(siderealTarget.coordinates.ra.toAngle.toHMS.hours).toString,
-      new DMS(siderealTarget.coordinates.dec.toAngle.toDegrees).toString,
-        MagnitudeBand.all.find(_.name == unusedBands(0)).map(siderealTarget.magnitudeIn).flatten.orNull,
-        MagnitudeBand.all.find(_.name == unusedBands(1)).map(siderealTarget.magnitudeIn).flatten.orNull).asJava)
+      new DMS(siderealTarget.coordinates.dec.toDegrees).toString,
+      MagnitudeBand.all.find(_.name == unusedBands(0)).flatMap(siderealTarget.magnitudeIn).map(v => Double.box(v.value)).orNull,
+      MagnitudeBand.all.find(_.name == unusedBands(1)).flatMap(siderealTarget.magnitudeIn).map(v => Double.box(v.value)).orNull).asJava)
   }
 }


### PR DESCRIPTION
This PR updates the manual guide star search feature to work with UCAC4.

Note that this is not the final PR as we may need to support non UCAC4 catalogs too, but we can use to test the basic functionality. Currently, queries to any other catalog will go to UCAC4.

The usual code cleanups and conversions of lambdas, raw types, etc.. are included

Here are a couple of screenshots of the Dialog box

![screenshot 2015-04-23 08 17 27](https://cloud.githubusercontent.com/assets/3615303/7297019/3bdeb0d8-e99b-11e4-9420-f89821b4ee11.png)

![screenshot 2015-04-23 09 31 02](https://cloud.githubusercontent.com/assets/3615303/7297051/80f36380-e99b-11e4-94db-1b948bdb4f67.png)
