### PR TITLE
OCSADV-329: Target I/O Bug

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -143,6 +143,18 @@ public class SPTargetPio {
         return paramSet;
     }
 
+    private static void setCoordinate(ICoordinate c, String s) {
+        // We don't know whether we have HH:MM:SS (DD:MM:SS) or a double in
+        // degrees.  Try to parse as a Double and use it if that works.
+        if (s != null) {
+            try {
+                c.setAs(Double.parseDouble(s), CoordinateParam.Units.DEGREES);
+            } catch (NumberFormatException ex) {
+                c.setValue(s);
+            }
+        }
+    }
+
     public static void setParamSet(final ParamSet paramSet, final SPTarget spt) {
         if (paramSet == null) return;
 
@@ -167,8 +179,8 @@ public class SPTargetPio {
 
             final String c1 = Pio.getValue(paramSet, _C1);
             final String c2 = Pio.getValue(paramSet, _C2);
-            t.getRa().setValue(c1);
-            t.getDec().setValue(c2);
+            setCoordinate(t.getRa(), c1);
+            setCoordinate(t.getDec(), c2);
 
             final CoordinateTypes.Epoch e = new CoordinateTypes.Epoch();
             e.setParam(paramSet.getParam(_EPOCH));
@@ -202,10 +214,8 @@ public class SPTargetPio {
             // XXX FIXME: Temporary, until nonsidereal support is implemented
             final String c1 = Pio.getValue(paramSet, _C1);
             final String c2 = Pio.getValue(paramSet, _C2);
-            if (c1 != null && c2 != null) {
-                nst.getRa().setValue(c1);
-                nst.getDec().setValue(c2);
-            }
+            setCoordinate(nst.getRa(), c1);
+            setCoordinate(nst.getDec(), c2);
 
             final String dateStr = Pio.getValue(paramSet, _VALID_DATE);
             final Date validDate = parseDate(dateStr);

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
@@ -119,10 +119,10 @@ object To2015B {
       // Set new values
       pRa.setValue(ra0.toString)
       pDec.setValue(dec0.toString)
-      pdRa.setValue((dRa0 * 60 * 60).toString)
-      pdRa.setUnits(UNITS_SECONDS_PER_YEAR)
-      pdDec.setValue((dDec0 * 60 * 60).toString)
-      pdDec.setUnits(UNITS_SECONDS_PER_YEAR)
+      pdRa.setValue((dRa0 * 1000 * 60 * 60).toString)
+      pdRa.setUnits(UNITS_MILLI_ARCSECONDS_PER_YEAR)
+      pdDec.setValue((dDec0 * 1000 * 60 * 60).toString)
+      pdDec.setUnits(UNITS_MILLI_ARCSECONDS_PER_YEAR)
       pSys.setValue(VALUE_SYSTEM_J2000)
 
     }


### PR DESCRIPTION
This PR introduces fixes for a couple of bugs in target I/O.

* In this release we precess B1950 targets in a migration step.  The migration code writes the precessed RA and Dec back into the `ParamSet` to be later read by `SPTargetPio`.  It takes the B1950 RA `String` in HH:MM:SS format, does the math to convert it to J2000 and then writes the value in degrees as a `String`.  This `String` value in degrees was being interpreted by `SPTargetIO` as hours.  The fix is to first try parsing the value as a `Double` degrees and, failing that, fallback to HH:MM:SS (or DD:MM:SS for declination).

* `To2015B` was setting the proper motion value and units incorrectly in the updated `ParamSet`.  The result coming back from the precession code is in degrees per year which was being converted to arcsec/year but stored with the units seconds/year.  The PR updates this to take degrees/year to mas/year and use the proper units.
