### PR TITLE
OCSADV-350: target conversion updates

### DIFF
--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
@@ -40,6 +40,7 @@ object To2015B {
   val PARAM_DEC        = "c2"
   val PARAM_DELTA_RA   = "pm1"
   val PARAM_DELTA_DEC  = "pm2"
+  val PARAM_EPOCH      = "epoch"
   val PARAM_NOTE_TEXT  = "NoteText"
   val PARAM_NAME       = "name"
   val PARAM_BRIGHTNESS = "brightness"
@@ -67,6 +68,7 @@ object To2015B {
   val UNITS_SECONDS_PER_YEAR          = "seconds/year"
   val UNITS_ARCSECONDS_PER_YEAR       = "arcsecs/year"
   val UNITS_MILLI_ARCSECONDS_PER_YEAR = "milli-arcsecs/year"
+  val UNITS_YEARS                     = "years"
 
   val SYS_ASA_MAJOR_PLANET = "AsA major planet"
   val SYS_ASA_MINOR_PLANET = "AsA minor planet"
@@ -125,10 +127,11 @@ object To2015B {
     } {
 
       // Params
-      val pRa   = ps.getParam(PARAM_RA)
-      val pDec  = ps.getParam(PARAM_DEC)
-      val pdRa  = ps.getParam(PARAM_DELTA_RA)
-      val pdDec = ps.getParam(PARAM_DELTA_DEC)
+      val pRa    = ps.getParam(PARAM_RA)
+      val pDec   = ps.getParam(PARAM_DEC)
+      val pdRa   = ps.getParam(PARAM_DELTA_RA)
+      val pdDec  = ps.getParam(PARAM_DELTA_DEC)
+      val pEpoch = ps.getParam(PARAM_EPOCH)
 
       // Get coords in degrees and PM in degrees/yr
       val ra   = parseHmsOrDegrees(pRa.getValue).unsafeExtract
@@ -146,8 +149,9 @@ object To2015B {
       pdRa.setUnits(UNITS_MILLI_ARCSECONDS_PER_YEAR)
       pdDec.setValue((dDec0 * 1000 * 60 * 60).toString)
       pdDec.setUnits(UNITS_MILLI_ARCSECONDS_PER_YEAR)
+      pEpoch.setValue("2000")
+      pEpoch.setUnits(UNITS_YEARS)
       pSys.setValue(VALUE_SYSTEM_J2000)
-
     }
 
   }

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2015B/GS-2015B-T-1.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2015B/GS-2015B-T-1.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
 
 <document>
-  <container kind="program" type="Program" version="2015A-1" subtype="basic" key="faff97c2-6d6b-4b64-82f5-254317c66ae1" name="GS-2013B-Q-29">
+  <container kind="program" type="Program" version="2015A-1" subtype="basic" key="340289cd-a6c1-4802-9de7-aa6bcc4e305b" name="GS-2015B-T-1">
     <paramset name="Science Program" kind="dataObj">
       <param name="title" value="Template Target Import Test"/>
       <param name="programMode" value="QUEUE"/>
@@ -26,12 +26,11 @@
         </paramset>
       </paramset>
       <param name="awardedTime" value="3.5" units="hours"/>
-      <param name="minimumTime" value="0.75" units="hours"/>
       <param name="fetched" value="yes"/>
       <param name="completed" value="true"/>
       <param name="notifyPi" value="YES"/>
     </paramset>
-    <container kind="templateFolder" type="Template" version="2015A-1" subtype="Folder" key="d013a162-3ecf-4f6b-b9e5-ca54d6b21474" name="Template Folder">
+    <container kind="templateFolder" type="Template" version="2015A-1" subtype="Folder" key="4c445a8a-86e9-4816-877f-2a62d3d26ce7" name="Template Folder">
       <paramset name="Template Folder" kind="dataObj">
         <param name="title" value="Templates"/>
         <paramset name="gmosSBlueprintImaging">
@@ -47,7 +46,7 @@
           <param name="templateFolderMapKey" value="blueprint-1"/>
         </paramset>
       </paramset>
-      <container kind="templateGroup" type="Template" version="2015A-1" subtype="Group" key="7e20ba44-eab3-4ae9-8b16-f6792bb3f071" name="Template Group">
+      <container kind="templateGroup" type="Template" version="2015A-1" subtype="Group" key="eda1cef8-1ea4-473d-8641-76748bb58b3e" name="Template Group">
         <paramset name="Template Group" kind="dataObj">
           <param name="title" value="GMOS-S Imaging g_G0325+r_G0326+i_G0327"/>
           <param name="blueprint" value="blueprint-1"/>
@@ -55,17 +54,17 @@
           <param name="versionToken" value="1"/>
           <param name="versionTokenNext" value="1"/>
         </paramset>
-        <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="8691d0a5-5689-4090-8cec-1ca13769f93a" name="GS-2013B-Q-29-1">
+        <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="c1c77e02-59dc-42d3-a311-219dab3687c5" name="GS-2015B-T-1-2">
           <paramset name="Observation" kind="dataObj">
             <param name="title" value="Imaging"/>
             <param name="libraryId" value=""/>
             <param name="priority" value="HIGH"/>
-            <param name="tooOverrideRapid" value="true"/>
+            <param name="tooOverrideRapid" value="false"/>
             <param name="phase2Status" value="PI_TO_COMPLETE"/>
             <param name="qaState" value="UNDEFINED"/>
             <param name="overrideQaState" value="false"/>
           </paramset>
-          <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="955a0ce7-10eb-43c3-a515-9c759882f2ea" name="GMOS-S">
+          <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="3ced6baa-1c43-46f6-9c3c-cabaa0e2a1e5" name="GMOS-S">
             <paramset name="GMOS-S" kind="dataObj">
               <param name="exposureTime" value="60.0"/>
               <param name="posAngle" value="0"/>
@@ -94,12 +93,12 @@
               <param name="mosPreimaging" value="NO"/>
             </paramset>
           </container>
-          <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e9611c7f-2d29-4f56-b3f2-5a7d8cbc87f9" name="Observing Log">
+          <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="973ac9b9-817f-44f7-8dd9-535c000e6e1d" name="Observing Log">
             <paramset name="Observing Log" kind="dataObj">
               <paramset name="obsQaRecord"/>
             </paramset>
           </container>
-          <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="49a7e9a2-a0c8-4f3a-8cba-76bcea22d913" name="Observation Exec Log">
+          <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="7354edd7-036c-4ad6-b4c1-f633ce87de2f" name="Observation Exec Log">
             <paramset name="Observation Exec Log" kind="dataObj">
               <paramset name="obsExecRecord">
                 <paramset name="datasets"/>
@@ -108,9 +107,9 @@
               </paramset>
             </paramset>
           </container>
-          <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="e3e553bf-3928-4589-8d04-9839c0c61447" name="Sequence">
+          <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c791aae8-d694-4035-b0fd-e08b2f880e4a" name="Sequence">
             <paramset name="Sequence" kind="dataObj"/>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOSSouth" key="9309f5ee-e2ae-4f31-8259-de3032e1449f" name="GMOS-S Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOSSouth" key="e22b5454-3ed1-4162-92a0-e7a73dfc0254" name="GMOS-S Sequence">
               <paramset name="GMOS-S Sequence" kind="dataObj">
                 <param name="exposureTime">
                   <value sequence="0">60.0</value>
@@ -123,7 +122,7 @@
                   <value sequence="2">i_G0327</value>
                 </param>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="d61097e7-8c5f-40f2-b320-d895c493bd40" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="58da0bd6-c0ff-43e2-bc9b-ad9d20de1266" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <paramset name="offsets">
                     <paramset name="Offset1" sequence="0">
@@ -148,7 +147,7 @@
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="37ef38aa-2390-4fba-89d4-45c0f8c9e726" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="7e2cf6c9-1c66-4af5-bf24-3f1cc85e2e97" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="SCIENCE"/>
@@ -158,7 +157,7 @@
             </container>
           </container>
         </container>
-        <container kind="templateParameters" type="Template" version="2015A-1" subtype="Parameters" key="fda5aed1-ca32-4928-881a-5d4cfe113d4d" name="Template Parameters">
+        <container kind="templateParameters" type="Template" version="2015A-1" subtype="Parameters" key="46fcf682-2d79-4c3b-90b7-92c7168f5d2d" name="Template Parameters">
           <paramset name="Template Parameters" kind="dataObj">
             <param name="title" value="Template Parameters"/>
             <paramset name="spTarget">
@@ -192,7 +191,7 @@
           </paramset>
         </container>
       </container>
-      <container kind="templateGroup" type="Template" version="2015A-1" subtype="Group" key="587a9941-9bfa-4cdd-989d-02215c4c26fd" name="Template Group">
+      <container kind="templateGroup" type="Template" version="2015A-1" subtype="Group" key="700f0711-b16d-4d6a-9359-7a92da0455ff" name="Template Group">
         <paramset name="Template Group" kind="dataObj">
           <param name="title" value="GMOS-S Imaging r_G0326"/>
           <param name="blueprint" value="blueprint-0"/>
@@ -200,17 +199,17 @@
           <param name="versionToken" value="2"/>
           <param name="versionTokenNext" value="1"/>
         </paramset>
-        <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="d6da3a4e-23f6-4cdc-9699-037e6aa06c15" name="GS-2013B-Q-29-2">
+        <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="db20cca0-2b0c-442e-b66d-f20d632b5016" name="GS-2015B-T-1-3">
           <paramset name="Observation" kind="dataObj">
             <param name="title" value="Imaging"/>
             <param name="libraryId" value=""/>
             <param name="priority" value="HIGH"/>
-            <param name="tooOverrideRapid" value="true"/>
+            <param name="tooOverrideRapid" value="false"/>
             <param name="phase2Status" value="PI_TO_COMPLETE"/>
             <param name="qaState" value="UNDEFINED"/>
             <param name="overrideQaState" value="false"/>
           </paramset>
-          <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="bf6ab53a-37f0-4d9e-b5a6-01e2d1f76ad6" name="GMOS-S">
+          <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="97a4f2b5-d6af-457a-8bb3-0d24035d16c0" name="GMOS-S">
             <paramset name="GMOS-S" kind="dataObj">
               <param name="exposureTime" value="40.0"/>
               <param name="posAngle" value="0"/>
@@ -239,12 +238,12 @@
               <param name="mosPreimaging" value="NO"/>
             </paramset>
           </container>
-          <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e770b68b-46b9-434b-908f-1afd821a3a14" name="Observing Log">
+          <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="0c68d17b-9199-4d18-b658-26ae7e6eab05" name="Observing Log">
             <paramset name="Observing Log" kind="dataObj">
               <paramset name="obsQaRecord"/>
             </paramset>
           </container>
-          <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="27b71291-bc1b-4600-8ea1-cb3c5d7957e6" name="Observation Exec Log">
+          <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="750b13f5-9a1f-4558-8bce-fd79ada96a86" name="Observation Exec Log">
             <paramset name="Observation Exec Log" kind="dataObj">
               <paramset name="obsExecRecord">
                 <paramset name="datasets"/>
@@ -253,14 +252,14 @@
               </paramset>
             </paramset>
           </container>
-          <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="522ca593-c5cd-4456-93c2-c3933655712e" name="Sequence">
+          <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="1a6e8f1a-95dc-4557-ba10-976514d1c9a8" name="Sequence">
             <paramset name="Sequence" kind="dataObj"/>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOSSouth" key="6301c077-a106-4ba7-8f41-4f983254a08f" name="GMOS-S Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOSSouth" key="276c0850-6f02-4e0b-a4d3-753bf609f7b9" name="GMOS-S Sequence">
               <paramset name="GMOS-S Sequence" kind="dataObj">
                 <param name="exposureTime" value="40.0"/>
                 <param name="filter" value="r_G0326"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="4ce4abb7-0fde-4f98-a2aa-48d8c3c0beac" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="77e58d2c-4fb7-48c5-bbd8-b42f2f05ddb2" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <paramset name="offsets">
                     <paramset name="Offset1" sequence="0">
@@ -285,7 +284,7 @@
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="0bb11920-30e5-425b-b928-6526c06d6f4b" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="eab007a5-0139-435c-adda-72e99ddfe06f" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="SCIENCE"/>
@@ -295,7 +294,7 @@
             </container>
           </container>
         </container>
-        <container kind="templateParameters" type="Template" version="2015A-1" subtype="Parameters" key="c21f31fe-7193-4a00-be8d-0e192222d9a8" name="Template Parameters">
+        <container kind="templateParameters" type="Template" version="2015A-1" subtype="Parameters" key="ec18134b-1a09-4644-87c7-63d3a39115ad" name="Template Parameters">
           <paramset name="Template Parameters" kind="dataObj">
             <param name="title" value="Template Parameters"/>
             <paramset name="spTarget">
@@ -324,7 +323,7 @@
             <param name="time" value="3600000"/>
           </paramset>
         </container>
-        <container kind="templateParameters" type="Template" version="2015A-1" subtype="Parameters" key="0ff683aa-6f34-42a7-a300-6719256134d3" name="Template Parameters">
+        <container kind="templateParameters" type="Template" version="2015A-1" subtype="Parameters" key="75461c4e-7351-42aa-8a71-33a8bec06fe7" name="Template Parameters">
           <paramset name="Template Parameters" kind="dataObj">
             <param name="title" value="Template Parameters"/>
             <paramset name="spTarget">
@@ -359,7 +358,222 @@
         </container>
       </container>
     </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="68f361a8-f54c-4cc0-a412-6ab457b2ef66" name="GS-2015B-T-1-1">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="Rigel"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="a6ab8fa2-1a29-4310-ae74-bbc06faf7ba3" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="7b49376b-cf64-444b-b27e-4812fefc40b6" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="Rigel"/>
+              <param name="system" value="B1950"/>
+              <param name="epoch" value="1950.0" units="years"/>
+              <param name="brightness" value=""/>
+              <param name="c1" value="05:12:07.990"/>
+              <param name="c2" value="-08:15:28.60"/>
+              <param name="pm1" value="-1.72" units="milli-arcsecs/year"/>
+              <param name="pm2" value="1.27" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="arcsecs"/>
+              <param name="rv" value="0.0" units="km/sec"/>
+              <param name="wavelength" value="-1.0" units="angstroms"/>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="active">
+                <value sequence="0">GMOS OIWFS</value>
+                <value sequence="1">PWFS1</value>
+                <value sequence="2">PWFS2</value>
+              </param>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="158d441e-d25b-472c-b957-d72dbdb4c0cf" name="GMOS-S">
+        <paramset name="GMOS-S" kind="dataObj">
+          <param name="exposureTime" value="300.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <paramset name="parallacticAngleDuration">
+            <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
+            <param name="explicitDuration" value="0"/>
+          </paramset>
+          <param name="adc" value="NONE"/>
+          <param name="ampCount" value="TWELVE"/>
+          <param name="gainChoice" value="LOW"/>
+          <param name="ampReadMode" value="SLOW"/>
+          <param name="detectorManufacturer" value="HAMAMATSU"/>
+          <param name="disperser" value="MIRROR"/>
+          <param name="fpuMode" value="BUILTIN"/>
+          <param name="fpu" value="FPU_NONE"/>
+          <param name="filter" value="NONE"/>
+          <param name="ccdXBinning" value="ONE"/>
+          <param name="ccdYBinning" value="ONE"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="stageMode" value="FOLLOW_XYZ"/>
+          <param name="dtaXOffset" value="ZERO"/>
+          <param name="builtinROI" value="FULL_FRAME"/>
+          <param name="useNS" value="FALSE"/>
+          <param name="mosPreimaging" value="NO"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="18f0de17-4cf9-4d99-a98a-21f79f4a5309" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="9d44372a-ad96-4e5b-acea-3503c466903e" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="6e7d8887-192c-41c8-92af-621c43b38149" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
   </container>
   <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="eab007a5-0139-435c-adda-72e99ddfe06f"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e22b5454-3ed1-4162-92a0-e7a73dfc0254"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="6e7d8887-192c-41c8-92af-621c43b38149"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="db20cca0-2b0c-442e-b66d-f20d632b5016"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="158d441e-d25b-472c-b957-d72dbdb4c0cf"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="18f0de17-4cf9-4d99-a98a-21f79f4a5309"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3ced6baa-1c43-46f6-9c3c-cabaa0e2a1e5"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4c445a8a-86e9-4816-877f-2a62d3d26ce7"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="700f0711-b16d-4d6a-9359-7a92da0455ff"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="75461c4e-7351-42aa-8a71-33a8bec06fe7"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="58da0bd6-c0ff-43e2-bc9b-ad9d20de1266"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="68f361a8-f54c-4cc0-a412-6ab457b2ef66"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="9"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c1c77e02-59dc-42d3-a311-219dab3687c5"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1a6e8f1a-95dc-4557-ba10-976514d1c9a8"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="340289cd-a6c1-4802-9de7-aa6bcc4e305b"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="97a4f2b5-d6af-457a-8bb3-0d24035d16c0"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="9d44372a-ad96-4e5b-acea-3503c466903e"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="750b13f5-9a1f-4558-8bce-fd79ada96a86"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="77e58d2c-4fb7-48c5-bbd8-b42f2f05ddb2"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="a6ab8fa2-1a29-4310-ae74-bbc06faf7ba3"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c791aae8-d694-4035-b0fd-e08b2f880e4a"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="7354edd7-036c-4ad6-b4c1-f633ce87de2f"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="7b49376b-cf64-444b-b27e-4812fefc40b6"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="27"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="46fcf682-2d79-4c3b-90b7-92c7168f5d2d"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="973ac9b9-817f-44f7-8dd9-535c000e6e1d"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="276c0850-6f02-4e0b-a4d3-753bf609f7b9"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ec18134b-1a09-4644-87c7-63d3a39115ad"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="eda1cef8-1ea4-473d-8641-76748bb58b3e"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="0c68d17b-9199-4d18-b658-26ae7e6eab05"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="7e2cf6c9-1c66-4af5-bf24-3f1cc85e2e97"/>
+      <param name="03ca3870-c819-4429-a29b-1bbd22d6f2ee" value="1"/>
+    </paramset>
   </container>
 </document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
@@ -110,11 +110,16 @@ class TargetConversionTest {
     val dra   = rigel.getPropMotionRA
     val ddec  = rigel.getPropMotionDec
     val epoch = rigel.getEpoch.getValue
-    
+
     assertEquals("05:14:32.269", (new HMSFormat).format(ra))
     assertEquals("-08:12:05.86", (new DMSFormat).format(dec))
     assertEquals("1.30", f"$dra%.2f")
     assertEquals("0.50", f"$ddec%.2f")
     assertEquals(2000.0000, epoch, 0.0000001)
+
+    // Check for the note.
+    val noteComp = obs.getObsComponents.asScala.find(_.getType == SPComponentType.INFO_NOTE).get
+    val text     = noteComp.getDataObject.asInstanceOf[SPNote].getNote
+    assertTrue(text.contains("Rigel"))
   }
 }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
@@ -1,11 +1,12 @@
 package edu.gemini.spModel.io.impl.migration.to2015B
 
 import edu.gemini.spModel.obscomp.SPNote
-import edu.gemini.spModel.target.system.{NonSiderealTarget, HmsDegTarget}
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.target.system.{DMSFormat, HMSFormat, CoordinateParam, NonSiderealTarget, HmsDegTarget}
 
 import java.io.{StringReader, StringWriter, InputStreamReader}
 
-import edu.gemini.pot.sp.{ISPTemplateFolder, ISPTemplateGroup, ISPProgram}
+import edu.gemini.pot.sp.{SPComponentType, ISPObservation, ISPTemplateFolder, ISPTemplateGroup, ISPProgram}
 import edu.gemini.pot.spdb.{IDBDatabaseService, DBLocalDatabase}
 import edu.gemini.spModel.io.impl.{PioSpXmlWriter, PioSpXmlParser}
 import edu.gemini.spModel.template.{TemplateParameters, TemplateGroup}
@@ -17,7 +18,7 @@ import scala.collection.JavaConverters._
 
 // a rudimentary test to make sure it doesn't blow up
 
-class TemplateTargetConversionTest {
+class TargetConversionTest {
   private def withTestOdb(block: IDBDatabaseService => Unit): Unit = {
     val odb = DBLocalDatabase.createTransient()
     try {
@@ -29,7 +30,7 @@ class TemplateTargetConversionTest {
 
   private def withTestProgram(block: (IDBDatabaseService, ISPProgram) => Unit): Unit = withTestOdb { odb =>
     val parser = new PioSpXmlParser(odb.getFactory)
-    parser.parseDocument(new InputStreamReader(getClass.getResourceAsStream("AsAcomet.xml"))) match {
+    parser.parseDocument(new InputStreamReader(getClass.getResourceAsStream("GS-2015B-T-1.xml"))) match {
       case p: ISPProgram => block(odb, p)
       case _             => fail("Expecting a science program")
     }
@@ -55,6 +56,11 @@ class TemplateTargetConversionTest {
     }
 
   private def validateProgram(p: ISPProgram): Unit = {
+    validateTemplateFolder(p.getTemplateFolder)
+    validateB1950(p.getObservations.asScala.find(_.getDataObject.getTitle == "Rigel").get)
+  }
+
+  private def validateTemplateFolder(tf: ISPTemplateFolder): Unit = {
     def validateGroup(g: ISPTemplateGroup): Unit = {
       g.getDataObject match {
         case tg: TemplateGroup =>
@@ -87,12 +93,28 @@ class TemplateTargetConversionTest {
       }
     }
 
-    def validateFolder(f: ISPTemplateFolder): Unit =
-      f.getTemplateGroups.asScala.toList match {
-        case List(g1, g2) => validateGroup(g2)
-        case _            => fail("expecting two template groups")
-      }
+    tf.getTemplateGroups.asScala.toList match {
+      case List(g1, g2) => validateGroup(g2)
+      case _            => fail("expecting two template groups")
+    }
+  }
 
-    validateFolder(p.getTemplateFolder)
+  def validateB1950(obs: ISPObservation): Unit = {
+    // unsafe extravaganza!
+    val targetComp = obs.getObsComponents.asScala.find(_.getType == SPComponentType.TELESCOPE_TARGETENV).get
+    val toc        = targetComp.getDataObject.asInstanceOf[TargetObsComp]
+    val rigel      = toc.getBase.getTarget.asInstanceOf[HmsDegTarget]
+
+    val ra    = rigel.getRa.getAs(CoordinateParam.Units.DEGREES)
+    val dec   = rigel.getDec.getAs(CoordinateParam.Units.DEGREES)
+    val dra   = rigel.getPropMotionRA
+    val ddec  = rigel.getPropMotionDec
+    val epoch = rigel.getEpoch.getValue
+    
+    assertEquals("05:14:32.269", (new HMSFormat).format(ra))
+    assertEquals("-08:12:05.86", (new DMSFormat).format(dec))
+    assertEquals("1.30", f"$dra%.2f")
+    assertEquals("0.50", f"$ddec%.2f")
+    assertEquals(2000.0000, epoch, 0.0000001)
   }
 }


### PR DESCRIPTION
This PR tweaks the B1950 conversion process in a couple of ways:

1. Sets the epoch to 2000.0.
2. Adds a note with the original B1950 coordinates.