### PR TITLE
OCSADV-309: magnitude sorting fixes

### DIFF
--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -1,0 +1,187 @@
+package edu.gemini.ags.impl
+
+
+import edu.gemini.ags.api.AgsAnalysis.Usable
+import edu.gemini.ags.api.AgsGuideQuality.Unusable
+import edu.gemini.ags.api.{AgsGuideQuality, AgsStrategy}
+import edu.gemini.ags.conf.ProbeLimitsTable
+import edu.gemini.catalog.votable.CannedBackend
+import edu.gemini.pot.ModelConverters._
+import edu.gemini.spModel.ags.AgsStrategyKey.GmosNorthOiwfsKey
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.MagnitudeBand.{_r, R, UC}
+import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.gemini.gmos.{InstGmosNorth, GmosOiwfsGuideProbe}
+import edu.gemini.spModel.inst.VignettingArbitraries
+import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.telescope.PosAngleConstraintAware
+import edu.gemini.spModel.telescope.PosAngleConstraint.FIXED_180
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import org.specs2.time.NoTimeConversions
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import scalaz._
+import Scalaz._
+
+
+object SingleProbeVignettingTest extends Specification with ScalaCheck with VignettingArbitraries with Helpers with NoTimeConversions {
+  private val magTable = ProbeLimitsTable.loadOrThrow()
+
+  val genRMag: Gen[Magnitude] =
+    for {
+      band   <- Gen.oneOf(MagnitudeBand._r, MagnitudeBand.R, MagnitudeBand.UC)
+      bright <- Gen.chooseNum(5, 20)
+    } yield Magnitude(bright, band, None, MagnitudeSystem.VEGA)
+
+  def genGuideStar(ctx: ObsContext, coords: Coordinates): Gen[SiderealTarget] =
+    for {
+      name    <- Gen.alphaStr
+      bands   <- Gen.someOf(List(_r, R, UC))
+      brights <- Gen.listOfN(bands.size, Gen.chooseNum(5, 20))
+    } yield {
+      val mags = bands.zip(brights).map { case (band, bright) => Magnitude(bright, band, None, MagnitudeSystem.VEGA) }
+      SiderealTarget(name, coords, None, mags.toList, None)
+    }
+
+  // why do i have to write this myself?
+  def sequence[A](lst: List[Gen[A]]): Gen[List[A]] =
+    (lst:\Gen.value[List[A]](Nil)) { (ga, glst) =>
+      for {
+        a   <- ga
+        lst <- glst
+      } yield a :: lst
+    }
+
+  def genGuidStars(ctx: ObsContext): Gen[List[SiderealTarget]] = {
+    def farEnough(c: Coordinates): Boolean = {
+      val minDistance = SingleProbeStrategyParams.GmosOiwfsParams.apply(Site.GN).minDistance.map(_.toDegrees) | 0
+      val diff        = Coordinates.difference(ctx.getBaseCoordinates.toNewModel, c).distance.toDegrees
+      diff > minDistance
+    }
+
+    for {
+      coords  <- genCandidates(ctx)
+      targets <- sequence(coords.collect { case c if farEnough(c) => genGuideStar(ctx, c) })
+    } yield targets
+  }
+
+
+  implicit val arbTest: Arbitrary[(ObsContext, List[SiderealTarget])] =
+    Arbitrary {
+      for {
+        ctx <- arbitrary[ObsContext]
+        gs  <- genGuidStars(ctx)
+      } yield (ctx, gs)
+    }
+
+  def ctx180(ctx: ObsContext): ObsContext =
+    ctx.withPositionAngle(ctx.getPositionAngle.add(180, edu.gemini.skycalc.Angle.Unit.DEGREES))
+
+  def contexts(ctx: ObsContext): List[ObsContext] =
+    ctx.getInstrument match {
+      case paca: PosAngleConstraintAware if paca.getPosAngleConstraint == FIXED_180 =>
+        List(ctx, ctx180(ctx))
+      case _ =>
+        List(ctx)
+    }
+
+  def analyze(strategy: AgsStrategy, ctx: ObsContext, guideStar: SiderealTarget): AgsGuideQuality = {
+    val a0 = strategy.analyze(ctx, magTable, GmosOiwfsGuideProbe.instance, guideStar).get
+
+    val a = ctx.getInstrument match {
+      case paca: PosAngleConstraintAware if paca.getPosAngleConstraint == FIXED_180 =>
+        val a1 = strategy.analyze(ctx180(ctx), magTable, GmosOiwfsGuideProbe.instance, guideStar).get
+        if (a0.quality < a1.quality) a0 else a1
+      case _ => a0
+    }
+
+    a match {
+      case u: Usable => u.quality
+      case _         => Unusable
+    }
+  }
+
+  "SingleProbeStrategy" should {
+    // This is just a slightly different, more direct less efficient, means of
+    // calculating the brightest, least vignetting star than the
+    // SingleProbeStrategy uses.  Really all that is being tested here is the
+    // magnitude comparison.
+    "pick the brightest candidate when they have equal vignetting" !
+      forAll { (env: (ObsContext, List[SiderealTarget])) =>
+        val (ctx, candidates) = env
+
+        val strategy  = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), CannedBackend(candidates))
+        val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+
+        val analyzedCandidates = for {
+          gs <- candidates
+          c  <- contexts(ctx)
+          q = analyze(strategy, c, gs)
+          if q < AgsGuideQuality.PossiblyUnusable
+          m  <- strategy.params.referenceMagnitude.apply(gs)
+        } yield (gs, c, q, GmosOiwfsGuideProbe.instance.calculator(c).calc(gs.coordinates), m.value)
+
+         analyzedCandidates match {
+          case Nil =>
+            selection.isEmpty
+
+          case acs =>
+            val best              = acs.minBy(_._3)._3
+            val qualityCandidates = analyzedCandidates.filter(_._3 == best)
+            val sorted = qualityCandidates.sortWith { case ((_,_,_,vig0,mag0), (_,_,_,vig1,mag1)) =>
+              if (vig0 == vig1) mag0 < mag1 else vig0 < vig1
+            }
+            val empty = List.empty[(SiderealTarget, ObsContext, AgsGuideQuality, Double, Double)]
+            val winners = sorted.headOption.fold(empty) { case (_, _, _, vig0,mag0) =>
+              sorted.takeWhile { case (_, _, _, vig1, mag1) =>
+                (vig0 == vig1) && (mag0 == mag1)
+              }
+            }
+
+            def almostEqual(d0: Double, d1: Double) = math.abs(d0 - d1) < 0.000001
+
+            val res = selection.exists { sel =>
+              winners.exists { case (gs, c, _, _, _) =>
+                almostEqual(sel.posAngle.toDegrees, c.getPositionAngle.toNewModel.toDegrees) &&
+                  sel.assignments.exists { _.guideStar == gs }
+              }
+            }
+
+            if (!res) {
+              println("Selection is: " + selection)
+              println("  " + selection.flatMap(_.assignments.headOption.map(_.guideStar.coordinates.shows)))
+              println("Winners are.: " + winners.mkString("\n\t", "\n\t", ""))
+
+              val gmosN = ctx.getInstrument.asInstanceOf[InstGmosNorth]
+              println(
+              s"""--- Test Env ---
+                 |  Base        = ${ctx.getBaseCoordinates.toNewModel.shows}
+                 |  Instrument:
+                 |    Pos Angle = ${ctx.getPositionAngle}
+                 |    PA Mode   = ${gmosN.getPosAngleConstraint}
+                 |    ISS Port  = ${ctx.getIssPort}
+                 |    Mode      = ${gmosN.getFPUnitMode}
+                 |    IFU       = ${gmosN.getFPUnit}
+                 |  Conditions  = ${ctx.getConditions}
+                 |  Offsets     = ${ctx.getSciencePositions.asScala.map(_.toNewModel.shows).mkString(",")}
+                 |  Candidates:
+                 |    ${winners.map { case (gs, c, _, _, _) =>
+                         s"${gs.coordinates.shows} ${c.getPositionAngle}"
+                       }.mkString("\n    ")}
+               """.stripMargin
+              )
+            }
+            res
+        }
+      }
+  }
+
+}

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -1,8 +1,5 @@
 package edu.gemini.ags.impl
 
-
-import edu.gemini.ags.api.AgsAnalysis.Usable
-import edu.gemini.ags.api.AgsGuideQuality.Unusable
 import edu.gemini.ags.api.{AgsGuideQuality, AgsStrategy}
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.votable.CannedBackend
@@ -93,24 +90,11 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
         List(ctx)
     }
 
-  def analyze(strategy: AgsStrategy, ctx: ObsContext, guideStar: SiderealTarget): AgsGuideQuality = {
-    val a0 = strategy.analyze(ctx, magTable, GmosOiwfsGuideProbe.instance, guideStar).get
-
-    val a = ctx.getInstrument match {
-      case paca: PosAngleConstraintAware if paca.getPosAngleConstraint == FIXED_180 =>
-        val a1 = strategy.analyze(ctx180(ctx), magTable, GmosOiwfsGuideProbe.instance, guideStar).get
-        if (a0.quality < a1.quality) a0 else a1
-      case _ => a0
-    }
-
-    a match {
-      case u: Usable => u.quality
-      case _         => Unusable
-    }
-  }
+  def analyze(strategy: AgsStrategy, ctx: ObsContext, guideStar: SiderealTarget): AgsGuideQuality =
+    strategy.analyze(ctx, magTable, GmosOiwfsGuideProbe.instance, guideStar).get.quality
 
   "SingleProbeStrategy" should {
-    // This is just a slightly different, more direct less efficient, means of
+    // This is just a slightly different, more direct/less efficient, means of
     // calculating the brightest, least vignetting star than the
     // SingleProbeStrategy uses.  Really all that is being tested here is the
     // magnitude comparison.
@@ -129,7 +113,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
           m  <- strategy.params.referenceMagnitude.apply(gs)
         } yield (gs, c, q, GmosOiwfsGuideProbe.instance.calculator(c).calc(gs.coordinates), m.value)
 
-         analyzedCandidates match {
+        analyzedCandidates match {
           case Nil =>
             selection.isEmpty
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -6,6 +6,7 @@ import java.util.logging.Logger
 
 import edu.gemini.catalog.api.CatalogQuery
 import edu.gemini.spModel.core.Angle
+import edu.gemini.spModel.core.Target.SiderealTarget
 import org.apache.commons.httpclient.{NameValuePair, HttpClient}
 import org.apache.commons.httpclient.methods.GetMethod
 
@@ -90,7 +91,7 @@ trait CachedBackend extends VoTableBackend {
      * Builds a cache with a contains function to find cache hits
      */
     def buildCache[K, V](contains: FindFunction[K, V], maxSize: Int = 100) = lruCache(Vector.empty, contains, maxSize)
-    
+
   }
 
   private val cache:Cache[SearchKey, QueryResult] = {
@@ -173,6 +174,13 @@ case object RemoteBackend extends CachedBackend {
     }
   }
 
+}
+
+case class CannedBackend(results: List[SiderealTarget]) extends VoTableBackend {
+  override protected[votable] def doQuery(query: CatalogQuery, url: String): Future[QueryResult] =
+    Future.successful {
+      QueryResult(query, CatalogQueryResult(TargetsTable(results), Nil))
+    }
 }
 
 trait VoTableClient {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -527,48 +527,6 @@ public class GmosCommonType {
         }
     }
 
-
-    /**
-     * PosAngleMode indicates how to handle setting the
-     * GMOS Position Angle.
-     */
-    public static enum PosAngleMode implements DisplayableSpType, LoggableSpType, SequenceableSpType {
-        SET_VALUE("Set Value"),
-        AVERAGE_PARALLACTIC("Average Parallactic"),
-        FOLLOW_PARALLACTIC ("Follow Parallactic"),
-        ;
-
-        public static final PosAngleMode DEFAULT = SET_VALUE;
-
-        private String _displayValue;
-
-        private PosAngleMode(String displayValue) {
-            _displayValue = displayValue;
-        }
-
-        public String displayValue() {
-            return _displayValue;
-        }
-
-        public String sequenceValue() {
-            return _displayValue;
-        }
-
-        public String logValue() {
-            return _displayValue;
-        }
-
-        /** Return a PosAngleMode by name **/
-        public static PosAngleMode getPosAngleMode(String name) {
-            return getPosAngleMode(name, DEFAULT);
-        }
-
-        /** Return a PosAngleMode by name giving a value to return upon error **/
-        public static PosAngleMode getPosAngleMode(String name, PosAngleMode nvalue) {
-            return SpTypeUtil.oldValueOf(PosAngleMode.class, name, nvalue);
-        }
-    }
-
     public static final ROIDescription DEFAULT_BUILTIN_ROID = new ROIDescription(1, 1, 6144, 4608);
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -308,7 +308,6 @@ public abstract class InstGmosCommon<
     private F _filter;
     private GmosCommonType.Binning _xBin = GmosCommonType.Binning.DEFAULT;
     private GmosCommonType.Binning _yBin = GmosCommonType.Binning.DEFAULT;
-    private GmosCommonType.PosAngleMode _posAngleMode = GmosCommonType.PosAngleMode.DEFAULT;
     private PosAngleConstraint _posAngleConstraint = PosAngleConstraint.FIXED;
 
     //    private GmosCommonType.StageMode _stageMode = GmosCommonType.StageMode.DEFAULT;

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
@@ -1,0 +1,133 @@
+package edu.gemini.spModel.inst
+
+import java.awt.geom.{Point2D, AffineTransform}
+
+import edu.gemini.pot.ModelConverters._
+import edu.gemini.skycalc.{Offset => SkyCalcOffset}
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.AngleSyntax._
+import edu.gemini.spModel.gemini.gmos.GmosCommonType.FPUnitMode._
+import edu.gemini.spModel.gemini.gmos._
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.TargetEnvironment
+import edu.gemini.spModel.telescope.{PosAngleConstraintAware, PosAngleConstraint, IssPort}
+import edu.gemini.spModel.telescope.PosAngleConstraint.FIXED_180
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+import scala.collection.JavaConverters._
+
+import scalaz._
+import Scalaz._
+
+trait VignettingArbitraries extends Arbitraries {
+  implicit val arbTargetEnv: Arbitrary[TargetEnvironment] =
+    Arbitrary {
+      arbitrary[Coordinates].map { c =>
+        val ra  = c.ra.toAngle.toDegrees
+        val dec = c.dec.toDegrees
+        TargetEnvironment.create(new SPTarget(ra, dec))
+      }
+    }
+
+  implicit val arbGmosN: Arbitrary[InstGmosNorth] =
+    Arbitrary {
+      for {
+        fpu      <- Gen.oneOf(GmosNorthType.FPUnitNorth.values)
+        mode     <- Gen.frequency((1, CUSTOM_MASK), (9, BUILTIN))
+        port     <- Gen.oneOf(IssPort.values)
+        posAngle <- arbitrary[Angle]
+        pac      <- Gen.oneOf(PosAngleConstraint.FIXED, PosAngleConstraint.FIXED_180)
+      } yield
+        new InstGmosNorth                    <|
+              (_.setFPUnit(fpu))             <|
+              (_.setFPUnitMode(mode))        <|
+              (_.setIssPort(port))           <|
+              (_.setPosAngleConstraint(pac)) <|
+              (_.setPosAngle(posAngle.toDegrees))
+    }
+
+  val genSmallOffset: Gen[SkyCalcOffset] =
+    for {
+      pi <- Gen.chooseNum(-50, 50)
+      qi <- Gen.chooseNum(-50, 50)
+    } yield Offset(pi.toDouble.arcsecs[OffsetP], qi.toDouble.arcsecs[OffsetQ]).toOldModel
+
+  implicit val arbSciencePosSet: Arbitrary[java.util.Set[SkyCalcOffset]] =
+    Arbitrary {
+      for {
+        count <- Gen.chooseNum(1, 4)
+        offs  <- Gen.listOfN(count, genSmallOffset)
+      } yield new java.util.HashSet(offs.asJava)
+    }
+
+  implicit val arbContext: Arbitrary[ObsContext] =
+    Arbitrary {
+      for {
+        env  <- arbitrary[TargetEnvironment]
+        gmos <- arbitrary[InstGmosNorth]
+        offs <- arbitrary[java.util.Set[SkyCalcOffset]]
+      } yield ObsContext.create(env, gmos, Conditions.NOMINAL, offs, null)
+    }
+
+  // Generate guide star candidates at all position angles supported by the
+  // instrument configuration in the context.
+  def genCandidates(ctx: ObsContext): Gen[List[Coordinates]] =
+    ctx.getInstrument match {
+      case paca: PosAngleConstraintAware if paca.getPosAngleConstraint == FIXED_180 =>
+        val ctx180 = ctx.withPositionAngle(ctx.getPositionAngle.add(180, edu.gemini.skycalc.Angle.Unit.DEGREES))
+        for {
+          a0 <- genFixedPosAngleCandidates(ctx)
+          a1 <- genFixedPosAngleCandidates(ctx180)
+        } yield a0 ++ a1
+      case _ =>
+        // FIXED for now
+        genFixedPosAngleCandidates(ctx)
+    }
+
+  // Generate candidates for the specific position angle in the provided context
+  def genFixedPosAngleCandidates(ctx: ObsContext): Gen[List[Coordinates]] = {
+    // Get the (un-rotated) usable area at the position angle. Get the "safe"
+    // area because rounding errors in back and forth model translations can
+    // make edge cases appear to be in or out arbitrarily.
+    val patField = GmosOiwfsGuideProbe.instance.getCorrectedPatrolField(ctx).getValue
+    val usable   = patField.safeOffsetIntersection(ctx.getSciencePositions).getBounds2D
+
+    // Generate a candidate that falls in the usable area.
+    val genCandidate =
+      for {
+        p  <- Gen.chooseNum(usable.getMinX, usable.getMaxX)
+        q  <- Gen.chooseNum(usable.getMinY, usable.getMaxY)
+      } yield {
+        // Rotate the offset in p and q by the position angle. To get the
+        // p delta and q delta (which are negated because screen coords
+        // are flipped)
+        val rot      = AffineTransform.getRotateInstance(-ctx.getPositionAngle.toRadians.getMagnitude)
+        val offsetPt = rot.transform(new Point2D.Double(p, q), new Point2D.Double())
+        val pd       = -offsetPt.getX // arcsecs
+        val qd       = -offsetPt.getY // arcsecs
+
+        // The deltaDec is just qd but we have to adjust the offset in p
+        // to take into account the declination.
+        //    p = delta RA * cos(dec)
+        // so
+        //    deltaRA = p / cos(dec)
+        val base     = ctx.getBaseCoordinates.toNewModel
+        val cos      = math.cos(math.toRadians(base.dec.toDegrees))
+        val deltaRa  = if (cos == 0) 0.0 else pd/cos
+        val deltaDec = qd
+
+        // Finally we have a candidate that falls in the usable area.
+        base.offset(Angle.fromArcsecs(deltaRa), Angle.fromArcsecs(deltaDec))
+      }
+
+    for {
+      count <- Gen.chooseNum(0, 100)
+      cands <- Gen.listOfN(count, genCandidate)
+    } yield cands
+  }
+}

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Coordinates.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Coordinates.scala
@@ -42,6 +42,12 @@ object Coordinates extends ((RightAscension, Declination) => Coordinates) {
   implicit val CoordinatesEqual: Equal[Coordinates] =
     Equal.equalA
 
+  /** @group Typeclass Instances. */
+  implicit val ShowCoordinates: Show[Coordinates] =
+    Show.shows { c =>
+      s"(${Angle.formatHMS(c.ra.toAngle)}, ${Declination.formatDMS(c.dec)})"
+    }
+
   case class Difference(posAngle: Angle, distance: Angle) {
     /**
      * Gets the offset coordinates relative to the base position.

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Magnitude.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Magnitude.scala
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.core
 
+import scalaz._
+import Scalaz._
 
 case class Magnitude(value: Double, band: MagnitudeBand, error: Option[Double], system: MagnitudeSystem) {
 
@@ -40,6 +42,12 @@ object Magnitude {
   }
 
   /** @group Typeclass Instances */
-  implicit val equals = scalaz.Equal.equalA[Magnitude]
+  implicit val equals = Equal.equalA[Magnitude]
 
+  /** group Typeclass Instances */
+  implicit val MagnitudeShow: Show[Magnitude] =
+    scalaz.Show.shows { mag =>
+      val errStr = mag.error.map { e => f" e$e%.2f " } | " "
+      f"${mag.band.name}${mag.value}%.2f$errStr(${mag.system.name})"
+    }
 }

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -355,7 +355,7 @@ trait OcsBundle {
   lazy val bundle_edu_gemini_ags = 
     project.in(file("bundle/edu.gemini.ags")).dependsOn(
       bundle_edu_gemini_shared_skyobject,
-      bundle_edu_gemini_pot,
+      bundle_edu_gemini_pot          % "test->test;compile->compile",
       bundle_edu_gemini_catalog      % "test->test;compile->compile",
       bundle_edu_gemini_shared_util,
       bundle_edu_gemini_spModel_core % "test->test;compile->compile",


### PR DESCRIPTION
This PR fixes an issue in which the default `Magnitude` ordering (which considers magnitude band) does not produce expected results for AGS. 

````scala
  // by system name, band name, value and error (in that order)
  implicit val MagnitudeOrdering: scala.math.Ordering[Magnitude] =
    scala.math.Ordering.by(m => (m.system.name, m.band.name, m.value, m.error))
````

AGS works with "any" R-like band (r, R, and UC) and uses the magnitude value of the first one that it finds.

The bulk of the updates are to the test cases.  The only substantive changes are those in `SingleProbeStrategy` itself. Along the way I also deleted an unused GMOS type called `PosAngleMode` which has been superseded by `PosAngleConstraint`.
