### PR TITLE
REL-2327: Remove OT "Archives" menu

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/resources/jsky/catalog/osgi/skycat.cfg
+++ b/bundle/edu.gemini.catalog/src/main/resources/jsky/catalog/osgi/skycat.cfg
@@ -135,25 +135,6 @@ search_cols:    m1 {m1} : m2 {m2}
 skyobj_factory: edu.gemini.catalog.skycat.binding.skyobj.Gsc2EsoSkyObjectFactory
 
 #
-serv_type:      archive
-long_name:      HST Archive at CADC
-short_name:     hst@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/hst-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:		ra plus 2
-#
-serv_type:      archive
-long_name:      CFHT Archive at CADC
-short_name:     cfht@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/cfht-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         ra plus 3
-copyright:      Preview data provided courtesy of CADC/DAO/NRC
-#
-serv_type:      archive
-long_name:      NTT Archive at ESO
-short_name:     ntt@eso
-url:            http://archive.eso.org/skycat/servers/ntt-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         ra plus 4
-#
 serv_type:      catalog
 long_name:      PPM at ESO
 short_name:     ppm@eso

--- a/bundle/edu.gemini.catalog/src/main/resources/resources/conf/AstroCat.xml
+++ b/bundle/edu.gemini.catalog/src/main/resources/resources/conf/AstroCat.xml
@@ -26,12 +26,6 @@
   <catalog name="GSC-2 at ESO"/>
   <catalog name="GSC-2 at STScI"/>
 
-<!-- Skycat Archives (should be defined in the skycat.cfg file) -->
-
-  <catalog name="CFHT Archive at CADC"/>
-  <catalog name="HST Archive at CADC"/>
-  <catalog name="NTT Archive at ESO"/>
-
 <!-- Skycat Image Servers (should be defined in the skycat.cfg file) -->
   <catalog name="Digitized Sky at Gemini North"/>
   <catalog name="Digitized Sky at Gemini South"/>

--- a/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorCatalogMenu.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorCatalogMenu.java
@@ -43,9 +43,6 @@ public class NavigatorCatalogMenu extends JMenu implements TreeModelListener {
     /** Catalog submenu */
     private JMenu _catalogMenu;
 
-    /** Archive submenu */
-    private JMenu _archiveMenu;
-
     /** Image server submenu */
     private JMenu _imageServerMenu;
 
@@ -95,8 +92,6 @@ public class NavigatorCatalogMenu extends JMenu implements TreeModelListener {
         dir.addTreeModelListener(this);
 
         _catalogMenu = _createCatalogSubMenu(this, _catalogMenu, true, dir, Catalog.CATALOG, _I18N.getString("catalogs"));
-
-        _archiveMenu = _createCatalogSubMenu(this, _archiveMenu, true, dir, Catalog.ARCHIVE, _I18N.getString("archives"));
 
         _imageServerMenu = _createCatalogSubMenu(this, _imageServerMenu, true, dir, Catalog.IMAGE_SERVER, _I18N.getString("imageServers"));
 


### PR DESCRIPTION
Small PR that removes the "Archives" menu from the Position Editor
A bunch of code could be removed right away, but it will be easier to do when we do the full replacement of the skycat queries