### PR TITLE
REL-2338: smartgcal servlet startup issue

### DIFF
--- a/bundle/edu.gemini.smartgcal.servlet/build.sbt
+++ b/bundle/edu.gemini.smartgcal.servlet/build.sbt
@@ -34,3 +34,7 @@ OsgiKeys.importPackage := Seq(
   "!org.tigris.subversion.*",
   "!org.tmatesoft.svn.core.*",
   "*")
+
+OsgiKeys.privatePackage := Seq(
+  "edu.gemini.smartgcal.servlet.*"
+)


### PR DESCRIPTION
The smartgcal servlet was not starting because of a `ClassNotFound` exception.  The class in question was actually part of the smartgcal servlet bundle so I think it is just a matter of getting the bnd parameters set correctly. 