### PR TITLE
OCSADV-338: added missing guiding feedback update

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -364,6 +364,11 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         toggleAgsGuiElements();
         final Option<ObsContext> ctx = getObsContext(env);
         _w.guidingControls.update(ctx);
+
+        // Update the guiding feedback.
+        final ISPObsComponent node = getContextTargetObsComp();
+        final SPTarget      target = TargetSelection.get(env, node);
+        _w.detailEditor.gfe().edit(getObsContext(env), target, node);
     }
 
     private final PropertyChangeListener selectionListener = new PropertyChangeListener() {


### PR DESCRIPTION
Somehow in all the changes the guiding feedback is not updated when the selected strategy changes.  This PR takes care of that little issue.