### PR TITLE
REL-2314: horizons bug fixes

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/horizons/HorizonsService.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/horizons/HorizonsService.java
@@ -170,8 +170,12 @@ public final class HorizonsService {
             handler.updateTable(_reply.getResultsTable());
             handler.show();
             String newObjectId = handler.getObjectId();
-            //try again if we have a choice
-            if (newObjectId != null) {
+            //try again if we have a choice, give up otherwise
+            if (newObjectId == null) {
+                // if cancelled we won't have an object id so don't return a
+                // half-baked reply in this case
+                _reply = null;
+            } else {
                 setObjectId(newObjectId);
                 _reply = execute();
             }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
@@ -41,6 +41,10 @@ final class ConicNameEditor(date: HorizonsIO[Date]) extends JPanel with Telescop
       override def textBoxKeyPress(tbwe: TextBoxWidget): Unit =
         nonreentrant {
           spt.getTarget.setName(tbwe.getValue)
+          // editing the name so invalidate the horizons id.
+          ct.setHorizonsObjectId(null) //
+          ct.setHorizonsObjectTypeOrdinal(-1)
+          hid.setText(hidText(ct))
           spt.notifyOfGenericUpdate()
         }
 
@@ -77,13 +81,16 @@ final class ConicNameEditor(date: HorizonsIO[Date]) extends JPanel with Telescop
     c.insets = new Insets(0, 5, 0, 0)
   })
 
+  def hidText(ct: ConicTarget): String =
+    "Horizons ID: " + (ct.isHorizonsDataPopulated ?
+            s"${ct.getHorizonsObjectId}/${ct.getHorizonsObjectType}" |
+            "«unknown»")
+
   def edit(ctx: GOption[ObsContext], target: SPTarget, node: ISPNode): Unit = {
     this.spt = target
     nonreentrant {
       name.setText(ct.getName)
-      hid.setText("Horizons ID: " + (ct.isHorizonsDataPopulated ?
-        s"${ct.getHorizonsObjectId}/${ct.getHorizonsObjectType}" |
-        "«unknown»"))
+      hid.setText(hidText(ct))
     }
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/Horizons.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/Horizons.scala
@@ -218,11 +218,13 @@ object Horizons {
     hObjType: ObjectType,
     date: Date
   ): Option[HorizonsReply] =
-    Option(service.getLastResult)
-      .filter(_.getObjectId.toString === hObjId)
-      .filter(_.getObjectType == hObjType)
-      .filter(_.hasEphemeris)
-      .filter(_.getEphemeris.get(0).getDate == date)
+    Option(service.getLastResult).filter { r =>
+      // just assume anything in the reply can be null
+      Option(r.getObjectId).exists(_.toString === hObjId) &&
+      (r.getObjectType == hObjType)                       &&
+      r.hasEphemeris                                      &&
+      Option(r.getEphemeris).filter(_.size() > 0).exists(_.get(0).getDate == date)
+    }
 
   /**
    * Construct a program to look up a target on the provided service and return the Horizons reply.


### PR DESCRIPTION
This PR offers fixes for a null pointer exception reported by Andy in REL-2314 along with a couple of other issues that fell out of testing.  First, when canceling a lookup of a "multiple answer" result we were showing a popup that read "Internal error: MultipleResults".  This was because the canceled result was being taken for a valid answer from Horizons (see `HorizonsService`).  Second, if we change the name of a conic target, the horizons ID was not being reset which resulted in unintended cache hits on the lookup as well as misleading information in the UI (see `ConicNameEditor`).

For the actual null pointer exception, I just assume that a `HorizonsReply` can return `null` for any of its fields, which is a decent assumption given the state of the old Java horizons code.  One thing that is still confusing though is that the "object id" is set to the name of the target.  For example, "ceres" which corresponds to minor body 1.  Unless the user does a lookup on "ceres" and then goes to the trouble of actually renaming the target "1" there is a cache miss on each subsequent lookup because we compare "ceres" to the `HorizonReply`'s object id `1`.  Perhaps that intended behavior I don't know.

This is all terrible.