### PR TITLE
REL-2331: disappearing target detail panel

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -59,6 +59,8 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
         c.weightx = 1
         c.fill = GridBagConstraints.HORIZONTAL
       })
+      revalidate()  // REL-2331?  revalidate/repaint for good measure
+      repaint()
     }
 
     // Forward the `edit` call.


### PR DESCRIPTION
Apparently the `TargetDetailPanel` disappears permanently from the target editor in some cases and requires an OT restart to reenable it.  I've been unable to reproduce the issue and unable to spot any obvious issues with the code.  However past experience has shown that when adding and removing components from a panel in response to events, a `revalidate` is often needed.  I threw in a `repaint` for good measure.  I propose that we continue testing with these changes and reevaluate if necessary.  Sorry, I realize this is wholly unsatisfactory.