### PR TITLE
OCSADV-357: minor target changes

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ConicTarget.java
@@ -6,7 +6,6 @@
 //
 package edu.gemini.spModel.target.system;
 
-import edu.gemini.spModel.target.system.CoordinateParam.Units;
 import edu.gemini.spModel.target.system.CoordinateTypes.*;
 
 /**
@@ -28,6 +27,13 @@ public final class ConicTarget extends NonSiderealTarget  {
 
     private static final double DEFAULT_E = 0.0;
 
+
+    protected CoordinateTypes.Epoch defaultEpoch() {
+        // inexplicably mutable, so always create a new value
+        return new CoordinateTypes.Epoch("0", CoordinateParam.Units.JD);
+    }
+
+
     private ANode _anode = new ANode();
     private AQ _aq = new AQ();
     private double _e = DEFAULT_E;
@@ -35,7 +41,7 @@ public final class ConicTarget extends NonSiderealTarget  {
     private LM _lm = new LM();
     private N _n = new N();
     private Perihelion _perihelion = new Perihelion();
-    private Epoch _epochOfPeri = new Epoch("2000", Units.YEARS);
+    private Epoch _epochOfPeri = defaultEpoch();
     private final Tag _tag;
 
 
@@ -178,23 +184,8 @@ public final class ConicTarget extends NonSiderealTarget  {
      * Gets the epoch of perihelion of this object.
      */
     public Epoch getEpochOfPeri() {
-        if (_epochOfPeri == null) {
-            _epochOfPeri = _createDefaultEpochOfPeri();
-        }
         return _epochOfPeri;
     }
-
-
-
-    /**
-     * Returns the current epoch of perihelion, creating it if necessary.
-     */
-    private Epoch _createDefaultEpochOfPeri() {
-        return new Epoch("2000", Units.YEARS);
-    }
-
-
-
 
     /**
      * Sets the epoch of perihelion.  The value of the parameter is not
@@ -202,6 +193,7 @@ public final class ConicTarget extends NonSiderealTarget  {
      * stored in this class.
      */
     public void setEpochOfPeri(Epoch newValue) {
+        if (newValue == null) newValue = defaultEpoch();
         _epochOfPeri = newValue;
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateParam.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateParam.java
@@ -56,6 +56,7 @@ public abstract class CoordinateParam implements Cloneable, Serializable {
         public static final int _YEARS = 11;
         public static final int _MILLI_ARCSECS_PER_YEAR = 12;
         public static final int _JD = 13;
+        public static final int _MILLI_ARCSECS = 14;
 
         public static final Units ANGSTROMS =
                 new Units(_ANGSTROMS, "angstroms");
@@ -99,6 +100,9 @@ public abstract class CoordinateParam implements Cloneable, Serializable {
         public static final Units JD =
                 new Units(_JD, "JD");
 
+        public static final Units MILLI_ARCSECS =
+                new Units(_MILLI_ARCSECS, "mas");
+
         public static final Units[] TYPES = new Units[]{
             ANGSTROMS,
             ARCSECS,
@@ -114,6 +118,7 @@ public abstract class CoordinateParam implements Cloneable, Serializable {
             YEARS,
             MILLI_ARCSECS_PER_YEAR,
             JD,
+            MILLI_ARCSECS,
         };
 
         private Units(int type, String name) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateParam.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateParam.java
@@ -55,6 +55,7 @@ public abstract class CoordinateParam implements Cloneable, Serializable {
         public static final int _SECS_PER_YEAR = 10;
         public static final int _YEARS = 11;
         public static final int _MILLI_ARCSECS_PER_YEAR = 12;
+        public static final int _JD = 13;
 
         public static final Units ANGSTROMS =
                 new Units(_ANGSTROMS, "angstroms");
@@ -95,6 +96,9 @@ public abstract class CoordinateParam implements Cloneable, Serializable {
         public static final Units MILLI_ARCSECS_PER_YEAR =
                 new Units(_MILLI_ARCSECS_PER_YEAR, "milli-arcsecs/year");
 
+        public static final Units JD =
+                new Units(_JD, "JD");
+
         public static final Units[] TYPES = new Units[]{
             ANGSTROMS,
             ARCSECS,
@@ -109,6 +113,7 @@ public abstract class CoordinateParam implements Cloneable, Serializable {
             SECS_PER_YEAR,
             YEARS,
             MILLI_ARCSECS_PER_YEAR,
+            JD,
         };
 
         private Units(int type, String name) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateTypes.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateTypes.java
@@ -6,8 +6,6 @@
 //
 package edu.gemini.spModel.target.system;
 
-import edu.gemini.spModel.target.system.CoordinateParam.Units;
-
 /**
  * A container class for localizing the various parameter types used by
  * the target coordinate systems.
@@ -137,10 +135,10 @@ public final class CoordinateTypes {
      * The Parallax parameter type.
      */
     public static final class Parallax extends CoordinateParam {
-        public static final Units[] UNITS = {Units.ARCSECS};
+        public static final Units[] UNITS = {Units.MILLI_ARCSECS, Units.ARCSECS};
 
         public Object clone() {
-            return (Parallax) super.clone();
+            return super.clone();
         }
 
         public Parallax() {
@@ -165,6 +163,14 @@ public final class CoordinateTypes {
 
         public Units[] getUnitOptions() {
             return UNITS;
+        }
+
+        public Double arcsecs() {
+            return (getUnits() == Units.MILLI_ARCSECS) ? getValue()/1000.0 : getValue();
+        }
+
+        public Double mas() {
+            return (getUnits() == Units.ARCSECS) ? getValue() * 1000.0 : getValue();
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateTypes.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateTypes.java
@@ -242,10 +242,10 @@ public final class CoordinateTypes {
      * The Epoch parameter type.
      */
     public static final class Epoch extends CoordinateParam {
-        public static final Units[] UNITS = {Units.YEARS};
+        public static final Units[] UNITS = {Units.YEARS, Units.JD};
 
         public Object clone() {
-            return (Epoch) super.clone();
+            return super.clone();
         }
 
         public Epoch() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/HmsDegTarget.java
@@ -319,12 +319,12 @@ public final class HmsDegTarget extends ITarget {
 
     /** Get the PM parallax in arcsec. */
     public double getTrackingParallax() {
-        return getParallax().getValue();
+        return getParallax().arcsecs();
     }
 
     /** Set the PM parallax in arcsec. */
     public void setTrackingParallax(final double newValue) {
-        setParallax(new Parallax(newValue));
+        setParallax(new Parallax(newValue, Units.ARCSECS));
     }
 
     /** Get the PM radial velocity in km/s. */

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
@@ -12,11 +12,15 @@ public final class NamedTarget extends NonSiderealTarget {
         return TAG;
     }
 
+    protected CoordinateTypes.Epoch defaultEpoch() {
+        // inexplicably mutable, so always create a new value
+        return new CoordinateTypes.Epoch("2000", CoordinateParam.Units.YEARS);
+    }
 
     /**
      * Solar System Objects
      */
-    public static enum SolarObject {
+    public enum SolarObject {
         MOON   ("Moon",    301),
         MERCURY("Mercury", 199, 1),
         VENUS  ("Venus",   299, 2),

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NonSiderealTarget.java
@@ -13,7 +13,7 @@ public abstract class NonSiderealTarget extends ITarget {
     // XXX temporary, until there is conversion code
     private HMS _ra = new HMS();
     private DMS _dec = new DMS();
-    private CoordinateTypes.Epoch _epoch = new CoordinateTypes.Epoch("2000", CoordinateParam.Units.YEARS);
+    private CoordinateTypes.Epoch _epoch = defaultEpoch();
     private String _name = DEFAULT_NAME;
     private Date _date = null; // The date for which the position is valid
 
@@ -60,9 +60,6 @@ public abstract class NonSiderealTarget extends ITarget {
      * Gets the epoch of this object.
      */
     public CoordinateTypes.Epoch getEpoch() {
-        if (_epoch == null) {
-            _epoch = _createDefaultEpoch();
-        }
         return _epoch;
     }
 
@@ -73,6 +70,7 @@ public abstract class NonSiderealTarget extends ITarget {
      * stored in this class.
      */
     public void setEpoch(CoordinateTypes.Epoch newValue) {
+        if (newValue == null) newValue = defaultEpoch();
         _epoch = newValue;
     }
 
@@ -82,13 +80,6 @@ public abstract class NonSiderealTarget extends ITarget {
 
     public void setDateForPosition(Date date) {
         _date = date;
-    }
-
-    /**
-     * Returns the current epoch, creating it if necessary.
-     */
-    private CoordinateTypes.Epoch _createDefaultEpoch() {
-        return new CoordinateTypes.Epoch("2000", CoordinateParam.Units.YEARS);
     }
 
     /**
@@ -135,6 +126,10 @@ public abstract class NonSiderealTarget extends ITarget {
         result._hObjTypeOrd = _hObjTypeOrd;
         return result;
     }
+
+    // A dangerous method because it is called from the constructor yet
+    // overridden in subclasses.  Must return a constant value.
+    protected abstract CoordinateTypes.Epoch defaultEpoch();
 
     ///
     /// IHorizonsTarget Impl

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -141,7 +141,7 @@ public final class TargetConfig extends ParamSet {
         String pmunits = target.getPM2().getUnits().getName();
         if (pmunits.equals(TccNames.OT_PMUNITS)) pmunits = TccNames.TCC_PMUNITS;
         ps.putParameter(TccNames.PMUNITS, pmunits);
-        ps.putParameter(TccNames.PARALLAX, target.getParallax().getStringValue());
+        ps.putParameter(TccNames.PARALLAX, Double.toString(target.getParallax().arcsecs()));
         ps.putParameter(TccNames.RV, target.getRV().getStringValue());
         return ps;
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/JplMinorBodyDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/JplMinorBodyDetailEditor.scala
@@ -1,19 +1,21 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
 import edu.gemini.spModel.target.system.ConicTarget
+import edu.gemini.spModel.target.system.CoordinateParam.Units
+import edu.gemini.spModel.target.system.CoordinateTypes.Epoch
 import edu.gemini.spModel.target.system.ITarget.Tag
 
 final class JplMinorBodyDetailEditor extends ConicDetailEditor(Tag.JPL_MINOR_BODY) {
   import NumericPropertySheet.Prop
 
   lazy val props = NumericPropertySheet[ConicTarget](Some("Orbital Elements"), _.getTarget.asInstanceOf[ConicTarget],
-    Prop("EPOCH", "Orbital Element Epoch (JD)",        _.getEpoch),
+    Prop("EPOCH", "Orbital Element Epoch (JD)",        _.getEpoch.getValue, (t,d) => t.setEpoch(new Epoch(d, Units.JD))),
     Prop("IN",    "Inclination (deg)",                 _.getInclination),
     Prop("OM",    "Longitude of Ascending Node (deg)", _.getANode),
     Prop("W",     "Argument of Perihelion (deg)",      _.getPerihelion),
     Prop("QR",    "Perihelion Distance (AU)",          _.getAQ),
     Prop("EC",    "Eccentricity",                      _.getE, _.setE(_)),
-    Prop("TP",    "Time of Perihelion Passage (JD)",   _.getEpochOfPeri)
+    Prop("TP",    "Time of Perihelion Passage (JD)",   _.getEpochOfPeri.getValue, (t, d) => t.setEpochOfPeri(new Epoch(d, Units.JD)))
   )
 
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/MpcMinorPlanetDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/MpcMinorPlanetDetailEditor.scala
@@ -1,12 +1,14 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
+import edu.gemini.spModel.target.system.CoordinateParam.Units
+import edu.gemini.spModel.target.system.CoordinateTypes.Epoch
 import edu.gemini.spModel.target.system.{ConicTarget, ITarget}
 
 final class MpcMinorPlanetDetailEditor extends ConicDetailEditor(ITarget.Tag.MPC_MINOR_PLANET) {
   import NumericPropertySheet.Prop
 
   lazy val props = NumericPropertySheet[ConicTarget](Some("Orbital Elements"), _.getTarget.asInstanceOf[ConicTarget],
-    Prop("EPOCH", "Orbital Element Epoch (JD)",        _.getEpoch),
+    Prop("EPOCH", "Orbital Element Epoch (JD)",        _.getEpoch.getValue, (t,d) => t.setEpoch(new Epoch(d, Units.JD))),
     Prop("IN",    "Inclination (deg)",                 _.getInclination),
     Prop("OM",    "Longitude of Ascending Node (deg)", _.getANode),
     Prop("W",     "Argument of Perihelion (deg)",      _.getPerihelion),

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
@@ -26,10 +26,10 @@ final class SiderealDetailEditor extends TargetDetailEditor(ITarget.Tag.SIDEREAL
   }
 
   val props = NumericPropertySheet[HmsDegTarget](Some("Motion"), _.getTarget.asInstanceOf[HmsDegTarget],
-    Prop("∆ RA",     "mas/year", _.getPM1),
-    Prop("∆ Dec",    "mas/year", _.getPM2),
-    Prop("Epoch",    "JD",       _.getEpoch),
-    Prop("Parallax", "arcsec",   _.getParallax),
+    Prop("µ RA",     "mas/year", _.getPM1),
+    Prop("µ Dec",    "mas/year", _.getPM2),
+    Prop("Epoch",    "years",    _.getEpoch),
+    Prop("Parallax", "mas",      _.getParallax),
     Prop("RV",       "km/sec",   _.getRV)
   )
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
@@ -1,5 +1,8 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
+import edu.gemini.spModel.target.system.CoordinateParam.Units
+import edu.gemini.spModel.target.system.CoordinateTypes.{Epoch, Parallax}
+
 import java.awt.{GridBagConstraints, GridBagLayout, Insets}
 import javax.swing.{Box, JComponent, JLabel, JPanel}
 
@@ -28,8 +31,8 @@ final class SiderealDetailEditor extends TargetDetailEditor(ITarget.Tag.SIDEREAL
   val props = NumericPropertySheet[HmsDegTarget](Some("Motion"), _.getTarget.asInstanceOf[HmsDegTarget],
     Prop("µ RA",     "mas/year", _.getPM1),
     Prop("µ Dec",    "mas/year", _.getPM2),
-    Prop("Epoch",    "years",    _.getEpoch),
-    Prop("Parallax", "mas",      _.getParallax),
+    Prop("Epoch",    "years",    _.getEpoch.getValue, (t, d) => t.setEpoch(new Epoch(d, Units.YEARS))),
+    Prop("Parallax", "mas",      _.getParallax.mas,   (t, d) => t.setParallax(new Parallax(d, Units.MILLI_ARCSECS))),
     Prop("RV",       "km/sec",   _.getRV)
   )
 


### PR DESCRIPTION
This PR contains a handful of label changes

> * Change the Sidereal target Epoch units from "JD" to "years" 
> * Change the Sidereal target proper motion label from Delta to mu 
> * Change the parallax units from arcsec to mas 

and one slightly more significant change

> * For comets and asteroids, I don't think we should pre-fill the Epoch or TP with 2000, since those are in Julian days and will have values around 2.45e6 

Here the epoch is being stored in `NonSiderealTarget` and shared by the two subclasses, `ConicTarget` and `NamedTarget`.  Presumably the epoch for `NamedTarget`, if relevant at all, should continue to be 2000.0 years while the two epoch values for `ConicTarget` now default to 0.0 JD.

The old `ITarget` hierarchy is fairly poor and this change continues the tradition.  In particular, rather than move the epoch field down to the subclasses it makes a call to an abstract method in the constructor of `NamedTarget` to get the default value.  Also, there were places where we assume epoch is not `null` and places where we explicitly check for `null`.  Instead I've tried to make it impossible to set the epoch value to `null` at all.  Of course `Epoch` values themselves are mutable and I've done nothing to fix that.  In short, the new target model will be a huge improvement.
