### PR TITLE
REL-2339: make target table scroll horizontally

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopeForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopeForm.java
@@ -137,6 +137,7 @@ class TelescopeForm extends JPanel {
             add(feedbackAndButtonPanel, BorderLayout.SOUTH);
             final JScrollPane posTableScrollPane = new JScrollPane() {{
                 setViewportView(positionTable);
+                getViewport().setBackground(Color.WHITE);
             }};
             add(posTableScrollPane, BorderLayout.CENTER);
         }};

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -328,19 +328,8 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             final Set<Magnitude.Band> bands;
             bands = new TreeSet<>(Magnitude.Band.WAVELENGTH_COMPARATOR);
 
-            // An operation that adds a target's bands to the set.
-            final ApplyOp<SPTarget> op = new ApplyOp<SPTarget>() {
-                @Override public void apply(SPTarget spTarget) {
-                    bands.addAll(spTarget.getTarget().getMagnitudeBands());
-                }
-            };
-
             // Extract all the magnitude bands from the environment.
-            bands.addAll(env.getBase().getTarget().getMagnitudeBands());
-            for (GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
-                gt.getOptions().foreach(op);
-            }
-            env.getUserTargets().foreach(op);
+            env.getTargets().foreach(spTarget -> bands.addAll(spTarget.getTarget().getMagnitudeBands()));
 
             // Create an immutable sorted list containing the results.
             return DefaultImList.create(bands);
@@ -612,6 +601,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
      */
     public TelescopePosTableWidget(EdCompTargetList owner) {
         this.owner = owner;
+        setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
         // disable editing by default
         setTreeTableModel(new TableData());
         setCellSelectionEnabled(false);


### PR DESCRIPTION
This PR gives the OT target component a horizontal scrollbar when necessary (as opposed to shrinking all the columns to fit in the available space).

![horizontal](https://cloud.githubusercontent.com/assets/4906023/7816800/d0f10c3c-03a6-11e5-8eea-82c23c0f2ccb.jpg)
