### PR TITLE
OCSADV-341: Show saturation warnings in OT

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/AcqCamPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/AcqCamPrinter.java
@@ -4,7 +4,9 @@ import edu.gemini.itc.acqcam.AcqCamRecipe;
 import edu.gemini.itc.acqcam.AcquisitionCamera;
 import edu.gemini.itc.base.*;
 import edu.gemini.itc.shared.AcquisitionCamParameters;
+import edu.gemini.itc.shared.ItcWarning;
 import edu.gemini.itc.shared.Parameters;
+import scala.collection.JavaConversions;
 
 import java.io.PrintWriter;
 
@@ -49,8 +51,9 @@ public final class AcqCamPrinter extends PrinterBase {
                 device.toString(result.peakPixelCount() / instrument.getWellDepth() * 100) +
                 "% of the full well depth of " + device.toString(instrument.getWellDepth()) + ".");
 
-        if (result.peakPixelCount() > (.8 * instrument.getWellDepth()))
-            _println("Warning: peak pixel exceeds 80% of the well depth and may be saturated");
+        for (final ItcWarning warning : JavaConversions.asJavaList(result.warnings())) {
+            _println(warning.msg());
+        }
 
         _println("");
         device.setPrecision(2);  // TWO decimal places

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/Flamingos2Printer.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/Flamingos2Printer.java
@@ -8,6 +8,7 @@ import edu.gemini.itc.flamingos2.Flamingos2Recipe;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.FPUnit;
 import scala.Tuple2;
+import scala.collection.JavaConversions;
 
 import java.io.PrintWriter;
 import java.util.UUID;
@@ -133,8 +134,9 @@ public final class Flamingos2Printer extends PrinterBase {
                 + "% of the full well depth of "
                 + device.toString(instrument.getWellDepth()) + ".");
 
-        if (result.peakPixelCount() > (.8 * instrument.getWellDepth()))
-            _println("Warning: peak pixel exceeds 80% of the well depth and may be saturated");
+        for (final ItcWarning warning : JavaConversions.asJavaList(result.warnings())) {
+            _println(warning.msg());
+        }
 
         _println("");
         device.setPrecision(2); // TWO decimal places

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GsaoiPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GsaoiPrinter.java
@@ -6,7 +6,9 @@ import edu.gemini.itc.gsaoi.Camera;
 import edu.gemini.itc.gsaoi.Gsaoi;
 import edu.gemini.itc.gsaoi.GsaoiRecipe;
 import edu.gemini.itc.shared.GsaoiParameters;
+import edu.gemini.itc.shared.ItcWarning;
 import edu.gemini.itc.shared.Parameters;
+import scala.collection.JavaConversions;
 
 import java.io.PrintWriter;
 
@@ -54,12 +56,10 @@ public final class GsaoiPrinter extends PrinterBase {
         _println("The peak pixel signal + background is " + device.toString(result.peakPixelCount()));
 
         // REL-1353
-        final int peak_pixel_percent = (int) (100 * result.peakPixelCount() / 126000);
-        _println("This is " + peak_pixel_percent + "% of the full well depth of 126000 electrons");
-        if (peak_pixel_percent > 65 && peak_pixel_percent <= 85) {
-            _error("Warning: the peak pixel + background level exceeds 65% of the well depth and will cause deviations from linearity of more than 5%.");
-        } else if (peak_pixel_percent > 85) {
-            _error("Warning: the peak pixel + background level exceeds 85% of the well depth and may cause saturation.");
+        final int peak_pixel_percent = (int) (100 * result.peakPixelCount() / Gsaoi.WELL_DEPTH);
+        _println("This is " + peak_pixel_percent + "% of the full well depth of " + Gsaoi.WELL_DEPTH + " electrons");
+        for (final ItcWarning warning : JavaConversions.asJavaList(result.warnings())) {
+            _println(warning.msg());
         }
 
         _println("");

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/NiriPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/NiriPrinter.java
@@ -11,6 +11,7 @@ import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.gemini.niri.Niri.Mask;
 import scala.Option;
 import scala.Tuple2;
+import scala.collection.JavaConversions;
 
 import java.io.PrintWriter;
 import java.util.UUID;
@@ -148,8 +149,9 @@ public final class NiriPrinter extends PrinterBase {
                 + "% of the full well depth of "
                 + device.toString(instrument.getWellDepthValue()) + ".");
 
-        if (result.peakPixelCount() > (.8 * instrument.getWellDepthValue()))
-            _println("Warning: peak pixel exceeds 80% of the well depth and may be saturated");
+        for (final ItcWarning warning : JavaConversions.asJavaList(result.warnings())) {
+            _println(warning.msg());
+        }
 
         _println("");
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
@@ -4,7 +4,6 @@ import edu.gemini.itc.base.*;
 import edu.gemini.itc.operation.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.core.Site;
-import scala.collection.JavaConversions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -108,9 +107,9 @@ public final class AcqCamRecipe implements ImagingRecipe {
         final ImagingS2NCalculatable IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(_obsDetailParameters, instrument, SFcalc, sed_integral, sky_integral);
         IS2Ncalc.calculate();
 
-        final Parameters        p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
-        final List<ItcWarning>  w = warningsForImaging(instrument, peak_pixel_count);
-        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, JavaConversions.asScalaBuffer(w).toList());
+        final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
+        final List<ItcWarning>  warnings = warningsForImaging(instrument, peak_pixel_count);
+        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, warnings);
 
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -5,7 +5,6 @@ import edu.gemini.itc.operation.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.core.Site;
 import scala.Tuple2;
-import scala.collection.JavaConversions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -197,8 +196,8 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
         IS2Ncalc.calculate();
 
         final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
-        final List<ItcWarning> w = warningsForImaging(instrument, peak_pixel_count);
-        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, JavaConversions.asScalaBuffer(w).toList());
+        final List<ItcWarning> warnings = warningsForImaging(instrument, peak_pixel_count);
+        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, warnings);
     }
 
     // TODO: some of these warnings are similar for different instruments and could be calculated in a central place

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -197,7 +197,17 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
         IS2Ncalc.calculate();
 
         final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
-        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc);
+        final List<ItcWarning> w = warningsForImaging(instrument, peak_pixel_count);
+        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, JavaConversions.asScalaBuffer(w).toList());
     }
+
+    // TODO: some of these warnings are similar for different instruments and could be calculated in a central place
+    private List<ItcWarning> warningsForImaging(final Flamingos2 instrument, final double peakPixelCount) {
+        final double wellLimit = 0.8 * instrument.getWellDepth();
+        return new ArrayList<ItcWarning>() {{
+            if (peakPixelCount > wellLimit) add(new ItcWarning("Warning: peak pixel exceeds 80% of the well depth and may be saturated"));
+        }};
+    }
+
 
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -71,7 +71,7 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -67,7 +67,7 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             add(new SpcDataFile(SingleS2NData.instance(),  toFile(r, "Sin")));
             add(new SpcDataFile(FinalS2NData.instance(),   toFile(r, "Fin")));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     protected static String toFile(final SpectroscopyResult[] results, final String filename) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -335,6 +335,7 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
 
     }
 
+    // TODO: some of these warnings are similar for different instruments and could be calculated in a central place
     private List<ItcWarning> warningsForImaging(final Gmos instrument, final double peakPixelCount) {
         final double wellLimit     = 0.95 * instrument.getWellDepth() * instrument.getSpatialBinning() * instrument.getSpectralBinning();
         final double lowGainLimit  = 0.95 * instrument.getADSaturation() * instrument.getLowGain();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -91,7 +91,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
                 add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
             }
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     protected static String toFile(final VisitableSampledSpectrum[] sedArr) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -259,7 +259,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
 
         final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
         final SpecS2N[] specS2Narr = new SpecS2N[] {specS2N};
-        return new GnirsSpectroscopyResult(p, instrument, SFcalc, IQcalc, specS2Narr, st, Option.<AOSystem>empty(), signalOrder, backGroundOrder, finalS2NOrder);
+        return new GnirsSpectroscopyResult(p, instrument, SFcalc, IQcalc, specS2Narr, st, Option.<AOSystem>empty(), signalOrder, backGroundOrder, finalS2NOrder, ImagingResult.NoWarnings());
 
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
@@ -8,6 +8,9 @@ import edu.gemini.itc.shared.ObservationDetails;
  * Gsaoi specification class
  */
 public final class Gsaoi extends Instrument {
+
+    public static final int WELL_DEPTH = 126000;
+
     /**
      * Related files will be in this subdir of lib
      */

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
@@ -6,7 +6,6 @@ import edu.gemini.itc.operation.*;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.core.Site;
 import scala.Some;
-import scala.collection.JavaConversions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -129,8 +128,8 @@ public final class GsaoiRecipe implements ImagingRecipe {
         IS2Ncalc.calculate();
 
         final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
-        final List<ItcWarning> w = warningsForImaging(instrument, peak_pixel_count);
-        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, gems, JavaConversions.asScalaBuffer(w).toList());
+        final List<ItcWarning> warnings = warningsForImaging(instrument, peak_pixel_count);
+        return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, gems, warnings);
     }
 
     // TODO: some of these warnings are similar for different instruments and could be calculated in a central place

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
@@ -101,7 +101,7 @@ public final class MichelleRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -202,7 +202,7 @@ public final class NifsRecipe implements SpectroscopyRecipe {
 
         final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
         // TODO: no SFCalc and ST for Nifs, introduce specific result type? or optional values? work with null for now
-        return new GenericSpectroscopyResult(p, instrument, null, IQcalc, specS2Narr, null, altair);
+        return new GenericSpectroscopyResult(p, instrument, null, IQcalc, specS2Narr, null, altair, ImagingResult.NoWarnings());
     }
 
     // NIFS CHARTS

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -75,7 +75,7 @@ public final class NifsRecipe implements SpectroscopyRecipe {
                 add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[i].getFinalS2NSpectrum().printSpecAsString()));
             }
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     private SpectroscopyResult calculateSpectroscopy(final Nifs instrument) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -198,7 +198,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
         final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
         final SpecS2N[] specS2Narr = new SpecS2N[1];
         specS2Narr[0] = specS2N;
-        return new GenericSpectroscopyResult(p, instrument, SFcalc, IQcalc, specS2Narr, st, altair);
+        return new GenericSpectroscopyResult(p, instrument, SFcalc, IQcalc, specS2Narr, st, altair, ImagingResult.NoWarnings());
     }
 
     private ImagingResult calculateImaging(final Niri instrument) {
@@ -283,7 +283,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
         IS2Ncalc.calculate();
 
         final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
-        return new ImagingResult(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, altair);
+        return new ImagingResult(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, altair, ImagingResult.NoWarnings());
 
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -81,7 +81,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     private SpectroscopyResult calculateSpectroscopy(final Niri instrument) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -282,9 +282,18 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
         }
         IS2Ncalc.calculate();
 
-        final Parameters p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
-        return new ImagingResult(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, altair, ImagingResult.NoWarnings());
+        final Parameters        p = new Parameters(_sdParameters, _obsDetailParameters, _obsConditionParameters, _telescope);
+        final List<ItcWarning>  w = warningsForImaging(instrument, peak_pixel_count);
+        return new ImagingResult(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc, altair, JavaConversions.asScalaBuffer(w).toList());
 
+    }
+
+    // TODO: some of these warnings are similar for different instruments and could be calculated in a central place
+    private List<ItcWarning> warningsForImaging(final Niri instrument, final double peakPixelCount) {
+        final double wellLimit = 0.8 * instrument.getWellDepthValue();
+        return new ArrayList<ItcWarning>() {{
+            if (peakPixelCount > wellLimit) add(new ItcWarning("Warning: peak pixel exceeds 80% of the well depth and may be saturated"));
+        }};
     }
 
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
@@ -102,7 +102,7 @@ public final class TRecsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(new ItcSpectroscopyResult(_sdParameters, _obsDetailParameters, JavaConversions.asScalaBuffer(dataSets).toList(), JavaConversions.asScalaBuffer(dataFiles).toList()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
@@ -6,6 +6,9 @@ import edu.gemini.itc.shared._
 
 import scala.collection.JavaConversions._
 
+import scalaz._
+import Scalaz._
+
 sealed trait Recipe
 
 trait ImagingRecipe extends Recipe {
@@ -13,7 +16,7 @@ trait ImagingRecipe extends Recipe {
 }
 
 trait ImagingArrayRecipe extends Recipe {
-  def calculateImaging(): Array[ImagingResult]
+  def calculateImaging(): NonEmptyList[ImagingResult]
 }
 
 

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Result.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Result.scala
@@ -48,6 +48,8 @@ object ImagingResult {
   def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, warnings: List[ItcWarning]) =
     new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, None, warnings)
 
+  def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, aoSystem: AOSystem, warnings: List[ItcWarning]) =
+    new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, Some(aoSystem), warnings)
 }
 
 sealed trait SpectroscopyResult extends Result {

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Result.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Result.scala
@@ -1,7 +1,7 @@
 package edu.gemini.itc.base
 
 import edu.gemini.itc.operation._
-import edu.gemini.itc.shared.Parameters
+import edu.gemini.itc.shared.{ItcWarning, Parameters}
 
 /*
  * Helper objects that are used to pass around results of imaging and spectroscopy calculations.
@@ -12,34 +12,41 @@ import edu.gemini.itc.shared.Parameters
  */
 
 sealed trait Result {
-  val parameters: Parameters
-  val instrument: Instrument
+  def warnings:   List[ItcWarning]
+  def parameters: Parameters
+  def instrument: Instrument
 
   // Accessors for convenience.
   val source      = parameters.source
   val observation = parameters.observation
   val telescope   = parameters.telescope
   val conditions  = parameters.conditions
-
 }
 
 /* Internal object for imaging results. */
 final case class ImagingResult(
-                      parameters: Parameters,
-                      instrument: Instrument,
-                      iqCalc: ImageQualityCalculatable,
-                      sfCalc: SourceFraction,
-                      peakPixelCount: Double,
-                      is2nCalc: ImagingS2NCalculatable,
-                      aoSystem: Option[AOSystem]) extends Result
+                      parameters:       Parameters,
+                      instrument:       Instrument,
+                      iqCalc:           ImageQualityCalculatable,
+                      sfCalc:           SourceFraction,
+                      peakPixelCount:   Double,
+                      is2nCalc:         ImagingS2NCalculatable,
+                      aoSystem:         Option[AOSystem],
+                      warnings:         List[ItcWarning] = List()) extends Result
 
 object ImagingResult {
+
+  // Helper for Java usage
+  val NoWarnings = List[ItcWarning]()
 
   def apply(parameters: Parameters, instrument: Instrument, iqCalc: ImageQualityCalculatable, sfCalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable) =
     new ImagingResult(parameters, instrument, iqCalc, sfCalc, peakPixelCount, IS2Ncalc, None)
 
   def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, aoSystem: AOSystem) =
     new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, Some(aoSystem))
+
+  def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, warnings: List[ItcWarning]) =
+    new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, None, warnings)
 
 }
 
@@ -53,33 +60,33 @@ sealed trait SpectroscopyResult extends Result {
 
 /* Internal object for generic spectroscopy results (all instruments except for GNIRS). */
 final case class GenericSpectroscopyResult(
-                      parameters: Parameters,
-                      instrument: Instrument,
-                      sfCalc: SourceFraction,
-                      iqCalc: ImageQualityCalculatable,
-                      specS2N: Array[SpecS2N],
-                      st: SlitThroughput,
-                      aoSystem: Option[AOSystem]) extends SpectroscopyResult
+                      parameters:       Parameters,
+                      instrument:       Instrument,
+                      sfCalc:           SourceFraction,
+                      iqCalc:           ImageQualityCalculatable,
+                      specS2N:          Array[SpecS2N],
+                      st:               SlitThroughput,
+                      aoSystem:         Option[AOSystem],
+                      warnings:         List[ItcWarning] = List()) extends SpectroscopyResult
 
 /* Internal object for GNIRS spectroscopy results.
  * I somehow think it should be possible to unify this in a clever way with the "generic" spectroscopy result
  * used for the other instruments, but right now I don't understand the calculations well enough to figure out
  * how to do that in a meaningful way. */
 final case class GnirsSpectroscopyResult(
-                      parameters: Parameters,
-                      instrument: Instrument,
-                      sfCalc: SourceFraction,
-                      iqCalc: ImageQualityCalculatable,
-                      specS2N: Array[SpecS2N],
-                      st: SlitThroughput,
-                      aoSystem: Option[AOSystem],
-                      signalOrder: Array[VisitableSampledSpectrum],
-                      backGroundOrder: Array[VisitableSampledSpectrum],
-                      finalS2NOrder: Array[VisitableSampledSpectrum]) extends SpectroscopyResult
+                      parameters:       Parameters,
+                      instrument:       Instrument,
+                      sfCalc:           SourceFraction,
+                      iqCalc:           ImageQualityCalculatable,
+                      specS2N:          Array[SpecS2N],
+                      st:               SlitThroughput,
+                      aoSystem:         Option[AOSystem],
+                      signalOrder:      Array[VisitableSampledSpectrum],
+                      backGroundOrder:  Array[VisitableSampledSpectrum],
+                      finalS2NOrder:    Array[VisitableSampledSpectrum],
+                      warnings:         List[ItcWarning] = List()) extends SpectroscopyResult
 
 object SpectroscopyResult {
-
-  def instance = this
 
   def apply(parameters: Parameters, instrument: Instrument, sfCalc: SourceFraction, iqCalc: ImageQualityCalculatable, specS2N: Array[SpecS2N], st: SlitThroughput) =
     new GenericSpectroscopyResult(parameters, instrument, sfCalc, iqCalc, specS2N, st, None)

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Result.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Result.scala
@@ -3,6 +3,8 @@ package edu.gemini.itc.base
 import edu.gemini.itc.operation._
 import edu.gemini.itc.shared.{ItcWarning, Parameters}
 
+import scala.collection.JavaConversions._
+
 /*
  * Helper objects that are used to pass around results of imaging and spectroscopy calculations.
  * These objects also contain the parameter objects that were used for the calculations so that input values
@@ -45,11 +47,11 @@ object ImagingResult {
   def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, aoSystem: AOSystem) =
     new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, Some(aoSystem))
 
-  def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, warnings: List[ItcWarning]) =
-    new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, None, warnings)
+  def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, warnings: java.util.List[ItcWarning]) =
+    new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, None, warnings.toList)
 
-  def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, aoSystem: AOSystem, warnings: List[ItcWarning]) =
-    new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, Some(aoSystem), warnings)
+  def apply(parameters: Parameters, instrument: Instrument, IQcalc: ImageQualityCalculatable, SFcalc: SourceFraction, peakPixelCount: Double, IS2Ncalc: ImagingS2NCalculatable, aoSystem: AOSystem, warnings: java.util.List[ItcWarning]) =
+    new ImagingResult(parameters, instrument, IQcalc, SFcalc, peakPixelCount, IS2Ncalc, Some(aoSystem), warnings.toList)
 }
 
 sealed trait SpectroscopyResult extends Result {
@@ -92,6 +94,9 @@ object SpectroscopyResult {
 
   def apply(parameters: Parameters, instrument: Instrument, sfCalc: SourceFraction, iqCalc: ImageQualityCalculatable, specS2N: Array[SpecS2N], st: SlitThroughput) =
     new GenericSpectroscopyResult(parameters, instrument, sfCalc, iqCalc, specS2N, st, None)
+
+  def apply(parameters: Parameters, instrument: Instrument, sfCalc: SourceFraction, iqCalc: ImageQualityCalculatable, specS2N: Array[SpecS2N], st: SlitThroughput, warnings: java.util.List[ItcWarning]) =
+    new GenericSpectroscopyResult(parameters, instrument, sfCalc, iqCalc, specS2N, st, None, warnings.toList)
 
 }
 

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -39,31 +39,25 @@ class ItcServiceImpl extends ItcService {
 
   private def calculateImaging(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Result =
     ins match {
+      case i: MichelleParameters          => ItcResult.forMessage ("Imaging not implemented.")
+      case i: TRecsParameters             => ItcResult.forMessage ("Imaging not implemented.")
       case i: AcquisitionCamParameters    => imagingResult        (new AcqCamRecipe(source, obs, cond, tele, i))
       case i: Flamingos2Parameters        => imagingResult        (new Flamingos2Recipe(source, obs, cond, i, tele))
       case i: GmosParameters              => imagingResult        (new GmosRecipe(source, obs, cond, i, tele))
       case i: GsaoiParameters             => imagingResult        (new GsaoiRecipe(source, obs, cond, i, tele))
-      case i: MichelleParameters          => ItcResult.forMessage ("Imaging not implemented.")
       case i: NiriParameters              => imagingResult        (new NiriRecipe(source, obs, cond, i, tele))
-      case i: TRecsParameters             => ItcResult.forMessage ("Imaging not implemented.")
       case _                              => ItcResult.forMessage ("Imaging with this instrument is not supported by ITC.")
     }
 
-  private def imagingResult(recipe: ImagingRecipe): Result =
-    imagingResult(NonEmptyList(recipe.calculateImaging()))
+  private def imagingResult(recipe: ImagingRecipe): Result = {
+    val r = recipe.calculateImaging()
+    ItcResult.forResult(ItcImagingResult(r.source, r.observation, List(toImgData(r)), r.warnings))
+  }
 
-  private def imagingResult(recipe: ImagingArrayRecipe): Result =
-    imagingResult(recipe.calculateImaging())
-
-  private def imagingResult(r: NonEmptyList[ImagingResult]): Result =
-    ItcResult.forResult(ItcImagingResult(r.head.source, r.head.observation, r.map(toImgData).toList, combineWarnings(r)))
-
-  // combine all warnings for the different CCDs and prepend a "CCD x:" in front of them
-  private def combineWarnings(rs: NonEmptyList[ImagingResult]): List[ItcWarning] =
-    if (rs.size > 1)
-      rs.toList.zipWithIndex.flatMap { case (r, i) => r.warnings.map(w => new ItcWarning(s"CCD $i: ${w.msg}")) }
-    else
-      rs.head.warnings
+  private def imagingResult(recipe: ImagingArrayRecipe): Result = {
+    val r = recipe.calculateImaging()
+    ItcResult.forResult(ItcImagingResult(r.head.source, r.head.observation, r.map(toImgData).toList, combineWarnings(r.toList)))
+  }
 
   private def toImgData(result: ImagingResult): ImgData = result.is2nCalc match {
     case i: ImagingS2NMethodACalculation  => ImgData(i.singleSNRatio(), i.totalSNRatio(), result.peakPixelCount)
@@ -74,29 +68,41 @@ class ItcServiceImpl extends ItcService {
 
   private def calculateSpectroscopy(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Result =
     ins match {
+      case i: MichelleParameters          => ItcResult.forMessage ("Spectroscopy not implemented.")
+      case i: TRecsParameters             => ItcResult.forMessage ("Spectroscopy not implemented.")
       case i: Flamingos2Parameters        => spectroscopyResult   (new Flamingos2Recipe(source, obs, cond, i , tele))
       case i: GmosParameters              => spectroscopyResult   (new GmosRecipe(source, obs, cond, i, tele))
       case i: GnirsParameters             => spectroscopyResult   (new GnirsRecipe(source, obs, cond, i, tele))
-      case i: MichelleParameters          => ItcResult.forMessage ("Spectroscopy not implemented.")
       case i: NifsParameters              => spectroscopyResult   (new NifsRecipe(source, obs, cond, i, tele))
       case i: NiriParameters              => spectroscopyResult   (new NiriRecipe(source, obs, cond, i, tele))
-      case i: TRecsParameters             => ItcResult.forMessage ("Spectroscopy not implemented.")
       case _                              => ItcResult.forMessage ("Spectroscopy with this instrument is not supported by ITC.")
 
     }
 
-  private def spectroscopyResult(recipe: SpectroscopyRecipe): Result =
-    resultWithoutFiles(recipe.calculateSpectroscopy()._1)
+  private def spectroscopyResult(recipe: SpectroscopyRecipe): Result = {
+    val r = recipe.calculateSpectroscopy()
+    resultWithoutFiles(r._1, r._2.warnings)
+  }
 
-  private def spectroscopyResult(recipe: SpectroscopyArrayRecipe): Result =
-    resultWithoutFiles(recipe.calculateSpectroscopy()._1)
+  private def spectroscopyResult(recipe: SpectroscopyArrayRecipe): Result = {
+    val r = recipe.calculateSpectroscopy()
+    resultWithoutFiles(r._1, combineWarnings(r._2.toList))
+  }
 
   // Currently the OT does not use the text files that can be downloaded from the web page. Andy S. says it is
   // unlikely that we want to display those files in the OT, so for now, we don't send them in order to save
   // a bit of bandwidth. If the need arises to have the files accessible in the clients just change this to
   // send the original result.
-  private def resultWithoutFiles(result: ItcSpectroscopyResult): Result =
-    ItcResult.forResult(ItcSpectroscopyResult(result.source, result.obsDetails, result.charts, List(), result.warnings))
+  private def resultWithoutFiles(result: ItcSpectroscopyResult, warnings: List[ItcWarning]): Result =
+    ItcResult.forResult(ItcSpectroscopyResult(result.source, result.obsDetails, result.charts, List(), warnings))
+
+
+  // combine all warnings for the different CCDs and prepend a "CCD x:" in front of them
+  private def combineWarnings[A <: edu.gemini.itc.base.Result](rs: List[A]): List[ItcWarning] =
+    if (rs.size > 1)
+      rs.zipWithIndex.flatMap { case (r, i) => r.warnings.map(w => new ItcWarning(s"CCD $i: ${w.msg}")) }
+    else
+      rs.head.warnings
 
 
 }

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -47,13 +47,13 @@ class ItcServiceImpl extends ItcService {
     }
 
   private def imagingResult(recipe: ImagingRecipe): Result =
-    imagingResult(Seq(recipe.calculateImaging()))
+    imagingResult(List(recipe.calculateImaging()))
 
   private def imagingResult(recipe: ImagingArrayRecipe): Result =
-    imagingResult(recipe.calculateImaging())
+    imagingResult(recipe.calculateImaging().toList)
 
-  private def imagingResult(r: Seq[ImagingResult]): Result =
-    ItcResult.forResult(ItcImagingResult(r.head.source, r.head.observation, r.map(toImgData)))
+  private def imagingResult(r: List[ImagingResult]): Result =
+    ItcResult.forResult(ItcImagingResult(r.head.source, r.head.observation, r.map(toImgData), List()))
 
   private def toImgData(result: ImagingResult): ImgData = result.is2nCalc match {
     case i: ImagingS2NMethodACalculation  => ImgData(i.singleSNRatio(), i.totalSNRatio(), result.peakPixelCount)
@@ -86,7 +86,7 @@ class ItcServiceImpl extends ItcService {
   // a bit of bandwidth. If the need arises to have the files accessible in the clients just change this to
   // send the original result.
   private def resultWithoutFiles(result: ItcSpectroscopyResult): Result =
-    ItcResult.forResult(ItcSpectroscopyResult(result.source, result.obsDetails, result.charts, Seq()))
+    ItcResult.forResult(ItcSpectroscopyResult(result.source, result.obsDetails, result.charts, List(), result.warnings))
 
 
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -196,7 +196,7 @@ private class ItcFeedbackPanel(table: ItcTable) extends Label {
       case Failure(t)                           => feedback(ErrorIcon,    t.getMessage, LIGHT_SALMON)
       case Success(s) => s match {
         case -\/(err)                           => feedback(ErrorIcon,    err.msg,      LIGHT_SALMON)
-        case \/-(res) if res.warnings.nonEmpty  => feedback(WarningIcon,  res.warnings.mkString("<html><body>","<br>","</body></html>"), BANANA)
+        case \/-(res) if res.warnings.nonEmpty  => feedback(WarningIcon,  res.warnings.map(_.msg).mkString("<html><body>","<br>","</body></html>"), BANANA)
         case _                                  => None
       }
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -22,10 +22,14 @@ import scala.swing.event._
 import scala.swing.{ButtonGroup, _}
 import scala.util.{Failure, Success}
 
+import scalaz._
+import Scalaz._
+
 object ItcPanel {
 
-  val ErrorIcon   = new ImageIcon(classOf[ItcTableModel].getResource("/resources/images/error_tsk.gif"))
-  val SpinnerIcon = new ImageIcon(classOf[ItcTableModel].getResource("/resources/images/spinner16.gif"))
+  val ErrorIcon   = new ImageIcon(classOf[ItcPanel].getResource("/resources/images/error_tsk.gif"))
+  val WarningIcon = new ImageIcon(classOf[ItcPanel].getResource("/resources/images/warn_tsk.gif"))
+  val SpinnerIcon = new ImageIcon(classOf[ItcPanel].getResource("/resources/images/spinner16.gif"))
 
   /** Creates a panel for ITC imaging results. */
   def forImaging(owner: EdIteratorFolder)       = new ItcImagingPanel(owner)
@@ -185,17 +189,17 @@ private class ItcFeedbackPanel(table: ItcTable) extends Label {
     revalidate()
   }
 
-  private def feedback(f: Future[ItcService.Result]): Option[(Icon, String, Color)] = {
+  private def feedback(f: Future[ItcService.Result]): Option[(Icon, String, Color)] =
     f.value.fold {
       feedback(SpinnerIcon, "Calculating...", BANANA)
     } {
-      case Failure(t)               => feedback(ErrorIcon, t.getMessage, LIGHT_SALMON)
+      case Failure(t)                           => feedback(ErrorIcon,    t.getMessage, LIGHT_SALMON)
       case Success(s) => s match {
-        case scalaz.Failure(errs)   => feedback(ErrorIcon, errs.mkString(", "), LIGHT_SALMON)
-        case scalaz.Success(_)      => None
+        case -\/(err)                           => feedback(ErrorIcon,    err.msg,      LIGHT_SALMON)
+        case \/-(res) if res.warnings.nonEmpty  => feedback(WarningIcon,  res.warnings.mkString("<html><body>","<br>","</body></html>"), BANANA)
+        case _                                  => None
       }
     }
-  }
 
   private def feedback(ico: Icon, msg: String, col: Color): Option[(Icon, String, Color)] = Some((ico, msg, col))
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -139,10 +139,8 @@ trait ItcTable extends Table {
     }
 
     s match {
-      case -\/(l) => Future {
-        List(l).fail
-      }
-      case \/-(r) => r
+      case -\/(err) => Future { ItcError(err).left }
+      case \/-(res) => res
     }
 
   }


### PR DESCRIPTION
In order to improve the usefulness of the ITC results in the OT we added some saturation warnings which previously were only shown on the web pages.

Unfortunately this PR shows, that there is still quite some repetition of code between different instruments, that could/should be addressed at some point, like e.g. some of the warnings are the same for the different instruments. So, there's still room for improvement for the ITC code, but I guess it's quite a bit better than 4 months ago.. 

![image](https://cloud.githubusercontent.com/assets/7856060/7781097/f4582870-0083-11e5-81ea-fffccaf76d5b.png)
