### PR TITLE
Log fine tuning.

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/servlets/ImageServlet.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/servlets/ImageServlet.java
@@ -93,7 +93,8 @@ public final class ImageServlet extends HttpServlet {
             }
 
         } catch (IdTimedOutException e) {
-            Log.log(Level.WARNING, "Session has timed out, the requested result is not available anymore", e);
+            // if this messages comes up a lot we might need to tweak the cache settings
+            Log.log(Level.WARNING, "Session has timed out, the requested result is not available anymore");
             response.sendError(HttpServletResponse.SC_REQUEST_TIMEOUT);
 
         } catch (NumberFormatException e) {

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/DatFile.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/DatFile.scala
@@ -71,8 +71,8 @@ object DatFile {
 
   def scanFile(f: String): Scanner = {
     Option(getClass.getResourceAsStream(f)).fold {
-      val msg = s"Missing data file: $f"
-      Log.severe(msg)
+      val msg = s"Unsupported configuration, missing data file $f"
+      Log.fine(msg)
       throw new IllegalArgumentException(msg)
     } {
       new Scanner(_).useDelimiter(Delimiters)


### PR DESCRIPTION
Not all available components in the OT are supported by the ITC, for some filters and other components we don't have the necessary data files. While the options in the web app are restricted to the available components now with the OT this originally severe problem became a regular occurrence, which is why I turned down the log level in order to keep it from flooding the logs.