### PR TITLE
OCSADV-337: NPE creating observation context

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -148,7 +148,8 @@ public final class ObsContext {
      */
     @SuppressWarnings("rawtypes")
     public static Option<ObsContext> create(ISPObservation obs)  {
-        Option<ObsData> opt = ObsData.extract(obs);
+        if (obs == null) return None.instance();
+        final Option<ObsData> opt = ObsData.extract(obs);
         if (opt.isEmpty()) return None.instance();
 
         final TargetObsComp target                 = opt.getValue().target;


### PR DESCRIPTION
`EdCompTargetList`, responding to an event after the target component it is editing has been cut, makes a call to get the `ObsContext` passing in the target component's "context observation". See `OtItemEditor.getContextObservation` (which really should return an `Option` instead of `null`).  Of course having been cut there is no context observation.

In general you cannot construct an `ObsContext` from a `null` `ISPObservation` so this little hack seems somewhat defendable.  All apologies.