### PR TITLE
REL-2329: Remove obsolete CADC catalogs

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/resources/jsky/catalog/osgi/skycat.cfg
+++ b/bundle/edu.gemini.catalog/src/main/resources/jsky/catalog/osgi/skycat.cfg
@@ -80,26 +80,9 @@ search_cols:    Jmag {Brightest (min Jmag)} {Faintest (max Jmag)} : Kmag {Bright
 skyobj_factory: edu.gemini.catalog.skycat.binding.skyobj.PpmxlSkyObjectFactory
 
 serv_type:      catalog
-long_name:      PPMXL Catalog at CADC
-short_name:     PPMXL@CADC
-url:            http://vizier.hia.nrc.ca/viz-bin/asu-acl?-source=ppmxl&-c.ra=%ra&-c.dec=%dec&-c.rm=%r1/%r2&-out.max=%n&-out.all&-sort=Kmag&%cond(..)
-symbol:         r1mag {circle red {} {} {} {$r1mag > 0.}} {{(25-$r1mag)/2.} {}}
-search_cols:    Jmag {Brightest (min Jmag)} {Faintest (max Jmag)} : Kmag {Brightest (min Kmag)} {Faintest (max Kmag)} : Hmag {Brightest (min Hmag)} {Faintest (max Hmag)} : b1mag {Brightest (min b1mag)} {Faintest (max b1mag)} : b2mag {Brightest (min b2mag)} {Faintest (max b2mag)} : r1mag {Brightest (min r1mag)} {Faintest (max r1mag)} : r2mag {Brightest (min r2mag)} {Faintest (max r2mag)} : imag {Brightest (min imag)} {Faintest (max imag)}
-skyobj_factory: edu.gemini.catalog.skycat.binding.skyobj.PpmxlSkyObjectFactory
-
-serv_type:      catalog
 long_name:      NOMAD1 catalog at CDS
 short_name:     NOMAD1@CDS
 url:            http://vizier.u-strasbg.fr/viz-bin/asu-acl?-source=NOMAD1&-c.ra=%ra&-c.dec=%dec&-c.rm=%r2&-out.max=%n&-sort=Bmag&%cond(..)
-symbol:         Jmag {circle red {} {} {} {$Jmag > 0.}} {{(25-$Jmag)/2.} {}}
-copyright:      The Naval Observatory Merged Astrometric Dataset (NOMAD)
-search_cols:    Jmag {Brightest (min Jmag)} {Faintest (max Jmag)} : Kmag {Brightest (min Kmag)} {Faintest (max Kmag)} : Hmag {Brightest (min Hmag)} {Faintest (max Hmag)} : Bmag {Brightest (min Bmag)} {Faintest (max Bmag)} : Rmag {Brightest (min Rmag)} {Faintest (max Rmag)}
-skyobj_factory: edu.gemini.catalog.skycat.binding.skyobj.Nomad1SkyObjectFactory
-
-serv_type:      catalog
-long_name:      NOMAD1 catalog at CADC
-short_name:     NOMAD1@CADC
-url:            http://vizier.hia.nrc.ca/viz-bin/asu-acl?-source=NOMAD1&-c.ra=%ra&-c.dec=%dec&-c.rm=%r2&-out.max=%n&-sort=Bmag&%cond(..)
 symbol:         Jmag {circle red {} {} {} {$Jmag > 0.}} {{(25-$Jmag)/2.} {}}
 copyright:      The Naval Observatory Merged Astrometric Dataset (NOMAD)
 search_cols:    Jmag {Brightest (min Jmag)} {Faintest (max Jmag)} : Kmag {Brightest (min Kmag)} {Faintest (max Kmag)} : Hmag {Brightest (min Hmag)} {Faintest (max Hmag)} : Bmag {Brightest (min Bmag)} {Faintest (max Bmag)} : Rmag {Brightest (min Rmag)} {Faintest (max Rmag)}
@@ -141,47 +124,11 @@ short_name:     ppm@eso
 url:            http://archive.eso.org/skycat/servers/ppm-server?ra=%ra&dec=%dec&radius=%r2&nout=%n&mime=skycat
 symbol:         mag circle {15-$mag}
 #
-#serv_type:      catalog
-#long_name:      PPM1 at ESO
-#short_name:     ppm1@eso
-#url:            http://archive.eso.org:8123/general-server/bin/general-server?-source=ppm&-c.ra=%ra&-c.dec=%dec&-c.bm=%r2&-out.max=%n&-mime=skycat
-#symbol:         VMag circle {15-$VMag}
-#
-serv_type:      catalog
-long_name:      SAO at CADC
-short_name:     sao@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/sao-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         V_MAGNITUDE circle {15-$V_MAGNITUDE/100.0}
-#
-serv_type:      catalog
-long_name:      ZCAT at CADC
-short_name:     zcat@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/zcat-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         VHELIO cross {$VHELIO/100.0}
-#
-serv_type:      catalog
-long_name:      QSO at CADC
-short_name:     qso@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/qso-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         REDSHIFT diamond {5-$REDSHIFT}
-#
-serv_type:      catalog
-long_name:      IRAS at CADC
-short_name:     iras@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/iras-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         ra triangle 2
-#
-serv_type:      catalog
-long_name:      RC3 at CADC
-short_name:     rc3@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/rc3-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         ra square 3
-#
-serv_type:      catalog
-long_name:      ABELL at CADC
-short_name:     abell@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadcbin/abell-server?ra=%ra&dec=%dec&radius=%r2&nout=%n
-symbol:         ra square 3
+#serv_type:     catalog
+#long_name:     PPM1 at ESO
+#short_name:    ppm1@eso
+#url:           http://archive.eso.org:8123/general-server/bin/general-server?-source=ppm&-c.ra=%ra&-c.dec=%dec&-c.bm=%r2&-out.max=%n&-mime=skycat
+#symbol:        VMag circle {15-$VMag}
 #
 serv_type:      catalog
 long_name:      SIMBAD via ESO
@@ -275,13 +222,3 @@ short_name:     PPMXL@Gemini
 #
 # Catalog Directories
 #
-serv_type:      directory
-long_name:      ESO Catalogs
-short_name:     catalogs@eso
-url:            http://archive.eso.org/skycat/skycat.cfg
-
-serv_type:      directory
-long_name:      CADC Catalogs
-short_name:     catalogs@cadc
-url:            http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/skycat/skycat2.0.cfg
-


### PR DESCRIPTION
The name says it all. Besides removing CADC catalogs, two "catalog directories" were removed as they produce NPEs shown in the OT when clicked