### PR TITLE
REL-2310: Remote RPM building

### DIFF
--- a/app/ot/build.sbt
+++ b/app/ot/build.sbt
@@ -1,7 +1,9 @@
 
 import OcsKeys._
+import edu.gemini.osgi.tools.Version
 import edu.gemini.osgi.tools.app.{ Configuration => AppConfig, _ }
 import edu.gemini.osgi.tools.app.Configuration.Distribution.{ Test => TestDistro, _ }
+import OcsCredentials.Ot._
 
 ocsAppSettings
 
@@ -67,7 +69,7 @@ def common(version: Version) = AppConfig(
     BundleSpec("org.apache.commons.logging",   Version(1, 1, 0))
   ),
   spec = Some(file("app/ot/dist/RPM64/ot.spec.template"))
-) extending List()
+) extending List(common_credentials(version))
 
 // WITH-TEST-DBS
 def with_test_dbs(version: Version) = AppConfig(

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/AppBuilder.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/AppBuilder.scala
@@ -63,7 +63,7 @@ class AppBuilder(rootDir: File, solver: Configuration => Map[BundleSpec, (File, 
               rm(f)
             mkdir(dDir, c.id)
           }
-          b.build(cDir, jreDir, app.meta, v, c, d, solver(c), appProjectBaseDir)
+          b.build(cDir, jreDir, app.meta, v, c, d, solver(c), log, appProjectBaseDir)
         case None => log.warn("no application builder is available for distribution platform " + d)
       }
 
@@ -73,7 +73,7 @@ class AppBuilder(rootDir: File, solver: Configuration => Map[BundleSpec, (File, 
 
 trait DistHandler {
 
-  def build(outDir: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Distribution, solution: Map[BundleSpec, (File, Manifest)], appProjectBaseDir: File): Unit
+  def build(outDir: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Distribution, solution: Map[BundleSpec, (File, Manifest)], log: sbt.Logger, appProjectBaseDir: File): Unit
 
   protected def buildCommon(rootDir: File, meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], appProjectBaseDir: File) {
 

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
@@ -7,6 +7,8 @@ object Configuration {
     val Test, MacOS, Windows, Linux32, Linux64, RPM64 /*, Solaris */ = Value
   }
   type Distribution = this.Distribution.Value
+
+  case class HostInfo(hostname: String, username: String, password: String, port: Int = 22, timeout: Int = 5000)
 }
 
 case class Configuration(
@@ -20,6 +22,7 @@ case class Configuration(
   log: Option[String] = None,
   script: Option[File] = None,
   spec: Option[File] = None,
+  remoteBuildInfo: Option[Configuration.HostInfo] = None,
   extending: List[Configuration] = Nil) {
 
   // Default; this can be overridden in instances
@@ -43,6 +46,7 @@ case class Configuration(
     props = c.props ++ props,
     log = log.orElse(c.log),
     spec = spec.orElse(c.spec),
+    remoteBuildInfo = remoteBuildInfo.orElse(c.remoteBuildInfo),
     extending = extending :+ c
   )
 

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
@@ -8,7 +8,7 @@ object Configuration {
   }
   type Distribution = this.Distribution.Value
 
-  case class HostInfo(hostname: String, username: String, password: String, port: Int = 22, timeout: Int = 5000)
+  case class HostInfo(hostname: String, username: String, password: String, port: Int = 22, timeout: Int = 15000)
 }
 
 case class Configuration(

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/GenericUnixDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/GenericUnixDistHandler.scala
@@ -6,7 +6,7 @@ import java.util.jar.Manifest
 
 class GenericUnixDistHandler(compress: Boolean, jre: Option[String]) extends DistHandler {
 
-  def build(wd: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], appProjectBaseDir: File) {
+  def build(wd: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], log: sbt.Logger, appProjectBaseDir: File) {
 
     // Work in a subdir if we're compressing
     val scriptName = meta.executableName(version)

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
@@ -14,7 +14,7 @@ object MacDistHandler {
 
 case class MacDistHandler(jre: Option[String], jreName: String) extends DistHandler {
 
-  def build(outDir: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], appProjectBaseDir: File) {
+  def build(outDir: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], log: sbt.Logger, appProjectBaseDir: File) {
 
     // Output dirs
     val name = meta.osxVisibleName(version)
@@ -63,8 +63,8 @@ case class MacDistHandler(jre: Option[String], jreName: String) extends DistHand
     val args = Array("hdiutil", "create", "-srcfolder", appDir.getPath, "-volname", volname, dest)
     val result = Runtime.getRuntime.exec(args).waitFor()
     if (result != 0) {
-      println("*** " + args.mkString(" "))
-      println("*** HDIUTIL RETURNED " + result)
+      log.error("*** " + args.mkString(" "))
+      log.error("*** HDIUTIL RETURNED " + result)
     }
 
     // And remove the app

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/RPMDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/RPMDistHandler.scala
@@ -1,5 +1,9 @@
 package edu.gemini.osgi.tools.app
 
+//import OcsCredentials._
+
+import com.jcraft.jsch.{JSch, Session, ChannelExec, ChannelSftp, SftpException}
+
 import java.io.{ File, PrintWriter, InputStream, FileInputStream, FilterInputStream }
 import java.nio.file.{Paths, Files, StandardCopyOption}
 import java.nio.charset.StandardCharsets
@@ -7,28 +11,21 @@ import scala.io.Source
 
 import java.util.jar.Manifest
 import scala.collection.JavaConversions._
+import scala.collection.mutable.StringBuilder
 
 class RPMDistHandler(jre: Option[String]) extends DistHandler {
 
-  def build(wd: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], appProjectBaseDir: File) {
+  def build(wd: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], log: sbt.Logger, appProjectBaseDir: File) {
     // Work in a subdir if we're compressing
-    val scriptName = meta.executableName(version)
-    val name = "%s_%s".format(meta.executableName(version), d.toString.toLowerCase)
+    val execName = meta.executableName(version)
+    val name = "%s_%s".format(execName, d.toString.toLowerCase)
     val outDir = mkdir(wd, name)
-
-    // Due to permission issues and limitations on rpmbuild we need to override .rpmmacros
-    val rpmbuild = wd // Hardcoded to avoid permission issues
-    // Set topdir and prevent the binary stripping step on RPM creation
-    val rpmmacros = s"%_topdir $rpmbuild\n%__os_install_post %{nil}\n"
-
-    // Overwrite it, it changes per project
-    val rpmmacrosFiles = new File(System.getProperty("user.home"), ".rpmmacros")
-    Files.write(rpmmacrosFiles.toPath, rpmmacros.getBytes(StandardCharsets.UTF_8))
 
     // Common part
     buildCommon(outDir, meta, version, config, d, solution, appProjectBaseDir)
 
     // Shell script
+    val scriptName = execName
     config.script foreach { s => copy(s, outDir) }
     if (config.script.isEmpty) {
       val unixFile = new File(outDir, scriptName)
@@ -82,17 +79,70 @@ class RPMDistHandler(jre: Option[String]) extends DistHandler {
     val ret = proc.waitFor
     if (ret != 0) sys.error("tar returned " + ret)
 
-    // Now create the RPM
+    // The RPM spec file.
     val specPath = new File(wd, "rpm.spec")
-    val rpmArgs = Array("rpmbuild", "-bb", s"${specPath.getAbsolutePath}")
-    val result = Runtime.getRuntime.exec(rpmArgs).waitFor()
-    if (result != 0) {
-      println("*** " + rpmArgs.mkString(" "))
-      println("*** rpmbuild returned " + result)
+
+    // Set up an SSH connection to the Linux VM where rpmbuild will be run.
+    if (config.remoteBuildInfo.isEmpty)
+      log.error("no remote build info: update OcsCredentials?")
+    val remoteBuildInfo = config.remoteBuildInfo.get
+
+    log.info(s"establishing ssh session to ${remoteBuildInfo.hostname}")
+    JSch.setConfig("StrictHostKeyChecking", "no")
+    val session = new JSch().getSession(remoteBuildInfo.username, remoteBuildInfo.hostname, remoteBuildInfo.port)
+    session.setPassword(remoteBuildInfo.password)
+    session.setTimeout(remoteBuildInfo.timeout)
+    session.connect
+
+    // Create an SFTP session to transfer to / from Linux VM.
+    val rpmBuildDir = "rpmbuild"
+    log.info("opening sftp channel")
+    val sftp = session.openChannel("sftp").asInstanceOf[ChannelSftp]
+    sftp.connect(remoteBuildInfo.timeout)
+
+    // ChannelSftp.mkdir fails with an SftpException if a directory already exists: handle this by allowing this exception.
+    def rmkdir(dir: String): Unit =
+      try {
+	sftp.mkdir(dir)
+      } catch {
+	case e: SftpException =>
+      }
+
+    log.info("creating remote directories")
+    rmkdir(rpmBuildDir)
+    sftp.cd(rpmBuildDir)
+    rmkdir("SOURCES")
+
+    log.info("copying tarball")
+    sftp.put(archiveName.getAbsolutePath, s"SOURCES/${name}.tar.gz")
+
+    log.info("copying rpm spec file")
+    sftp.put(specPath.getAbsolutePath, "rpm.spec")
+
+    // Remote execution of rpmbuild.
+    // Note that this will not work for '-test' releases, as rpmbuild does not accept '-' characters in versions.
+    log.info("opening ssh channel")
+    val ssh = session.openChannel("exec").asInstanceOf[ChannelExec]
+    val cmd = s"cd $rpmBuildDir && rpmbuild -bb rpm.spec"
+    ssh.setCommand(cmd)
+
+    log.info("executing rpmbuild")
+    ssh.connect(remoteBuildInfo.timeout)
+
+    // Retrieve the constructed RPMs.
+    log.info("retrieving rpm")
+    val rpmOutputDir = mkdir(wd, "RPMS")
+    sftp.cd("RPMS")
+    val appName = execName.substring(0, execName.indexOf("_"))
+    sftp.ls(s"${appName}*.rpm").foreach { f =>
+      val fStr           = f.toString
+      val sourceFilename = fStr.substring(fStr.lastIndexOf(" ")+1)
+      val destFilename   = new File(rpmOutputDir, sourceFilename).toPath.toString
+      sftp.get(sourceFilename, destFilename)
     }
 
     // Move the rpm back to wd
-    val rpms = Files.newDirectoryStream(new File(rpmbuild, "RPMS").toPath, "*.rpm")
+    val rpms = Files.newDirectoryStream(new File(wd, "RPMS").toPath, "*.rpm")
     rpms.iterator.foreach { f =>
        Files.move(f, wd.getParentFile.toPath.resolve(f.getFileName), StandardCopyOption.REPLACE_EXISTING)
     }

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/WinDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/WinDistHandler.scala
@@ -7,7 +7,7 @@ import java.util.jar.Manifest
 
 object WinDistHandler extends DistHandler {
 
-  def build(wd: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], appProjectBaseDir: File) {
+  def build(wd: File, jreDir: Option[File], meta: ApplicationMeta, version:String, config: Configuration, d: Configuration.Distribution, solution: Map[BundleSpec, (File, Manifest)], log: sbt.Logger, appProjectBaseDir: File) {
 
     // Vals in this class attempt to mirror those in proj/ot/appbuild.xml as closely as is reasonable
 
@@ -16,7 +16,7 @@ object WinDistHandler extends DistHandler {
 
     // Some helpers
     def exec(as: String*) {
-      //println("> " + as.mkString(" "))
+      //log.info("> " + as.mkString(" "))
       val ret = Runtime.getRuntime.exec(as.toArray, null, wd).waitFor()
       if (ret != 0)
         sys.error("Process returned %d: %s".format(ret, as.mkString(" ")))


### PR DESCRIPTION
Now builds OCS RPMs remotely.
NOTE: this requires an update to your OcsCredentials file, which must be checked out of the Gemini svn repository.