### PR TITLE
REL-2341: change shrinking order in target details panel

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicDetailEditor.scala
@@ -155,14 +155,12 @@ abstract class ConicDetailEditor(tag: ITarget.Tag) extends TargetDetailEditor(ta
   add(general, new GridBagConstraints <| { c =>
     c.gridx   = 0
     c.gridy   = 0
-    c.weightx = 1.0
     c.fill    = GridBagConstraints.HORIZONTAL
   })
 
   add(props, new GridBagConstraints <| { c =>
     c.gridx   = 0
     c.gridy   = 1
-    c.weightx = 1.0
     c.fill    = GridBagConstraints.HORIZONTAL
   })
 
@@ -170,7 +168,9 @@ abstract class ConicDetailEditor(tag: ITarget.Tag) extends TargetDetailEditor(ta
     c.gridx      = 1
     c.gridy      = 0
     c.gridheight = 2
-    c.fill       = GridBagConstraints.VERTICAL
+    c.weightx    = 1.0
+    c.weighty    = 1.0
+    c.fill       = GridBagConstraints.BOTH
   })
 
   // Implementation

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
@@ -193,15 +193,16 @@ final class NamedDetailEditor extends TargetDetailEditor(Tag.NAMED) with Reentra
   add(general, new GridBagConstraints <| { c =>
     c.gridx     = 0
     c.gridy     = 0
-    c.weightx   = 1.0
     c.fill      = GridBagConstraints.HORIZONTAL
   })
 
 
   add(mags.getComponent, new GridBagConstraints <| { c =>
-    c.gridx      = 1
-    c.gridy      = 0
-    c.fill       = GridBagConstraints.VERTICAL
+    c.gridx     = 1
+    c.gridy     = 0
+    c.weightx   = 1.0
+    c.weighty   = 1.0
+    c.fill      = GridBagConstraints.BOTH
   })
 
   // Implementation

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
@@ -142,14 +142,15 @@ final class SiderealDetailEditor extends TargetDetailEditor(ITarget.Tag.SIDEREAL
     c.gridx      = 1
     c.gridy      = 0
     c.gridheight = 2
-    c.fill       = GridBagConstraints.VERTICAL
+    c.weightx    = 1.0
+    c.weighty    = 1.0
+    c.fill       = GridBagConstraints.BOTH
   })
 
   add(props, new GridBagConstraints <| { c =>
     c.anchor  = GridBagConstraints.WEST
     c.gridx   = 0
     c.gridy   = 1
-    c.weightx = 1
     c.fill    = GridBagConstraints.HORIZONTAL
   })
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -56,8 +56,9 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
     c.anchor    = GridBagConstraints.NORTH
     c.gridx     = 1
     c.gridy     = 0
-    c.weighty   = 1
-    c.fill      = GridBagConstraints.VERTICAL
+    c.weightx   = 1.0
+    c.weighty   = 1.0
+    c.fill      = GridBagConstraints.BOTH
   })
   add(gfe.getComponent, new GridBagConstraints() <| { c =>
     c.gridx     = 0
@@ -78,8 +79,6 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
       add(tde, new GridBagConstraints() <| { c =>
         c.gridx = 0
         c.gridy = 0
-        c.weightx = 1
-        c.fill = GridBagConstraints.HORIZONTAL
       })
       revalidate()
       repaint()


### PR DESCRIPTION
This PR offers a small adjustment to the target detail panel layout.  In particular, when space is tight and sub-panels begin to shrink we should prefer to first conceal the "Source" panel, then "Magnitudes" and finally "General".  Before the shrinking order was exactly the opposite.

