### PR TITLE
Add "undefined" option to source profile and distribution editors.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -134,7 +134,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 updateEnabledState(new Component[] {ed}, enabled);
             }
         }
-        _w.detailEditor.source().updateEnabledState(enabled);
     }
 
     private final ActionListener _tagListener = new ActionListener() {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
@@ -26,7 +26,6 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor {
 
   private[this] var spt: SPTarget = new SPTarget
   private[this] var isBase: Boolean = false
-  private[this] var node: Option[ISPNode] = None
 
   private def setDistribution(sd: SpectralDistribution): Unit         = setDistribution(Some(sd))
   private def setDistribution(sd: Option[SpectralDistribution]): Unit = spt.getTarget.setSpectralDistribution(sd)
@@ -197,11 +196,6 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor {
 
   }
 
-  def editable: Boolean =
-    node.exists { n =>
-      OTOptions.areRootAndCurrentObsIfAnyEditable(n.getProgram, n.getContextObservation)
-    }
-
   // react to any kind of target change by updating all UI elements
   def edit(obsContext: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {
 
@@ -209,7 +203,6 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor {
 
     spt       = spTarget
     isBase    = if (obsContext.isDefined) obsContext.getValue.getTargets.getBase == spTarget else false
-    this.node = Option(node)
 
     spt.getTarget.getSpatialProfile match {
       case None                     => profiles.selection.item = profilePanels.head
@@ -250,10 +243,6 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor {
     }
     revalidate()
     repaint()
-  }
-
-  def updateEnabledState(b: Boolean): Unit = {
-    peer.getComponents.foreach(_.setEnabled(b))
   }
 
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
@@ -206,13 +206,13 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor {
 
     spt.getTarget.getSpatialProfile match {
       case None                     => profiles.selection.item = profilePanels.head
-      case Some(s: PointSource)     => profiles.selection.item = profilePanels(1);
+      case Some(s: PointSource)     => profiles.selection.item = profilePanels(1)
       case Some(s: GaussianSource)  => profiles.selection.item = profilePanels(2); profilePanels(2).panel.asInstanceOf[NumericPropertySheet[GaussianSource]].edit(obsContext, spTarget, node)
-      case Some(s: UniformSource)   => profiles.selection.item = profilePanels(3);
+      case Some(s: UniformSource)   => profiles.selection.item = profilePanels(3)
     }
 
     spt.getTarget.getSpectralDistribution match {
-      case None                     => distributions.selection.item = distributionPanels.head;
+      case None                     => distributions.selection.item = distributionPanels.head
       case Some(s: LibraryStar)     => distributions.selection.item = distributionPanels(1); libraryStarDetails.selection.item = s
       case Some(s: LibraryNonStar)  => distributions.selection.item = distributionPanels(2); libraryNonStarDetails.selection.item = s
       case Some(s: BlackBody)       => distributions.selection.item = distributionPanels(3); distributionPanels(3).panel.asInstanceOf[NumericPropertySheet[BlackBody]].edit(obsContext, spTarget, node)


### PR DESCRIPTION
Yes, ok. The "Click to Activate" idea was not going to win any awards. It has been replaced by "«undefined»" options for both pull down menus.

@swalker2m : I simplified the ```updateEnabledState()```. However I am wondering about the ```editable``` method and the additional ```node```. ```editable``` doesn't seem to be called anywhere. Can we delete this or am I missing something?

![image](https://cloud.githubusercontent.com/assets/7856060/7646075/e4fba512-fa59-11e4-843f-ef3b699613ed.png)