### PR TITLE
REL-2246: Workaround for hdiutil issue on Mavericks.

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
@@ -60,7 +60,7 @@ case class MacDistHandler(jre: Option[String], jreName: String) extends DistHand
     val volname = "%s_%s".format(meta.executableName(version), d.toString.toLowerCase)
     val dmgname = volname + ".dmg"
     val dest = new File(outDir, dmgname).getPath
-    val args = Array("hdiutil", "create", "-srcfolder", appDir.getPath, "-volname", volname, dest)
+    val args = Array("hdiutil", "create", "-size", "500m", "-srcfolder", appDir.getPath, "-volname", volname, dest)
     val result = Runtime.getRuntime.exec(args).waitFor()
     if (result != 0) {
       println("*** " + args.mkString(" "))


### PR DESCRIPTION
There is a bug on Mavericks which (sometimes) prevents `hdiutil` from making `dmg` files of sizes over 100 MB. This is a workaround for that for now.

See https://discussions.apple.com/thread/5667409
