### PR TITLE
REL-2012: Configuration from GPI/Seqexec must set Optimize and No FPM

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -1106,6 +1106,8 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     public static final boolean DEFAULT_ALWAYS_RESTORE_MODEL = false;
     public static final boolean DEFAULT_USE_AO = true;
     public static final boolean DEFAULT_USE_CAL = true;
+    public static final boolean DEFAULT_AO_OPTIMIZE = true;
+    public static final boolean DEFAULT_NO_FPM_PINHOLE = true;
 
     // OT-95: overhead times for single or multiple changes in a sequence
     public static final double SINGLE_CHANGE_OVERHEAD_SECS = 30;
@@ -1118,7 +1120,6 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     public static final double SCIENCE_AREA_ARCSEC = 2.8;
 
     public static final ItemKey HALFWAVE_PLATE_ANGLE_KEY = new ItemKey(INSTRUMENT_KEY, "halfWavePlateAngle");
-
 
     /**
      * This obs component's SP type.
@@ -1193,6 +1194,9 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
 
     public static final PropertyDescriptor USE_AO_PROP;
     public static final PropertyDescriptor USE_CAL_PROP;
+
+    public static final PropertyDescriptor AO_OPTIMIZE_PROP;
+    public static final PropertyDescriptor NO_FPM_PINHOLE_PROP;
 
     public static final String MAG_H_PROP = "magH";
     public static final String MAG_I_PROP = "magI";
@@ -1300,6 +1304,16 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
                 query_no, iter_no);
         USE_CAL_PROP.setExpert(true);
 
+        AO_OPTIMIZE_PROP = initProp("aoOptimize",
+                "AO Optimize",
+                query_no, iter_no);
+        AO_OPTIMIZE_PROP.setExpert(true);
+
+        NO_FPM_PINHOLE_PROP = initProp("noFpmPinhole",
+                "No FPM/Pinhole",
+                query_no, iter_no);
+        NO_FPM_PINHOLE_PROP.setExpert(true);
+
     }
 
     // instrument properties
@@ -1343,6 +1357,9 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     // OT-136 useAo and useCal
     private boolean _useAo = DEFAULT_USE_AO;
     private boolean _useCal = DEFAULT_USE_CAL;
+    // REL-2012 Ao Optimize and No FPM/Pinhole
+    private boolean _aoOptimize = DEFAULT_AO_OPTIMIZE;
+    private boolean _noFpmPinhole = DEFAULT_NO_FPM_PINHOLE;
 
     public Gpi() {
         super(SP_TYPE);
@@ -1926,6 +1943,30 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         }
     }
 
+    public boolean isAoOptimize() {
+        return _aoOptimize;
+    }
+
+    public void setAoOptimize(boolean newValue) {
+        boolean oldValue = isAoOptimize();
+        if (oldValue != newValue) {
+            _aoOptimize = newValue;
+            firePropertyChange(AO_OPTIMIZE_PROP, oldValue, newValue);
+        }
+    }
+
+    public boolean isNoFpmPinhole() {
+        return _noFpmPinhole;
+    }
+
+    public void setNoFpmPinhole(boolean newValue) {
+        boolean oldValue = isNoFpmPinhole();
+        if (oldValue != newValue) {
+            _noFpmPinhole = newValue;
+            firePropertyChange(NO_FPM_PINHOLE_PROP, oldValue, newValue);
+        }
+    }
+
     /**
      * @return the min exposure time in seconds
      */
@@ -1984,6 +2025,8 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         Pio.addParam(factory, paramSet, ALWAYS_RESTORE_MODEL_PROP, String.valueOf(isAlwaysRestoreModel()));
         Pio.addParam(factory, paramSet, USE_AO_PROP, String.valueOf(isUseAo()));
         Pio.addParam(factory, paramSet, USE_CAL_PROP, String.valueOf(isUseCal()));
+        Pio.addParam(factory, paramSet, AO_OPTIMIZE_PROP, String.valueOf(isAoOptimize()));
+        Pio.addParam(factory, paramSet, NO_FPM_PINHOLE_PROP, String.valueOf(isNoFpmPinhole()));
 
         return paramSet;
     }
@@ -2080,6 +2123,10 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
                 DEFAULT_USE_AO));
         setUseCal(Pio.getBooleanValue(paramSet, USE_CAL_PROP.getName(),
                 DEFAULT_USE_CAL));
+        setAoOptimize(Pio.getBooleanValue(paramSet, AO_OPTIMIZE_PROP.getName(),
+                DEFAULT_AO_OPTIMIZE));
+        setNoFpmPinhole(Pio.getBooleanValue(paramSet, NO_FPM_PINHOLE_PROP.getName(),
+                DEFAULT_NO_FPM_PINHOLE));
     }
 
     /**
@@ -2134,6 +2181,8 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         sc.putParameter(DefaultParameter.getInstance(ALWAYS_RESTORE_MODEL_PROP, isAlwaysRestoreModel()));
         sc.putParameter(DefaultParameter.getInstance(USE_AO_PROP, isUseAo()));
         sc.putParameter(DefaultParameter.getInstance(USE_CAL_PROP, isUseCal()));
+        sc.putParameter(DefaultParameter.getInstance(AO_OPTIMIZE_PROP, isAoOptimize()));
+        sc.putParameter(DefaultParameter.getInstance(NO_FPM_PINHOLE_PROP, isNoFpmPinhole()));
 
         return sc;
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -1107,7 +1107,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     public static final boolean DEFAULT_USE_AO = true;
     public static final boolean DEFAULT_USE_CAL = true;
     public static final boolean DEFAULT_AO_OPTIMIZE = true;
-    public static final boolean DEFAULT_NO_FPM_PINHOLE = true;
+    public static final boolean DEFAULT_ALIGN_FPM_PINHOLE_BIAS = false;
 
     // OT-95: overhead times for single or multiple changes in a sequence
     public static final double SINGLE_CHANGE_OVERHEAD_SECS = 30;
@@ -1196,7 +1196,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     public static final PropertyDescriptor USE_CAL_PROP;
 
     public static final PropertyDescriptor AO_OPTIMIZE_PROP;
-    public static final PropertyDescriptor NO_FPM_PINHOLE_PROP;
+    public static final PropertyDescriptor ALIGN_FPM_PINHOLE_BIAS_PROP;
 
     public static final String MAG_H_PROP = "magH";
     public static final String MAG_I_PROP = "magI";
@@ -1309,10 +1309,10 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
                 query_no, iter_no);
         AO_OPTIMIZE_PROP.setExpert(true);
 
-        NO_FPM_PINHOLE_PROP = initProp("noFpmPinhole",
-                "No FPM/Pinhole",
+        ALIGN_FPM_PINHOLE_BIAS_PROP = initProp("alignFpmPinholeBias",
+                "Align FPM/Pinhole/Bias",
                 query_no, iter_no);
-        NO_FPM_PINHOLE_PROP.setExpert(true);
+        ALIGN_FPM_PINHOLE_BIAS_PROP.setExpert(true);
 
     }
 
@@ -1357,9 +1357,9 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     // OT-136 useAo and useCal
     private boolean _useAo = DEFAULT_USE_AO;
     private boolean _useCal = DEFAULT_USE_CAL;
-    // REL-2012 Ao Optimize and No FPM/Pinhole
+    // REL-2012 Ao Optimize and Align FPM/Pinhole/Bias
     private boolean _aoOptimize = DEFAULT_AO_OPTIMIZE;
-    private boolean _noFpmPinhole = DEFAULT_NO_FPM_PINHOLE;
+    private boolean _alignFpmPinholeBias = DEFAULT_ALIGN_FPM_PINHOLE_BIAS;
 
     public Gpi() {
         super(SP_TYPE);
@@ -1955,15 +1955,15 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         }
     }
 
-    public boolean isNoFpmPinhole() {
-        return _noFpmPinhole;
+    public boolean isAlignFpmPinholeBias() {
+        return _alignFpmPinholeBias;
     }
 
-    public void setNoFpmPinhole(boolean newValue) {
-        boolean oldValue = isNoFpmPinhole();
+    public void setAlignFpmPinholeBias(boolean newValue) {
+        boolean oldValue = isAlignFpmPinholeBias();
         if (oldValue != newValue) {
-            _noFpmPinhole = newValue;
-            firePropertyChange(NO_FPM_PINHOLE_PROP, oldValue, newValue);
+            _alignFpmPinholeBias = newValue;
+            firePropertyChange(ALIGN_FPM_PINHOLE_BIAS_PROP, oldValue, newValue);
         }
     }
 
@@ -2026,7 +2026,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         Pio.addParam(factory, paramSet, USE_AO_PROP, String.valueOf(isUseAo()));
         Pio.addParam(factory, paramSet, USE_CAL_PROP, String.valueOf(isUseCal()));
         Pio.addParam(factory, paramSet, AO_OPTIMIZE_PROP, String.valueOf(isAoOptimize()));
-        Pio.addParam(factory, paramSet, NO_FPM_PINHOLE_PROP, String.valueOf(isNoFpmPinhole()));
+        Pio.addParam(factory, paramSet, ALIGN_FPM_PINHOLE_BIAS_PROP, String.valueOf(isAlignFpmPinholeBias()));
 
         return paramSet;
     }
@@ -2125,8 +2125,8 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
                 DEFAULT_USE_CAL));
         setAoOptimize(Pio.getBooleanValue(paramSet, AO_OPTIMIZE_PROP.getName(),
                 DEFAULT_AO_OPTIMIZE));
-        setNoFpmPinhole(Pio.getBooleanValue(paramSet, NO_FPM_PINHOLE_PROP.getName(),
-                DEFAULT_NO_FPM_PINHOLE));
+        setAlignFpmPinholeBias(Pio.getBooleanValue(paramSet, ALIGN_FPM_PINHOLE_BIAS_PROP.getName(),
+                DEFAULT_ALIGN_FPM_PINHOLE_BIAS));
     }
 
     /**
@@ -2182,7 +2182,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         sc.putParameter(DefaultParameter.getInstance(USE_AO_PROP, isUseAo()));
         sc.putParameter(DefaultParameter.getInstance(USE_CAL_PROP, isUseCal()));
         sc.putParameter(DefaultParameter.getInstance(AO_OPTIMIZE_PROP, isAoOptimize()));
-        sc.putParameter(DefaultParameter.getInstance(NO_FPM_PINHOLE_PROP, isNoFpmPinhole()));
+        sc.putParameter(DefaultParameter.getInstance(ALIGN_FPM_PINHOLE_BIAS_PROP, isAlignFpmPinholeBias()));
 
         return sc;
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/GpiTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/GpiTest.java
@@ -51,7 +51,7 @@ public class GpiTest  extends TestCase {
         assertEquals(inst.getPosAngleDegrees(), InstConstants.DEF_POS_ANGLE, _ERROR);
         assertEquals(inst.getTotalExposureTime(), Gpi.DEFAULT_EXPOSURE_TIME, _ERROR);
         assertEquals(inst.isAoOptimize(), Gpi.DEFAULT_AO_OPTIMIZE);
-        assertEquals(inst.isNoFpmPinhole(), Gpi.DEFAULT_NO_FPM_PINHOLE);
+        assertEquals(inst.isAlignFpmPinholeBias(), Gpi.DEFAULT_ALIGN_FPM_PINHOLE_BIAS);
     }
 
     // test get/set paramset
@@ -73,7 +73,7 @@ public class GpiTest  extends TestCase {
         inst.setCoadds(2);
         inst.setPosAngleDegrees(90.);
         inst.setAoOptimize(false);
-        inst.setNoFpmPinhole(false);
+        inst.setAlignFpmPinholeBias(true);
 
         ParamSet p = inst.getParamSet(new PioXmlFactory());
 
@@ -125,7 +125,7 @@ public class GpiTest  extends TestCase {
         assertEquals(90., copy.getPosAngleDegrees(), _ERROR);
 
         assertFalse(copy.isAoOptimize());
-        assertFalse(copy.isNoFpmPinhole());
+        assertTrue(copy.isAlignFpmPinholeBias());
     }
 
     public void testResetASUAttenuation() {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/GpiTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/GpiTest.java
@@ -50,6 +50,8 @@ public class GpiTest  extends TestCase {
         assertEquals(inst.getCoadds(), InstConstants.DEF_COADDS);
         assertEquals(inst.getPosAngleDegrees(), InstConstants.DEF_POS_ANGLE, _ERROR);
         assertEquals(inst.getTotalExposureTime(), Gpi.DEFAULT_EXPOSURE_TIME, _ERROR);
+        assertEquals(inst.isAoOptimize(), Gpi.DEFAULT_AO_OPTIMIZE);
+        assertEquals(inst.isNoFpmPinhole(), Gpi.DEFAULT_NO_FPM_PINHOLE);
     }
 
     // test get/set paramset
@@ -70,6 +72,8 @@ public class GpiTest  extends TestCase {
         inst.setExposureTime(300.);
         inst.setCoadds(2);
         inst.setPosAngleDegrees(90.);
+        inst.setAoOptimize(false);
+        inst.setNoFpmPinhole(false);
 
         ParamSet p = inst.getParamSet(new PioXmlFactory());
 
@@ -119,6 +123,9 @@ public class GpiTest  extends TestCase {
         assertEquals(300., copy.getExposureTime(), _ERROR);
         assertEquals(2, copy.getCoadds(), _ERROR);
         assertEquals(90., copy.getPosAngleDegrees(), _ERROR);
+
+        assertFalse(copy.isAoOptimize());
+        assertFalse(copy.isNoFpmPinhole());
     }
 
     public void testResetASUAttenuation() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
@@ -258,7 +258,7 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
         }
     }
 
-    // Updates the value of the useCal if it changes
+    // Updates the value of the useCal/useAo/noFpmPinhole/aoOptimize if it changes
     private final class UseLoopListener implements PropertyChangeListener {
         private final CheckboxPropertyCtrl<Gpi> ctrl;
 
@@ -322,6 +322,11 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
     private final CheckboxPropertyCtrl<Gpi> useCalCtrl;
     private final UseLoopListener useCalUpdater;
     private final UseLoopListener useAoUpdater;
+
+    private final CheckboxPropertyCtrl<Gpi> aoOptimizeCtrl;
+    private final CheckboxPropertyCtrl<Gpi> noFpmPinholeCtrl;
+    private final UseLoopListener aoOptimizeUpdater;
+    private final UseLoopListener noFpmPinholeUpdater;
 
     private static final int halfWidth     = 3;
 
@@ -472,6 +477,12 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
 
         useCalCtrl = new CheckboxPropertyCtrl<>(Gpi.USE_CAL_PROP);
         useCalUpdater = new UseLoopListener(useCalCtrl);
+
+        aoOptimizeCtrl = new CheckboxPropertyCtrl<>(Gpi.AO_OPTIMIZE_PROP);
+        aoOptimizeUpdater = new UseLoopListener(aoOptimizeCtrl);
+
+        noFpmPinholeCtrl = new CheckboxPropertyCtrl<>(Gpi.NO_FPM_PINHOLE_PROP);
+        noFpmPinholeUpdater = new UseLoopListener(noFpmPinholeCtrl);
     }
 
     @Override
@@ -526,6 +537,9 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
 
         pan.add(useAoCtrl.getComponent(), propWidgetGbc(leftWidgetCol, row++, 3, 1));
         pan.add(useCalCtrl.getComponent(), propWidgetGbc(leftWidgetCol, row++, 3, 1));
+
+        pan.add(aoOptimizeCtrl.getComponent(), propWidgetGbc(leftWidgetCol, row++, 3, 1));
+        pan.add(noFpmPinholeCtrl.getComponent(), propWidgetGbc(leftWidgetCol, row++, 3, 1));
 
         // filler
         final int finalRow = row;
@@ -629,5 +643,10 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
         inst.addPropertyChangeListener(Gpi.USE_CAL_PROP.getName(), useCalUpdater);
         inst.addPropertyChangeListener(Gpi.USE_AO_PROP.getName(), useAoUpdater);
         useCalCtrl.setBean(inst);
+
+        aoOptimizeCtrl.setBean(inst);
+        noFpmPinholeCtrl.setBean(inst);
+        inst.addPropertyChangeListener(Gpi.AO_OPTIMIZE_PROP.getName(), aoOptimizeUpdater);
+        inst.addPropertyChangeListener(Gpi.NO_FPM_PINHOLE_PROP.getName(), noFpmPinholeUpdater);
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
@@ -481,7 +481,7 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
         aoOptimizeCtrl = new CheckboxPropertyCtrl<>(Gpi.AO_OPTIMIZE_PROP);
         aoOptimizeUpdater = new UseLoopListener(aoOptimizeCtrl);
 
-        noFpmPinholeCtrl = new CheckboxPropertyCtrl<>(Gpi.NO_FPM_PINHOLE_PROP);
+        noFpmPinholeCtrl = new CheckboxPropertyCtrl<>(Gpi.ALIGN_FPM_PINHOLE_BIAS_PROP);
         noFpmPinholeUpdater = new UseLoopListener(noFpmPinholeCtrl);
     }
 
@@ -647,6 +647,6 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
         aoOptimizeCtrl.setBean(inst);
         noFpmPinholeCtrl.setBean(inst);
         inst.addPropertyChangeListener(Gpi.AO_OPTIMIZE_PROP.getName(), aoOptimizeUpdater);
-        inst.addPropertyChangeListener(Gpi.NO_FPM_PINHOLE_PROP.getName(), noFpmPinholeUpdater);
+        inst.addPropertyChangeListener(Gpi.ALIGN_FPM_PINHOLE_BIAS_PROP.getName(), noFpmPinholeUpdater);
     }
 }


### PR DESCRIPTION
As part of REL-2012 it is necessary to add two parameters (aoOptimize, NoFPMPinhole) to let the Seqexec configure the instrument properly
This PR contains code adding the parameters and UI updates to GPI's Engineering Tab