### PR TITLE
OCSADV-346: Better handling of coadds

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -206,6 +206,9 @@ object ConfigExtractor {
     }).map(Wavelength.fromMicrons)
   }
 
+  // Extract an optional integer, values in the configuration are Java objects
+  def extractOptionalInteger(c: Config, key: ItemKey): Option[Int] =
+    extract[java.lang.Integer](c, key).map(_.toInt).toOption
 
   // Extract a value of the given type from the configuration
   def extract[A](c: Config, key: ItemKey)(implicit clazz: ClassTag[A]): String \/ A =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -34,15 +34,15 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
 
   // Define different sets of columns as headers
-  val Headers           = Seq(LabelsColumn, ImagesColumn, ExpTimeColumn, TotTimeColumn, SrcMagColumn, SrcFracColumn)
-  val HeadersWithCoadds = Seq(LabelsColumn, ImagesColumn, CoaddsColumn, ExpTimeColumn, TotTimeColumn, SrcMagColumn, SrcFracColumn)
+  val Headers           = List(LabelsColumn, ImagesColumn, ExpTimeColumn, TotTimeColumn, SrcMagColumn, SrcFracColumn)
+  val HeadersWithCoadds = List(LabelsColumn, ImagesColumn, CoaddsColumn, ExpTimeColumn, TotTimeColumn, SrcMagColumn, SrcFracColumn)
 
-  val headers:      Seq[Column]
-  val keys:         Seq[ItemKey]
-  val results:      Seq[Column]
+  val headers:      List[Column]
+  val keys:         List[ItemKey]
+  val results:      List[Column]
 
-  val uniqueSteps:  Seq[ItcUniqueConfig]
-  val res:          Seq[Future[ItcService.Result]]
+  val uniqueSteps:  List[ItcUniqueConfig]
+  val res:          List[Future[ItcService.Result]]
 
 
   // Gets the imaging result from the service result future (if present).
@@ -145,9 +145,9 @@ sealed trait ItcTableModel extends AbstractTableModel {
 /** Generic ITC imaging tables model. */
 sealed trait ItcImagingTableModel extends ItcTableModel
 
-class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcImagingTableModel {
+class ItcGenericImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcImagingTableModel {
   val headers = if (showCoadds) HeadersWithCoadds else Headers
-  val results = Seq(
+  val results = List(
     Column("Peak",            (c, r) => imgPeakPixelFlux(r),          tooltip = ItcTableModel.PeakPixelTooltip),
     Column("S/N Single",      (c, r) => imgSingleSNRatio(r)),
     Column("S/N Total",       (c, r) => imgTotalSNRatio (r))
@@ -155,9 +155,9 @@ class ItcGenericImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[I
 }
 
 /** GMOS specific ITC imaging table model. */
-class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]]) extends ItcImagingTableModel {
+class ItcGmosImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = Headers
-  val results = Seq(
+  val results = List(
     Column("CCD1 Peak",       (c, r) => imgPeakPixelFlux(r, ccd=0),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 1"),
     Column("CCD1 S/N Single", (c, r) => imgSingleSNRatio(r, ccd=0)),
     Column("CCD1 S/N Total",  (c, r) => imgTotalSNRatio (r, ccd=0)),
@@ -174,9 +174,9 @@ class ItcGmosImagingTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcU
 /** Generic ITC spectroscopy table model. */
 sealed trait ItcSpectroscopyTableModel extends ItcTableModel
 
-class ItcGenericSpectroscopyTableModel(val keys: Seq[ItemKey], val uniqueSteps: Seq[ItcUniqueConfig], val res: Seq[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcSpectroscopyTableModel {
+class ItcGenericSpectroscopyTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcSpectroscopyTableModel {
   val headers = if (showCoadds) HeadersWithCoadds else Headers
-  val results = Seq(
+  val results = List(
     Column("Peak",            (c, r) => spcPeakElectrons(r),          tooltip = "Peak e- per exposure"),
     Column("S/N Single",      (c, r) => spcPeakSNSingle(r)),
     Column("S/N Total",       (c, r) => spcPeakSNFinal(r))

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -1,5 +1,6 @@
 package jsky.app.ot.editor.seq
 
+import edu.gemini.itc.shared.ConfigExtractor
 import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
 import edu.gemini.spModel.gemini.acqcam.InstAcqCam
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
@@ -24,11 +25,14 @@ case class ItcUniqueConfig(count: Int, labels: String, configs: NonEmptyList[Con
 
   def config = configs.head
 
-  /** Single exposure time is either the given exposure time or the time on source divided by the number of images. */
-  def singleExposureTime: Double = singleTime.getOrElse(totalTime.orZero / count)
+  /** Single exposure time is either the given exposure time or the time on source divided by the number of images and coadds. */
+  def singleExposureTime: Double = singleTime.getOrElse(totalTime.orZero / (count * coadds.getOrElse(1)))
 
-  /** Total exposure time is either total time on source (TReCS/Michelle) or the single exposure time times the number of images. */
-  def totalExposureTime: Double = totalTime.getOrElse(singleTime.orZero * count)
+  /** Total exposure time is either total time on source (TReCS/Michelle) or the single exposure time times the number of images and coadds. */
+  def totalExposureTime: Double = totalTime.getOrElse(singleTime.orZero * (count * coadds.getOrElse(1)))
+
+  /** The coadds for this step. */
+  def coadds: Option[Int] = ConfigExtractor.extractOptionalInteger(config, INST_COADDS_KEY)
 
   /** TReCS and Michelle have an optional total time on source. */
   private val totalTime = Option(config.getItemValue(INST_TIME_ON_SRC_KEY)).map(_.asInstanceOf[Double])

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -61,11 +61,11 @@ object ItcUniqueConfig {
 
 
   /** Gets all unique science imaging configurations from the given sequence. */
-  def imagingConfigs(seq: ConfigSequence): Seq[ItcUniqueConfig] =
+  def imagingConfigs(seq: ConfigSequence): List[ItcUniqueConfig] =
     uniqueConfigs(seq, c => isScience(c) && isImaging(c))
 
   /** Gets all unique spectroscopy configurations from the given sequence. */
-  def spectroscopyConfigs(seq: ConfigSequence): Seq[ItcUniqueConfig] =
+  def spectroscopyConfigs(seq: ConfigSequence): List[ItcUniqueConfig] =
     uniqueConfigs(seq, c => isScience(c) && isSpectroscopy(c))
 
   // Checks if a config is science or not; only science observations are relevant for ITC
@@ -91,7 +91,7 @@ object ItcUniqueConfig {
 
   // Gets all "unique configs" (i.e. configs that are relevant for ITC) from the given sequence. The predicate
   // defines which steps have to be taken into account, i.e. spectroscopy vs imaging and no calibrations.
-  private def uniqueConfigs(seq: ConfigSequence, predicate: Config => Boolean): Seq[ItcUniqueConfig] = {
+  private def uniqueConfigs(seq: ConfigSequence, predicate: Config => Boolean): List[ItcUniqueConfig] = {
     val steps        = seq.getAllSteps.toList.filter(predicate)
     val groupedSteps = steps.groupBy(hash).toList
     val mappedSteps  = groupedSteps.map { case (h, cs) => ItcUniqueConfig(cs.size, labels(cs), NonEmptyList(cs.head, cs.tail:_*)) }


### PR DESCRIPTION
Coadds can change during a sequence and the correct values need to be read from the configuration sequence. The coadd values are now also displayed on the ITC result tables for instruments that support them (NIRI, GSAOI, GNIRS, NIFS).