### PR TITLE
OCSINF-437 OCSINF-438 revert to original SwingWorker logic

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/package.scala
@@ -1,12 +1,15 @@
 package jsky.app.ot.gemini.editor.targetComponent
 
 import javax.swing.BorderFactory._
+
+import scalaz.\/
+
 import javax.swing.border.Border
 
 import edu.gemini.horizons.api.HorizonsQuery.ObjectType
 import edu.gemini.spModel.target.system.{CoordinateParam, NamedTarget, NonSiderealTarget}
 import edu.gemini.spModel.target.system.ITarget.Tag
-import jsky.util.gui.{TextBoxWidget, TextBoxWidgetWatcher}
+import jsky.util.gui.{SwingWorker, TextBoxWidget, TextBoxWidgetWatcher}
 
 package object details {
 
@@ -50,5 +53,11 @@ package object details {
     def setOrZero(d: java.lang.Double): Unit =
       p.setValue(if (d == null) 0.0 else d.doubleValue)
   }
+
+  def forkSwingWorker[A <: AnyRef](constructImpl: => A)(finishedImpl: Throwable \/ A => Unit): Unit =
+    new SwingWorker {
+      def construct = \/.fromTryCatch(constructImpl)
+      override def finished = finishedImpl(getValue.asInstanceOf[Throwable \/ A])
+    }.start()
 
 }


### PR DESCRIPTION
This resolves (I think) some threading issues ([OCSINF-437](http://swgserv01.cl.gemini.edu:8080/browse/OCSINF-437) and [OCSINF-438](http://swgserv01.cl.gemini.edu:8080/browse/OCSINF-438)) and  that can cause races and deadlocks when doing a SIMBAD lookup. Basically I restored the old `SwingWorker` logic, in a slightly saner Scala wrapper.

Recommend viewing the diff with `?w=1` on the URL; most of the diff lines are due to a loss of a level of indentation.