### PR TITLE
OCSADV-323C: Usability and UI improvements on ITC panels

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ITCChart.java
+++ b/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ITCChart.java
@@ -38,6 +38,10 @@ public final class ITCChart {
         }
     }
 
+    public JFreeChart getChart() {
+        return chart;
+    }
+
     public BufferedImage getBufferedImage(final int width, final int height)  {
         return chart.createBufferedImage(width, height);
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/SequenceTabUtil.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/SequenceTabUtil.java
@@ -1,25 +1,18 @@
-//
-// $Id$
-//
-
 package jsky.app.ot.editor.seq;
 
 import edu.gemini.pot.sp.ISPObservation;
-import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.config2.Config;
-import edu.gemini.spModel.data.OptionTypeUtil;
 import edu.gemini.spModel.io.SequenceOutputService;
-import edu.gemini.spModel.type.DisplayableSpType;
 import jsky.app.ot.viewer.OpenUtils;
 import jsky.util.Preferences;
 import jsky.util.gui.ExampleFileFilter;
 
 import javax.swing.*;
+import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
-import java.awt.Component;
-import java.awt.FontMetrics;
+import java.awt.*;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -103,39 +96,28 @@ final class SequenceTabUtil {
     }
 
     static void resizeTableColumns(JTable table, TableModel model) {
-        TableColumnModel colModel = table.getColumnModel();
-        FontMetrics fm = table.getFontMetrics(table.getFont());
-        int rows = model.getRowCount();
+        final TableColumnModel colModel = table.getColumnModel();
+        final FontMetrics fm = table.getFontMetrics(table.getFont());
+        final int rows = model.getRowCount();
 
         for (int col=0; col<model.getColumnCount(); ++col) {
-            String title = model.getColumnName(col);
+            final String title = model.getColumnName(col);
 
             // Start with the width of the column header
             int size = fm.stringWidth(title);
 
-            // Check the width of each item in the column to get the maximum
-            // width
+            // Check the width of each item in the column to get the maximum width
             for (int row=0; row<rows; ++row) {
-                Object val = model.getValueAt(row, col);
-                if (val == null) continue;
-
-                String strVal;
-                if (val instanceof DisplayableSpType) {
-                    strVal = ((DisplayableSpType) val).displayValue();
-                } else if (val instanceof Option) {
-                    strVal = OptionTypeUtil.toDisplayString((Option) val);
-                } else {
-                    strVal = val.toString();
-                }
-
-                int tmp = fm.stringWidth(strVal);
+                final TableCellRenderer renderer = table.getCellRenderer(row, col);
+                final Component component = table.prepareRenderer(renderer, row, col);
+                final int tmp = component.getPreferredSize().width;
                 if (tmp > size) size = tmp;
             }
 
-            size += 10; // add a bit of padding
+            size += 20; // add a bit of padding
 
             // Resize the column
-            TableColumn tc = colModel.getColumn(col);
+            final TableColumn tc = colModel.getColumn(col);
             _setColumnWidth(tc, size, size, size);
         }
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -169,17 +169,13 @@ private class ItcFeedbackPanel(table: ItcTable) extends Label {
   }
 
   private def update(): Unit = {
-    table.selected.fold {
-      visible = false                 // no table row selected, don't show feedback panel
-    } {
-      feedback(_).fold {
-        visible = false               // no feedback for this row, don't show feedback panel
-      } { case (ico, msg, col) =>
-        icon        = ico             // feedback available, show it
-        text        = msg
-        background  = col
-        visible     = true
-      }
+    table.selected.flatMap(feedback).fold {
+      visible = false                 // no table row selected or no feedback, don't show feedback panel
+    } { case (ico, msg, col) =>
+      icon        = ico               // feedback available, show it
+      text        = msg
+      background  = col
+      visible     = true
     }
     revalidate()
   }
@@ -457,8 +453,7 @@ private class NumberEdit(label: Label, units: Label, default: Double = 0) extend
         try {
           publish(new ValueChanged(NumberEdit.this))
           tbwe.requestFocus()
-        }
-        catch {
+        } catch {
           case _: NumberFormatException =>
         }
     })
@@ -473,7 +468,7 @@ private class NumberEdit(label: Label, units: Label, default: Double = 0) extend
   def value: Option[Double] =
     try {
       Some(peer.getValue.toDouble)
-    }catch {
+    } catch {
       case _: NumberFormatException => None
     }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -89,7 +89,7 @@ sealed trait ItcPanel extends GridBagPanel {
     table.update()
   }
 
-  def analysis: AnalysisMethod = analysisMethod.analysisMethod
+  def analysis: Option[AnalysisMethod] = analysisMethod.analysisMethod
 
   def conditions: ObservingConditions = currentConditions.conditions
 
@@ -388,11 +388,8 @@ private class AnalysisMethodPanel extends GridBagPanel {
     case ValueChanged(_)                => publish(new SelectionChanged(this))
   }
 
-  def analysisMethod: AnalysisMethod =
-    if (autoAperture.selected) autoApertureValue.getOrElse(default)
-    else userApertureValue.getOrElse(default)
-
-  private val default = AutoAperture(5.0)
+  def analysisMethod: Option[AnalysisMethod] =
+    if (autoAperture.selected) autoApertureValue else userApertureValue
 
   private def autoApertureValue: Option[AnalysisMethod] =
     skyAperture.value.map(AutoAperture)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -1,20 +1,27 @@
 package jsky.app.ot.editor.seq
 
 import java.awt.Color
-import javax.swing.{BorderFactory, ImageIcon}
+import javax.swing._
 
 import edu.gemini.itc.shared.PlottingDetails.PlotLimits
 import edu.gemini.itc.shared._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{CloudCover, ImageQuality, SkyBackground, WaterVapor}
+import jsky.app.ot.util.OtColor
 
-import scala.swing.GridBagPanel.Fill
+import scala.concurrent.Future
+import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing.ListView.Renderer
 import scala.swing.ScrollPane.BarPolicy._
-import scala.swing._
+import scala.swing.{ButtonGroup, _}
 import scala.swing.event.{ButtonClicked, KeyEvent, SelectionChanged, TableRowsSelected}
+import scala.util.{Failure, Success}
 
 object ItcPanel {
+
+  val OkIcon      = new ImageIcon(classOf[ItcTableModel].getResource("/resources/images/check.png"))
+  val ErrorIcon   = new ImageIcon(classOf[ItcTableModel].getResource("/resources/images/error_tsk.gif"))
+  val SpinnerIcon = new ImageIcon(classOf[ItcTableModel].getResource("/resources/images/spinner16.gif"))
 
   /** Creates a panel for ITC imaging results. */
   def forImaging(owner: EdIteratorFolder)       = new ItcImagingPanel(owner)
@@ -45,26 +52,58 @@ class InputField[A](labelStr: String, unitsStr: String, valueStr: A, convert: St
   } catch {
     case _: NumberFormatException => None
   }
-
 }
 
 /** Base trait for different panels which are used to present ITC calculation results to the users. */
 sealed trait ItcPanel extends GridBagPanel {
-  val owner: EdIteratorFolder
-  val table: ItcTable
 
-  protected val currentConditions = new ConditionsPanel
-  protected val analysisMethod    = new AnalysisMethodPanel
-
+  def owner: EdIteratorFolder
+  def table: ItcTable
+  def display: Component
   def visibleFor(t: SPComponentType): Boolean
 
-  def analysis = analysisMethod.analysisMethod
-  def conditions = currentConditions.conditions
+  val currentConditions = new ConditionsPanel(owner)
+  val analysisMethod    = new AnalysisMethodPanel
+  val message           = new ItcFeedbackPanel(table)
+
+  border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+  layout(currentConditions) = new Constraints {
+    gridx     = 0
+    gridy     = 0
+    weightx   = 0.5
+    fill      = GridBagPanel.Fill.Horizontal
+    insets    = new Insets(10, 10, 10, 10)
+  }
+  layout(analysisMethod) = new Constraints {
+    gridx     = 1
+    gridy     = 0
+    weightx   = 0.5
+    fill      = GridBagPanel.Fill.Horizontal
+    insets    = new Insets(10, 10, 10, 10)
+  }
+  layout(display) = new Constraints {
+    gridx     = 0
+    gridy     = 2
+    weightx   = 1
+    weighty   = 1
+    gridwidth = 2
+    fill      = GridBagPanel.Fill.Both
+    insets    = new Insets(10, 0, 0, 0)
+  }
+  layout(message) = new Constraints {
+    anchor    = Anchor.West
+    gridx     = 0
+    gridy     = 3
+    gridwidth = 2
+    weightx   = 1
+    fill      = GridBagPanel.Fill.Horizontal
+    insets    = new Insets(10, 0, 0, 0)
+  }
 
   listenTo(currentConditions, analysisMethod)
   reactions += {
-    case SelectionChanged(`currentConditions`)  => updateInternal()
-    case SelectionChanged(`analysisMethod`)     => updateInternal()
+    case SelectionChanged(`currentConditions`)  => table.update()
+    case SelectionChanged(`analysisMethod`)     => table.update()
   }
 
   def update() = {
@@ -72,141 +111,20 @@ sealed trait ItcPanel extends GridBagPanel {
     table.update()
   }
 
-  private def updateInternal() = {
-// TODO: keep selected table row
-//    val selectedRow = table.selection.rows.headOption
-    table.update()
-    // re-establish previously selected row, this is relevant
-    // for charts displayed on spectroscopy panel
-//    selectedRow.foreach(r => if (r < table.rowCount) table.selection.rows += r)
-  }
+  def analysis = analysisMethod.analysisMethod
 
-  // ==== Conditions display and edit panels
-
-  class ConditionsPanel extends GridBagPanel {
-
-    private class ConditionCB[A](items: Seq[A], renderFunc: A => String) extends ComboBox[A](items) {
-      private var programValue = selection.item
-      tooltip  = "Select conditions for ITC calculations. Values different from program conditions are shown in red."
-      renderer = Renderer(renderFunc)
-      listenTo(selection)
-      reactions += {
-        case SelectionChanged(_) =>
-          foreground = color()
-          tooltip    = tt()
-      }
-
-      def sync(newValue: A) = {
-        if (programValue == selection.item) {
-          // if we are "in sync" with program value (i.e. the program value is currently selected), update it
-          deafTo(selection)
-          selection.item = newValue
-          listenTo(selection)
-        }
-        // set new program value and update coloring
-        programValue = newValue
-        foreground = color()
-        tooltip    = tt()
-      }
-
-      private def color() = if (inSync()) Color.BLACK else Color.RED
-
-      private def tt() = if (inSync()) "" else s"Program condition is ${renderFunc(programValue)}"
-
-      private def inSync() = programValue == selection.item
-
-    }
-
-    private val t  = new Label("Conditions:")
-    private val sb = new ConditionCB[SkyBackground]  (SkyBackground.values,                       _.displayValue())
-    private val cc = new ConditionCB[CloudCover]     (CloudCover.values.filterNot(_.isObsolete),  _.displayValue())
-    private val iq = new ConditionCB[ImageQuality]   (ImageQuality.values,                        _.displayValue())
-    private val wv = new ConditionCB[WaterVapor]     (WaterVapor.values,                          _.displayValue())
-    private val am = new ConditionCB[Double]         (List(1.0, 1.5, 2.0),                        d => f"Airmass $d%.1f")
-
-    def conditions = new ObservingConditions(
-      iq.selection.item,
-      cc.selection.item,
-      wv.selection.item,
-      sb.selection.item,
-      am.selection.item)
-
-    def update() = {
-      // Note: site quality node can be missing (i.e. null)
-      Option(owner.getContextSiteQuality).foreach { qual =>
-        sb.sync(qual.getSkyBackground)
-        cc.sync(qual.getCloudCover)
-        iq.sync(qual.getImageQuality)
-        wv.sync(qual.getWaterVapor)
-        // TODO: currently the airmass program value is fixed to 1.5am; get this value from constraints?
-        am.sync(1.5)
-        // TODO: update necessary??
-      }
-    }
-
-    border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
-
-    layout(t)  = new Constraints {
-      gridx   = 0
-      gridy   = 0
-    }
-    layout(sb) = new Constraints {
-      gridx   = 1
-      gridy   = 0
-    }
-    layout(cc) = new Constraints {
-      gridx   = 2
-      gridy   = 0
-    }
-    layout(iq) = new Constraints {
-      gridx   = 3
-      gridy   = 0
-    }
-    layout(wv) = new Constraints {
-      gridx   = 4
-      gridy   = 0
-    }
-    layout(am) = new Constraints {
-      gridx   = 5
-      gridy   = 0
-    }
-
-    deafTo(this)
-    listenTo(sb.selection, cc.selection, iq.selection, wv.selection, am.selection)
-    reactions += {
-      case SelectionChanged(_) => publish(new SelectionChanged(this))
-    }
-
-  }
+  def conditions = currentConditions.conditions
 
 }
 
 /** Panel holding the ITC imaging calculation result table. */
 class ItcImagingPanel(val owner: EdIteratorFolder) extends ItcPanel {
 
-  val table = new ItcImagingTable(ItcParametersProvider(owner, this))
+  lazy val table = new ItcImagingTable(ItcParametersProvider(owner, this))
 
-  border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
-
-  private val scrollPane = new ScrollPane(table) {
+  lazy val display = new ScrollPane(table) {
     verticalScrollBarPolicy = AsNeeded
     horizontalScrollBarPolicy = AsNeeded
-  }
-
-  layout(currentConditions) = new Constraints {
-    gridx       = 0
-    gridy       = 0
-  }
-  layout(analysisMethod) = new Constraints {
-    gridx       = 0
-    gridy       = 1
-  }
-  layout(scrollPane) = new Constraints {
-    gridx       = 0
-    gridy       = 2
-    weightx     = 1
-    weighty     = 1
-    fill        = Fill.Both
   }
 
   /** True for all instruments which support ITC calculations for imaging. */
@@ -226,37 +144,20 @@ class ItcImagingPanel(val owner: EdIteratorFolder) extends ItcPanel {
 /** Panel holding the ITC spectroscopy calculation result table and charts. */
 class ItcSpectroscopyPanel(val owner: EdIteratorFolder) extends ItcPanel {
 
-  val table = new ItcSpectroscopyTable(ItcParametersProvider(owner, this))
-  private val charts = new ItcChartsPanel(table)
+  lazy val table = new ItcSpectroscopyTable(ItcParametersProvider(owner, this))
 
-  border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+  lazy val display = new SplitPane(Orientation.Horizontal, tableScrollPane, chartsScrollPane) {
+    dividerLocation = 150
+  }
 
-  private val tableScrollPane = new ScrollPane(table) {
-    preferredSize             = new Dimension(100, 200)
+  private lazy val charts = new ItcChartsPanel(table)
+  private lazy val tableScrollPane = new ScrollPane(table) {
     verticalScrollBarPolicy   = AsNeeded
     horizontalScrollBarPolicy = AsNeeded
   }
-  private val chartsScrollPane = new ScrollPane(charts) {
-    preferredSize             = new Dimension(100, 400)
+  private lazy val chartsScrollPane = new ScrollPane(charts) {
     verticalScrollBarPolicy   = AsNeeded
     horizontalScrollBarPolicy = AsNeeded
-  }
-  private val splitPane = new SplitPane(Orientation.Horizontal, tableScrollPane, chartsScrollPane)
-
-  layout(currentConditions) = new Constraints {
-    gridx     = 0
-    gridy     = 0
-  }
-  layout(analysisMethod) = new Constraints {
-    gridx     = 0
-    gridy     = 1
-  }
-  layout(splitPane) = new Constraints {
-    gridx     = 0
-    gridy     = 2
-    weightx   = 1
-    weighty   = 1
-    fill      = GridBagPanel.Fill.Both
   }
 
   /** True for all instruments which support ITC calculations for spectroscopy. */
@@ -271,6 +172,49 @@ class ItcSpectroscopyPanel(val owner: EdIteratorFolder) extends ItcPanel {
     case SPComponentType.INSTRUMENT_TRECS       => true
     case _                                      => false
   }
+}
+
+/** Panel holding some feedback.
+  * Mainly important in case something went wrong with the ITC calculations. */
+class ItcFeedbackPanel(table: ItcTable) extends Label {
+
+  import ItcPanel._
+  import OtColor._
+
+  opaque              = true
+  foreground          = Color.DARK_GRAY
+  border              = BorderFactory.createEmptyBorder(2, 2, 2, 2)
+  horizontalAlignment = Alignment.Left
+
+  listenTo(table.selection)
+  reactions += {
+    case TableRowsSelected(_, _, false)  => update()
+  }
+
+  private def update(): Unit = {
+    if (table.selection.rows.isEmpty) {
+      visible = false
+    } else {
+      visible = true
+      table.selected.foreach { f =>
+        val (i, m, c) = feedback(f)
+        icon        = i
+        text        = m
+        background  = c
+      }
+    }
+    revalidate()
+  }
+
+  private def feedback(f: Future[ItcService.Result]): (Icon, String, Color) =
+    f.value.fold                    ((SpinnerIcon,  "Calculating...",     BANANA)) {
+      case Failure(t)             => (ErrorIcon,    t.getMessage,         LIGHT_SALMON)
+      case Success(s) => s match {
+        case scalaz.Failure(errs) => (ErrorIcon,    errs.mkString(", "),  LIGHT_SALMON)
+        case scalaz.Success(_)    => (OkIcon,       "OK",                 HONEY_DEW)
+      }
+    }
+
 }
 
 /** Panel holding spectroscopy charts.
@@ -322,6 +266,110 @@ private class ItcChartsPanel(table: ItcSpectroscopyTable) extends GridBagPanel {
   }
 }
 
+/** User element that allows to change the conditions taken for the calculations on-the-fly. */
+protected class ConditionsPanel(owner: EdIteratorFolder) extends GridBagPanel {
+
+  private class ConditionCB[A](items: Seq[A], renderFunc: A => String) extends ComboBox[A](items) {
+    private var programValue = selection.item
+    tooltip  = "Select conditions for ITC calculations. Values different from program conditions are shown in red."
+    renderer = new Renderer[A] {
+      override def componentFor(list: ListView[_ <: A], isSelected: Boolean, focused: Boolean, a: A, index: Int): Component = {
+        new Label(renderFunc(a)) {{ foreground = if (programValue == a) Color.BLACK else Color.RED }}
+      }
+    }
+    listenTo(selection)
+    reactions += {
+      case SelectionChanged(_) =>
+        foreground = color()
+        tooltip    = tt()
+    }
+
+    def sync(newValue: A) = {
+      if (programValue == selection.item) {
+        // if we are "in sync" with program value (i.e. the program value is currently selected), update it
+        deafTo(selection)
+        selection.item = newValue
+        listenTo(selection)
+      }
+      // set new program value and update coloring
+      programValue = newValue
+      foreground = color()
+      tooltip    = tt()
+    }
+
+    private def color() = if (inSync()) Color.BLACK else Color.RED
+
+    private def tt() = if (inSync()) "" else s"Program condition is ${renderFunc(programValue)}"
+
+    private def inSync() = programValue == selection.item
+
+  }
+
+  private val sb = new ConditionCB[SkyBackground]  (SkyBackground.values,                       "SB " + _.displayValue())
+  private val cc = new ConditionCB[CloudCover]     (CloudCover.values.filterNot(_.isObsolete),  "CC " + _.displayValue())
+  private val iq = new ConditionCB[ImageQuality]   (ImageQuality.values,                        "IQ " + _.displayValue())
+  private val wv = new ConditionCB[WaterVapor]     (WaterVapor.values,                          "WV " + _.displayValue())
+  private val am = new ConditionCB[Double]         (List(1.0, 1.5, 2.0),                        d => f"Airmass $d%.1f")
+
+  def conditions = new ObservingConditions(
+    iq.selection.item,
+    cc.selection.item,
+    wv.selection.item,
+    sb.selection.item,
+    am.selection.item)
+
+  def update() = {
+    // Note: site quality node can be missing (i.e. null)
+    Option(owner.getContextSiteQuality).foreach { qual =>
+      sb.sync(qual.getSkyBackground)
+      cc.sync(qual.getCloudCover)
+      iq.sync(qual.getImageQuality)
+      wv.sync(qual.getWaterVapor)
+      // TODO: currently the airmass program value is fixed to 1.5 airmass
+      // TODO: can we get this value from the airmass constraints?
+      am.sync(1.5)
+    }
+  }
+
+  border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+
+  layout(new Label("Conditions:"))  = new Constraints {
+    gridx   = 0
+    gridy   = 0
+  }
+  layout(sb) = new Constraints {
+    gridx   = 1
+    gridy   = 0
+    insets  = new Insets(0, 10, 0, 0)
+  }
+  layout(cc) = new Constraints {
+    gridx   = 2
+    gridy   = 0
+    insets  = new Insets(0, 5, 0, 0)
+  }
+  layout(iq) = new Constraints {
+    gridx   = 3
+    gridy   = 0
+    insets  = new Insets(0, 5, 0, 0)
+  }
+  layout(wv) = new Constraints {
+    gridx   = 4
+    gridy   = 0
+    insets  = new Insets(0, 5, 0, 0)
+  }
+  layout(am) = new Constraints {
+    gridx   = 5
+    gridy   = 0
+    insets  = new Insets(0, 5, 0, 0)
+  }
+
+  deafTo(this)
+  listenTo(sb.selection, cc.selection, iq.selection, wv.selection, am.selection)
+  reactions += {
+    case SelectionChanged(_) => publish(new SelectionChanged(this))
+  }
+
+}
 protected class AnalysisMethodPanel extends GridBagPanel {
 
   val autoAperture = new RadioButton("Auto") { focusable = false; selected = true }
@@ -334,10 +382,10 @@ protected class AnalysisMethodPanel extends GridBagPanel {
   layout(autoAperture)                  = new Constraints { gridx = 1; gridy = 0; insets = new Insets(0, 0, 0, 20) }
   layout(userAperture)                  = new Constraints { gridx = 1; gridy = 1; insets = new Insets(0, 0, 0, 20) }
   layout(skyAperture.label)             = new Constraints { gridx = 2; gridy = 0; insets = new Insets(0, 0, 0, 10) }
-  layout(skyAperture.text)              = new Constraints { gridx = 3; gridy = 0; insets = new Insets(0, 0, 0, 10) }
+  layout(skyAperture.text)              = new Constraints { gridx = 3; gridy = 0; insets = new Insets(0, 0, 0, 10); fill = Fill.Horizontal }
   layout(skyAperture.units)             = new Constraints { gridx = 4; gridy = 0 }
   layout(diameter.label)                = new Constraints { gridx = 2; gridy = 1; insets = new Insets(0, 0, 0, 10) }
-  layout(diameter.text)                 = new Constraints { gridx = 3; gridy = 1; insets = new Insets(0, 0, 0, 10) }
+  layout(diameter.text)                 = new Constraints { gridx = 3; gridy = 1; insets = new Insets(0, 0, 0, 10); fill = Fill.Horizontal }
   layout(diameter.units)                = new Constraints { gridx = 4; gridy = 1 }
 
   listenTo(autoAperture, userAperture, diameter.keys, skyAperture.keys)
@@ -377,10 +425,10 @@ protected class PlotDetailsPanel extends GridBagPanel {
   layout(autoLimits)            = new Constraints { gridx = 1; gridy = 0; insets = new Insets(0, 0, 0, 20) }
   layout(userLimits)            = new Constraints { gridx = 2; gridy = 0; insets = new Insets(0, 0, 0, 20) }
   layout(lowLimit.label)        = new Constraints { gridx = 3; gridy = 0 }
-  layout(lowLimit.text)         = new Constraints { gridx = 4; gridy = 0 }
+  layout(lowLimit.text)         = new Constraints { gridx = 4; gridy = 0; fill = Fill.Horizontal }
   layout(lowLimit.units)        = new Constraints { gridx = 5; gridy = 0; insets = new Insets(0, 0, 0, 20) }
   layout(highLimit.label)       = new Constraints { gridx = 6; gridy = 0 }
-  layout(highLimit.text)        = new Constraints { gridx = 7; gridy = 0 }
+  layout(highLimit.text)        = new Constraints { gridx = 7; gridy = 0; fill = Fill.Horizontal }
   layout(highLimit.units)       = new Constraints { gridx = 8; gridy = 0 }
 
   listenTo(autoLimits, userLimits, lowLimit.keys, highLimit.keys)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -8,6 +8,7 @@ import edu.gemini.itc.shared._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{CloudCover, ImageQuality, SkyBackground, WaterVapor}
 import jsky.app.ot.util.OtColor
+import org.jfree.chart.{ChartPanel, JFreeChart}
 
 import scala.concurrent.Future
 import scala.swing.GridBagPanel.{Anchor, Fill}
@@ -246,10 +247,8 @@ private class ItcChartsPanel(table: ItcSpectroscopyTable) extends GridBagPanel {
 
   private def update(result: ItcSpectroscopyResult): Unit = {
     charts = result.charts.map { ds =>
-      val chart = ITCChart.forSpcDataSet(ds, limitsPanel.plottingDetails).getBufferedImage(600, 400)
-      new Label("", new ImageIcon(chart), Alignment.Center) {
-        border = BorderFactory.createEmptyBorder(10, 25, 10, 25)
-      }
+      val chart = ITCChart.forSpcDataSet(ds, limitsPanel.plottingDetails).getChart
+      new JFChartComponent(chart)
     }
     layout(limitsPanel) = new Constraints {
       gridx     = 0
@@ -257,13 +256,26 @@ private class ItcChartsPanel(table: ItcSpectroscopyTable) extends GridBagPanel {
       gridwidth = charts.size
       insets    = new Insets(20, 0, 20, 0)
     }
-    charts.zipWithIndex.foreach { case (l, x) =>
-      layout(l) = new Constraints {
-        gridx = x
-        gridy = 1
+    charts.zipWithIndex.foreach { case (c, x) =>
+      layout(c) = new Constraints {
+        gridx   = x
+        gridy   = 1
+        weightx = 1
+        weighty = 1
+        fill    = Fill.Both
+        insets  = new Insets(10, 25, 10, 25)
       }
     }
   }
+
+  // a very simple Scala wrapper for JFreeChart charts
+  class JFChartComponent(chart: JFreeChart) extends Component {
+    override lazy val peer = new ChartPanel(chart)
+    peer.setMaximumDrawHeight(Int.MaxValue)                       // don't limit drawing resolution
+    peer.setMaximumDrawWidth(Int.MaxValue)                        // don't limit drawing resolution
+    peer.setBackground(Color.white)
+  }
+
 }
 
 /** User element that allows to change the conditions taken for the calculations on-the-fly. */

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
@@ -20,7 +20,7 @@ trait ItcParametersProvider {
   def sequence: ConfigSequence
   def instrument: Option[SPComponentType]
   def observation: Option[ISPObservation]
-  def analysisMethod: AnalysisMethod
+  def analysisMethod: String \/ AnalysisMethod
   def conditions: String \/ ObservingConditions
   def instrumentPort: String \/ IssPort
   def targetEnvironment: String \/ TargetEnvironment
@@ -40,8 +40,8 @@ object ItcParametersProvider {
     def observation: Option[ISPObservation] =
       Option(owner.getContextObservation)
 
-    def analysisMethod: AnalysisMethod =
-      itcPanel.analysis
+    def analysisMethod: String \/ AnalysisMethod =
+      itcPanel.analysis.fold("Analysis method is invalid".left[AnalysisMethod])(_.right)
 
     def conditions: String \/ ObservingConditions =
       itcPanel.conditions.right

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -112,18 +112,15 @@ trait ItcTable extends Table {
 
   }
 
-  protected def calculateSpectroscopy(peer: Peer, instrument: SPComponentType, c: ItcUniqueConfig): Future[ItcService.Result] = {
-    val obs = new ObservationDetails(SpectroscopySN(c.count, c.singleExposureTime, 1.0), parameters.analysisMethod)
-    calculate(peer, instrument, c, obs)
-  }
+  protected def calculateSpectroscopy(peer: Peer, instrument: SPComponentType, c: ItcUniqueConfig): Future[ItcService.Result] =
+    calculate(peer, instrument, c, SpectroscopySN(c.count, c.singleExposureTime, 1.0))
 
-  protected def calculateImaging(peer: Peer, instrument: SPComponentType, c: ItcUniqueConfig): Future[ItcService.Result] = {
-    val obs = new ObservationDetails(ImagingSN(c.count, c.singleExposureTime, 1.0), parameters.analysisMethod)
-    calculate(peer, instrument, c, obs)
-  }
+  protected def calculateImaging(peer: Peer, instrument: SPComponentType, c: ItcUniqueConfig): Future[ItcService.Result] =
+    calculate(peer, instrument, c, ImagingSN(c.count, c.singleExposureTime, 1.0))
 
-  protected def calculate(peer: Peer, instrument: SPComponentType, c: ItcUniqueConfig, obs: ObservationDetails): Future[ItcService.Result] = {
+  protected def calculate(peer: Peer, instrument: SPComponentType, c: ItcUniqueConfig, cm: CalculationMethod): Future[ItcService.Result] = {
     val s = for {
+      analysis  <- parameters.analysisMethod
       cond      <- parameters.conditions
       port      <- parameters.instrumentPort
       targetEnv <- parameters.targetEnvironment
@@ -132,7 +129,7 @@ trait ItcTable extends Table {
       tele      <- ConfigExtractor.extractTelescope(port, probe, targetEnv, c.config)
       ins       <- ConfigExtractor.extractInstrumentDetails(instrument, probe, targetEnv, c.config)
     } yield {
-        doServiceCall(peer, c, src, ins, tele, cond, obs)
+        doServiceCall(peer, c, src, ins, tele, cond, new ObservationDetails(cm, analysis))
     }
 
     s match {


### PR DESCRIPTION
Lots of UI changes.

* Added a feedback panel at the bottom for error messages (similar to guider feedback)
* Adapt table column widths to actual content (use less space horizontally)
* Charts adapt to available vertical space
* Fixed plot limits input fields
* Use ```NumberBoxWidget``` for input (same widget as in ```TargetEditor```)
* Keep current row selected, select row 0 as default
* Condition values deviating from program conditions are shown in red, identical values in black
* Mark rows with problems with x icon in first column
* Fixed rendering for special values, e.g. ```DisplayableSpType```
* and some other tiny bits and pieces 


![image](https://cloud.githubusercontent.com/assets/7856060/7624982/ef43a79a-f98c-11e4-8d02-befe176736dc.png)

![image](https://cloud.githubusercontent.com/assets/7856060/7624986/075b30d2-f98d-11e4-89b9-7df4f04d8424.png)
