### PR TITLE
OCSADV-347 preserve mags, spectral info on horizons update

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
@@ -30,7 +30,11 @@ final class ConicNameEditor(date: HorizonsIO[Date]) extends JPanel with Telescop
       d  <- date
       t0 <- HorizonsIO.delay(ct)
       p  <- Horizons.lookupConicTargetByName(t0.getName, t0.getTag.unsafeToHorizonsObjectType, d)
-      _  <- HorizonsIO.delay(spt.setTarget(p._1))
+      _  <- HorizonsIO.delay(spt.setTarget {
+        p._1 <| (_.setMagnitudes(ct.getMagnitudes)) <|
+                (_.setSpatialProfile(ct.getSpatialProfile)) <|
+                (_.setSpectralDistribution(ct.getSpectralDistribution))
+      })
     } yield ()
 
   val name = new TextBoxWidget <| { w =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
@@ -172,7 +172,14 @@ abstract class ValidAtEditor[A <: ITarget](empty: A) extends JPanel with Telesco
    * editor being replaced entirely. This is ok!
    */
   def updateSPTarget(t: ITarget): HorizonsIO[Unit] =
-    HorizonsIO.delay(spt.setTarget(t))
+    HorizonsIO.delay {
+      val old = spt.getTarget
+      spt.setTarget {
+        t <| (_.setMagnitudes(old.getMagnitudes)) <|
+             (_.setSpatialProfile(old.getSpatialProfile)) <|
+             (_.setSpectralDistribution(old.getSpectralDistribution))
+      }
+    }
 
   /**
    * Program that implements the "go" button behavior: it looks up a conic target in Horizons based


### PR DESCRIPTION
This changes the nonsidereal editor to preserve magnitude and spectral info on Horizons lookup.