### PR TITLE
OCSADV-332: default to AB for sloan filters in brightness parser

### DIFF
--- a/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
+++ b/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
@@ -7,10 +7,7 @@ import edu.gemini.spModel.core.Wavelength;
 import edu.gemini.spModel.core.Wavelength$;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 
 /**
  * Celestial object brightness information.  Magnitudes are relative to
@@ -18,6 +15,17 @@ import java.util.List;
  * in the measurement.
  */
 public final class Magnitude implements Comparable, Serializable {
+    /**
+     * REL-549: Magnitude information for targets and guide stars in OT must be stored in value, bandpass, system triples.
+     */
+    public enum System {
+        Vega,
+        AB,
+        Jy,
+        ;
+
+        public static final System DEFAULT = Vega;
+    }
 
     /**
      * Common wavelength bands.
@@ -25,40 +33,28 @@ public final class Magnitude implements Comparable, Serializable {
     public enum Band {
 
         // OCSADV-203
-        u(350, "UV"),
-        g(475, "green"),
-        r(630, "red"),
-        i(780, "far red"),
-        z(925, "near-infrared"),
+        u(System.AB, 350, "UV"),
+        g(System.AB, 475, "green"),
+        r(System.AB, 630, "red"),
+        i(System.AB, 780, "far red"),
+        z(System.AB, 925, "near-infrared"),
 
-        U( 365, "ultraviolet"),
-        B( 445, "blue"),
-        V( 551, "visual"),
-        UC(610, "UCAC"), // unknown FWHM
-        R( 658, "red"),
-        I( 806, "infrared"),
-        Y(1020),
-        J(1220),
-        H(1630),
-        K(2190),
-        L(3450),
-        M(4750),
-        N(10000),
-        Q(16000),
-        AP(None.INTEGER, new Some<>("apparent"))
+        U(System.Vega,  365, "ultraviolet"),
+        B(System.Vega,  445, "blue"),
+        V(System.Vega,  551, "visual"),
+        UC(System.Vega, 610, "UCAC"), // unknown FWHM
+        R(System.Vega,  658, "red"),
+        I(System.Vega,  806, "infrared"),
+        Y(System.Vega, 1020),
+        J(System.Vega, 1220),
+        H(System.Vega, 1630),
+        K(System.Vega, 2190),
+        L(System.Vega, 3450),
+        M(System.Vega, 4750),
+        N(System.Vega, 10000),
+        Q(System.Vega, 16000),
+        AP(System.Vega, None.INTEGER, new Some<>("apparent"))
         ;
-
-        public static final List<Band> AB_BANDS;
-
-        static {
-            List<Band> bands = new ArrayList<>();
-            bands.add(u);
-            bands.add(g);
-            bands.add(r);
-            bands.add(i);
-            bands.add(z);
-            AB_BANDS = Collections.unmodifiableList(bands);
-        }
 
         /**
          * A Comparator of magnitude bands based upon the associated
@@ -77,19 +73,22 @@ public final class Magnitude implements Comparable, Serializable {
                 }
             };
 
+        public final System defaultSystem;
         private final Option<Wavelength> wavelengthMidPoint;
         private final Option<String> description;
 
-        Band(Option<Integer> mid, Option<String> desc) {
+        Band(System sys, Option<Integer> mid, Option<String> desc) {
+            this.defaultSystem      = sys;
             this.wavelengthMidPoint = mid.map(Wavelength$.MODULE$::fromNanometers);
             this.description        = desc;
         }
 
-        Band(int mid) {
-            this(mid, null);
+        Band(System sys, int mid) {
+            this(sys, mid, null);
         }
 
-        Band(int mid, String desc) {
+        Band(System sys, int mid, String desc) {
+            this.defaultSystem      = sys;
             this.wavelengthMidPoint = new Some<>(Wavelength$.MODULE$.fromNanometers(mid));
             this.description = (desc == null) ? None.STRING : new Some<>(desc);
         }
@@ -104,17 +103,6 @@ public final class Magnitude implements Comparable, Serializable {
 
     }
 
-    /**
-     * REL-549: Magnitude information for targets and guide stars in OT must be stored in value, bandpass, system triples.
-     */
-    public enum System {
-        Vega,
-        AB,
-        Jy,
-        ;
-
-        public static final System DEFAULT = Vega;
-    }
 
 
     /**

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/BrightnessParserSpec.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/BrightnessParserSpec.scala
@@ -30,7 +30,7 @@ object BrightnessParserSpec extends Specification {
     "14.8 Jmag, 14.2 Hmag"        -> NonEmptyList(mag(14.8, J, Vega), mag(14.2, H, Vega)),
     "14.9mag at K"                -> one(14.9, K, Vega),
     "15: H"                       -> one(15, H, Vega),
-    "17.9 (i mag)"                -> one(17.9, i, Vega),
+    "17.9 (i mag)"                -> one(17.9, i, AB),
     "18.74  K"                    -> one(18.74, K, Vega),
     "19.05 (I-band)"              -> one(19.05, I, Vega),
     "19.7(iAB)"                   -> one(19.7, i, AB),
@@ -49,7 +49,7 @@ object BrightnessParserSpec extends Specification {
     "B_mag=9.4"                   -> one(9.4, B, Vega),
     "H,11.268"                    -> one(11.268, H, Vega),
     "Hband 13.07"                 -> one(13.07, H, Vega),
-    "i mag = 18.1"                -> one(18.1, i, Vega),
+    "i mag = 18.1"                -> one(18.1, i, AB),
     "I(AB)18.96"                  -> one(18.96, I, AB),
     "i(AB)=16.6"                  -> one(16.6, i, AB),
     "I_AB=19.09"                  -> one(19.09, I, AB),
@@ -83,7 +83,7 @@ object BrightnessParserSpec extends Specification {
     "7.39 in V"                   -> one(7.39, V, Vega),
     "13.774 in J-band "           -> one(13.774, J, Vega),
     "L'=7.055,M=7.04"             -> NonEmptyList(mag(7.055, L, Vega), mag(7.04, M, Vega)),
-    "22.7 z'"                     -> one(22.7, z, Vega)
+    "22.7 z'"                     -> one(22.7, z, AB)
   )
 
   "Brightness Parser" should {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -104,11 +104,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
                 if (newBand == MagEditRow.this.band) return;
                 changeBand(MagEditRow.this.band, newBand);
                 // OCSADV-355 If the bands is one on the AB list, switch the magnitude system to AB or else to VEGA
-                if (Magnitude.Band.AB_BANDS.stream().anyMatch(b -> b.equals(newBand))) {
-                    changeSystem(newBand, Magnitude.System.AB);
-                } else {
-                    changeSystem(newBand, Magnitude.System.Vega);
-                }
+                changeSystem(newBand, newBand.defaultSystem);
             }
         };
 
@@ -481,7 +477,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
         final Option<Magnitude> magOpt = target.getTarget().getMagnitude(b);
         if (!magOpt.isEmpty()) return; // shouldn't happen ...
 
-        final Magnitude newMag = new Magnitude(b, Magnitude.UNDEFINED_MAG, 0);
+        final Magnitude newMag = new Magnitude(b, Magnitude.UNDEFINED_MAG, 0, b.defaultSystem);
 
         target.getTarget().setMagnitudes(target.getTarget().getMagnitudes().cons(newMag));
         target.notifyOfGenericUpdate();


### PR DESCRIPTION
> Make sure that all Sloan filters (u, g, r, i, z) are imported with System = AB.

Also added a `defaultSystem` field to the `Band` itself for convenience and removed the explicit `AB_BANDS` listing.