### PR TITLE
REL-2298: disappearing P2 check bug fix.

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/P2Problems.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/P2Problems.java
@@ -7,11 +7,7 @@ package edu.gemini.p2checker.api;
 import edu.gemini.pot.sp.ISPProgramNode;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 /**
  * A storage class that contains <code>Problem</code> associated to
@@ -24,7 +20,7 @@ public class P2Problems implements Serializable, IP2Problems {
 
 //    public static final String PROBLEMS_PROP = "Problems";
 
-    public static final List<Problem> NO_PROBLEM = Collections.unmodifiableList(new ArrayList<Problem>());
+    public static final List<Problem> NO_PROBLEM = Collections.unmodifiableList(new ArrayList<>());
 
 
     private Set<Problem> _problemSet;
@@ -35,7 +31,7 @@ public class P2Problems implements Serializable, IP2Problems {
 
     public P2Problems(IP2Problems copy) {
         if (copy != null) {
-            _problemSet = new TreeSet<Problem>(copy.getProblems());
+            _problemSet = new HashSet<>(copy.getProblems());
         }
     }
 
@@ -93,11 +89,11 @@ public class P2Problems implements Serializable, IP2Problems {
      */
     public List<Problem> getProblems() {
         if (_problemSet ==  null) return NO_PROBLEM;
-        return Collections.unmodifiableList(new ArrayList(_problemSet));
+        return Collections.unmodifiableList(new ArrayList<>(_problemSet));
     }
 
     private Set<Problem> _getProblems() {
-        if (_problemSet ==  null) _problemSet = new TreeSet<Problem>();
+        if (_problemSet ==  null) _problemSet = new HashSet<>();
         return _problemSet;
     }
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/Problem.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/Problem.java
@@ -12,104 +12,78 @@ import java.io.Serializable;
  * A Problem contains the description of a condition that needs to
  * be fixed in a given <code>ISPProgramNode</code>
  */
-public class Problem implements Serializable, Comparable<Problem> {
+public class Problem implements Serializable {
 
-    public static enum Type {
-
+    public enum Type {
         NONE("None"),
         WARNING("Warning"),
         ERROR("Error");
 
-        private String _displayValue;
+        public final String displayValue;
 
-        private Type(String displayValue) {
-            _displayValue = displayValue;
+        Type(String displayValue) {
+            this.displayValue = displayValue;
         }
 
         public String getDisplayValue() {
-            return _displayValue;
+            return displayValue;
         }
     }
 
-    private Type _type;
+    public final Type type;
 
-    private String _id; // A unique id for this problem
+    public final String id; // A unique id for this problem
 
-    private String _description;
+    public final String description;
 
-    private ISPProgramNode _node; //The node that produced the problem
+    private final ISPProgramNode node; //The node that produced the problem
 
-//    public Problem(Type type, String description, ISPProgramNode n) {
-//        // XXX set ID!
-//        _type = type;
-//        _description = description;
-//        _node = n;
-//    }
-    
     public Problem(Type type, String id, String description, ISPProgramNode n) {
-        _type = type;
-        _id = id;
-        _description = description;
-        _node = n;
+        this.type        = type;
+        this.id          = id;
+        this.description = description;
+        this.node        = n;
     }
 
-    public Type getType() {
-        return _type;
+    public final Type getType() {
+        return type;
     }
 
-    public String getDescription() {
-        return _description;
+    public final String getDescription() {
+        return description;
     }
 
-    public String getId() {
-        return _id;
+    public final String getId() {
+        return id;
     }
 
-    public String toString() {
-        return _type.getDisplayValue() + ":" + _description + " at " + _node;
+    public final String toString() {
+        return type.getDisplayValue() + ":" + description + " at " + node;
     }
 
-    public ISPProgramNode getAffectedNode() {
-        return _node;
+    public final ISPProgramNode getAffectedNode() {
+        return node;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Problem)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
 
-        Problem problem = (Problem) o;
+        final Problem that = (Problem) o;
 
-        if (_description != null ? !_description.equals(problem._description) : problem._description != null)
-            return false;
-        if (_id != null ? !_id.equals(problem._id) : problem._id != null) return false;
-        if (_node != null ? !_node.equals(problem._node) : problem._node != null) return false;
-        if (_type != problem._type) return false;
-
-        return true;
+        if (type != that.type) return false;
+        if (!id.equals(that.id)) return false;
+        if (!description.equals(that.description)) return false;
+        return node.equals(that.node);
     }
 
     @Override
     public int hashCode() {
-        int result = _description != null ? _description.hashCode() : 0;
-        result = 31 * result + (_type != null ? _type.hashCode() : 0);
-        result = 31 * result + (_node != null ? _node.hashCode() : 0);
-        result = 31 * result + (_id != null ? _id.hashCode() : 0);
-        return result;
-    }
-
-    @Override
-    public int compareTo(Problem o) {
-        int result = _id.compareTo(o._id);
-        if (result == 0) {
-            result = _description.compareTo(o._description);
-            if (result == 0) {
-                result = _type.compareTo(o._type);
-                if (result == 0) {
-                    result = _node.toString().compareTo(o._node.toString());
-                }
-            }
-        }
+        int result = type.hashCode();
+        result = 31 * result + id.hashCode();
+        result = 31 * result + description.hashCode();
+        result = 31 * result + node.hashCode();
         return result;
     }
 }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ProblemRollup.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ProblemRollup.java
@@ -9,21 +9,38 @@ import edu.gemini.pot.sp.ISPProgramNode;
 import java.io.Serializable;
 
 /**
-     * A Problem that represents a collection of Problems.
+ * A Problem that represents a collection of Problems.
  * Provides a way to easily summarize the content of a container node.
  * <code>ProblemRepresentative</code> objects are associated commonly to nodes that
  * contain other nodes with actual <code>Problem</code>s
  */
 public final class ProblemRollup extends Problem implements Serializable {
 
-    private int _representedCount;
+    public final int representedCount;
 
     public ProblemRollup(Type type, String id, String description, ISPProgramNode node, int representedCount) {
         super (type, id, description, node);
-        _representedCount = representedCount;
+        this.representedCount = representedCount;
     }
 
     public int getRepresentedCount() {
-        return _representedCount;
+        return representedCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        final ProblemRollup that = (ProblemRollup) o;
+        return representedCount == that.representedCount;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + representedCount;
+        return result;
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPProblemsViewer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPProblemsViewer.java
@@ -2,7 +2,6 @@ package jsky.app.ot.viewer;
 
 import edu.gemini.p2checker.api.IP2Problems;
 import edu.gemini.p2checker.api.Problem;
-import edu.gemini.p2checker.util.P2CheckerUtil;
 import jsky.app.ot.ui.util.UIConstants;
 
 import javax.swing.JPanel;
@@ -11,6 +10,9 @@ import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.table.*;
 import java.awt.Component;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Controller for the Problem Viewer, in charge of displaying the problems found
@@ -191,7 +193,7 @@ public class SPProblemsViewer {
         }
     }
 
-    public static class ProblemsDataModel extends DefaultTableModel {
+    public static class ProblemsDataModel extends AbstractTableModel {
 
         public enum Col {
             TYPE(" ", new ProblemTypeRenderer(), Problem.class) {
@@ -235,18 +237,12 @@ public class SPProblemsViewer {
          * Reference to the viewer that's showing the observation being evaluated
          */
         private SPViewer _viewer;
-        private IP2Problems _problems;
+        private List<Problem> _problems;
         private NodeData _node; //the node whose information is shown
 
         ProblemsDataModel(SPViewer viewer) {
-            _viewer = viewer;
-        }
-
-        private IP2Problems _getProblems() {
-            if (_problems == null) {
-                _problems = P2CheckerUtil.NO_PROBLEMS;
-            }
-            return _problems;
+            _problems = Collections.emptyList();
+            _viewer   = viewer;
         }
 
         public void setNodeData(NodeData node) {
@@ -262,8 +258,17 @@ public class SPProblemsViewer {
         private void _updateProblems() {
             //Notify the viewer of the new problems being shown, only if
             //the engine is set up
-            _problems = (_node == null) ? P2CheckerUtil.NO_PROBLEMS : _node.getProblems();
-            _viewer.updateProblemToolWindow(_problems);
+            final IP2Problems p2Problems = _node.getProblems();
+            final List<Problem> ps = new ArrayList<>(p2Problems.getProblems());
+
+            // Sort by severity (in reverse so ERROR comes first) then description.
+            Collections.sort(ps, (p1, p2) -> {
+                final int t = p2.type.compareTo(p1.type);
+                return t == 0 ? (p1.description.compareTo(p2.description)) : t;
+            });
+
+            _problems = Collections.unmodifiableList(ps);
+            _viewer.updateProblemToolWindow(p2Problems);
         }
 
         public int getColumnCount() {
@@ -275,12 +280,12 @@ public class SPProblemsViewer {
         }
 
         public int getRowCount() {
-            return _getProblems().getProblemCount();
+            return _problems.size();
         }
 
         public Object getValueAt(int row, int col) {
-            if (_getProblems().getProblemCount() < row) return null;
-            Problem problem = _getProblems().getProblems().get(row);
+            if (row >= _problems.size()) return null;
+            final Problem problem = _problems.get(row);
             return Col.values()[col].getValue(problem);
         }
 
@@ -345,8 +350,8 @@ public class SPProblemsViewer {
         */
 
         public Problem getProblem(int row) {
-            if (row < 0 || row >= _getProblems().getProblemCount()) return null;
-            return _getProblems().getProblems().get(row);
+            if (row < 0 || row >= _problems.size()) return null;
+            return _problems.get(row);
         }
     }
 


### PR DESCRIPTION
Fixes a mysterious disappearing P2 check problem.  The issue is that the `Problem`s were being stored in a `TreeSet` and yet had a `Comparable` implementation wasn't consistent with `equals`.  So when you copy and paste an observation with problems and it recalculates the combined problem set, the problems in the new observation counted as already existing in the `TreeSet`.  The solution is to remove the bogus `Comparable` implementation and store the problems in a `HashSet` instead.

To keep the problem list from being displayed in random order, they are now sorted by severity and description before being listed.

This bug falls firmly into the category, "how did this ever work?".