### PR TITLE
REL-2322: always show the pos angle triangle

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/SciAreaPlotFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/SciAreaPlotFeature.scala
@@ -91,8 +91,10 @@ class SciAreaPlotFeature(sciArea: ScienceAreaGeometry)
   // science area figure pointing away from the base.  It isn't scaled with
   // the image but rather should always be an absolute size.  For that reason
   // it is created and transformed here.
+  // Note, the site quality conditions are irrelevant so we supply nominal
+  // conditions here rather than risk not having an ObsContext to work with.
   def tickMarkFigure(tpeCtx: TpeContext, tii: TpeImageInfo): Option[Figure] =
-    tpeCtx.obsContext.map { obsCtx =>
+    tpeCtx.obsContextWithConditions(SPSiteQuality.Conditions.NOMINAL).map { obsCtx =>
       val yRaw  = sciArea.unadjustedGeometry(obsCtx).fold(0.0) { _.getBounds2D.getMinY }
       val y     = (yRaw * tii.getPixelsPerArcsec) min -30.0
       val tick  = tickMark(new Point2D.Double(0, y))


### PR DESCRIPTION
This is a bug fix for a problem in which the position angle triangle plotted in the TPE would disappear unless the observation has site quality / observing conditions.  Ordinarily if an important part of an observation is missing we cannot construct an `ObsContext`.  In this case though the observing conditions are irrelevant so we simply provide them to allow the construction of `ObsContext` even without the site quality node.