### PR TITLE
OCSADV-355: SDSS filters must default to AB mag system

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/java/edu/gemini/catalog/skycat/table/CatalogValueExtractor.java
+++ b/bundle/edu.gemini.catalog/src/main/java/edu/gemini/catalog/skycat/table/CatalogValueExtractor.java
@@ -311,6 +311,6 @@ public final class CatalogValueExtractor {
             error = getOptionalDouble(errorColName.getValue());
         }
 
-        return new Some<>(new Magnitude(band, mag.getValue(), error));
+        return new Some<>(new Magnitude(band, mag.getValue(), error, band.defaultSystem));
     }
 }

--- a/bundle/edu.gemini.catalog/src/main/resources/resources/conf/AstroCat.xml
+++ b/bundle/edu.gemini.catalog/src/main/resources/resources/conf/AstroCat.xml
@@ -16,20 +16,16 @@
 <!-- Include references to some of the Skycat catalogs (Should be defined in the skycat.cfg file) -->
 
   <catalog name="PPMXL Catalog at CDS"/>
-  <catalog name="PPMXL Catalog at CADC"/>
   <catalog name="2MASS Catalog at CDS"/>
   <catalog name="UCAC4 Catalog at Gemini"/>
   <catalog name="UCAC3 Catalog at CDS"/>
-  <catalog name="UCAC3 Catalog at CADC"/>
   <catalog name="NOMAD1 catalog at CDS"/>
-  <catalog name="NOMAD1 catalog at CADC"/>
   <catalog name="GSC-2 at ESO"/>
   <catalog name="GSC-2 at STScI"/>
 
 <!-- Skycat Image Servers (should be defined in the skycat.cfg file) -->
   <catalog name="Digitized Sky at Gemini North"/>
   <catalog name="Digitized Sky at Gemini South"/>
-  <catalog name="Digitized Sky at CADC (2nd Generation)"/>
   <catalog name="Digitized Sky at ESO"/>
   <catalog name="Digitized Sky (Version II) at ESO"/>
   <catalog name="Digitized Sky (Version II infrared) at ESO"/>

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -210,7 +210,7 @@ trait VoTableParser {
 
     def combineWithErrorsAndFilter(m: List[(FieldId, MagnitudeBand, Double)], e: List[(FieldId, MagnitudeBand, Double)]): List[Magnitude] = {
       val mags = m.map {
-          case (f, b, d) => f -> new Magnitude(d, b)
+          case (f, b, d) => f -> new Magnitude(d, b, b.defaultSystem)
         }
       val magErrors = e.map {
           case (_, b, d) => b -> d

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -378,8 +378,8 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       parse(voTableWithErrors).tables.head should beEqualTo(result)
     }
     "be able to parse an xml into a list of SiderealTargets including proper motion" in {
-      val magsTarget1 = List(new Magnitude(14.76, MagnitudeBand._r))
-      val magsTarget2 = List(new Magnitude(12.983, MagnitudeBand._r))
+      val magsTarget1 = List(new Magnitude(14.76, MagnitudeBand._r, MagnitudeSystem.AB))
+      val magsTarget2 = List(new Magnitude(12.983, MagnitudeBand._r, MagnitudeSystem.AB))
       val pm1 = ProperMotion(RightAscensionAngularVelocity(AngularVelocity(-10.199999999999999)), DeclinationAngularVelocity(AngularVelocity(-4.9000000000000004))).some
       val pm2 = ProperMotion(RightAscensionAngularVelocity(AngularVelocity(-7)), DeclinationAngularVelocity(AngularVelocity(-13.9))).some
 
@@ -456,13 +456,13 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
 
       val gmag = result.map(_.magnitudeIn(MagnitudeBand._g))
       // gmag gets converted to g'
-      gmag should beEqualTo(\/.right(Some(Magnitude(15.0, MagnitudeBand._g, 0.39.some, MagnitudeSystem.VEGA))))
+      gmag should beEqualTo(\/.right(Some(Magnitude(15.0, MagnitudeBand._g, 0.39.some, MagnitudeSystem.AB))))
       val rmag = result.map(_.magnitudeIn(MagnitudeBand._r))
       // rmag gets converted to r'
-      rmag should beEqualTo(\/.right(Some(Magnitude(13.2, MagnitudeBand._r, 0.5.some, MagnitudeSystem.VEGA))))
+      rmag should beEqualTo(\/.right(Some(Magnitude(13.2, MagnitudeBand._r, 0.5.some, MagnitudeSystem.AB))))
       val imag = result.map(_.magnitudeIn(MagnitudeBand._i))
       // rmag gets converted to r'
-      imag should beEqualTo(\/.right(Some(Magnitude(5, MagnitudeBand._i, 0.34.some, MagnitudeSystem.VEGA))))
+      imag should beEqualTo(\/.right(Some(Magnitude(5, MagnitudeBand._i, 0.34.some, MagnitudeSystem.AB))))
     }
   }
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpTargetFactory.scala
@@ -60,7 +60,7 @@ object SpTargetFactory {
 
       // Add apparent magnitude, if any.
       nsid.magnitude(time)
-        .map(new SO.Magnitude(SO.Magnitude.Band.AP, _))
+        .map(new SO.Magnitude(SO.Magnitude.Band.AP, _, SO.Magnitude.System.AB))
         .foreach(spTarget.getTarget.putMagnitude)
 
       spTarget
@@ -74,7 +74,7 @@ object SpTargetFactory {
     } yield {
       val itarget  = new SP.system.HmsDegTarget()
       setRaDec(itarget, coords)
-      sid.properMotion map { pm =>
+      sid.properMotion.foreach { pm =>
         val ra  = pm.deltaRA
         val dec = pm.deltaDec
         itarget.setPM1(new SPProperMotionRA(ra,   SP.system.CoordinateParam.Units.MILLI_ARCSECS_PER_YEAR))

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -77,7 +77,7 @@ object ModelConverters {
       system match {
         case MagnitudeSystem.AB   => skyobject.Magnitude.System.AB
         case MagnitudeSystem.VEGA => skyobject.Magnitude.System.Vega
-        case MagnitudeSystem.JY   =>skyobject.Magnitude.System.Jy
+        case MagnitudeSystem.JY   => skyobject.Magnitude.System.Jy
       }
   }
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -63,6 +63,24 @@ object ModelConverters {
       Offset(offset.getXaxis.arcsecs[OffsetP], offset.getYaxis.arcsecs[OffsetQ])
   }
 
+  implicit class OldMagnitudeSystem2New(val system: skyobject.Magnitude.System) extends AnyVal {
+    def toNewModel: MagnitudeSystem =
+      system match {
+        case skyobject.Magnitude.System.AB   => MagnitudeSystem.AB
+        case skyobject.Magnitude.System.Vega => MagnitudeSystem.VEGA
+        case skyobject.Magnitude.System.Jy   => MagnitudeSystem.JY
+      }
+  }
+
+  implicit class NewMagnitudeSystem2Old(val system: MagnitudeSystem) extends AnyVal {
+    def toOldModel: skyobject.Magnitude.System =
+      system match {
+        case MagnitudeSystem.AB   => skyobject.Magnitude.System.AB
+        case MagnitudeSystem.VEGA => skyobject.Magnitude.System.Vega
+        case MagnitudeSystem.JY   =>skyobject.Magnitude.System.Jy
+      }
+  }
+
   implicit class OldOffset2New(val offset: skycalc.Offset) extends AnyVal {
     def toNewModel: Offset =
       Offset(offset.p().toDegrees.getMagnitude.degrees[OffsetP],
@@ -135,11 +153,12 @@ object ModelConverters {
   }
 
   implicit class OldMagnitude2New(val m: skyobject.Magnitude) extends AnyVal {
-    def toNewModel: Magnitude = new Magnitude(m.getBrightness, m.getBand.toNewModel)
+    def toNewModel: Magnitude = new Magnitude(m.getBrightness, m.getBand.toNewModel, m.getSystem.toNewModel)
   }
 
   implicit class NewMagnitude2Old(val m: Magnitude) extends AnyVal {
-    def toOldModel: skyobject.Magnitude = new skyobject.Magnitude(m.band.toOldModel, m.value)
+    def toOldModel: skyobject.Magnitude =
+      new skyobject.Magnitude(m.band.toOldModel, m.value, m.system.toOldModel)
   }
 
   implicit class HmsDegCoords2Coordinates(val c: skyobject.coords.HmsDegCoordinates) extends AnyVal {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/ModelConversionsSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/ModelConversionsSpec.scala
@@ -82,7 +82,7 @@ class ModelConversionsSpec extends Specification with ScalaCheck with Arbitrarie
           t.name shouldEqual "name"
           t.coordinates ~= c
           (t.properMotion |@| properMotion)(_ ~= _).getOrElse {properMotion should beNone}
-          t.magnitudeIn(mag.band) should beSome(mag.copy(error = None, system = MagnitudeSystem.VEGA))
+          t.magnitudeIn(mag.band) should beSome(mag.copy(error = None))
         }
       }
     }
@@ -97,7 +97,7 @@ class ModelConversionsSpec extends Specification with ScalaCheck with Arbitrarie
           t.name shouldEqual "name"
           t.coordinates ~= c
           (t.properMotion |@| properMotion)(_ ~= _).getOrElse {properMotion should beNone}
-          t.magnitudeIn(mag.band) should beSome(mag.copy(error = None, system = MagnitudeSystem.VEGA))
+          t.magnitudeIn(mag.band) should beSome(mag.copy(error = None))
         }
       }
     }

--- a/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
+++ b/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
@@ -122,7 +122,7 @@ public final class Magnitude implements Comparable, Serializable {
      */
     public Magnitude(Band band, double brightness) {
         //noinspection unchecked
-        this(band, brightness, None.INSTANCE, System.DEFAULT);
+        this(band, brightness, None.INSTANCE, band != null ? band.defaultSystem : System.DEFAULT);
     }
 
     /**
@@ -143,7 +143,7 @@ public final class Magnitude implements Comparable, Serializable {
      * @param error error in measurement
      */
     public Magnitude(Band band, double brightness, double error) {
-        this(band, brightness, new Some<>(error), System.DEFAULT);
+        this(band, brightness, new Some<>(error), band.defaultSystem);
     }
 
     /**
@@ -165,8 +165,8 @@ public final class Magnitude implements Comparable, Serializable {
      * @param brightness absolute brightness
      * @param error optional error in measurement
      */
-    protected Magnitude(Band band, double brightness, Option<Double> error) {
-        this(band, brightness, error, System.DEFAULT);
+    public Magnitude(Band band, double brightness, Option<Double> error) {
+        this(band, brightness, error, band != null ? band.defaultSystem : System.DEFAULT);
     }
 
     /**

--- a/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
+++ b/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
@@ -103,8 +103,6 @@ public final class Magnitude implements Comparable, Serializable {
 
     }
 
-
-
     /**
      * Magnitudes with this brightness are undefined.
      */

--- a/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
+++ b/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
@@ -14,7 +14,7 @@ import java.util.Comparator;
  * particular wavelengths of light, and optionally are associated with an error
  * in the measurement.
  */
-public final class Magnitude implements Comparable, Serializable {
+public final class Magnitude implements Comparable<Magnitude>, Serializable {
     /**
      * REL-549: Magnitude information for targets and guide stars in OT must be stored in value, bandpass, system triples.
      */
@@ -231,12 +231,10 @@ public final class Magnitude implements Comparable, Serializable {
      * Compares two magnitude objects by system, band, brightness and error (in that
      * order).
      *
-     * @param o other magnitude object
+     * @param that other magnitude object
      */
     @Override
-    public int compareTo(Object o) {
-        Magnitude that = (Magnitude) o;
-
+    public int compareTo(Magnitude that) {
         int res = system.compareTo(that.system);
         if (res != 0) return res;
 
@@ -248,7 +246,7 @@ public final class Magnitude implements Comparable, Serializable {
 
         if (error.isEmpty()) {
             return that.error.isEmpty() ? 0 : -1;
-        } else if (that.error.isEmpty()){
+        } else if (that.error.isEmpty()) {
             return 1;
         } else {
             return error.getValue().compareTo(that.error.getValue());

--- a/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
+++ b/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
@@ -165,7 +165,7 @@ public final class Magnitude implements Comparable, Serializable {
      * @param brightness absolute brightness
      * @param error optional error in measurement
      */
-    public Magnitude(Band band, double brightness, Option<Double> error) {
+    protected Magnitude(Band band, double brightness, Option<Double> error) {
         this(band, brightness, error, System.DEFAULT);
     }
 
@@ -198,7 +198,7 @@ public final class Magnitude implements Comparable, Serializable {
      * its brightness adjusted by the given amount.
      */
     public Magnitude add(double brightness) {
-        return new Magnitude(band, this.brightness + brightness, error);
+        return new Magnitude(band, this.brightness + brightness, error, system);
     }
 
 

--- a/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
+++ b/bundle/edu.gemini.shared.skyobject/src/main/java/edu/gemini/shared/skyobject/Magnitude.java
@@ -122,7 +122,7 @@ public final class Magnitude implements Comparable<Magnitude>, Serializable {
      */
     public Magnitude(Band band, double brightness) {
         //noinspection unchecked
-        this(band, brightness, None.INSTANCE, band != null ? band.defaultSystem : System.DEFAULT);
+        this(band, brightness, None.INSTANCE, band.defaultSystem);
     }
 
     /**
@@ -166,7 +166,7 @@ public final class Magnitude implements Comparable<Magnitude>, Serializable {
      * @param error optional error in measurement
      */
     public Magnitude(Band band, double brightness, Option<Double> error) {
-        this(band, brightness, error, band != null ? band.defaultSystem : System.DEFAULT);
+        this(band, brightness, error, band.defaultSystem);
     }
 
     /**

--- a/bundle/edu.gemini.shared.skyobject/src/test/java/edu/gemini/shared/skyobject/MagnitudeTest.java
+++ b/bundle/edu.gemini.shared.skyobject/src/test/java/edu/gemini/shared/skyobject/MagnitudeTest.java
@@ -29,7 +29,7 @@ public class MagnitudeTest {
         try {
             new Magnitude(null, 1.0);
             fail();
-        } catch (IllegalArgumentException ex) {
+        } catch (RuntimeException ex) {
             // expected
         }
     }
@@ -66,14 +66,14 @@ public class MagnitudeTest {
         try {
             new Magnitude(null, 1.0, new Some<>(0.1));
             fail();
-        } catch (IllegalArgumentException ex) {
+        } catch (RuntimeException ex) {
             // expected
         }
 
         try {
             new Magnitude(Band.J, 1.0, None.INSTANCE, null);
             fail();
-        } catch (IllegalArgumentException ex) {
+        } catch (RuntimeException ex) {
             // expected
         }
     }

--- a/bundle/edu.gemini.shared.skyobject/src/test/java/edu/gemini/shared/skyobject/MagnitudeTest.java
+++ b/bundle/edu.gemini.shared.skyobject/src/test/java/edu/gemini/shared/skyobject/MagnitudeTest.java
@@ -64,7 +64,7 @@ public class MagnitudeTest {
         assertEquals(0.1, m.getError().getValue(), DELTA);
 
         try {
-            new Magnitude(null, 1.0, new Some<Double>(0.1));
+            new Magnitude(null, 1.0, new Some<>(0.1));
             fail();
         } catch (IllegalArgumentException ex) {
             // expected

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
@@ -1,12 +1,15 @@
 package edu.gemini.spModel.core
 
-sealed abstract class MagnitudeBand private (val name: String, val wavelengthMidPointNm: Option[Int], val description: Option[String]) extends Product with Serializable {
+sealed abstract class MagnitudeBand private (val name: String, val wavelengthMidPointNm: Option[Int], val description: Option[String], val defaultSystem: MagnitudeSystem) extends Product with Serializable {
 
   private def this(name: String, wavelengthMidPointNm: Int) =
-    this(name, Some(wavelengthMidPointNm), None)
+    this(name, Some(wavelengthMidPointNm), None, MagnitudeSystem.VEGA)
 
   private def this(name: String, wavelengthMidPointNm: Int, description: String) =
-    this(name, Some(wavelengthMidPointNm), Some(description))
+    this(name, Some(wavelengthMidPointNm), Some(description), MagnitudeSystem.VEGA)
+
+  private def this(name: String, wavelengthMidPointNm: Int, description: String, defaultMagnitudeSystem: MagnitudeSystem) =
+    this(name, Some(wavelengthMidPointNm), Some(description), defaultMagnitudeSystem)
 
 }
 
@@ -15,11 +18,11 @@ object MagnitudeBand {
   // OCSADV-203
   // Class files clobber one another on OS X so names can't differ only in case.
   // We may need to revisit and come up with better names.
-  case object _u extends MagnitudeBand("u", 350, "UV")
-  case object _g extends MagnitudeBand("g", 475, "green")
-  case object _r extends MagnitudeBand("r", 630, "red")
-  case object _i extends MagnitudeBand("i", 780, "far red")
-  case object _z extends MagnitudeBand("z", 925, "near-infrared")
+  case object _u extends MagnitudeBand("u", 350, "UV", MagnitudeSystem.AB)
+  case object _g extends MagnitudeBand("g", 475, "green", MagnitudeSystem.AB)
+  case object _r extends MagnitudeBand("r", 630, "red", MagnitudeSystem.AB)
+  case object _i extends MagnitudeBand("i", 780, "far red", MagnitudeSystem.AB)
+  case object _z extends MagnitudeBand("z", 925, "near-infrared", MagnitudeSystem.AB)
 
   case object U  extends MagnitudeBand("U", 365, "ultraviolet")
   case object B  extends MagnitudeBand("B", 445, "blue")
@@ -38,7 +41,7 @@ object MagnitudeBand {
   case object N  extends MagnitudeBand("N", 10000)
   case object Q  extends MagnitudeBand("Q", 16000)
 
-  case object AP extends MagnitudeBand("AP", None, Some("apparent"))
+  case object AP extends MagnitudeBand("AP", None, Some("apparent"), MagnitudeSystem.VEGA)
 
   val all: List[MagnitudeBand] =
     List(_u, _g, _r, _i, _z, U, B, G, V, UC, R, I, Z, Y, J, H, K, L, M, N, Q, AP)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -309,7 +309,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
 
     object MagnitudesPanel extends ColumnPanel {
       def magRow(band: Magnitude.Band): Row = {
-        lazy val zero = new Magnitude(band, 0.0)
+        lazy val zero = new Magnitude(band, 0.0, band.defaultSystem)
 
         def mag(tp: TemplateParameters): Option[Magnitude] =
           tp.getTarget.getTarget.getMagnitude(band).asScalaOpt


### PR DESCRIPTION
This PR builds on PR #416 adding the Magnitude system to the conversions from the old to the new model, making AGS and Manual GS aware of the `MagnitudeSystem` when creating magnitudes
Additionally a few usages of the `Magnitude` constructors without a `Magnitude.System` were fixed to explicitly set it when appropriate in the catalog, phase2 templates and the template editor bundles