### PR TITLE
OCSADV-353: Calculate peak and S/N values for multiple CCDs correctly

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -9,7 +9,7 @@ import scala.swing.Color
 import scalaz.{Failure, Success, Validation}
 
 /** The data structures here are an attempt to unify the results produced by the different instrument recipes.
-  * Results are either a few simple numbers in case of imaging or a set charts made up by data series with (x,y)
+  * Results are either a few simple numbers in case of imaging or a set of charts made up by data series with (x,y)
   * value pairs for spectroscopy.
   *
   * For spectroscopy the data series are also used to produce some text data files which can be downloaded from
@@ -56,14 +56,12 @@ final case class SpcSeriesData(dataType: SpcDataType, title: String, data: Array
 }
 
 /** Charts are made up of a set of data series which are all plotted in the same XY-plot. */
-final case class SpcChartData(chartType: SpcChartType, title: String, xAxisLabel: String, yAxisLabel: String, series: Seq[SpcSeriesData]) {
+final case class SpcChartData(chartType: SpcChartType, title: String, xAxisLabel: String, yAxisLabel: String, series: List[SpcSeriesData]) {
   // JFreeChart requires a unique name for each series
   require(series.map(_.title).distinct.size == series.size, "titles of series are not unique")
 
-  /** Gets a data series by type and index. Note that for a given type there can be more than one result.
-    * This method will fail if the result you're looking for does not exist.
-    */
-  def series(t: SpcDataType, i: Int = 0): SpcSeriesData     = series.filter(_.dataType == t)(i)
+  /** Gets all data series for the given type. */
+  def allSeries(t: SpcDataType): List[SpcSeriesData]        = series.filter(_.dataType == t)
 }
 
 /** The result of a spectroscpy ITC calculation is a set of charts and text files.
@@ -73,7 +71,7 @@ final case class SpcChartData(chartType: SpcChartType, title: String, xAxisLabel
 final case class ItcSpectroscopyResult(source: SourceDefinition, obsDetails: ObservationDetails, charts: Seq[SpcChartData], files: Seq[SpcDataFile]) extends ItcResult {
 
   /** Gets a text file for a data series by type and index.
-    * This method will fail if the result you're looking for does not exist.
+    * This method will fail if the result (data) you're looking for does not exist.
     */
   def file(t: SpcDataType, i: Int = 0): SpcDataFile         = files.filter(_.dataType == t)(i)
 
@@ -82,10 +80,10 @@ final case class ItcSpectroscopyResult(source: SourceDefinition, obsDetails: Obs
     */
   def chart(t: SpcChartType, i: Int = 0): SpcChartData      = charts.filter(_.chartType == t)(i)
 
-  /** Gets a data series by chart type, data type and index.
-    * This method will fail if the result you're looking for does not exist.
+  /** Gets all data series by chart type and data type.
+    * This method will fail if the result (chart/data) you're looking for does not exist.
     */
-  def series(ct: SpcChartType, dt: SpcDataType): SpcSeriesData = chart(ct).series(dt)
+  def allSeries(ct: SpcChartType, dt: SpcDataType): List[SpcSeriesData] = chart(ct).allSeries(dt)
 }
 
 object ItcResult {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -403,7 +403,7 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             }
         }
 
-        return new SpcChartData(type, title, "Wavelength (nm)", yAxis, JavaConversions.asScalaBuffer(data));
+        return new SpcChartData(type, title, "Wavelength (nm)", yAxis, JavaConversions.asScalaBuffer(data).toList());
     }
 
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -274,7 +274,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
             data.add(new SpcSeriesData(SignalData.instance(),     "Signal Order "           + (i + 3), result.signalOrder()[i].getData(),     new Some<>(ITCChart.colorByIndex(2*i    ))));
             data.add(new SpcSeriesData(BackgroundData.instance(), "SQRT(Background) Order " + (i + 3), result.backGroundOrder()[i].getData(), new Some<>(ITCChart.colorByIndex(2*i + 1))));
         }
-        return new SpcChartData(SignalChart.instance(), title, xAxis, yAxis, JavaConversions.asScalaBuffer(data));
+        return new SpcChartData(SignalChart.instance(), title, xAxis, yAxis, JavaConversions.asScalaBuffer(data).toList());
     }
 
     private static SpcChartData createGnirsS2NChart(final GnirsSpectroscopyResult result) {
@@ -285,7 +285,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
         for (int i = 0; i < GnirsRecipe.ORDERS; i++) {
            data.add(new SpcSeriesData(FinalS2NData.instance(),   "Final S/N Order "        + (i + 3), result.finalS2NOrder()[i].getData(),     new Some<>(ITCChart.colorByIndex(2*i))));
         }
-        return new SpcChartData(S2NChart.instance(), title, xAxis, yAxis, JavaConversions.asScalaBuffer(data));
+        return new SpcChartData(S2NChart.instance(), title, xAxis, yAxis, JavaConversions.asScalaBuffer(data).toList());
     }
 
 }

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
@@ -4,7 +4,7 @@ import java.util
 
 import edu.gemini.itc.shared._
 
-import scala.collection.JavaConversions
+import scala.collection.JavaConversions._
 
 sealed trait Recipe
 
@@ -48,7 +48,7 @@ object Recipe {
     val data: java.util.List[SpcSeriesData] = new java.util.ArrayList[SpcSeriesData]()
     data.add(new SpcSeriesData(SignalData,     "Signal ",            result.specS2N(index).getSignalSpectrum.getData))
     data.add(new SpcSeriesData(BackgroundData, "SQRT(Background)  ", result.specS2N(index).getBackgroundSpectrum.getData))
-    new SpcChartData(SignalChart, title, "Wavelength (nm)", "e- per exposure per spectral pixel", JavaConversions.asScalaBuffer(data))
+    new SpcChartData(SignalChart, title, "Wavelength (nm)", "e- per exposure per spectral pixel", data.toList)
   }
 
   def createS2NChart(result: SpectroscopyResult): SpcChartData = {
@@ -63,7 +63,7 @@ object Recipe {
     val data: java.util.List[SpcSeriesData] = new util.ArrayList[SpcSeriesData]
     data.add(new SpcSeriesData(SingleS2NData, "Single Exp S/N", result.specS2N(index).getExpS2NSpectrum.getData))
     data.add(new SpcSeriesData(FinalS2NData,  "Final S/N  ",    result.specS2N(index).getFinalS2NSpectrum.getData))
-    new SpcChartData(S2NChart, title, "Wavelength (nm)", "Signal / Noise per spectral pixel", JavaConversions.asScalaBuffer(data))
+    new SpcChartData(S2NChart, title, "Wavelength (nm)", "Signal / Noise per spectral pixel", data.toList)
   }
 
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -83,11 +83,11 @@ sealed trait ItcTableModel extends AbstractTableModel {
   protected def sourceFraction  (result: Future[ItcService.Result]) = serviceResult(result).map(r => f"${r.obsDetails.getSourceFraction}%.2f")
 
 
-  protected def spcPeakElectrons(result: Future[ItcService.Result]) = spectroscopyResult(result).map(_.series(SignalChart, SignalData).yValues.max.toInt)
+  protected def spcPeakElectrons(result: Future[ItcService.Result]) = spectroscopyResult(result).map(_.allSeries(SignalChart, SignalData).map(_.yValues.max).max.toInt)
 
-  protected def spcPeakSNSingle (result: Future[ItcService.Result]) = spectroscopyResult(result).map(_.series(S2NChart, SingleS2NData).yValues.max)
+  protected def spcPeakSNSingle (result: Future[ItcService.Result]) = spectroscopyResult(result).map(_.allSeries(S2NChart, SingleS2NData).map(_.yValues.max).max)
 
-  protected def spcPeakSNFinal  (result: Future[ItcService.Result]) = spectroscopyResult(result).map(_.series(S2NChart, FinalS2NData).yValues.max)
+  protected def spcPeakSNFinal  (result: Future[ItcService.Result]) = spectroscopyResult(result).map(_.allSeries(S2NChart, FinalS2NData).map(_.yValues.max).max)
 
 
   protected def imgPeakPixelFlux(result: Future[ItcService.Result], ccd: Int = 0) = imagingResult(result).map(_.ccd(ccd).peakPixelFlux.toInt)


### PR DESCRIPTION
For GMOS all calculations are done for each CCD individually in order to take CCD specific properties into account. When reporting max flow and S/N values we have to take all those CCDs into account.