### PR TITLE
OCSADV-362: Improve event handling on source editor.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NumericPropertySheet.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NumericPropertySheet.scala
@@ -32,7 +32,6 @@ case class NumericPropertySheet[A](title: scala.Option[String], f: SPTarget => A
               try nonreentrant {
                 p.g(f(spt), tbwe.getValue.toDouble)
                 spt.notifyOfGenericUpdate()
-                tbwe.requestFocus()
               }
               catch { case _: NumberFormatException => }
         })


### PR DESCRIPTION
Some mess-up with the event handling / repaint / whatever cycle caused the text edit widgets on the source editor to loose focus. An earlier "fix" to work around this by resetting the focus after every key stroke did not work as expected on Windows and made those edit boxes unusable.

I settled on a more streamlined event handling that in particular only changes the visibility of some of the data entry panels (implemented using ```NumericPropertySheet```) if necessary, this seems to avoid taking away the focus from the text edit box which avoids the need of resetting the focus on the widget and therefore should hopefully also resolve this issue on Windows.