### PR TITLE
OCSADV-330: bug fix for enabled state setting

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -22,6 +22,7 @@ import edu.gemini.spModel.target.system.*;
 import jsky.app.ot.OTOptions;
 import jsky.app.ot.ags.*;
 import jsky.app.ot.editor.OtItemEditor;
+import jsky.app.ot.gemini.editor.targetComponent.details.TargetDetailEditor;
 import jsky.app.ot.tpe.AgsClient;
 import jsky.app.ot.tpe.GuideStarSupport;
 import jsky.app.ot.tpe.TelescopePosEditor;
@@ -124,6 +125,15 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         final SPInstObsComp inst = getContextInstrumentDataObject();
         _w.newMenu.setEnabled(enabled && inst != null);
+
+        // Update enabled state for all detail widgets.  The current editor
+        // will have already been updated by the super.updateEnabledState so
+        // update the others.
+        for (final TargetDetailEditor ed : TargetDetailEditor.AllJava()) {
+            if (_w.detailEditor.currentEditorJava().forall(cur -> cur != ed)) {
+                updateEnabledState(new Component[] {ed}, enabled);
+            }
+        }
     }
 
     private final ActionListener _tagListener = new ActionListener() {
@@ -567,14 +577,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.tag.setRenderer(tagRenderer);
         showTargetTag();
 
-        // Update target details, and ensure that any new controls constructed via the update are
-        // correctly disabled if editing is not allowed. Ordering is important!
-        boolean structChange =_w.detailEditor.willCauseStructureChange(_curPos);
+        // Update target details
         _w.detailEditor.edit(getObsContext(env), _curPos, getNode());
-        if (structChange && !OTOptions.isEditable(getProgram(), getContextObservation())) {
-            updateEnabledState(new Component[]{_w.detailEditor}, false);
-        }
-
     }
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailEditor.scala
@@ -1,20 +1,34 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
-import javax.swing.JPanel
 import edu.gemini.pot.sp.ISPNode
 import edu.gemini.shared.util.immutable.{ Option => GOption }
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.ITarget.Tag
+
 import jsky.app.ot.gemini.editor.targetComponent.TelescopePosEditor
 
+import javax.swing.JPanel
+
+import scala.collection.JavaConverters._
+
+
 object TargetDetailEditor {
+  val JplMinorBody   = new JplMinorBodyDetailEditor
+  val MpcMinorPlanet = new MpcMinorPlanetDetailEditor
+  val Named          = new NamedDetailEditor
+  val Sidereal       = new SiderealDetailEditor
+
+  val All = List(JplMinorBody, MpcMinorPlanet, Named, Sidereal)
+
+  val AllJava = All.asJava
+
   def forTag(t: Tag): TargetDetailEditor =
     t match {
-      case Tag.JPL_MINOR_BODY   => new JplMinorBodyDetailEditor
-      case Tag.MPC_MINOR_PLANET => new MpcMinorPlanetDetailEditor
-      case Tag.NAMED            => new NamedDetailEditor
-      case Tag.SIDEREAL         => new SiderealDetailEditor
+      case Tag.JPL_MINOR_BODY   => JplMinorBody
+      case Tag.MPC_MINOR_PLANET => MpcMinorPlanet
+      case Tag.NAMED            => Named
+      case Tag.SIDEREAL         => Sidereal
     }
 }
 
@@ -22,7 +36,7 @@ abstract class TargetDetailEditor(val getTag: Tag) extends JPanel with Telescope
   def edit(ctx: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {
     require(ctx      != null, "obsContext should never be null")
     require(spTarget != null, "spTarget should never be null")
-    val tag = spTarget.getTarget().getTag()
+    val tag = spTarget.getTarget.getTag
     require(tag == getTag, "target tag should always be " + getTag + ", received " + tag)
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -4,8 +4,9 @@ import edu.gemini.pot.sp.ISPNode
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.shared.util.immutable.{ Option => GOption }
+import edu.gemini.shared.util.immutable.ScalaConverters.ScalaOptionOps
 import java.awt.{ GridBagConstraints, GridBagLayout}
-import javax.swing.{ JPanel}
+import javax.swing.JPanel
 import jsky.app.ot.gemini.editor.targetComponent.TelescopePosEditor
 import scalaz.syntax.id._
 
@@ -17,17 +18,14 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
   val tpw = new ForwardingTelescopePosWatcher(this)
 
   // Fields
-  private[this] var tde: TargetDetailEditor = null;
+  private[this] var tde: TargetDetailEditor = null
+
+  def currentEditor: Option[TargetDetailEditor] = Option(tde)
+
+  def currentEditorJava: GOption[TargetDetailEditor] = currentEditor.asGeminiOpt
 
   // Put it all together
   setLayout(new GridBagLayout)
-
-  // Very sadly, we need to know whether or not calling `edit` will change the internal structure
-  // of the editor. If so, the editor needs to do some extra work afterwards to make sure enabled
-  // state is correct.
-  def willCauseStructureChange(spTarget: SPTarget): Boolean = {
-    tde == null || tde.getTag != spTarget.getTarget.getTag
-  }
 
   def edit(obsContext: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {
 
@@ -40,7 +38,7 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
         c.fill = GridBagConstraints.BOTH
       })
     }
-  
+
     // Forward the `edit` call.
     tpw.edit(obsContext, spTarget, node)
     tde.edit(obsContext, spTarget, node)


### PR DESCRIPTION
The `OtItemEditor` `updateEnabledState` methods are charged with enabling and disabling widgets in the various editors.  Unfortunately it's a bit of a flawed mechanism and getting it to work correctly is very tricky.  This PR is a bit of a hack that addresses a problem with enabled state in the target editors.  Namely, visiting an executed observation's target before looking at an editable target will incorrectly record the "previous" edit state of the widgets. If that makes no sense to you, well, don't worry it shouldn't.  Ideally we would rework the enabled state setting altogether but obviously not just before the release.

Unfortunately the changes introduced to the `TargetDetailPanel` will conflict with @fnussber's current PR (OCSADV-323B) so I will wait for that one to be merged and incorporate the new widgets it introduces before committing the changes.