### PR TITLE
Changes in itc build file and credentials template

### DIFF
--- a/bundle/edu.gemini.itc/build.sbt
+++ b/bundle/edu.gemini.itc/build.sbt
@@ -36,9 +36,7 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.itc.operation",
   "edu.gemini.itc.parameters",
   "edu.gemini.itc.shared",
-  "edu.gemini.itc.trecs",
-  "org.jfree",
-  "org.jfree.chart"
+  "edu.gemini.itc.trecs"
 )
 
 OsgiKeys.importPackage := Seq(

--- a/project/OcsCredentials.scala.template
+++ b/project/OcsCredentials.scala.template
@@ -57,6 +57,20 @@ object OcsCredentials {
       id = "with-remote-gogo-credentials"
     )
 
+    // CONFIGS
+    def rnorris_credentials(version: Version) = AppConfig(id = "rnorris_credentials")
+    def swalker_credentials(version: Version) = AppConfig(id = "swalker_credentials")
+    def fnussber_credentials(version: Version) = AppConfig(id = "fnussber_credentials")
+    def sraaphorst_credentials(version: Version) = AppConfig(id = "sraaphorst_credentials")
+    def cquiroz_credentials(version: Version) = AppConfig(id = "cquiroz_credentials")
+    def jluhrs_credentials(version: Version) = AppConfig(id = "jluhrs_credentials")
+    def abrighton_credentials(version: Version) = AppConfig(id = "abrighton_credentials")
+    def gnodbtest_credentials(version: Version) = AppConfig(id = "gnodbtest_credentials")
+    def gnodb_credentials(version: Version) = AppConfig(id = "gnodb_credentials")
+    def gsodbtest_credentials(version: Version) = AppConfig(id = "gsodbtest_credentials")
+    def gsodb_credentials(version: Version) = AppConfig(id = "gsodb_credentials")
+
+
     // ODBTEST
     def odbtest_credentials(version: Version) = AppConfig(
       id = "odbtest_credentials",


### PR DESCRIPTION
Changes in itc build file and credentials template that allow to build and run ITC as a standalone app.

(This is Florian talking on behalf of Sabrina ;): I've fixed a bug in the itc app build file and also added (empty) configurations for everybody to the credentials template file. This makes it easier to do a build without the credentials because the template file can be used as-is as a stand in for the "real" credentials file and allows to compile the code.