### PR TITLE
OCSADV-328/346: ITC on-source fraction and coadds.

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ObservationDetails.java
+++ b/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ObservationDetails.java
@@ -1,7 +1,5 @@
 package edu.gemini.itc.shared;
 
-import edu.gemini.itc.shared.*;
-
 import java.io.Serializable;
 
 /**

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -17,13 +17,16 @@ import scalaz.{Failure, Success, Validation}
   * unfortunately there is some special handling involved for some of the instruments and therefore those files
   * are created by the recipes and then added to the result data as strings. Maybe this can be unified.
   */
-sealed trait ItcResult extends Serializable
+sealed trait ItcResult extends Serializable {
+  def source:     SourceDefinition
+  def obsDetails: ObservationDetails
+}
 
 // === IMAGING RESULTS
 
 final case class ImgData(singleSNRatio: Double, totalSNRatio: Double, peakPixelFlux: Double)
 
-final case class ItcImagingResult(source: SourceDefinition, ccds: Seq[ImgData]) extends ItcResult {
+final case class ItcImagingResult(source: SourceDefinition, obsDetails: ObservationDetails, ccds: Seq[ImgData]) extends ItcResult {
   def ccd(i: Int) = ccds(i % ccds.length)
 }
 
@@ -67,7 +70,7 @@ final case class SpcChartData(chartType: SpcChartType, title: String, xAxisLabel
   * Individual charts and data series can be referenced by their types and an index. For most instruments there
   * is only one chart and data series of each type, however for NIFS for example there will be several charts
   * of each type in case of multiple IFU elements. */
-final case class ItcSpectroscopyResult(source: SourceDefinition, charts: Seq[SpcChartData], files: Seq[SpcDataFile]) extends ItcResult {
+final case class ItcSpectroscopyResult(source: SourceDefinition, obsDetails: ObservationDetails, charts: Seq[SpcChartData], files: Seq[SpcDataFile]) extends ItcResult {
 
   /** Gets a text file for a data series by type and index.
     * This method will fail if the result you're looking for does not exist.

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -71,7 +71,7 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -67,7 +67,7 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             add(new SpcDataFile(SingleS2NData.instance(),  toFile(r, "Sin")));
             add(new SpcDataFile(FinalS2NData.instance(),   toFile(r, "Fin")));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
     }
 
     protected static String toFile(final SpectroscopyResult[] results, final String filename) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -91,7 +91,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
                 add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
             }
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
     }
 
     protected static String toFile(final VisitableSampledSpectrum[] sedArr) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
@@ -101,7 +101,7 @@ public final class MichelleRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -75,7 +75,7 @@ public final class NifsRecipe implements SpectroscopyRecipe {
                 add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[i].getFinalS2NSpectrum().printSpecAsString()));
             }
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
     }
 
     private SpectroscopyResult calculateSpectroscopy(final Nifs instrument) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -81,7 +81,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
     }
 
     private SpectroscopyResult calculateSpectroscopy(final Niri instrument) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
@@ -102,7 +102,7 @@ public final class TRecsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -29,10 +29,7 @@ class ItcServiceImpl extends ItcService {
     else                          calculateSpectroscopy(source, obs, cond, tele, ins)
 
   } catch {
-    // TODO: for now in most cases where a validation problem should be reported to the user the ITC code throws an exception instead
-    case e: Throwable =>
-      e.printStackTrace()
-      ItcResult.forException(e)
+    case e: Throwable => ItcResult.forException(e)
   }
 
   // === Imaging

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -53,7 +53,7 @@ class ItcServiceImpl extends ItcService {
     imagingResult(recipe.calculateImaging())
 
   private def imagingResult(r: Seq[ImagingResult]): Result =
-    ItcResult.forResult(ItcImagingResult(r.head.source, r.map(toImgData)))
+    ItcResult.forResult(ItcImagingResult(r.head.source, r.head.observation, r.map(toImgData)))
 
   private def toImgData(result: ImagingResult): ImgData = result.is2nCalc match {
     case i: ImagingS2NMethodACalculation  => ImgData(i.singleSNRatio(), i.totalSNRatio(), result.peakPixelCount)
@@ -86,7 +86,7 @@ class ItcServiceImpl extends ItcService {
   // a bit of bandwidth. If the need arises to have the files accessible in the clients just change this to
   // send the original result.
   private def resultWithoutFiles(result: ItcSpectroscopyResult): Result =
-    ItcResult.forResult(ItcSpectroscopyResult(result.source, result.charts, Seq()))
+    ItcResult.forResult(ItcSpectroscopyResult(result.source, result.obsDetails, result.charts, Seq()))
 
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
@@ -524,6 +524,11 @@ public final class Gsaoi extends SPInstObsComp implements PropertyProvider, Guid
         return Site.SET_GS;
     }
 
+    @Override
+    public double[] getScienceArea() {
+        return new double[]{85.0, 85.0};
+    }
+
     public String getPhaseIResourceName() {
         return "gemGSAOI";
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
@@ -1,10 +1,11 @@
 package jsky.app.ot.editor.seq
 
 import edu.gemini.itc.shared.{AnalysisMethod, ObservingConditions}
-import edu.gemini.pot.sp.{ISPObservation, SPComponentType}
+import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
 import edu.gemini.spModel.config2.ConfigSequence
+import edu.gemini.spModel.obscomp.SPInstObsComp
 import edu.gemini.spModel.target.env.TargetEnvironment
 import edu.gemini.spModel.target.system.HmsDegTarget
 import edu.gemini.spModel.target.{SpatialProfile, SpectralDistribution}
@@ -18,7 +19,7 @@ import Scalaz._
   * the outside world (EdIterFolder, ItcPanel etc) from the ItcTable and ItcTableModel. */
 trait ItcParametersProvider {
   def sequence: ConfigSequence
-  def instrument: Option[SPComponentType]
+  def instrument: Option[SPInstObsComp]
   def observation: Option[ISPObservation]
   def analysisMethod: String \/ AnalysisMethod
   def conditions: String \/ ObservingConditions
@@ -34,8 +35,8 @@ object ItcParametersProvider {
   /** Creates a parameters provider that can extract ITC values from a given EdIteratorFolder and ItcPanel. */
   def apply(owner: EdIteratorFolder, itcPanel: ItcPanel) = new ItcParametersProvider {
 
-    def instrument: Option[SPComponentType] =
-      Option(owner.getContextInstrument).map(_.getType)
+    def instrument: Option[SPInstObsComp] =
+      Option(owner.getContextInstrumentDataObject)
 
     def observation: Option[ISPObservation] =
       Option(owner.getContextObservation)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -110,11 +110,15 @@ trait ItcTable extends Table {
 
   }
 
-  protected def calculateSpectroscopy(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig): Future[ItcService.Result] =
-    calculate(peer, instrument, uc, srcFrac => SpectroscopySN(uc.count, uc.singleExposureTime, srcFrac))
+  protected def calculateSpectroscopy(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig): Future[ItcService.Result] = {
+    def method(srcFraction: Double) = SpectroscopySN(uc.count * instrument.getCoadds, uc.singleExposureTime, srcFraction)
+    calculate(peer, instrument, uc, method)
+  }
 
-  protected def calculateImaging(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig): Future[ItcService.Result] =
-    calculate(peer, instrument, uc, srcFrac => ImagingSN(uc.count, uc.singleExposureTime, srcFrac))
+  protected def calculateImaging(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig): Future[ItcService.Result] = {
+    def method(srcFraction: Double) = ImagingSN(uc.count * instrument.getCoadds, uc.singleExposureTime, srcFraction)
+    calculate(peer, instrument, uc, method)
+  }
 
   protected def calculate(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig, method: Double => CalculationMethod): Future[ItcService.Result] = {
     val s = for {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -22,8 +22,10 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.swing._
-import scalaz.Scalaz._
+
 import scalaz._
+import Scalaz._
+
 /**
  * A table to display ITC calculation results to users.
  */
@@ -262,7 +264,7 @@ trait ItcTable extends Table {
 
     // check how many images are "off-source" which is defined as having an offset > 1/2 the size of the fov
     // this is an educated guesstimate only; ROIs are not taken into account at all (yet)
-    val offSource = uc.configs.count { c =>
+    val offSource = uc.configs.toList.count { c =>
       val p = ConfigExtractor.extractDoubleFromString(c, TEL_P_KEY).getOrElse(0.0)
       val q = ConfigExtractor.extractDoubleFromString(c, TEL_Q_KEY).getOrElse(0.0)
       Math.abs(p) > w/2.0 || Math.abs(q) > h/2.0

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -13,13 +13,14 @@ import edu.gemini.spModel.gemini.trecs.{InstTReCS, TReCSParams}
 import edu.gemini.spModel.obscomp.InstConstants
 import jsky.app.ot.editor.seq.Keys._
 
-import scalaz.Scalaz._
+import scalaz._
+import Scalaz._
 
 /**
  * Unique configurations represent sets of observes in a sequence which are done with the same
  * instrument configuration and exposure times.
  */
-case class ItcUniqueConfig(count: Int, labels: String, configs: Seq[Config]) {
+case class ItcUniqueConfig(count: Int, labels: String, configs: NonEmptyList[Config]) {
 
   def config = configs.head
 
@@ -87,9 +88,9 @@ object ItcUniqueConfig {
   // Gets all "unique configs" (i.e. configs that are relevant for ITC) from the given sequence. The predicate
   // defines which steps have to be taken into account, i.e. spectroscopy vs imaging and no calibrations.
   private def uniqueConfigs(seq: ConfigSequence, predicate: Config => Boolean): Seq[ItcUniqueConfig] = {
-    val steps        = seq.getAllSteps.toSeq.filter(predicate)
-    val groupedSteps = steps.groupBy(hash).toSeq
-    val mappedSteps  = groupedSteps.map { case (h, cs) => ItcUniqueConfig(cs.size, labels(cs), cs) }
+    val steps        = seq.getAllSteps.toList.filter(predicate)
+    val groupedSteps = steps.groupBy(hash).toList
+    val mappedSteps  = groupedSteps.map { case (h, cs) => ItcUniqueConfig(cs.size, labels(cs), NonEmptyList(cs.head, cs:_*)) }
     mappedSteps.sortBy(_.config.getItemValue(DATALABEL_KEY).toString)
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -90,7 +90,7 @@ object ItcUniqueConfig {
   private def uniqueConfigs(seq: ConfigSequence, predicate: Config => Boolean): Seq[ItcUniqueConfig] = {
     val steps        = seq.getAllSteps.toList.filter(predicate)
     val groupedSteps = steps.groupBy(hash).toList
-    val mappedSteps  = groupedSteps.map { case (h, cs) => ItcUniqueConfig(cs.size, labels(cs), NonEmptyList(cs.head, cs:_*)) }
+    val mappedSteps  = groupedSteps.map { case (h, cs) => ItcUniqueConfig(cs.size, labels(cs), NonEmptyList(cs.head, cs.tail:_*)) }
     mappedSteps.sortBy(_.config.getItemValue(DATALABEL_KEY).toString)
   }
 


### PR DESCRIPTION
In order to calculate the resulting S/N it is important to know the fraction of "on-source" vs "off-source" images. ITC uses a guesstimation algorithm as follows: take the FOV / science area of the instrument and check if  ```p-offset > 0.5*width or q-offset > 0.5*height```, if so, the image is considered to be off-source and on-source otherwise.

The science area returned by the instruments already takes into account that the FOV for spectroscopy is actually reduced to the slit width of the mask, which is precisely what we need here.

Note that I added a 85"x85" science area to the GSAOI instrument, replacing the default of -1"x-1". Tests are all still ok.

I also piggy-backed a small change on top of this one which deals with taking co-adds into account for NIRI and GSAOI (OCSADV-346).