### PR TITLE
OCSADV-319: Bug fix: Issues with nano- vs micro-meters in wavelengths.

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -170,12 +170,12 @@ object ConfigExtractor {
 
   // Gets the observing wavelength from the configuration.
   // For imaging this corresponds to the mid point of the selected filter, for spectroscopy the value
-  // is defined by the user. Unit is micro-meter [um]. Note that for Acq Cam the observing wavelength
+  // is defined by the user. Unit is microns [um]. Note that for Acq Cam the observing wavelength
   // is not defined, instead we need to get the wavelength from the color filter. Also some special
   // magic is needed for GNIRS.
-  def extractObservingWavelength(c: Config): String \/ Double = {
+  def extractObservingWavelength(c: Config): String \/ Wavelength = {
     val instrument = extract[String](c, InstrumentKey).getOrElse("")
-    instrument match {
+    (instrument match {
       case "AcqCam" =>
         extract[AcqCamParams.ColorFilter](c, ColorFilterKey).rightMap(_.getCentralWavelength.toDouble)
       case "GNIRS" =>
@@ -183,7 +183,8 @@ object ConfigExtractor {
       case _ =>
         if (c.containsItem(ObsWavelengthKey)) extractDoubleFromString(c, ObsWavelengthKey)
         else "Observing wavelength is not defined (missing filter?)".left
-    }
+
+    }).rightMap(Wavelength.fromMicrons)
   }
 
 

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
@@ -1,6 +1,6 @@
 package edu.gemini.itc.shared
 
-import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.core.{Wavelength, Site}
 import edu.gemini.spModel.gemini.acqcam.AcqCamParams
 import edu.gemini.spModel.gemini.altair.AltairParams
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
@@ -28,7 +28,7 @@ final case class Flamingos2Parameters(
 final case class GmosParameters(
                      filter:            GmosCommonType.Filter,
                      grating:           GmosCommonType.Disperser,
-                     centralWavelength: Double,
+                     centralWavelength: Wavelength,
                      fpMask:            GmosCommonType.FPUnit,
                      spatialBinning:    Int,
                      spectralBinning:   Int,

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -8,7 +8,7 @@ import edu.gemini.itc.nifs.NifsParameters
 import edu.gemini.itc.shared.SourceDefinition._
 import edu.gemini.itc.shared._
 import edu.gemini.itc.trecs.TRecsParameters
-import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.core.{Wavelength, Site}
 import edu.gemini.spModel.gemini.acqcam.AcqCamParams
 import edu.gemini.spModel.gemini.altair.AltairParams
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
@@ -117,7 +117,7 @@ object ITCRequest {
     val spatBinning = r.intParameter("spatBinning")
     val specBinning = r.intParameter("specBinning")
     val ccdType     = r.enumParameter(classOf[DetectorManufacturer])
-    val centralWl   = r.doubleParameter("instrumentCentralWavelength")
+    val centralWl   = Wavelength.fromNanometers(r.doubleParameter("instrumentCentralWavelength"))
     val fpMask      = if (site.equals(Site.GN)) r.enumParameter(classOf[FPUnitNorth],    "instrumentFPMask")   else r.enumParameter(classOf[FPUnitSouth],      "instrumentFPMask")
     val ifuMethod: Option[IfuMethod]   = if (fpMask.isIFU) {
       r.parameter("ifuMethod") match {
@@ -136,8 +136,8 @@ object ITCRequest {
     val camera      = r.parameter("instrumentCamera")
     val xDisp       = r.parameter("xdisp")
     val readNoise   = r.parameter("readNoise")
-    val centralWl   = r.doubleParameter("instrumentCentralWavelength")
-    val fpMask     = r.parameter("instrumentFPMask")
+    val centralWl   = Wavelength.fromMicrons(r.doubleParameter("instrumentCentralWavelength"))
+    val fpMask      = r.parameter("instrumentFPMask")
     new GnirsParameters(camera, grating, readNoise, xDisp, centralWl, fpMask)
   }
 
@@ -151,7 +151,7 @@ object ITCRequest {
   def michelleParameters(r: ITCRequest): MichelleParameters = {
     val filter      = r.parameter("instrumentFilter")
     val grating     = r.parameter("instrumentDisperser")
-    val centralWl   = r.doubleParameter("instrumentCentralWavelength")
+    val centralWl   = Wavelength.fromMicrons(r.doubleParameter("instrumentCentralWavelength"))
     val fpMask      = r.enumParameter(classOf[MichelleParams.Mask])
     val polarimetry = r.parameter("polarimetry")
     new MichelleParameters(filter, grating, centralWl, fpMask, polarimetry)
@@ -172,7 +172,7 @@ object ITCRequest {
     val filter      = r.parameter("instrumentFilter")
     val grating     = r.parameter("instrumentDisperser")
     val readNoise   = r.parameter("readNoise")
-    val centralWl   = r.doubleParameter("instrumentCentralWavelength")
+    val centralWl   = Wavelength.fromMicrons(r.doubleParameter("instrumentCentralWavelength"))
     val ifuMethod   = r.parameter("ifuMethod")
     val (offset, min, max, numX, numY, centerX, centerY) = ifuMethod match {
       case "singleIFU"  =>
@@ -197,7 +197,7 @@ object ITCRequest {
     val filter      = r.parameter("instrumentFilter")
     val window      = r.parameter("instrumentWindow")
     val grating     = r.parameter("instrumentDisperser")
-    val centralWl   = r.doubleParameter("instrumentCentralWavelength")
+    val centralWl   = Wavelength.fromMicrons(r.doubleParameter("instrumentCentralWavelength"))
     val fpMask      = r.parameter("instrumentFPMask")
     new TRecsParameters(filter, window, grating, centralWl, fpMask)
   }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -135,7 +135,7 @@ public abstract class Gmos extends Instrument implements BinningProvider {
         // TODO: grating is not yet defined, need to work with grating from gp, clean this up
         if (!gp.grating().equals(GmosNorthType.DisperserNorth.MIRROR) && !gp.grating().equals(GmosSouthType.DisperserSouth.MIRROR)) {
             _gratingOptics = new GmosGratingOptics(getDirectory() + "/" + getPrefix(), gp.grating(), _detector,
-                    gp.centralWavelength(),
+                    gp.centralWavelength().toNanometers(),
                     _detector.getDetectorPixels(),
                     gp.spectralBinning());
             _sampling = _gratingOptics.getGratingDispersion_nmppix();
@@ -281,7 +281,7 @@ public abstract class Gmos extends Instrument implements BinningProvider {
     }
 
     public double getCentralWavelength() {
-        return gp.centralWavelength();
+        return gp.centralWavelength().toNanometers();
     }
 
     //Abstract class for Detector Pixel Transmission  (i.e.  Create Detector gaps)

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsParameters.java
@@ -1,6 +1,7 @@
 package edu.gemini.itc.gnirs;
 
 import edu.gemini.itc.shared.InstrumentDetails;
+import edu.gemini.spModel.core.Wavelength;
 
 /**
  * This class holds the information from the Gnirs section
@@ -51,7 +52,7 @@ public final class GnirsParameters implements InstrumentDetails {
     private final String grating; // Grating or null
     private final String camera;
     private final String readNoise;
-    private final double instrumentCentralWavelength;
+    private final Wavelength instrumentCentralWavelength;
     private final String mask;
     private final String xDisp;
 
@@ -62,13 +63,13 @@ public final class GnirsParameters implements InstrumentDetails {
                            final String grating,
                            final String readNoise,
                            final String xDisp,
-                           final double instrumentCentralWavelength,
+                           final Wavelength instrumentCentralWavelength,
                            final String mask) {
         this.grating = grating;
         this.camera = camera;
         this.xDisp = xDisp;
         this.readNoise = readNoise;
-        this.instrumentCentralWavelength = instrumentCentralWavelength * 1000;
+        this.instrumentCentralWavelength = instrumentCentralWavelength;
         this.mask = mask;
     }
 
@@ -86,14 +87,14 @@ public final class GnirsParameters implements InstrumentDetails {
 
     public double getInstrumentCentralWavelength() {
         if (!isXDispUsed()) {
-            return instrumentCentralWavelength;
+            return instrumentCentralWavelength.toNanometers();
         } else {
             return XDISP_CENTRAL_WAVELENGTH;
         }
     }
 
     public double getUnXDispCentralWavelength() {
-        return instrumentCentralWavelength;
+        return instrumentCentralWavelength.toNanometers();
     }
 
     public String getStringSlitWidth() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleParameters.java
@@ -1,6 +1,7 @@
 package edu.gemini.itc.michelle;
 
 import edu.gemini.itc.shared.InstrumentDetails;
+import edu.gemini.spModel.core.Wavelength;
 import edu.gemini.spModel.gemini.michelle.MichelleParams.*;
 
 /**
@@ -27,7 +28,7 @@ public final class MichelleParameters implements InstrumentDetails {
     private final Mask mask;
     private final String filter;
     private final String grating;
-    private final double centralWavelength;
+    private final Wavelength centralWavelength;
     private final String polarimetry;
 
     /**
@@ -35,12 +36,12 @@ public final class MichelleParameters implements InstrumentDetails {
      */
     public MichelleParameters(final String filter,
                               final String grating,
-                              final double instrumentCentralWavelength,
+                              final Wavelength instrumentCentralWavelength,
                               final Mask mask,
                               final String polarimetry) {
         this.filter = filter;
         this.grating = grating;
-        this.centralWavelength = instrumentCentralWavelength * 1000;
+        this.centralWavelength = instrumentCentralWavelength;
         this.mask = mask;
         this.polarimetry = polarimetry;
 
@@ -59,7 +60,7 @@ public final class MichelleParameters implements InstrumentDetails {
     }
 
     public double getInstrumentCentralWavelength() {
-        return centralWavelength;
+        return centralWavelength.toNanometers();
     }
 
     public boolean polarimetryIsUsed() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsParameters.java
@@ -2,6 +2,7 @@ package edu.gemini.itc.nifs;
 
 import edu.gemini.itc.shared.AltairParameters;
 import edu.gemini.itc.shared.InstrumentDetails;
+import edu.gemini.spModel.core.Wavelength;
 import scala.Option;
 
 /**
@@ -43,7 +44,7 @@ public final class NifsParameters implements InstrumentDetails {
     private final String filter;
     private final String grating;
     private final String readNoise;
-    private final double cenralWavelength;
+    private final Wavelength cenralWavelength;
     private final String ifuMethod;
     private final String ifuOffset;
     private final String ifuMinOffset;
@@ -60,7 +61,7 @@ public final class NifsParameters implements InstrumentDetails {
     public NifsParameters(final String filter,
                           final String grating,
                           final String readNoise,
-                          final double centralWavelength,
+                          final Wavelength centralWavelength,
                           final String ifuMethod,
                           final String ifuOffset,
                           final String ifuMinOffset,
@@ -83,7 +84,7 @@ public final class NifsParameters implements InstrumentDetails {
         this.ifuCenterX         = ifuCenterX;
         this.ifuCenterY         = ifuCenterY;
         this.altair             = altair;
-        this.cenralWavelength   = centralWavelength * 1000; // convert to [nm]
+        this.cenralWavelength   = centralWavelength;
     }
 
     public String getFilter() {
@@ -99,11 +100,11 @@ public final class NifsParameters implements InstrumentDetails {
     }
 
     public double getInstrumentCentralWavelength() {
-        return cenralWavelength;
+        return cenralWavelength.toNanometers();
     }
 
     public double getUnXDispCentralWavelength() {
-        return cenralWavelength;
+        return cenralWavelength.toNanometers();
     }
 
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsParameters.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsParameters.java
@@ -1,6 +1,7 @@
 package edu.gemini.itc.trecs;
 
 import edu.gemini.itc.shared.InstrumentDetails;
+import edu.gemini.spModel.core.Wavelength;
 
 /**
  * This class holds the information from the Trecs section
@@ -62,7 +63,7 @@ public final class TRecsParameters implements InstrumentDetails {
     private final String _Filter;  // filters
     private final String _InstrumentWindow;
     private final String _grating; // Grating or null
-    private final double _instrumentCentralWavelength;
+    private final Wavelength _instrumentCentralWavelength;
     private final String _FP_Mask;
 
     /**
@@ -71,12 +72,12 @@ public final class TRecsParameters implements InstrumentDetails {
     public TRecsParameters(final String Filter,
                            final String instrumentWindow,
                            final String grating,
-                           final double instrumentCentralWavelength,
+                           final Wavelength instrumentCentralWavelength,
                            final String FP_Mask) {
         _Filter = Filter;
         _InstrumentWindow = instrumentWindow;
         _grating = grating;
-        _instrumentCentralWavelength = instrumentCentralWavelength * 1000; // convert to [nm]
+        _instrumentCentralWavelength = instrumentCentralWavelength;
         _FP_Mask = FP_Mask;
     }
 
@@ -97,7 +98,7 @@ public final class TRecsParameters implements InstrumentDetails {
     }
 
     public double getInstrumentCentralWavelength() {
-        return _instrumentCentralWavelength;
+        return _instrumentCentralWavelength.toNanometers();
     }
 
 }

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
@@ -1,8 +1,8 @@
 package edu.gemini.itc.baseline
 
 import edu.gemini.itc.baseline.util._
-import edu.gemini.itc.shared.{GmosParameters, IfuRadial, IfuSingle}
-import edu.gemini.spModel.core.Site
+import edu.gemini.itc.shared.{GmosParameters, IfuSingle}
+import edu.gemini.spModel.core.{Wavelength, Site}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.DetectorManufacturer
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.{DisperserNorth, FPUnitNorth, FilterNorth}
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.{DisperserSouth, FPUnitSouth, FilterSouth}
@@ -23,7 +23,7 @@ object BaselineGmos {
     GmosParameters(
       FilterNorth.i_G0302,
       DisperserNorth.MIRROR,
-      500.0,                        // central wavelength
+      Wavelength.fromNanometers(500.0), // central wavelength
       FPUnitNorth.FPU_NONE,
       1,
       1,
@@ -33,7 +33,7 @@ object BaselineGmos {
     GmosParameters(
       FilterNorth.i_G0302,
       DisperserNorth.MIRROR,
-      500.0,                        // central wavelength
+      Wavelength.fromNanometers(500.0), // central wavelength
       FPUnitNorth.FPU_NONE,
       2,
       2,
@@ -45,7 +45,7 @@ object BaselineGmos {
     GmosParameters(
       FilterSouth.g_G0325,
       DisperserSouth.MIRROR,
-      500.0,
+      Wavelength.fromNanometers(500.0),
       FPUnitSouth.FPU_NONE,
       2,
       4,
@@ -55,7 +55,7 @@ object BaselineGmos {
     GmosParameters(
       FilterSouth.g_G0325,
       DisperserSouth.MIRROR,
-      500.0,
+      Wavelength.fromNanometers(500.0),
       FPUnitSouth.FPU_NONE,
       4,
       4,
@@ -73,7 +73,7 @@ object BaselineGmos {
     GmosParameters(
       FilterNorth.g_G0301,
       DisperserNorth.R150_G5306,
-      500.0,
+      Wavelength.fromNanometers(500.0),
       FPUnitNorth.LONGSLIT_2,
       1,
       1,
@@ -83,7 +83,7 @@ object BaselineGmos {
     GmosParameters(
       FilterNorth.g_G0301,
       DisperserNorth.R400_G5305,
-      500.0,
+      Wavelength.fromNanometers(500.0),
       FPUnitNorth.IFU_1,
       2,
       2,
@@ -93,7 +93,7 @@ object BaselineGmos {
     GmosParameters(
       FilterNorth.g_G0301,
       DisperserNorth.R400_G5305,
-      500.0,
+      Wavelength.fromNanometers(500.0),
       FPUnitNorth.IFU_1,
       2,
       2,
@@ -105,7 +105,7 @@ object BaselineGmos {
     GmosParameters(
       FilterSouth.g_G0325,
       DisperserSouth.R150_G5326,
-      500.0,
+      Wavelength.fromNanometers(500.0),
       FPUnitSouth.LONGSLIT_2,
       2,
       4,
@@ -115,7 +115,7 @@ object BaselineGmos {
 //    GmosParameters(
 //      FilterSouth.g_G0325,
 //      DisperserSouth.R400_G5325,
-//      500.0,
+//      Wavelength.fromNanometers(500.0),
 //      FPUnitSouth.IFU_1,
 //      4,
 //      4,

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGnirs.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGnirs.scala
@@ -2,6 +2,7 @@ package edu.gemini.itc.baseline
 
 import edu.gemini.itc.baseline.util._
 import edu.gemini.itc.gnirs.GnirsParameters
+import edu.gemini.spModel.core.Wavelength
 
 /**
  * GNIRS baseline test fixtures.
@@ -16,7 +17,7 @@ object BaselineGnirs {
       GnirsParameters.G10,
       GnirsParameters.LOW_READ_NOISE,
       GnirsParameters.X_DISP_ON,
-      2.4,
+      Wavelength.fromMicrons(2.4),
       GnirsParameters.SLIT0_1),
 
     new GnirsParameters(
@@ -24,7 +25,7 @@ object BaselineGnirs {
       GnirsParameters.G110,
       GnirsParameters.HIGH_READ_NOISE,
       GnirsParameters.X_DISP_OFF,
-      2.4,
+      Wavelength.fromMicrons(2.4),
       GnirsParameters.SLIT0_2),
 
     new GnirsParameters(
@@ -32,7 +33,7 @@ object BaselineGnirs {
       GnirsParameters.G32,
       GnirsParameters.LOW_READ_NOISE,
       GnirsParameters.X_DISP_ON,
-      2.6,
+      Wavelength.fromMicrons(2.6),
       GnirsParameters.SLIT0_675),
 
     new GnirsParameters(
@@ -40,7 +41,7 @@ object BaselineGnirs {
       GnirsParameters.G32,
       GnirsParameters.HIGH_READ_NOISE,
       GnirsParameters.X_DISP_OFF,
-      2.6,
+      Wavelength.fromMicrons(2.6),
       GnirsParameters.SLIT3_0)
 
   ))

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineMichelle.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineMichelle.scala
@@ -2,6 +2,7 @@ package edu.gemini.itc.baseline
 
 import edu.gemini.itc.baseline.util._
 import edu.gemini.itc.michelle.MichelleParameters
+import edu.gemini.spModel.core.Wavelength
 import edu.gemini.spModel.gemini.michelle.MichelleParams.Mask
 
 /**
@@ -16,7 +17,7 @@ object BaselineMichelle {
     new MichelleParameters(
       "Nprime",                           //String Filter,
       "none",                             //String grating,
-      12,                                 //instrumentCentralWavelength,
+      Wavelength.fromMicrons(12),         //instrumentCentralWavelength,
       Mask.MASK_IMAGING,                  //FP_Mask,
       MichelleParameters.ENABLED          //String polarimetry (enabled only allowed if imaging)
     )
@@ -26,7 +27,7 @@ object BaselineMichelle {
     new MichelleParameters(
       "Nprime",                           //String Filter,
       "medN2",                            //String grating,
-      11,                                 //instrumentCentralWavelength,
+      Wavelength.fromMicrons(11),         //instrumentCentralWavelength,
       Mask.MASK_2,                        //FP_Mask,
       MichelleParameters.DISABLED         //String polarimetry (enabled only allowed if imaging)
     )
@@ -36,7 +37,7 @@ object BaselineMichelle {
     new MichelleParameters(
       "Qa",                               //String Filter,
       "lowQ",                             //String grating,
-      18.2,                               //instrumentCentralWavelength,
+      Wavelength.fromMicrons(18.2),       //instrumentCentralWavelength,
       Mask.MASK_4,                        //FP_Mask,
       MichelleParameters.DISABLED         //String polarimetry (enabled only allowed if imaging)
     )

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineNifs.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineNifs.scala
@@ -2,6 +2,7 @@ package edu.gemini.itc.baseline
 
 import edu.gemini.itc.baseline.util._
 import edu.gemini.itc.nifs.NifsParameters
+import edu.gemini.spModel.core.Wavelength
 
 /**
  * NIFS baseline test fixtures.
@@ -16,7 +17,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.K_G5605,
       NifsParameters.LOW_READ_NOISE,
-      2.1,                      // central wavelength
+      Wavelength.fromMicrons(2.1),// central wavelength
       NifsParameters.SINGLE_IFU,// IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -31,7 +32,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.K_G5605,
       NifsParameters.LOW_READ_NOISE,
-      2.1,                      // central wavelength
+      Wavelength.fromMicrons(2.1),// central wavelength
       NifsParameters.SINGLE_IFU,// IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -46,7 +47,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.K_G5605,
       NifsParameters.LOW_READ_NOISE,
-      2.1,                      // central wavelength
+      Wavelength.fromMicrons(2.1),// central wavelength
       NifsParameters.SINGLE_IFU,// IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -63,7 +64,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.H_G5604,
       NifsParameters.LOW_READ_NOISE,
-      2.2,                      // central wavelength
+      Wavelength.fromMicrons(2.2),// central wavelength
       NifsParameters.SUMMED_APERTURE_IFU, // IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -78,7 +79,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.H_G5604,
       NifsParameters.LOW_READ_NOISE,
-      2.2,                      // central wavelength
+      Wavelength.fromMicrons(2.2),// central wavelength
       NifsParameters.SUMMED_APERTURE_IFU, // IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -93,7 +94,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.H_G5604,
       NifsParameters.LOW_READ_NOISE,
-      2.2,                      // central wavelength
+      Wavelength.fromMicrons(2.2),// central wavelength
       NifsParameters.SUMMED_APERTURE_IFU, // IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -110,7 +111,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.H_G5604,
       NifsParameters.LOW_READ_NOISE,
-      2.2,                      // central wavelength
+      Wavelength.fromMicrons(2.2),// central wavelength
       NifsParameters.RADIAL_IFU,// IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -125,7 +126,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.H_G5604,
       NifsParameters.LOW_READ_NOISE,
-      2.2,                      // central wavelength
+      Wavelength.fromMicrons(2.2),// central wavelength
       NifsParameters.RADIAL_IFU,// IFU method
       "0",                      // offset
       "0.0",                    // min offset
@@ -140,7 +141,7 @@ object BaselineNifs {
       NifsParameters.HK_G0603,
       NifsParameters.H_G5604,
       NifsParameters.LOW_READ_NOISE,
-      2.2,                      // central wavelength
+      Wavelength.fromMicrons(2.2),// central wavelength
       NifsParameters.RADIAL_IFU,// IFU method
       "0",                      // offset
       "0.0",                    // min offset

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineTRecs.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineTRecs.scala
@@ -2,6 +2,7 @@ package edu.gemini.itc.baseline
 
 import edu.gemini.itc.baseline.util._
 import edu.gemini.itc.trecs.TRecsParameters
+import edu.gemini.spModel.core.Wavelength
 
 /**
  * TRecs baseline test fixtures.
@@ -19,7 +20,7 @@ object BaselineTRecs {
       "N",                                //String Filter,
       "KBr",                              //String cryostat window
       "HiRes-10",                         //String grating, ("none") for imaging
-      12,                                 //instrumentCentralWavelength
+      Wavelength.fromMicrons(12),         //instrumentCentralWavelength
       TRecsParameters.SLIT0_21            //String FP_Mask,
     )
   ), TRecsObservingConditions)

--- a/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
+++ b/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
@@ -1,12 +1,10 @@
-//
-// $
-//
-
 package edu.gemini.shared.skyobject;
 
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.spModel.core.Wavelength;
+import edu.gemini.spModel.core.Wavelength$;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -54,18 +52,21 @@ public final class Magnitude implements Comparable, Serializable {
         public static final Comparator<Band> WAVELENGTH_COMPARATOR =
             new Comparator<Band>() {
                 @Override public int compare(Band b1, Band b2) {
-                    int b1w = b1.wavelengthMidPoint.getOrElse(Integer.MAX_VALUE);
-                    int b2w = b2.wavelengthMidPoint.getOrElse(Integer.MAX_VALUE);
-                    int res = b1w - b2w;
-                    return res==0 ? b1.ordinal() - b2.ordinal() : res;
+                    if (b1.wavelengthMidPoint.isDefined() && b2.wavelengthMidPoint.isDefined()) {
+                        double w1 = b1.getWavelengthMidPoint().getValue().toNanometers();
+                        double w2 = b2.getWavelengthMidPoint().getValue().toNanometers();
+                        return (int) (w1 - w2);
+                    } else {
+                        return b1.ordinal() - b2.ordinal();
+                    }
                 }
             };
 
-        private final Option<Integer> wavelengthMidPoint;    // nm
+        private final Option<Wavelength> wavelengthMidPoint;
         private final Option<String> description;
 
         Band(Option<Integer> mid, Option<String> desc) {
-            this.wavelengthMidPoint = mid;
+            this.wavelengthMidPoint = mid.map(l -> Wavelength$.MODULE$.fromNanometers(l));
             this.description        = desc;
         }
 
@@ -74,7 +75,7 @@ public final class Magnitude implements Comparable, Serializable {
         }
 
         Band(int mid, String desc) {
-            this.wavelengthMidPoint = new Some<>(mid);
+            this.wavelengthMidPoint = new Some<>(Wavelength$.MODULE$.fromNanometers(mid));
             this.description = (desc == null) ? None.STRING : new Some<>(desc);
         }
 
@@ -82,7 +83,7 @@ public final class Magnitude implements Comparable, Serializable {
             return description;
         }
 
-        public Option<Integer> getWavelengthMidPoint() {
+        public Option<Wavelength> getWavelengthMidPoint() {
             return wavelengthMidPoint;
         }
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.core
 
+import scalaz.{Order, Monoid}
+
 /** Representation of wavelengths. */
 sealed trait Wavelength extends Serializable {
 
@@ -52,15 +54,52 @@ sealed trait Wavelength extends Serializable {
 
 object Wavelength {
 
+  /**
+   * Constructs a `Wavelength` from the given value in nanometers.
+   * @group Constructors
+   */
   def fromNanometers(l: Double) = new Wavelength {
     override val toNanometers = l
   }
 
+  /**
+   * Constructs a `Wavelength` from the given value in microns (aka. micrometers).
+   * @group Constructors
+   */
   def fromMicrons(l: Double) = fromMicrometers(l)
 
+  /**
+   * Constructs a `Wavelength` from the given value in micrometers (aka. microns).
+   * @group Constructors
+   */
   def fromMicrometers(l: Double) = new Wavelength {
     override val toNanometers = l * 1000
   }
+
+  /**
+   * The zero `Wavelength`.
+   * @group Constructors
+   */
+  lazy val zero = fromNanometers(0.0)
+
+  /**
+   * Additive monoid for `Wavelength`.
+   * @group Typeclass Instances
+   */
+  implicit val WavelengthMonoid: Monoid[Wavelength] =
+    new Monoid[Wavelength] {
+      val zero = Wavelength.zero
+      def append(a: Wavelength, b: => Wavelength): Wavelength = a + b
+    }
+
+  /** @group Typeclass Instances */
+  implicit val WavelengthOrder: Order[Wavelength] =
+    Order.orderBy(_.toNanometers)
+
+  /** @group Typeclass Instances */
+  implicit val WavelengthOrdering: scala.Ordering[Wavelength] =
+    scala.Ordering.by(_.toNanometers)
+
 
 }
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
@@ -13,7 +13,7 @@ sealed trait Wavelength extends Serializable {
   /** The wavelength as microns or micrometers.
     * @group Conversions
     */
-  def toMicrons: Double = toNanometers * 1000
+  def toMicrons: Double = toNanometers / 1000
 
   /**
    * Addition.
@@ -59,6 +59,7 @@ object Wavelength {
    * @group Constructors
    */
   def fromNanometers(l: Double) = new Wavelength {
+    require(l >= 0)
     override val toNanometers = l
   }
 
@@ -66,13 +67,8 @@ object Wavelength {
    * Constructs a `Wavelength` from the given value in microns (aka. micrometers).
    * @group Constructors
    */
-  def fromMicrons(l: Double) = fromMicrometers(l)
-
-  /**
-   * Constructs a `Wavelength` from the given value in micrometers (aka. microns).
-   * @group Constructors
-   */
-  def fromMicrometers(l: Double) = new Wavelength {
+  def fromMicrons(l: Double) = new Wavelength {
+    require(l >= 0)
     override val toNanometers = l * 1000
   }
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
@@ -1,0 +1,66 @@
+package edu.gemini.spModel.core
+
+/** Representation of wavelengths. */
+sealed trait Wavelength extends Serializable {
+
+  /** The wavelength as nanometers.
+    * @group Conversions
+    */
+  def toNanometers: Double
+
+  /** The wavelength as microns or micrometers.
+    * @group Conversions
+    */
+  def toMicrons: Double = toNanometers * 1000
+
+  /**
+   * Addition.
+   * @group Operations
+   */
+  def +(a: Wavelength): Wavelength =
+    Wavelength.fromNanometers(toNanometers + a.toNanometers)
+
+  /**
+   * Subtraction.
+   * @group Operations
+   */
+  def -(a: Wavelength): Wavelength =
+    Wavelength.fromNanometers(toNanometers - a.toNanometers)
+
+  /**
+   * Scalar multiplication.
+   * @group Operations
+   */
+  def *(factor: Double): Wavelength =
+    Wavelength.fromNanometers(toNanometers * factor)
+
+  /** @group Overrides */
+  final override def toString =
+    s"Wavelength(${toNanometers}nm)"
+
+  /** @group Overrides */
+  final override def equals(a: Any) =
+    a match {
+      case a: Wavelength => a.toNanometers == this.toNanometers
+      case _             => false
+    }
+
+  /** @group Overrides */
+  final override def hashCode =
+    toNanometers.hashCode
+}
+
+object Wavelength {
+
+  def fromNanometers(l: Double) = new Wavelength {
+    override val toNanometers = l
+  }
+
+  def fromMicrons(l: Double) = fromMicrometers(l)
+
+  def fromMicrometers(l: Double) = new Wavelength {
+    override val toNanometers = l * 1000
+  }
+
+}
+

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -58,4 +58,9 @@ object AlmostEqual {
         (a.ra ~= b.ra) && (a.dec ~= b.dec)
     }
 
+  implicit val WavelengthAlmostEqual =
+    new AlmostEqual[Wavelength] {
+      def almostEqual(a: Wavelength, b: Wavelength) =
+        a.toNanometers ~= b.toNanometers
+    }
 }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
@@ -131,6 +131,9 @@ trait Arbitraries {
       arbitrary[Target.NonSiderealTarget],
       arbitrary[Target.NamedTarget]))
 
+  implicit val arbWavelength: Arbitrary[Wavelength] =
+    Arbitrary(arbitrary[Short].map(n => Math.abs(n) / 1000.0).map(Wavelength.fromMicrons))
+
 }
 
 

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/WavelengthSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/WavelengthSpec.scala
@@ -1,0 +1,35 @@
+package edu.gemini.spModel.core
+
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import AlmostEqual.AlmostEqualOps
+
+object WavelengthSpec extends Specification with ScalaCheck with Arbitraries with Helpers {
+
+  "Wavelength Conversions" should {
+   
+    "support nanometers" !
+      forAll { (w: Wavelength) =>
+        Wavelength.fromNanometers(w.toNanometers) ~= w
+      }
+
+    "support microns" !
+      forAll { (w: Wavelength) =>
+        Wavelength.fromMicrons(w.toMicrons) ~= w
+      }
+
+  }
+
+ "Wavelength Serialization" should {
+
+    "Support Java Binary" ! 
+      forAll { (w: Wavelength) =>
+        canSerialize(w)
+      }
+
+  }
+
+}
+
+


### PR DESCRIPTION
This is a bug fix that deals with problems that stem from different units being used for wavelengths throughout the code (nanometers vs micrometers). It seemed appropriate to introduce a dedicated type that allows to deal with different units in a graceful way.