### PR TITLE
OCSADV-314 add j2000 label

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
@@ -51,6 +51,11 @@ class CoordinateEditor extends JPanel with TelescopePosEditor with ReentrancyHac
     c.weightx = 2
   })
 
+  add(new JLabel("(J2000)"), new GridBagConstraints <| { c =>
+    c.gridx = 4
+    c.insets = new Insets(0, 5, 0, 0)
+    c.weighty = 0
+  })
 
   ra.addWatcher(watcher { s =>
     nonreentrant {


### PR DESCRIPTION
In response to Andy's comment I added `(J2000)` to the right of the RA/DEC boxes. It would have pushed too many things around to put it on the left.

![image](https://cloud.githubusercontent.com/assets/1200131/7710910/f04ee486-fe1b-11e4-80b6-cac01ae83ff0.png)
