### PR TITLE
OCSADV-321: Fixes for GMOS and F2 custom masks

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -88,7 +88,7 @@ object ConfigExtractor {
 
     // Gets the site this GMOS belongs to
     def extractSite: String \/ Site =
-      extract[String](c, InstrumentKey).rightMap(s => if (s.equals("GMOS-N")) Site.GN else Site.GS)
+      extract[String](c, InstrumentKey).map(s => if (s.equals("GMOS-N")) Site.GN else Site.GS)
 
     // Gets the custom mask for the given site
     def customMask(s: Site): FPUnit = s match {
@@ -102,7 +102,7 @@ object ConfigExtractor {
 
     // Gets the optional custom slit width
     def extractCustomSlit: String \/ Option[CustomSlitWidth] =
-      if (c.containsItem(FpuKey)) None.right else extract[CustomSlitWidth](c, CustomSlitWidthKey).rightMap(Some(_))
+      if (c.containsItem(FpuKey)) None.right else extract[CustomSlitWidth](c, CustomSlitWidthKey).map(Some(_))
 
     // Note: In the future we will support more options, for now only single on-axis is supported.
     def extractIfu(mask: GmosCommonType.FPUnit): Option[IfuMethod] =
@@ -153,7 +153,7 @@ object ConfigExtractor {
     import AltairParams._
 
     def altairIsPresent =
-      c.containsItem(AoSystemKey) && extract[String](c, AoSystemKey).rightMap("Altair".equals).getOrElse(false)
+      c.containsItem(AoSystemKey) && extract[String](c, AoSystemKey).map("Altair".equals).getOrElse(false)
 
     def extractGroup =
       targetEnv.getPrimaryGuideProbeTargets(probe).asScalaOpt.fold("No guide star selected".left[GuideProbeTargets])(_.right)
@@ -196,14 +196,14 @@ object ConfigExtractor {
     val instrument = extract[String](c, InstrumentKey).getOrElse("")
     (instrument match {
       case "AcqCam" =>
-        extract[AcqCamParams.ColorFilter](c, ColorFilterKey).rightMap(_.getCentralWavelength.toDouble)
+        extract[AcqCamParams.ColorFilter](c, ColorFilterKey).map(_.getCentralWavelength.toDouble)
       case "GNIRS" =>
-        extract[GNIRSParams.Wavelength](c, ObsWavelengthKey).rightMap(_.doubleValue())
+        extract[GNIRSParams.Wavelength](c, ObsWavelengthKey).map(_.doubleValue())
       case _ =>
         if (c.containsItem(ObsWavelengthKey)) extractDoubleFromString(c, ObsWavelengthKey)
         else "Observing wavelength is not defined (missing filter?)".left
 
-    }).rightMap(Wavelength.fromMicrons)
+    }).map(Wavelength.fromMicrons)
   }
 
 

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -206,7 +206,7 @@ object ConfigExtractor {
   private def extractWithThrowable[A](c: Config, key: ItemKey)(implicit clazz: ClassTag[A]): Throwable \/ A = {
 
     def missingKey[A](key: ItemKey): \/[Throwable, A] =
-      new Error("Missing config value for key ${key.getPath}").left[A]
+      new Error(s"Missing config value for key ${key.getPath}").left[A]
 
     Option(c.getItemValue(key)).fold(missingKey[A](key)) { v =>
       \/.fromTryCatch(clazz.runtimeClass.cast(v).asInstanceOf[A])

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
@@ -30,6 +30,7 @@ final case class GmosParameters(
                      grating:           GmosCommonType.Disperser,
                      centralWavelength: Wavelength,
                      fpMask:            GmosCommonType.FPUnit,
+                     customSlitWidth:   Option[GmosCommonType.CustomSlitWidth],
                      spatialBinning:    Int,
                      spectralBinning:   Int,
                      ifuMethod:         Option[IfuMethod],

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -131,7 +131,7 @@ object ITCRequest {
       None
     }
 
-    GmosParameters(filter, grating, centralWl, fpMask, spatBinning, specBinning, ifuMethod, ccdType, site)
+    GmosParameters(filter, grating, centralWl, fpMask, None, spatBinning, specBinning, ifuMethod, ccdType, site)
   }
 
   def gnirsParameters(r: ITCRequest): GnirsParameters = {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -45,10 +45,12 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
     private void validateInputParameters() {
         if (_obsDetailParameters.getMethod().isSpectroscopy()) {
             switch (_flamingos2Parameters.grism()) {
-                case NONE: throw new IllegalArgumentException("In spectroscopy mode, a grism must be selected");
+                case NONE:          throw new IllegalArgumentException("In spectroscopy mode, a grism must be selected");
             }
             switch (_flamingos2Parameters.mask()) {
-                case FPU_NONE: throw new IllegalArgumentException("In spectroscopy mode, a FP must must be selected");
+                case FPU_NONE:      throw new IllegalArgumentException("In spectroscopy mode, a FP must be selected");
+                // NOTE: Currently it is not possible to set a slit width for custom masks for F2 in the OT
+                case CUSTOM_MASK:   throw new IllegalArgumentException("Custom masks with unknown slit widths are not supported");
             }
         }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -148,8 +148,14 @@ public abstract class Gmos extends Instrument implements BinningProvider {
 
     }
 
+    /**
+     * Gets the slit width for the currently selected fpu.
+     * @return
+     */
     public double getSlitWidth() {
-        return gp.fpMask().isIFU() ? 0.3 : gp.fpMask().getWidth();
+        if      (gp.fpMask().isIFU())               return 0.3;
+        else if (gp.customSlitWidth().isDefined())  return gp.customSlitWidth().get().getWidth();
+        else                                        return gp.fpMask().getWidth();
     }
 
     /**
@@ -294,33 +300,49 @@ public abstract class Gmos extends Instrument implements BinningProvider {
     private void validate() {
         //Test to see that all conditions for Spectroscopy are met
         if (odp.getMethod().isSpectroscopy()) {
+
             if (grating.isEmpty())
                 throw new RuntimeException("Spectroscopy calculation method is selected but a grating" +
                         " is not.\nPlease select a grating and a " +
                         "focal plane mask in the Instrument " +
                         "configuration section.");
+
             if (gp.fpMask().equals(GmosNorthType.FPUnitNorth.FPU_NONE) || gp.fpMask().equals(GmosSouthType.FPUnitSouth.FPU_NONE))
                 throw new RuntimeException("Spectroscopy calculation method is selected but a focal" +
                         " plane mask is not.\nPlease select a " +
                         "grating and a " +
                         "focal plane mask in the Instrument " +
                         "configuration section.");
+
+            if (gp.fpMask().equals(GmosNorthType.FPUnitNorth.CUSTOM_MASK) || gp.fpMask().equals(GmosSouthType.FPUnitSouth.CUSTOM_MASK)) {
+
+                if (gp.customSlitWidth().isEmpty())
+                    throw new RuntimeException("Custom mask is selected but custom slit width is undefined.");
+
+                if (gp.customSlitWidth().get().equals(GmosCommonType.CustomSlitWidth.OTHER))
+                    throw new RuntimeException("Slit width for the custom mask is not known.");
+            }
         }
 
         if (odp.getMethod().isImaging()) {
+
             if (filter.isEmpty())
-                throw new RuntimeException("Imaging calculation method is selected but a filter" +
-                        " is not.\n  Please select a filter and resubmit the " +
-                        "form to continue.");
+                throw new RuntimeException("Imaging calculation method is selected but a filter is not.");
+
             if (grating.isDefined())
                 throw new RuntimeException("Imaging calculation method is selected but a grating" +
                         " is also selected.\nPlease deselect the " +
                         "grating or change the method to spectroscopy.");
+
             if (!gp.fpMask().equals(GmosNorthType.FPUnitNorth.FPU_NONE) && !gp.fpMask().equals(GmosSouthType.FPUnitSouth.FPU_NONE))
                 throw new RuntimeException("Imaging calculation method is selected but a Focal" +
-                        " Plane Mask is also selected.\nPlease " +
-                        "deselect the Focal Plane Mask" +
+                        " Plane Mask is also selected.\nPlease deselect the Focal Plane Mask" +
                         " or change the method to spectroscopy.");
+
+            if (gp.customSlitWidth().isDefined())
+                throw new RuntimeException("Imaging calculation method is selected but a Custom" +
+                        " Slit Width is also selected.\n");
+
             if (isIfuUsed())
                 throw new RuntimeException("Imaging calculation method is selected but an IFU" +
                         " is also selected.\nPlease deselect the IFU or" +

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/BaselineGmos.scala
@@ -25,6 +25,7 @@ object BaselineGmos {
       DisperserNorth.MIRROR,
       Wavelength.fromNanometers(500.0), // central wavelength
       FPUnitNorth.FPU_NONE,
+      None,
       1,
       1,
       None,                         // IFU method
@@ -35,6 +36,7 @@ object BaselineGmos {
       DisperserNorth.MIRROR,
       Wavelength.fromNanometers(500.0), // central wavelength
       FPUnitNorth.FPU_NONE,
+      None,
       2,
       2,
       None,                         // IFU method
@@ -47,6 +49,7 @@ object BaselineGmos {
       DisperserSouth.MIRROR,
       Wavelength.fromNanometers(500.0),
       FPUnitSouth.FPU_NONE,
+      None,
       2,
       4,
       None,
@@ -57,6 +60,7 @@ object BaselineGmos {
       DisperserSouth.MIRROR,
       Wavelength.fromNanometers(500.0),
       FPUnitSouth.FPU_NONE,
+      None,
       4,
       4,
       None,
@@ -75,6 +79,7 @@ object BaselineGmos {
       DisperserNorth.R150_G5306,
       Wavelength.fromNanometers(500.0),
       FPUnitNorth.LONGSLIT_2,
+      None,
       1,
       1,
       None,
@@ -85,6 +90,7 @@ object BaselineGmos {
       DisperserNorth.R400_G5305,
       Wavelength.fromNanometers(500.0),
       FPUnitNorth.IFU_1,
+      None,
       2,
       2,
       Some(IfuSingle(0.0)),
@@ -95,6 +101,7 @@ object BaselineGmos {
       DisperserNorth.R400_G5305,
       Wavelength.fromNanometers(500.0),
       FPUnitNorth.IFU_1,
+      None,
       2,
       2,
       Some(IfuSingle(0.3)),
@@ -107,6 +114,7 @@ object BaselineGmos {
       DisperserSouth.R150_G5326,
       Wavelength.fromNanometers(500.0),
       FPUnitSouth.LONGSLIT_2,
+      None,
       2,
       4,
       None,

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/Keys.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/Keys.java
@@ -6,7 +6,7 @@ import edu.gemini.spModel.config2.ItemKey;
 final class Keys {
     static final ItemKey CALIBRATION_KEY= new ItemKey("calibration");
     static final ItemKey INSTRUMENT_KEY = new ItemKey("instrument");
-//    static final ItemKey OBSERVE_KEY    = new ItemKey("observe");
+    static final ItemKey OBSERVE_KEY    = new ItemKey("observe");
     static final ItemKey TELESCOPE_KEY  = new ItemKey("telescope");
 
     static final ItemKey DATALABEL_KEY   = new ItemKey("observe:dataLabel");

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -29,6 +29,8 @@ import scalaz._
  */
 trait ItcTable extends Table {
 
+  import ItcUniqueConfig._
+
   val parameters: ItcParametersProvider
 
   def tableModel(keys: Seq[ItemKey], seq: ConfigSequence): ItcTableModel
@@ -58,13 +60,9 @@ trait ItcTable extends Table {
     val seq = parameters.sequence
     val allKeys = seq.getStaticKeys.toSeq ++ seq.getIteratedKeys.toSeq
     val showKeys = seq.getIteratedKeys.toSeq.
-      filterNot(_.equals(DATALABEL_KEY)). // don't show the original data label (step number)
-      filterNot(_.equals(OBS_TYPE_KEY)). // don't show the type (science vs. calibration)
-      filterNot(_.equals(OBS_EXP_TIME_KEY)). // don't show observe exp time
-      filterNot(_.equals(INST_EXP_TIME_KEY)). // don't show instrument exp time
-      filterNot(_.equals(TEL_P_KEY)). // don't show offsets
-      filterNot(_.equals(TEL_Q_KEY)). // don't show offsets
-      filterNot(_.getParent().equals(CALIBRATION_KEY)). // calibration settings are not relevant
+      filterNot(k => ExcludedParentKeys.contains(k.getParent)).
+      filterNot(ExcludedKeys.contains).
+      filterNot(_.equals(INST_EXP_TIME_KEY)).   // exposure time will always be shown, don't repeat it in case it is part of the dynamic configuration
       sortBy(_.getPath)
 
     // update table model while keeping the current selection

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -60,8 +60,8 @@ trait ItcTable extends Table {
     val seq = parameters.sequence
     val allKeys = seq.getStaticKeys.toSeq ++ seq.getIteratedKeys.toSeq
     val showKeys = seq.getIteratedKeys.toSeq.
-      filterNot(k => ExcludedParentKeys.contains(k.getParent)).
-      filterNot(ExcludedKeys.contains).
+      filterNot(k => ExcludedParentKeys(k.getParent)).
+      filterNot(ExcludedKeys).
       filterNot(_.equals(INST_EXP_TIME_KEY)).   // exposure time will always be shown, don't repeat it in case it is part of the dynamic configuration
       sortBy(_.getPath)
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -1,6 +1,6 @@
 package jsky.app.ot.editor.seq
 
-import edu.gemini.spModel.config2.{Config, ConfigSequence}
+import edu.gemini.spModel.config2.{ItemKey, Config, ConfigSequence}
 import edu.gemini.spModel.gemini.acqcam.InstAcqCam
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gmos.{GmosNorthType, GmosSouthType, InstGmosNorth, InstGmosSouth}
@@ -39,6 +39,19 @@ case class ItcUniqueConfig(count: Int, labels: String, config: Config) {
  * Utility functions to get unique configurations from ConfigurationSequence objects.
  */
 object ItcUniqueConfig {
+
+  /** The following keys are for configuration values which are not relevant for ITC calculations
+    * and must be excluded when deciding on which configurations are unique with respect to ITC. */
+  val ExcludedParentKeys = List (
+      CALIBRATION_KEY,
+      TELESCOPE_KEY,                                // this includes P- and Q offsets
+      OBSERVE_KEY                                   // this includes the data label
+    )
+  val ExcludedKeys = List(
+      // == device specific exceptions
+      new ItemKey("instrument:dtaXOffset")          // DTA X-Offset (GMOS)
+    )
+
 
   /** Gets all unique science imaging configurations from the given sequence. */
   def imagingConfigs(seq: ConfigSequence): Seq[ItcUniqueConfig] =
@@ -81,13 +94,11 @@ object ItcUniqueConfig {
   // Creates a hash for the given config step taking into account only the values that are relevant for ITC
   // calculations, e.g. ignoring offsets and data labels.
   private def hash(step: Config): Int = step.getKeys.
-      filterNot(_.getParent.equals(CALIBRATION_KEY)).
-      filterNot(_.equals(DATALABEL_KEY)).           // don't take data label into account (step number)
-      filterNot(_.equals(TEL_P_KEY)).               // configs with different P offsets are considered as one config
-      filterNot(_.equals(TEL_Q_KEY)).               // dito for Q
-      filterNot(step.getItemValue(_) == null).      // occasionally we get null values..
-      map(step.getItemValue(_).hashCode()).
-      foldLeft(17)((acc, h) => 37*acc + h)
+    filterNot(k => ExcludedParentKeys.contains(k.getParent)).
+    filterNot(ExcludedKeys.contains).
+    filterNot(step.getItemValue(_) == null).      // occasionally we get null values..
+    map(step.getItemValue(_).hashCode()).
+    foldLeft(17)((acc, h) => 37*acc + h)
 
   // Creates a text label based on the spans of steps covered by the steps.
   // E.g. ((1,2,3),(10,11),(15)) is turned into "001-003, 010-011, 015"

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -42,12 +42,12 @@ object ItcUniqueConfig {
 
   /** The following keys are for configuration values which are not relevant for ITC calculations
     * and must be excluded when deciding on which configurations are unique with respect to ITC. */
-  val ExcludedParentKeys = List (
+  val ExcludedParentKeys = Set (
       CALIBRATION_KEY,
       TELESCOPE_KEY,                                // this includes P- and Q offsets
       OBSERVE_KEY                                   // this includes the data label
     )
-  val ExcludedKeys = List(
+  val ExcludedKeys = Set(
       // == device specific exceptions
       new ItemKey("instrument:dtaXOffset")          // DTA X-Offset (GMOS)
     )
@@ -94,8 +94,8 @@ object ItcUniqueConfig {
   // Creates a hash for the given config step taking into account only the values that are relevant for ITC
   // calculations, e.g. ignoring offsets and data labels.
   private def hash(step: Config): Int = step.getKeys.
-    filterNot(k => ExcludedParentKeys.contains(k.getParent)).
-    filterNot(ExcludedKeys.contains).
+    filterNot(k => ExcludedParentKeys(k.getParent)).
+    filterNot(ExcludedKeys).
     filterNot(step.getItemValue(_) == null).      // occasionally we get null values..
     map(step.getItemValue(_).hashCode()).
     foldLeft(17)((acc, h) => 37*acc + h)


### PR DESCRIPTION
This PR addresses the following issues:

* Use the custom slit width for GMOS custom masks.
* Give an error message for F2 for custom  masks (for F2 there is no way to know the slit width for custom masks).
* Ignore changing DTA X-Offset values for GMOS when calculating the "unique" configuration for ITC.
* Small fix in an error message.