### PR TITLE
OCSADV-330-B: target editor enabled state fixes

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -134,6 +134,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 updateEnabledState(new Component[] {ed}, enabled);
             }
         }
+        _w.detailEditor.source().updateEnabledState(enabled);
     }
 
     private final ActionListener _tagListener = new ActionListener() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -22,6 +22,7 @@ import edu.gemini.spModel.target.system.*;
 import jsky.app.ot.OTOptions;
 import jsky.app.ot.ags.*;
 import jsky.app.ot.editor.OtItemEditor;
+import jsky.app.ot.gemini.editor.targetComponent.details.TargetDetailEditor;
 import jsky.app.ot.tpe.AgsClient;
 import jsky.app.ot.tpe.GuideStarSupport;
 import jsky.app.ot.tpe.TelescopePosEditor;
@@ -124,6 +125,15 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         final SPInstObsComp inst = getContextInstrumentDataObject();
         _w.newMenu.setEnabled(enabled && inst != null);
+
+        // Update enabled state for all detail widgets.  The current editor
+        // will have already been updated by the super.updateEnabledState so
+        // update the others.
+        for (final TargetDetailEditor ed : TargetDetailEditor.AllJava()) {
+            if (_w.detailEditor.curDetailEdiorJava().forall(cur -> cur != ed)) {
+                updateEnabledState(new Component[] {ed}, enabled);
+            }
+        }
     }
 
     private final ActionListener _tagListener = new ActionListener() {
@@ -567,14 +577,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.tag.setRenderer(tagRenderer);
         showTargetTag();
 
-        // Update target details, and ensure that any new controls constructed via the update are
-        // correctly disabled if editing is not allowed. Ordering is important!
-        boolean structChange =_w.detailEditor.willCauseStructureChange(_curPos);
+        // Update target details
         _w.detailEditor.edit(getObsContext(env), _curPos, getNode());
-        if (structChange && !OTOptions.isEditable(getProgram(), getContextObservation())) {
-            updateEnabledState(new Component[]{_w.detailEditor}, false);
-        }
-
     }
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailEditor.scala
@@ -8,13 +8,24 @@ import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.ITarget.Tag
 import jsky.app.ot.gemini.editor.targetComponent.TelescopePosEditor
 
+import scala.collection.JavaConverters._
+
 object TargetDetailEditor {
+  val JplMinorBody   = new JplMinorBodyDetailEditor
+  val MpcMinorPlanet = new MpcMinorPlanetDetailEditor
+  val Named          = new NamedDetailEditor
+  val Sidereal       = new SiderealDetailEditor
+
+  val All = List(JplMinorBody, MpcMinorPlanet, Named, Sidereal)
+
+  val AllJava = All.asJava
+
   def forTag(t: Tag): TargetDetailEditor =
     t match {
-      case Tag.JPL_MINOR_BODY   => new JplMinorBodyDetailEditor
-      case Tag.MPC_MINOR_PLANET => new MpcMinorPlanetDetailEditor
-      case Tag.NAMED            => new NamedDetailEditor
-      case Tag.SIDEREAL         => new SiderealDetailEditor
+      case Tag.JPL_MINOR_BODY   => JplMinorBody
+      case Tag.MPC_MINOR_PLANET => MpcMinorPlanet
+      case Tag.NAMED            => Named
+      case Tag.SIDEREAL         => Sidereal
     }
 }
 
@@ -22,7 +33,7 @@ abstract class TargetDetailEditor(val getTag: Tag) extends JPanel with Telescope
   def edit(ctx: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {
     require(ctx      != null, "obsContext should never be null")
     require(spTarget != null, "spTarget should never be null")
-    val tag = spTarget.getTarget().getTag()
+    val tag = spTarget.getTarget.getTag
     require(tag == getTag, "target tag should always be " + getTag + ", received " + tag)
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -26,8 +26,8 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
 
   def curDetailEdiorJava: GOption[TargetDetailEditor] = curDetailEditor.asGeminiOpt
 
-  private[this] val source                   = new SourceDetailsEditor
-  private[this] val gfe                      = new GuidingFeedbackEditor
+  val source = new SourceDetailsEditor
+  val gfe    = new GuidingFeedbackEditor
 
   // Put it all together
   setLayout(new GridBagLayout)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -5,6 +5,7 @@ import javax.swing.JPanel
 
 import edu.gemini.pot.sp.ISPNode
 import edu.gemini.shared.util.immutable.{Option => GOption}
+import edu.gemini.shared.util.immutable.ScalaConverters.ScalaOptionOps
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import jsky.app.ot.gemini.editor.targetComponent.{GuidingFeedbackEditor, TelescopePosEditor}
@@ -20,6 +21,11 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
 
   // Fields
   private[this] var tde: TargetDetailEditor  = null
+
+  def curDetailEditor: Option[TargetDetailEditor] = Option(tde)
+
+  def curDetailEdiorJava: GOption[TargetDetailEditor] = curDetailEditor.asGeminiOpt
+
   private[this] val source                   = new SourceDetailsEditor
   private[this] val gfe                      = new GuidingFeedbackEditor
 
@@ -40,13 +46,6 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
     c.fill      = GridBagConstraints.HORIZONTAL
   })
 
-  // Very sadly, we need to know whether or not calling `edit` will change the internal structure
-  // of the editor. If so, the editor needs to do some extra work afterwards to make sure enabled
-  // state is correct.
-  def willCauseStructureChange(spTarget: SPTarget): Boolean = {
-    tde == null || tde.getTag != spTarget.getTarget.getTag
-  }
-
   def edit(obsContext: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {
 
     // Create or replace the existing detail editor, if needed
@@ -61,7 +60,7 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
         c.fill = GridBagConstraints.HORIZONTAL
       })
     }
-  
+
     // Forward the `edit` call.
     tpw.   edit(obsContext, spTarget, node)
     tde.   edit(obsContext, spTarget, node)


### PR DESCRIPTION
The `OtItemEditor` `updateEnabledState` methods are charged with enabling and disabling widgets in the various editors. Unfortunately it's a bit of a flawed mechanism and getting it to work correctly is very tricky. This PR is a bit of a hack that addresses a problem with enabled state in the target editors. Namely, visiting an executed observation's target before looking at an editable target will incorrectly record the "previous" edit state of the widgets. If that makes no sense to you, well, don't worry it shouldn't. Ideally we would rework the enabled state setting altogether but obviously not just before the release.

There are two commits.  The first fixes the enabled state issue for all non-ITC widgets and the second are the changes required for the ITC widgets.