### PR TITLE
REL-2322: missing observing conditions prevents plotting GMOS

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/OiwfsPlotFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/OiwfsPlotFeature.scala
@@ -4,6 +4,7 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.flamingos2.{F2OiwfsProbeArm, Flamingos2OiwfsGuideProbe}
 import edu.gemini.spModel.gemini.gmos.{GmosOiwfsProbeArm, GmosOiwfsGuideProbe}
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.guide.{PatrolField, OffsetValidatingGuideProbe}
 import edu.gemini.spModel.inst.{FeatureGeometry, ProbeArmGeometry}
 import edu.gemini.spModel.obs.context.ObsContext
@@ -105,8 +106,11 @@ sealed class OiwfsPlotFeature(probe: OffsetValidatingGuideProbe, probeArm: Probe
        reachableFigs ++ patrolFieldFigs ++ probeArmFig
     }
 
+    // For the purpose of plotting the OIWFS features, the site conditions are
+    // irrelevant.  Make sure the lack of site quality doesn't prevent creating
+    // an ObsContext by explicitly providing conditions.
     (for {
-      obsCtx   <- tpeCtx.obsContext
+      obsCtx   <- tpeCtx.obsContextWithConditions(SPSiteQuality.Conditions.NOMINAL)
       patField <- probe.getCorrectedPatrolField(obsCtx).asScalaOpt
     } yield go(obsCtx, patField)).toList.flatten
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/SciAreaPlotFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/SciAreaPlotFeature.scala
@@ -3,6 +3,7 @@ package jsky.app.ot.gemini.inst
 import edu.gemini.shared.util.immutable.{Option => JOption, ImPolygon}
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core.Offset
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.inst.ScienceAreaGeometry
 import jsky.app.ot.gemini.tpe.EdIterOffsetFeature
 import jsky.app.ot.tpe.TpeImageFeature.{Figure, MARKER_SIZE}
@@ -46,7 +47,10 @@ class SciAreaPlotFeature(sciArea: ScienceAreaGeometry)
   import SciAreaPlotFeature._
 
   def getFigures(tpeCtx: TpeContext, offset: Offset, color: Color): List[Figure] = {
-    val shapes = tpeCtx.obsContext.toList.flatMap { obsCtx =>
+    // For the purpose of plotting the science area, the site conditions are
+    // irrelevant.  Make sure the lack of site quality doesn't prevent creating
+    // an ObsContext by explicitly providing conditions.
+    val shapes = tpeCtx.obsContextWithConditions(SPSiteQuality.Conditions.NOMINAL).toList.flatMap { obsCtx =>
       sciArea.geometry(obsCtx, offset)
     }
 


### PR DESCRIPTION
A bit of an ad-hoc fix to a bug which prevented plotting the science area and probe range if the observation is missing the observing conditions.