### PR TITLE
REL-2333: target component layout updates

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopeForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopeForm.java
@@ -105,39 +105,21 @@ class TelescopeForm extends JPanel {
     final JPanel buttonPanel = new JPanel() {{
         setBackground(new Color(238, 238, 238));
         setBorder(new EmptyBorder(2, 2, 2, 2));
-        setLayout(new GridBagLayout() {{
-            columnWidths  = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-            rowHeights    = new int[] { 0, 0 };
-            columnWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0E-4 };
-            rowWeights    = new double[] { 0.0, 1.0E-4 };
-        }});
+        setLayout(new GridBagLayout());
         final JPanel spacerPanel = new JPanel() {{
             setBackground(null);
             setOpaque(false);
             setLayout(new BorderLayout());
         }};
-        add(newMenuBar,             new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0,  0, 0, 0), 0, 0));
-        add(removeButton,           new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0,  0, 0, 0), 0, 0));
-        add(copyButton,             new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 10, 0, 0), 0, 0));
-        add(pasteButton,            new GridBagConstraints(3, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0,  0, 0, 0), 0, 0));
-        add(duplicateButton,        new GridBagConstraints(4, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0,  0, 0, 0), 0, 0));
-        add(primaryButton,          new GridBagConstraints(5, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 10, 0, 0), 0, 0));
-        add(spacerPanel,            new GridBagConstraints(6, 0, 1, 1, 1.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0,  0, 0, 0), 0, 0));
-        add(guidingControls.peer(), new GridBagConstraints(7, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0,  0, 0, 0), 0, 0));
-
-        // Insert the tag menu at index 6 ... TODO: clean this up a bit
-        add(new JPanel() {{
-            setOpaque(false);
-            setLayout(new FlowLayout() {{
-                setVgap(0);
-            }});
-            add(new JLabel("Type Tag: ") {{
-                setOpaque(false);
-                setVerticalAlignment(SwingConstants.CENTER);
-            }});
-            add(tag);
-        }}, 6);
-
+        add(newMenuBar,             new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0,  0, 0, 0), 0, 0));
+        add(removeButton,           new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0,  0, 0, 0), 0, 0));
+        add(copyButton,             new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0, 10, 0, 0), 0, 0));
+        add(pasteButton,            new GridBagConstraints(3, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0,  0, 0, 0), 0, 0));
+        add(duplicateButton,        new GridBagConstraints(4, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0,  0, 0, 0), 0, 0));
+        add(primaryButton,          new GridBagConstraints(5, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0, 10, 0, 0), 0, 0));
+        add(tag,                    new GridBagConstraints(6, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0, 10, 0, 0), 0, 0));
+        add(spacerPanel,            new GridBagConstraints(7, 0, 1, 1, 1.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0,  0, 0, 0), 0, 0));
+        add(guidingControls.peer(), new GridBagConstraints(8, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(0,  0, 0, 0), 0, 0));
     }};
 
     final TelescopePosTableWidget positionTable;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicDetailEditor.scala
@@ -33,92 +33,144 @@ abstract class ConicDetailEditor(tag: ITarget.Tag) extends TargetDetailEditor(ta
 
   val general = new JPanel <| { p =>
     p.setLayout(new GridBagLayout)
-    p.setBorder(titleBorder("General"))
+    p.setBorder(BorderFactory.createCompoundBorder(titleBorder("General"),
+                BorderFactory.createEmptyBorder(1, 2, 1, 2)))
 
-    p.add(new JLabel("Target Type"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 0
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(0, 2, 0, 5)
+    p.add(new JLabel("Type"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 0
+      c.insets = new Insets(0, 0, 0, 5)
     })
 
     p.add(kind, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 0
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(0, 0, 0, 0)
+    })
+
+    p.add(new JLabel("Name"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
-      c.gridx = 1
-      c.gridy = 0
-      c.insets = new Insets(0, 5, 0, 2)
+      c.gridx  = 0
+      c.gridy  = 1
+      c.insets = new Insets(2, 0, 0, 5)
     })
 
-    p.add(new JLabel("Target Name"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 1
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
+    p.add(name.name, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 1
+      c.insets = new Insets(2, 0, 0, 0)
+      c.fill   = GridBagConstraints.HORIZONTAL
     })
 
-    p.add(name, new GridBagConstraints <| { c =>
-      c.gridx = 1
-      c.gridy = 1
-      c.insets = new Insets(2, 5, 0, 2)
+    p.add(name.search, new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
+      c.gridx  = 2
+      c.gridy  = 1
+      c.insets = new Insets(2, 0, 0, 0)
     })
 
-    p.add(new JLabel("Coordinates"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 2
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
-    })
-
-    p.add(coords, new GridBagConstraints <| { c =>
-      c.gridx = 1
-      c.gridy = 2
-      c.insets = new Insets(2, 5, 0, 2)
+    p.add(name.hid, new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
+      c.gridx  = 1
+      c.gridy  = 2
+      c.insets = new Insets(1, 0, 0, 0)
     })
 
-    p.add(new JLabel("Valid At"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 3
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
-    })
-
-    p.add(valid, new GridBagConstraints <| { c =>
-      c.gridx = 1
-      c.gridy = 3
-      c.insets = new Insets(2, 5, 0, 2)
+    p.add(new JLabel("RA"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 3
+      c.insets = new Insets(2, 0, 0, 5)
     })
+
+    p.add(coords.ra, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 3
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
+    })
+
+    p.add(new JLabel("Dec"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 4
+      c.insets = new Insets(2, 0, 0, 5)
+    })
+
+    p.add(coords.dec, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 4
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
+    })
+
+    p.add(new JLabel("J2000"), new GridBagConstraints <| { c =>
+      c.anchor     = GridBagConstraints.WEST
+      c.gridx      = 2
+      c.gridy      = 3
+      c.gridheight = 2
+      c.insets     = new Insets(2, 5, 0, 0)
+    })
+
+    p.add(new JLabel("Valid"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 5
+      c.insets = new Insets(2, 0, 0, 5)
+    })
+
+    p.add(valid.dateTimePanel, new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 1
+      c.gridy  = 5
+      c.insets = new Insets(2, 0, 0, 0)
+    })
+
+    p.add(new JLabel("UTC"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 2
+      c.gridy  = 5
+      c.insets = new Insets(2, 5, 0, 0)
+    })
+
+    p.add(valid.controlsPanel, new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 1
+      c.gridy  = 6
+      c.insets = new Insets(2, 0, 0, 0)
+    })
+
 
     p.add(Box.createHorizontalGlue(), new GridBagConstraints <| { c =>
-      c.gridx = 2
-      c.gridy = 0
+      c.gridx   = 4
+      c.gridy   = 0
       c.weightx = 1
-      c.fill = GridBagConstraints.HORIZONTAL
+      c.fill    = GridBagConstraints.HORIZONTAL
     })
 
   }
 
   add(general, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.gridy = 0
-    c.gridwidth = 2
-    c.fill = GridBagConstraints.HORIZONTAL
-  })
-
-
-  add(mags.getComponent, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.gridy = 1
-    c.fill = GridBagConstraints.BOTH
+    c.gridx   = 0
+    c.gridy   = 0
+    c.weightx = 1.0
+    c.fill    = GridBagConstraints.HORIZONTAL
   })
 
   add(props, new GridBagConstraints <| { c =>
-    c.gridx = 1
-    c.gridy = 1
-    c.weightx = 1
-    c.fill = GridBagConstraints.HORIZONTAL
+    c.gridx   = 0
+    c.gridy   = 1
+    c.weightx = 1.0
+    c.fill    = GridBagConstraints.HORIZONTAL
+  })
+
+  add(mags.getComponent, new GridBagConstraints <| { c =>
+    c.gridx      = 1
+    c.gridy      = 0
+    c.gridheight = 2
+    c.fill       = GridBagConstraints.VERTICAL
   })
 
   // Implementation

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
@@ -1,8 +1,8 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
-import java.awt.{Insets, Color, GridBagConstraints, GridBagLayout}
+import java.awt.Color
 import java.util.Date
-import javax.swing.{JLabel, JPanel}
+import javax.swing.JLabel
 
 import edu.gemini.pot.sp.ISPNode
 import edu.gemini.shared.util.immutable.{Option => GOption}
@@ -18,7 +18,7 @@ import scalaz._, Scalaz._
 
 // N.B. in order to do a Horizons lookup, we need a way to get the "current" date, which is known
 // to a different part of the editor. So we just pass in a program that knows how to do it.
-final class ConicNameEditor(date: HorizonsIO[Date]) extends JPanel with TelescopePosEditor with ReentrancyHack {
+final class ConicNameEditor(date: HorizonsIO[Date]) extends TelescopePosEditor with ReentrancyHack {
 
   private[this] var spt = new SPTarget // never null
 
@@ -38,7 +38,6 @@ final class ConicNameEditor(date: HorizonsIO[Date]) extends JPanel with Telescop
     } yield ()
 
   val name = new TextBoxWidget <| { w =>
-    w.setColumns(25)
     w.setMinimumSize(w.getPreferredSize)
     w.addWatcher(new TextBoxWidgetWatcher {
 
@@ -63,27 +62,6 @@ final class ConicNameEditor(date: HorizonsIO[Date]) extends JPanel with Telescop
   val hid = new JLabel <| { a =>
     a.setForeground(Color.DARK_GRAY)
   }
-
-  setLayout(new GridBagLayout)
-
-  add(name, new GridBagConstraints <| { c =>
-    c.gridx   = 0
-    c.gridy   = 0
-    c.fill    = GridBagConstraints.HORIZONTAL
-    c.weightx = 2
-  })
-
-  add(search, new GridBagConstraints <| { c =>
-    c.gridx  = 1
-    c.gridy  = 0
-    c.insets = new Insets(0, 2, 0, 0)
-  })
-
-  add(hid, new GridBagConstraints <| { c =>
-    c.gridx  = 2
-    c.gridy  = 0
-    c.insets = new Insets(0, 5, 0, 0)
-  })
 
   def hidText(ct: ConicTarget): String =
     "Horizons ID: " + (ct.isHorizonsDataPopulated ?

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
@@ -1,8 +1,5 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
-import java.awt.{Insets, GridBagConstraints, GridBagLayout}
-import javax.swing.{JLabel, JPanel}
-
 import edu.gemini.pot.sp.ISPNode
 import edu.gemini.shared.util.immutable.{ Option => GOption }
 import edu.gemini.spModel.obs.context.ObsContext
@@ -14,8 +11,8 @@ import jsky.util.gui.TextBoxWidget
 
 import scalaz.syntax.id._
 
-// RA and Dec, side by side
-class CoordinateEditor extends JPanel with TelescopePosEditor with ReentrancyHack {
+// RA and Dec
+class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
 
   private[this] var spt = new SPTarget
 
@@ -23,39 +20,6 @@ class CoordinateEditor extends JPanel with TelescopePosEditor with ReentrancyHac
     w.setColumns(10)
     w.setMinimumSize(w.getPreferredSize)
   }
-
-  setLayout(new GridBagLayout)
-
-  add(new JLabel("RA"), new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.insets = new Insets(0, 0, 0, 5)
-    c.weighty = 0
-  })
-
-  add(ra, new GridBagConstraints <| { c =>
-    c.gridx = 1
-    c.insets = new Insets(0, 0, 0, 10)
-    c.fill = GridBagConstraints.HORIZONTAL
-    c.weightx = 2
-  })
-
-  add(new JLabel("Dec"), new GridBagConstraints <| { c =>
-    c.gridx = 2
-    c.insets = new Insets(0, 0, 0, 5)
-    c.weighty = 0
-  })
-
-  add(dec, new GridBagConstraints <| { c =>
-    c.gridx = 3
-    c.fill = GridBagConstraints.HORIZONTAL
-    c.weightx = 2
-  })
-
-  add(new JLabel("(J2000)"), new GridBagConstraints <| { c =>
-    c.gridx = 4
-    c.insets = new Insets(0, 5, 0, 0)
-    c.weighty = 0
-  })
 
   ra.addWatcher(watcher { s =>
     nonreentrant {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
@@ -1,7 +1,7 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
 import java.awt._
-import javax.swing.{Box, JComponent, JLabel, JPanel}
+import javax.swing.{BorderFactory, Box, JComponent, JLabel, JPanel}
 
 import edu.gemini.pot.sp.ISPNode
 import edu.gemini.shared.util.immutable.{Option => GOption}
@@ -27,7 +27,7 @@ final class NamedDetailEditor extends TargetDetailEditor(Tag.NAMED) with Reentra
   val coords = new CoordinateEditor
 
   val name = new TextBoxWidget <| { w =>
-    w.setColumns(25)
+    w.setColumns(10)
     w.setMinimumSize(w.getPreferredSize)
     w.addWatcher(new TextBoxWidgetWatcher {
 
@@ -73,100 +73,135 @@ final class NamedDetailEditor extends TargetDetailEditor(Tag.NAMED) with Reentra
 
   val general = new JPanel <| { p =>
     p.setLayout(new GridBagLayout)
-    p.setBorder(titleBorder("General"))
+    p.setBorder(BorderFactory.createCompoundBorder(titleBorder("General"),
+                BorderFactory.createEmptyBorder(1, 2, 1, 2)))
 
-    p.add(new JLabel("Target Type"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 0
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(0, 2, 0, 5)
+    p.add(new JLabel("Type"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 0
+      c.insets = new Insets(0, 0, 0, 5)
     })
 
     p.add(kind, new GridBagConstraints <| { c =>
-      c.anchor = GridBagConstraints.WEST
-      c.gridx = 1
-      c.gridy = 0
-      c.insets = new Insets(0, 5, 0, 2)
+      c.gridx  = 1
+      c.gridy  = 0
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(0, 0, 0, 0)
     })
 
-    p.add(new JLabel("Target Name"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 1
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
+    p.add(new JLabel("Name"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 1
+      c.insets = new Insets(2, 0, 0, 5)
     })
 
     p.add(name, new GridBagConstraints <| { c =>
-      c.gridx = 1
-      c.gridy = 1
-      c.insets = new Insets(2, 5, 0, 2)
-      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 1
+      c.gridy  = 1
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
     })
 
     p.add(new JLabel("Object"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 2
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 2
+      c.insets = new Insets(2, 0, 0, 5)
     })
 
     p.add(solarObject, new GridBagConstraints <| { c =>
-      c.gridx = 1
-      c.gridy = 2
-      c.insets = new Insets(2, 5, 0, 2)
+      c.gridx  = 1
+      c.gridy  = 2
+      c.insets = new Insets(2, 0, 0, 0)
+      c.fill   = GridBagConstraints.HORIZONTAL
+    })
+
+    p.add(new JLabel("RA"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 3
+      c.insets = new Insets(2, 0, 0, 5)
     })
 
-    p.add(new JLabel("Coordinates"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 3
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
+    p.add(coords.ra, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 3
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
     })
 
-    p.add(coords, new GridBagConstraints <| { c =>
-      c.gridx = 1
-      c.gridy = 3
-      c.insets = new Insets(2, 5, 0, 2)
+    p.add(new JLabel("Dec"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 4
+      c.insets = new Insets(2, 0, 0, 5)
     })
 
-    p.add(new JLabel("Valid At"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 4
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
+    p.add(coords.dec, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 4
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
     })
 
-    p.add(valid, new GridBagConstraints <| { c =>
-      c.gridx = 1
-      c.gridy = 4
-      c.insets = new Insets(2, 5, 0, 2)
+    p.add(new JLabel("J2000"), new GridBagConstraints <| { c =>
+      c.anchor     = GridBagConstraints.WEST
+      c.gridx      = 2
+      c.gridy      = 3
+      c.gridheight = 2
+      c.insets     = new Insets(2, 5, 0, 0)
+    })
+
+    p.add(new JLabel("Valid"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 5
+      c.insets = new Insets(2, 0, 0, 5)
+    })
+
+    p.add(valid.dateTimePanel, new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 1
+      c.gridy  = 5
+      c.insets = new Insets(2, 0, 0, 0)
+    })
+
+    p.add(new JLabel("UTC"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 2
+      c.gridy  = 5
+      c.insets = new Insets(2, 5, 0, 0)
+    })
+
+    p.add(valid.controlsPanel, new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 1
+      c.gridy  = 6
+      c.insets = new Insets(2, 0, 0, 0)
     })
 
     p.add(Box.createHorizontalGlue(), new GridBagConstraints <| { c =>
-      c.gridx = 2
-      c.gridy = 0
+      c.gridx   = 3
+      c.gridy   = 0
       c.weightx = 1
-      c.fill = GridBagConstraints.HORIZONTAL
+      c.fill    = GridBagConstraints.HORIZONTAL
     })
-
   }
 
   add(general, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.gridy = 0
-    c.gridwidth = 2
-    c.weightx = 1
-    c.fill = GridBagConstraints.HORIZONTAL
+    c.gridx     = 0
+    c.gridy     = 0
+    c.weightx   = 1.0
+    c.fill      = GridBagConstraints.HORIZONTAL
   })
 
 
   add(mags.getComponent, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.gridy = 1
-    c.fill = GridBagConstraints.BOTH
+    c.gridx      = 1
+    c.gridy      = 0
+    c.fill       = GridBagConstraints.VERTICAL
   })
 
   // Implementation

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
@@ -4,7 +4,7 @@ import edu.gemini.spModel.target.system.CoordinateParam.Units
 import edu.gemini.spModel.target.system.CoordinateTypes.{Epoch, Parallax}
 
 import java.awt.{GridBagConstraints, GridBagLayout, Insets}
-import javax.swing.{Box, JComponent, JLabel, JPanel}
+import javax.swing.{BorderFactory, Box, JComponent, JLabel, JPanel}
 
 import edu.gemini.pot.sp.ISPNode
 import edu.gemini.shared.util.immutable.{Option => GOption}
@@ -42,86 +42,115 @@ final class SiderealDetailEditor extends TargetDetailEditor(ITarget.Tag.SIDEREAL
 
   val general = new JPanel <| { p =>
     p.setLayout(new GridBagLayout)
-    p.setBorder(titleBorder("General"))
+    p.setBorder(BorderFactory.createCompoundBorder(titleBorder("General"),
+                BorderFactory.createEmptyBorder(1, 2, 1, 2)))
 
-    p.add(new JLabel("Target Type"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 0
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(0, 2, 0, 5)
+    p.add(new JLabel("Type"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 0
+      c.insets = new Insets(0, 0, 0, 5)
     })
 
     p.add(kind, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 0
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(0, 0, 0, 0)
+    })
+
+    p.add(new JLabel("Name"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
-      c.gridx = 1
-      c.gridy = 0
-      c.insets = new Insets(0, 5, 0, 2)
+      c.gridx  = 0
+      c.gridy  = 1
+      c.insets = new Insets(2, 0, 0, 5)
     })
 
-    p.add(new JLabel("Target Name"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 1
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
+    p.add(name.name, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 1
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
     })
 
-    p.add(name, new GridBagConstraints <| { c =>
+    p.add(name.search, new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
-      c.gridx = 1
-      c.gridy = 1
-      c.insets = new Insets(2, 5, 0, 2)
+      c.gridx  = 2
+      c.gridy  = 1
+      c.insets = new Insets(2, 0, 0, 0)
     })
 
-    p.add(new JLabel("Coordinates"), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 2
-      c.fill = GridBagConstraints.HORIZONTAL
-      c.insets = new Insets(2, 2, 0, 5)
-    })
-
-    p.add(coords, new GridBagConstraints <| { c =>
+    p.add(new JLabel("RA"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
-      c.gridx = 1
-      c.gridy = 2
-      c.insets = new Insets(2, 5, 0, 2)
+      c.gridx  = 0
+      c.gridy  = 2
+      c.insets = new Insets(2, 0, 0, 5)
+    })
+
+    p.add(coords.ra, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 2
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
+    })
+
+    p.add(new JLabel("Dec"), new GridBagConstraints <| { c =>
+      c.anchor = GridBagConstraints.WEST
+      c.gridx  = 0
+      c.gridy  = 3
+      c.insets = new Insets(2, 0, 0, 5)
+    })
+
+    p.add(coords.dec, new GridBagConstraints <| { c =>
+      c.gridx  = 1
+      c.gridy  = 3
+      c.fill   = GridBagConstraints.HORIZONTAL
+      c.insets = new Insets(2, 0, 0, 0)
+    })
+
+    p.add(new JLabel("J2000"), new GridBagConstraints <| { c =>
+      c.anchor     = GridBagConstraints.WEST
+      c.gridx      = 2
+      c.gridy      = 2
+      c.gridheight = 2
+      c.insets     = new Insets(2, 5, 0, 0)
     })
 
     p.add(Box.createHorizontalGlue(), new GridBagConstraints <| { c =>
-      c.gridx = 2
-      c.gridy = 0
+      c.gridx   = 2
+      c.gridy   = 0
       c.weightx = 1
-      c.fill = GridBagConstraints.HORIZONTAL
+      c.fill    = GridBagConstraints.HORIZONTAL
     })
 
     p.add(Box.createVerticalGlue(), new GridBagConstraints <| { c =>
-      c.gridx = 0
-      c.gridy = 3
+      c.gridx   = 0
+      c.gridy   = 3
       c.weighty = 1
-      c.fill = GridBagConstraints.VERTICAL
+      c.fill    = GridBagConstraints.VERTICAL
     })
-
   }
 
   add(general, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.gridy = 0
-    c.weightx = 1
-    c.fill = GridBagConstraints.HORIZONTAL
-    c.gridwidth = 2
+    c.gridx     = 0
+    c.gridy     = 0
+    c.weightx   = 0
+    c.fill      = GridBagConstraints.HORIZONTAL
   })
 
   add(mags.getComponent, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.gridy = 1
-    c.fill = GridBagConstraints.VERTICAL
+    c.gridx      = 1
+    c.gridy      = 0
+    c.gridheight = 2
+    c.fill       = GridBagConstraints.VERTICAL
   })
 
   add(props, new GridBagConstraints <| { c =>
-    c.anchor = GridBagConstraints.WEST
-    c.gridx = 1
-    c.gridy = 1
+    c.anchor  = GridBagConstraints.WEST
+    c.gridx   = 0
+    c.gridy   = 1
     c.weightx = 1
-    c.fill = GridBagConstraints.HORIZONTAL
+    c.fill    = GridBagConstraints.HORIZONTAL
   })
 
   override def edit(obsContext: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
@@ -1,8 +1,5 @@
 package jsky.app.ot.gemini.editor.targetComponent.details
 
-import java.awt.{Insets, GridBagConstraints, GridBagLayout}
-import javax.swing.JPanel
-
 import edu.gemini.pot.sp.ISPNode
 import edu.gemini.shared.util.immutable.{ Option => GOption }
 import edu.gemini.catalog.skycat.CatalogException
@@ -20,7 +17,7 @@ import scalaz.syntax.id._
 import scalaz.{ \/-, -\/ }
 
 // Name editor, with catalog lookup for sidereal targets
-final class SiderealNameEditor extends JPanel with TelescopePosEditor with ReentrancyHack {
+final class SiderealNameEditor extends TelescopePosEditor with ReentrancyHack {
   private[this] var spt = new SPTarget // never null
 
   def forkSearch(): Unit = {
@@ -53,27 +50,6 @@ final class SiderealNameEditor extends JPanel with TelescopePosEditor with Reent
     m.setChoices(SkycatConfigFile.getConfigFile.getNameServers)
     m.setVisible(false) // just hide this for now
   }
-
-  setLayout(new GridBagLayout)
-
-  add(name, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.gridy = 0
-    c.fill = GridBagConstraints.HORIZONTAL
-    c.weightx = 2
-  })
-
-  add(search, new GridBagConstraints <| { c =>
-    c.gridx  = 1
-    c.gridy  = 0
-    c.insets = new Insets(0, 2, 0, 0)
-  })
-
-  add(cats, new GridBagConstraints <| { c =>
-    c.gridx = 2
-    c.gridy = 0
-    c.insets = new Insets(0, 2, 0, 0)
-  })
 
   def edit(ctx: GOption[ObsContext], target: SPTarget, node: ISPNode): Unit = {
     this.spt = target

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -2,7 +2,7 @@ package jsky.app.ot.gemini.editor.targetComponent.details
 
 import edu.gemini.spModel.target.system.ITarget.Tag
 
-import java.awt.{GridBagConstraints, GridBagLayout}
+import java.awt.{Insets, GridBagConstraints, GridBagLayout}
 import javax.swing.JPanel
 
 import edu.gemini.pot.sp.ISPNode
@@ -64,6 +64,7 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
     c.gridy     = 1
     c.weightx   = 1
     c.gridwidth = 2
+    c.insets    = new Insets(0,4,0,4)
     c.fill      = GridBagConstraints.HORIZONTAL
   })
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
@@ -22,8 +22,9 @@ import jsky.app.ot.ui.util.TimeDocument
 import scalaz._, Scalaz._
 import Horizons._
 
-// [DATE] at [TIME] UTC [Go] [Plot]
-abstract class ValidAtEditor[A <: ITarget](empty: A) extends JPanel with TelescopePosEditor with ReentrancyHack {
+// [DATE] [TIME] UTC
+// [Update] [Plot]
+abstract class ValidAtEditor[A <: ITarget](empty: A) extends TelescopePosEditor with ReentrancyHack {
 
   private[this] var spt: SPTarget = new SPTarget(empty)
   private[this] var node: ISPNode = null
@@ -72,8 +73,8 @@ abstract class ValidAtEditor[A <: ITarget](empty: A) extends JPanel with Telesco
 
   }
 
-  val go   = new JButton("Go")   <| { _.addActionListener(LookupListener(plot = false)) }
-  val plot = new JButton("Plot") <| { _.addActionListener(LookupListener(plot = true))  }
+  val go   = new JButton("Update") <| { _.addActionListener(LookupListener(plot = false)) }
+  val plot = new JButton("Plot")   <| { _.addActionListener(LookupListener(plot = true))  }
 
   /**
    * An action listener that performs a catalog lookup, replacing the current target on success, and
@@ -84,39 +85,20 @@ abstract class ValidAtEditor[A <: ITarget](empty: A) extends JPanel with Telesco
       lookupAndSet(plot, useCache = true).invokeAndWait
   }
 
-  setLayout(new GridBagLayout)
+  class PairPanel(c0: Component, c1: Component) extends JPanel {
+    setLayout(new GridBagLayout)
 
-  add(calendar, new GridBagConstraints <| { c =>
-    c.gridx = 0
-    c.fill = GridBagConstraints.HORIZONTAL
-    c.weightx = 2
-    c.insets = new Insets(2, 2, 0, 0)
-  })
+    add(c0, new GridBagConstraints <| { c =>
+      c.gridx   = 0
+    })
+    add(c1, new GridBagConstraints <| { c =>
+      c.gridx   = 1
+      c.insets  = new Insets(0, 5, 0, 0)
+    })
+  }
 
-  add(new JLabel("at"), new GridBagConstraints <| { c =>
-    c.gridx = 1
-    c.insets = new Insets(0, 5, 0, 0)
-  })
-
-  add(timeConfig, new GridBagConstraints <| { c =>
-    c.gridx = 2
-    c.insets = new Insets(2, 5, 0, 0)
-  })
-
-  add(new JLabel("UTC"), new GridBagConstraints <| { c =>
-    c.gridx = 3
-    c.insets = new Insets(2, 5, 0, 0)
-  })
-
-  add(go, new GridBagConstraints <| { c =>
-    c.gridx = 4
-    c.insets = new Insets(2, 5, 0, 0)
-  })
-
-  add(plot, new GridBagConstraints <| { c =>
-    c.gridx = 5
-    c.insets = new Insets(2, 2, 0, 0)
-  })
+  val dateTimePanel = new PairPanel(calendar, timeConfig)
+  val controlsPanel = new PairPanel(go, plot)
 
   ///
   /// METHODS


### PR DESCRIPTION
This PR contains updates to the target editor layout based on Andy's idea to move the magnitude table to the right of the coordinate editor.  These are all cosmetic changes whose goal is to make it it possible to see all widgets with a narrower OT window, place all coordinate information in a single column and make it possible to view more magnitude settings without scrolling. Unfortunately to achieve a nice layout I had to extract widgets from sub-editors so that they could be placed in a single grid bag.  My apologies go out especially to Rob for destroying that part of the code.  Perhaps there is a better way of achieving the same goal?

![antares](https://cloud.githubusercontent.com/assets/4906023/7812961/22f6574a-038d-11e5-8aba-1dec11d2c3eb.jpg)

![jupiter](https://cloud.githubusercontent.com/assets/4906023/7812965/29a45754-038d-11e5-9f2e-94e03d0d8325.jpg)

![vesta](https://cloud.githubusercontent.com/assets/4906023/7812966/2ee7e618-038d-11e5-9c93-6535bdf89c2c.jpg)
