### PR TITLE
REL-2331: create target detail editor instances for each panel

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -129,7 +129,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         // Update enabled state for all detail widgets.  The current editor
         // will have already been updated by the super.updateEnabledState so
         // update the others.
-        for (final TargetDetailEditor ed : TargetDetailEditor.AllJava()) {
+        for (final TargetDetailEditor ed : _w.detailEditor.allEditorsJava()) {
             if (_w.detailEditor.curDetailEdiorJava().forall(cur -> cur != ed)) {
                 updateEnabledState(new Component[] {ed}, enabled);
             }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailEditor.scala
@@ -8,27 +8,6 @@ import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.ITarget.Tag
 import jsky.app.ot.gemini.editor.targetComponent.TelescopePosEditor
 
-import scala.collection.JavaConverters._
-
-object TargetDetailEditor {
-  val JplMinorBody   = new JplMinorBodyDetailEditor
-  val MpcMinorPlanet = new MpcMinorPlanetDetailEditor
-  val Named          = new NamedDetailEditor
-  val Sidereal       = new SiderealDetailEditor
-
-  val All = List(JplMinorBody, MpcMinorPlanet, Named, Sidereal)
-
-  val AllJava = All.asJava
-
-  def forTag(t: Tag): TargetDetailEditor =
-    t match {
-      case Tag.JPL_MINOR_BODY   => JplMinorBody
-      case Tag.MPC_MINOR_PLANET => MpcMinorPlanet
-      case Tag.NAMED            => Named
-      case Tag.SIDEREAL         => Sidereal
-    }
-}
-
 abstract class TargetDetailEditor(val getTag: Tag) extends JPanel with TelescopePosEditor {
   def edit(ctx: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {
     require(ctx      != null, "obsContext should never be null")

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -1,5 +1,7 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
+import edu.gemini.spModel.target.system.ITarget.Tag
+
 import java.awt.{GridBagConstraints, GridBagLayout}
 import javax.swing.JPanel
 
@@ -10,9 +12,28 @@ import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import jsky.app.ot.gemini.editor.targetComponent.{GuidingFeedbackEditor, TelescopePosEditor}
 
+import scala.collection.JavaConverters._
+
 import scalaz.syntax.id._
 
 final class TargetDetailPanel extends JPanel with TelescopePosEditor with ReentrancyHack {
+
+  val jplMinorBody   = new JplMinorBodyDetailEditor
+  val mpcMinorPlanet = new MpcMinorPlanetDetailEditor
+  val named          = new NamedDetailEditor
+  val sidereal       = new SiderealDetailEditor
+
+  val allEditors = List(jplMinorBody, mpcMinorPlanet, named, sidereal)
+
+  val allEditorsJava = allEditors.asJava
+
+  def editorForTag(t: Tag): TargetDetailEditor =
+    t match {
+      case Tag.JPL_MINOR_BODY   => jplMinorBody
+      case Tag.MPC_MINOR_PLANET => mpcMinorPlanet
+      case Tag.NAMED            => named
+      case Tag.SIDEREAL         => sidereal
+    }
 
   // This doodad will ensure that any change event coming from the SPTarget will get turned into
   // a call to `edit`, so we don't have to worry about that case everywhere. Everything from here
@@ -52,14 +73,14 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
     val tag = spTarget.getTarget.getTag
     if (tde == null || tde.getTag != tag) {
       if (tde != null) remove(tde)
-      tde = TargetDetailEditor.forTag(tag)
+      tde = editorForTag(tag)
       add(tde, new GridBagConstraints() <| { c =>
         c.gridx = 0
         c.gridy = 0
         c.weightx = 1
         c.fill = GridBagConstraints.HORIZONTAL
       })
-      revalidate()  // REL-2331?  revalidate/repaint for good measure
+      revalidate()
       repaint()
     }
 


### PR DESCRIPTION
This is take 2 of an attempt to fix the problem with disappearing target detail editors.  The issue is that distinct`TargetDetailPanel` instances cannot share the same instances of the individual `TargetDetailEditor`s.

This is probably not the most elegant solution but it does correctly handle both the enabled state and fix the problem with shared detail panels.