### PR TITLE
REL-2340: change visitor instrument setup time

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/VisitorInstrument.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/VisitorInstrument.java
@@ -135,7 +135,7 @@ public class VisitorInstrument extends SPInstObsComp
      */
     @Override
     public double getSetupTime(ISPObservation obs) {
-        return 1200.0;
+        return 600.0;
     }
 
 


### PR DESCRIPTION
As requested, estimated visitor instrument setup time drops to 10 minutes (though unfortunately we express setup time in seconds as a double so that's 600.0 seconds).