### PR TITLE
OCSADV-351: Validate sky aperture >= 1 and Gaussian FWHM >= 0.1

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
@@ -44,8 +44,8 @@ public final class AcqCamRecipe implements ImagingRecipe {
             }
         }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Validation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Validation.java
@@ -1,8 +1,32 @@
 package edu.gemini.itc.base;
 
+import edu.gemini.itc.shared.AnalysisMethod;
+import edu.gemini.itc.shared.ObservationDetails;
+import edu.gemini.itc.shared.SourceDefinition;
+import edu.gemini.spModel.target.GaussianSource;
+import edu.gemini.spModel.target.SpatialProfile;
+
 public final class Validation {
 
-    public static void checkSourceFraction(double nExp, double fracSource) {
+    public static void validate(ObservationDetails obs, SourceDefinition source) {
+        checkSourceFraction(obs.getNumExposures(), obs.getSourceFraction());
+        checkGaussianFwhm(source.profile);
+        checkSkyAperture(obs.getAnalysis());
+    }
+
+    private static void checkSkyAperture(AnalysisMethod am) {
+        if (am.skyAperture() < 1.0) throw new IllegalArgumentException("The sky aperture must be 1.0 or greater.");
+    }
+
+    private static void checkGaussianFwhm(SpatialProfile sp) {
+        if (sp instanceof GaussianSource) {
+            if (((GaussianSource) sp).fwhm() < 0.1) {
+                throw new IllegalArgumentException("Please use a Gaussian FWHM of 0.1 or greater.");
+            }
+        }
+    }
+
+    private static void checkSourceFraction(double nExp, double fracSource) {
         double epsilon = 0.2;
         double number_source_exposures = nExp * fracSource;
         int iNumExposures = (int) (number_source_exposures + 0.5);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -54,8 +54,8 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
             }
         }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     public Tuple2<ItcSpectroscopyResult, SpectroscopyResult> calculateSpectroscopy() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -51,8 +51,8 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             }
         }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     public Tuple2<ItcSpectroscopyResult, SpectroscopyResult[]> calculateSpectroscopy() {
@@ -322,10 +322,6 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         // In this version we are bypassing morphology modules 3a-5a.
         // i.e. the output morphology is same as the input morphology.
         // Might implement these modules at a later time.
-        final int number_exposures = _obsDetailParameters.getNumExposures();
-        final double frac_with_source = _obsDetailParameters.getSourceFraction();
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(number_exposures, frac_with_source);
 
         final ImagingS2NCalculatable IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(_obsDetailParameters, instrument, SFcalc, sed_integral, sky_integral);
         IS2Ncalc.calculate();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -63,8 +63,8 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
                                 + " km/s) to avoid undersampling of the line profile when convolved with the transmission response");
             }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     public Tuple2<ItcSpectroscopyResult, SpectroscopyResult> calculateSpectroscopy() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
@@ -47,8 +47,8 @@ public final class GsaoiRecipe implements ImagingRecipe {
                                 + " km/s) to avoid undersampling of the line profile when convolved with the transmission response");
             }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
@@ -47,8 +47,8 @@ public final class MichelleRecipe implements ImagingRecipe, SpectroscopyRecipe {
                 throw new RuntimeException("Please use a model line width > 0.2 nm (or " + (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 5)) + " km/s) to avoid undersampling of the line profile when convolved with the transmission response");
             }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     private ObservationDetails correctedObsDetails(final MichelleParameters mp, final ObservationDetails odp) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -52,8 +52,8 @@ public final class NifsRecipe implements SpectroscopyRecipe {
             }
         }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -58,8 +58,8 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
                                 + " km/s) to avoid undersampling of the line profile when convolved with the transmission response");
             }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
 
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
@@ -56,8 +56,8 @@ public final class TRecsRecipe implements ImagingRecipe, SpectroscopyRecipe {
                     + "    and recalculate.");
         }
 
-        // report error if this does not come out to be an integer
-        Validation.checkSourceFraction(_obsDetailParameters.getNumExposures(), _obsDetailParameters.getSourceFraction());
+        // some general validations
+        Validation.validate(_obsDetailParameters, _sdParameters);
     }
 
     private ObservationDetails correctedObsDetails(final TRecsParameters tp, final ObservationDetails odp) {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SpatialProfile.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SpatialProfile.scala
@@ -2,7 +2,5 @@ package edu.gemini.spModel.target
 
 sealed trait SpatialProfile extends Serializable
 final case class PointSource() extends SpatialProfile
-final case class GaussianSource(fwhm: Double) extends SpatialProfile {
-  require (fwhm >= 0.1, "Please use a Gaussian FWHM greater than 0.1")
-}
+final case class GaussianSource(fwhm: Double) extends SpatialProfile
 final case class UniformSource() extends SpatialProfile


### PR DESCRIPTION
This moves some general validation logic down into the server so that it is executed for web requests and OT requests alike. Also, it deals with the problem noted in OCSADV-362 caused by exceptions thrown by ```require``` in the constructor of ```GaussianSource``` when entering values for FWHM in the target editor.