### PR TITLE
OCSADV-344: Implement GeMS Strehl approximation for GSAOI

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ObservingConditions.java
+++ b/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ObservingConditions.java
@@ -43,6 +43,10 @@ public final class ObservingConditions implements Serializable {
         return iq.ordinal() + 1;
     }
 
+    public ImageQuality iq() {
+        return iq;
+    }
+
     public double getImageQualityPercentile() {
         return iq.getPercentage() / 100.0;
     }

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -118,7 +118,7 @@ trait ItcService {
 
   import edu.gemini.itc.shared.ItcService._
 
-  def calculate(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails): Result
+  def calculate(source: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, instr: InstrumentDetails): Result
 
 }
 
@@ -126,7 +126,7 @@ sealed trait ItcMessage
 final case class ItcError(msg: String) extends ItcMessage
 final case class ItcWarning(msg: String) extends ItcMessage
 
-case class ItcInputs(src: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, ins: InstrumentDetails)
+case class ItcInputs(src: SourceDefinition, obs: ObservationDetails, cond: ObservingConditions, tele: TelescopeDetails, instr: InstrumentDetails)
 
 object ItcService {
 
@@ -135,7 +135,7 @@ object ItcService {
   /** Performs an ITC call on the given host. */
   def calculate(peer: Peer, inputs: ItcInputs): Future[Result] =
     TrpcClient(peer).withoutKeys future { r =>
-      r[ItcService].calculate(inputs.src, inputs.obs, inputs.cond, inputs.tele, inputs.ins)
+      r[ItcService].calculate(inputs.src, inputs.obs, inputs.cond, inputs.tele, inputs.instr)
     }
 
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -70,7 +70,7 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
@@ -168,7 +168,7 @@ public class Gems implements AOSystem {
                         break;
 
                     default:
-                        throw new IllegalArgumentException("GeMS does not support band " + strehlBand);
+                        throw new IllegalArgumentException("Current ITC implementation for GeMS does not support band " + strehlBand);
                 }
                 break;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gems/Gems.java
@@ -166,6 +166,9 @@ public class Gems implements AOSystem {
                                 return 0.12;
                         }
                         break;
+
+                    default:
+                        throw new IllegalArgumentException("GeMS does not support band " + strehlBand);
                 }
                 break;
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -71,7 +71,7 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             add(new SpcDataFile(SingleS2NData.instance(),  toFile(r, "Sin")));
             add(new SpcDataFile(FinalS2NData.instance(),   toFile(r, "Fin")));
         }};
-        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     protected static String toFile(final SpectroscopyResult[] results, final String filename) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -91,7 +91,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
                 add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
             }
         }};
-        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     protected static String toFile(final VisitableSampledSpectrum[] sedArr) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
@@ -101,7 +101,7 @@ public final class MichelleRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -2,12 +2,14 @@ package edu.gemini.itc.nifs;
 
 import edu.gemini.itc.altair.Altair;
 import edu.gemini.itc.base.*;
-import edu.gemini.itc.operation.*;
+import edu.gemini.itc.operation.ImageQualityCalculatable;
+import edu.gemini.itc.operation.ImageQualityCalculationFactory;
+import edu.gemini.itc.operation.SpecS2N;
+import edu.gemini.itc.operation.SpecS2NLargeSlitVisitor;
 import edu.gemini.itc.shared.*;
 import edu.gemini.spModel.core.Site;
 import scala.Option;
 import scala.Tuple2;
-import scala.collection.JavaConversions;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -75,7 +77,7 @@ public final class NifsRecipe implements SpectroscopyRecipe {
                 add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[i].getFinalS2NSpectrum().printSpecAsString()));
             }
         }};
-        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     private SpectroscopyResult calculateSpectroscopy(final Nifs instrument) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -81,7 +81,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     private SpectroscopyResult calculateSpectroscopy(final Niri instrument) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
@@ -102,7 +102,7 @@ public final class TRecsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             add(new SpcDataFile(SingleS2NData.instance(),  r.specS2N()[0].getExpS2NSpectrum().printSpecAsString()));
             add(new SpcDataFile(FinalS2NData.instance(),   r.specS2N()[0].getFinalS2NSpectrum().printSpecAsString()));
         }};
-        return new Tuple2<>(ItcSpectroscopyResult.apply(_sdParameters, _obsDetailParameters, dataSets, dataFiles, new ArrayList<>()), r);
+        return new Tuple2<>(ItcSpectroscopyResult.apply(dataSets, dataFiles, new ArrayList<>()), r);
     }
 
     public ImagingResult calculateImaging() {

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -51,12 +51,12 @@ class ItcServiceImpl extends ItcService {
 
   private def imagingResult(recipe: ImagingRecipe): Result = {
     val r = recipe.calculateImaging()
-    ItcResult.forResult(ItcImagingResult(r.source, r.observation, List(toImgData(r)), r.warnings))
+    ItcResult.forResult(ItcImagingResult(List(toImgData(r)), r.warnings))
   }
 
   private def imagingResult(recipe: ImagingArrayRecipe): Result = {
     val r = recipe.calculateImaging()
-    ItcResult.forResult(ItcImagingResult(r.head.source, r.head.observation, r.map(toImgData).toList, combineWarnings(r.toList)))
+    ItcResult.forResult(ItcImagingResult(r.map(toImgData).toList, combineWarnings(r.toList)))
   }
 
   private def toImgData(result: ImagingResult): ImgData = result.is2nCalc match {
@@ -94,7 +94,7 @@ class ItcServiceImpl extends ItcService {
   // a bit of bandwidth. If the need arises to have the files accessible in the clients just change this to
   // send the original result.
   private def resultWithoutFiles(result: ItcSpectroscopyResult, warnings: List[ItcWarning]): Result =
-    ItcResult.forResult(ItcSpectroscopyResult(result.source, result.obsDetails, result.charts, List(), warnings))
+    ItcResult.forResult(ItcSpectroscopyResult(result.charts, List(), warnings))
 
 
   // combine all warnings for the different CCDs and prepend a "CCD x:" in front of them

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -9,7 +9,7 @@ import edu.gemini.pot.sp.SPComponentType._
 import edu.gemini.shared.skyobject.Magnitude
 import edu.gemini.spModel.`type`.DisplayableSpType
 import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
-import edu.gemini.spModel.core.{Site, Peer, Wavelength}
+import edu.gemini.spModel.core.{Peer, Site, Wavelength}
 import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.obscomp.SPInstObsComp
@@ -113,57 +113,47 @@ trait ItcTable extends Table {
 
   }
 
-  protected def calculateSpectroscopy(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig): Future[ItcService.Result] = {
-    def method(srcFraction: Double) = SpectroscopySN(uc.count * uc.coadds.getOrElse(1), uc.singleExposureTime, srcFraction)
-    calculate(peer, instrument, uc, method)
-  }
-
-  protected def calculateImaging(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig): Future[ItcService.Result] = {
-    def method(srcFraction: Double) = ImagingSN(uc.count * uc.coadds.getOrElse(1), uc.singleExposureTime, srcFraction)
-    calculate(peer, instrument, uc, method)
-  }
-
-  protected def calculate(peer: Peer, instrument: SPInstObsComp, uc: ItcUniqueConfig, method: Double => CalculationMethod): Future[ItcService.Result] = {
-    val s = for {
-      analysis  <- parameters.analysisMethod
+  protected def extractInputs(instrument: SPInstObsComp, uc: ItcUniqueConfig, method: Double => CalculationMethod): String \/ ItcInputs =
+    for {
       cond      <- parameters.conditions
       port      <- parameters.instrumentPort
       targetEnv <- parameters.targetEnvironment
+      analysis  <- parameters.analysisMethod
       probe     <- extractGuideProbe()
       src       <- extractSource(targetEnv.getBase.getTarget, uc)
       tele      <- ConfigExtractor.extractTelescope(port, probe, targetEnv, uc.config)
-      ins       <- ConfigExtractor.extractInstrumentDetails(instrument, probe, targetEnv, uc.config)
+      ins       <- ConfigExtractor.extractInstrumentDetails(instrument, probe, targetEnv, uc.config, cond)
       srcFrac   <- extractSourceFraction(uc, instrument)
-    } yield {
-        doServiceCall(peer, uc, src, ins, tele, cond, new ObservationDetails(method(srcFrac), analysis))
-    }
 
-    s match {
-      case -\/(err) => Future { ItcError(err).left }
-      case \/-(res) => res
-    }
+    } yield ItcInputs(src, new ObservationDetails(method(srcFrac), analysis), cond, tele, ins)
 
-  }
+  protected def doServiceCall(peer: Peer, inputs: String \/ ItcInputs): Future[ItcService.Result] = inputs match {
 
-  protected def doServiceCall(peer: Peer, c: ItcUniqueConfig, src: SourceDefinition, ins: InstrumentDetails, tele: TelescopeDetails, cond: ObservingConditions, obs: ObservationDetails): Future[ItcService.Result] = {
-    // Do the service call
-    ItcService.calculate(peer, src, obs, cond, tele, ins).
+    case -\/(err) =>
+      Future {
+        ItcError(err).left
+      }
 
-      // whenever service call is finished notify table to update its contents
-      andThen {
-      case _ => Swing.onEDT {
+    case \/-(inp) =>
+      // Do the service call
+      ItcService.calculate(peer, inp).
 
-        // notify table of data update while keeping the current selection
-        restoreSelection {
-          this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged()
+        // whenever service call is finished notify table to update its contents
+        andThen {
+        case _ => Swing.onEDT {
+
+          // notify table of data update while keeping the current selection
+          restoreSelection {
+            this.peer.getModel.asInstanceOf[AbstractTableModel].fireTableDataChanged()
+          }
+
+          // make all columns as wide as needed
+          SequenceTabUtil.resizeTableColumns(this.peer, this.model)
         }
 
-        // make all columns as wide as needed
-        SequenceTabUtil.resizeTableColumns(this.peer, this.model)
       }
-    }
 
-  }
+    }
 
   // lacking a simple way to decide on the "closest" (i.e. "fastest to reach") peer we talk to the observing peer
   // if defined and GN or GS otherwise, if no site is defined you're out of luck and the ITC tables will stay empty
@@ -287,7 +277,7 @@ trait ItcTable extends Table {
 }
 
 class ItcImagingTable(val parameters: ItcParametersProvider) extends ItcTable {
-  private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(List(), List(), List())
+  private val emptyTable: ItcImagingTableModel = new ItcGenericImagingTableModel(List(), List(), List(), List())
 
   /** Creates a new table model for the current context (instrument) and config sequence.
     * Note that GMOS has a different table model with separate columns for its three CCDs. */
@@ -298,18 +288,22 @@ class ItcImagingTable(val parameters: ItcParametersProvider) extends ItcTable {
       instrument  <- parameters.instrument
 
     } yield {
-      val uniqConfigs = ItcUniqueConfig.imagingConfigs(seq)
-      val results     = uniqConfigs.map(calculateImaging(peer, instrument, _))
+      val uniqueConfigs = ItcUniqueConfig.imagingConfigs(seq)
+      val inputs        = uniqueConfigs.map(uc => extractInputs(instrument, uc, frac => ImagingSN(uc.count * uc.coadds.getOrElse(1), uc.singleExposureTime, frac)))
+      val results       = uniqueConfigs.zip(inputs).map { case (uc, i) => doServiceCall(peer, i) }
 
       instrument.getType match {
         case INSTRUMENT_GMOS | INSTRUMENT_GMOSSOUTH =>
-          new ItcGmosImagingTableModel(keys, uniqConfigs, results)
+          new ItcGmosImagingTableModel(keys, uniqueConfigs, inputs, results)
 
-        case INSTRUMENT_GNIRS | INSTRUMENT_GSAOI | INSTRUMENT_NIFS | INSTRUMENT_NIRI =>
-          new ItcGenericImagingTableModel(keys, uniqConfigs, results, showCoadds = true)
+        case INSTRUMENT_GSAOI  =>
+          new ItcGsaoiImagingTableModel(keys, uniqueConfigs, inputs, results)
+
+        case INSTRUMENT_GNIRS | INSTRUMENT_NIFS | INSTRUMENT_NIRI =>
+          new ItcGenericImagingTableModel(keys, uniqueConfigs, inputs, results, showCoadds = true)
 
         case _ =>
-          new ItcGenericImagingTableModel(keys, uniqConfigs, results, showCoadds = false)
+          new ItcGenericImagingTableModel(keys, uniqueConfigs, inputs, results, showCoadds = false)
       }
 
     }
@@ -320,7 +314,7 @@ class ItcImagingTable(val parameters: ItcParametersProvider) extends ItcTable {
 }
 
 class ItcSpectroscopyTable(val parameters: ItcParametersProvider) extends ItcTable {
-  private val emptyTable: ItcGenericSpectroscopyTableModel = new ItcGenericSpectroscopyTableModel(List(), List(), List())
+  private val emptyTable: ItcGenericSpectroscopyTableModel = new ItcGenericSpectroscopyTableModel(List(), List(), List(), List())
 
   /** Creates a new table model for the current context and config sequence. */
   def tableModel(keys: List[ItemKey], seq: ConfigSequence) = {
@@ -331,14 +325,15 @@ class ItcSpectroscopyTable(val parameters: ItcParametersProvider) extends ItcTab
 
     } yield {
       val uniqueConfigs = ItcUniqueConfig.spectroscopyConfigs(seq)
-      val results       = uniqueConfigs.map(calculateSpectroscopy(peer, instrument, _))
+      val inputs        = uniqueConfigs.map(uc => extractInputs(instrument, uc, frac => SpectroscopySN(uc.count * uc.coadds.getOrElse(1), uc.singleExposureTime, frac)))
+      val results       = uniqueConfigs.zip(inputs).map { case (uc, i) => doServiceCall(peer, i) }
 
       instrument.getType match {
         case INSTRUMENT_GNIRS | INSTRUMENT_GSAOI | INSTRUMENT_NIFS | INSTRUMENT_NIRI =>
-          new ItcGenericSpectroscopyTableModel(keys, uniqueConfigs, results, showCoadds = true)
+          new ItcGenericSpectroscopyTableModel(keys, uniqueConfigs, inputs, results, showCoadds = true)
 
         case _ =>
-          new ItcGenericSpectroscopyTableModel(keys, uniqueConfigs, results, showCoadds = false)
+          new ItcGenericSpectroscopyTableModel(keys, uniqueConfigs, inputs, results, showCoadds = false)
       }
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -187,7 +187,7 @@ class ItcGsaoiImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[I
   )
 
   def gems(i: String \/ ItcInputs): Option[String] = i.toOption.map { inputs =>
-    val gems = inputs.ins.asInstanceOf[GsaoiParameters].gems
+    val gems = inputs.instr.asInstanceOf[GsaoiParameters].gems
     f"${gems.avgStrehl}%.2f ${gems.strehlBand}"
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -14,7 +14,7 @@ import scalaz._
 import Scalaz._
 
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
-case class Column(label: String, value: (ItcUniqueConfig, Future[ItcService.Result]) => AnyRef, tooltip: String = "")
+case class Column(label: String, value: (ItcUniqueConfig, String\/ItcInputs, Future[ItcService.Result]) => AnyRef, tooltip: String = "")
 
 object ItcTableModel {
   val PeakPixelTooltip = "Peak pixel value = signal + background"
@@ -27,13 +27,13 @@ object ItcTableModel {
 sealed trait ItcTableModel extends AbstractTableModel {
 
   /// Define some generic columns. Values are rendered as strings in order to have them left aligned, similar to other sequence tables.
-  val LabelsColumn  = Column("Data Labels",     (c, r) => (resultIcon(r).orNull, c.labels))
-  val ImagesColumn  = Column("Images",          (c, r) => s"${c.count}",                      tooltip = "Number of exposures used in S/N calculation")
-  val CoaddsColumn  = Column("Coadds",          (c, r) => s"${c.coadds.getOrElse(1.0)}",      tooltip = "Number of coadds")
-  val ExpTimeColumn = Column("Exposure Time",   (c, r) => f"${c.singleExposureTime}%.1f",     tooltip = "Exposure time of each image [s]")
-  val TotTimeColumn = Column("Total Exp. Time", (c, r) => f"${c.totalExposureTime}%.1f",      tooltip = "Total exposure time [s]")
-  val SrcMagColumn  = Column("Source Mag",      (c, r) => sourceMag(r),                       tooltip = "Source magnitude [mag]")
-  val SrcFracColumn = Column("Source Fraction", (c, r) => sourceFraction(r),                  tooltip = "Fraction of images on source")
+  val LabelsColumn  = Column("Data Labels",     (c, i, r) => (resultIcon(r).orNull, c.labels))
+  val ImagesColumn  = Column("Images",          (c, i, r) => s"${c.count}",                      tooltip = "Number of exposures used in S/N calculation")
+  val CoaddsColumn  = Column("Coadds",          (c, i, r) => s"${c.coadds.getOrElse(1.0)}",      tooltip = "Number of coadds")
+  val ExpTimeColumn = Column("Exposure Time",   (c, i, r) => f"${c.singleExposureTime}%.1f",     tooltip = "Exposure time of each image [s]")
+  val TotTimeColumn = Column("Total Exp. Time", (c, i, r) => f"${c.totalExposureTime}%.1f",      tooltip = "Total exposure time [s]")
+  val SrcMagColumn  = Column("Source Mag",      (c, i, r) => i.map(sourceMag).toOption,          tooltip = "Source magnitude [mag]")
+  val SrcFracColumn = Column("Source Fraction", (c, i, r) => i.map(sourceFraction).toOption,     tooltip = "Fraction of images on source")
 
 
   // Define different sets of columns as headers
@@ -46,6 +46,7 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   val uniqueSteps:  List[ItcUniqueConfig]
   val res:          List[Future[ItcService.Result]]
+  val inputs:       List[String\/ItcInputs]
 
 
   // Gets the imaging result from the service result future (if present).
@@ -83,9 +84,9 @@ sealed trait ItcTableModel extends AbstractTableModel {
       }
     }
 
-  protected def sourceMag       (result: Future[ItcService.Result]) = serviceResult(result).map(r => f"${r.source.norm}%.2f ${r.source.getNormBand.name}")
+  protected def sourceMag       (i: ItcInputs) = f"${i.src.norm}%.2f ${i.src.getNormBand.name}"
 
-  protected def sourceFraction  (result: Future[ItcService.Result]) = serviceResult(result).map(r => f"${r.obsDetails.getSourceFraction}%.2f")
+  protected def sourceFraction  (i: ItcInputs) = f"${i.obs.getSourceFraction}%.2f"
 
 
   protected def spcPeakElectrons(result: Future[ItcService.Result]) = spectroscopyResult(result).map(_.allSeries(SignalChart, SignalData).map(_.yValues.max).max.toInt)
@@ -108,7 +109,7 @@ sealed trait ItcTableModel extends AbstractTableModel {
   override def getColumnCount: Int = headers.size + keys.size + results.size
 
   override def getValueAt(row: Int, col: Int): Object = column(col) match {
-    case Some(c) => c.value(uniqueSteps(row), res(row))
+    case Some(c) => c.value(uniqueSteps(row), inputs(row), res(row))
     case None    => uniqueSteps(row).config.getItemValue(toKey(col))
   }
 
@@ -150,41 +151,58 @@ sealed trait ItcTableModel extends AbstractTableModel {
 /** Generic ITC imaging tables model. */
 sealed trait ItcImagingTableModel extends ItcTableModel
 
-class ItcGenericImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcImagingTableModel {
+class ItcGenericImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcInputs], val res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcImagingTableModel {
   val headers = if (showCoadds) HeadersWithCoadds else Headers
   val results = List(
-    Column("Peak",            (c, r) => imgPeakPixelFlux(r),          tooltip = ItcTableModel.PeakPixelTooltip),
-    Column("S/N Single",      (c, r) => imgSingleSNRatio(r)),
-    Column("S/N Total",       (c, r) => imgTotalSNRatio (r))
+    Column("Peak",            (c, i, r) => imgPeakPixelFlux(r),          tooltip = ItcTableModel.PeakPixelTooltip),
+    Column("S/N Single",      (c, i, r) => imgSingleSNRatio(r)),
+    Column("S/N Total",       (c, i, r) => imgTotalSNRatio (r))
   )
 }
 
 /** GMOS specific ITC imaging table model. */
-class ItcGmosImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
+class ItcGmosImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcInputs], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = Headers
   val results = List(
-    Column("CCD1 Peak",       (c, r) => imgPeakPixelFlux(r, ccd=0),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 1"),
-    Column("CCD1 S/N Single", (c, r) => imgSingleSNRatio(r, ccd=0)),
-    Column("CCD1 S/N Total",  (c, r) => imgTotalSNRatio (r, ccd=0)),
-    Column("CCD2 Peak",       (c, r) => imgPeakPixelFlux(r, ccd=1),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 2"),
-    Column("CCD2 S/N Single", (c, r) => imgSingleSNRatio(r, ccd=1)),
-    Column("CCD2 S/N Total",  (c, r) => imgTotalSNRatio (r, ccd=1)),
-    Column("CCD3 Peak",       (c, r) => imgPeakPixelFlux(r, ccd=2),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 3"),
-    Column("CCD3 S/N Single", (c, r) => imgSingleSNRatio(r, ccd=2)),
-    Column("CCD3 S/N Total",  (c, r) => imgTotalSNRatio (r, ccd=2))
+    Column("CCD1 Peak",       (c, i, r) => imgPeakPixelFlux(r, ccd=0),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 1"),
+    Column("CCD1 S/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=0)),
+    Column("CCD1 S/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=0)),
+    Column("CCD2 Peak",       (c, i, r) => imgPeakPixelFlux(r, ccd=1),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 2"),
+    Column("CCD2 S/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=1)),
+    Column("CCD2 S/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=1)),
+    Column("CCD3 Peak",       (c, i, r) => imgPeakPixelFlux(r, ccd=2),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 3"),
+    Column("CCD3 S/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=2)),
+    Column("CCD3 S/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=2))
   )
+}
+
+class ItcGsaoiImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcInputs], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
+  val headers = HeadersWithCoadds ++ List(
+    Column("Strehl",          (c, i, r) => gems(i),                      tooltip = "Estimated Strehl and band")
+  )
+  val results = List(
+    Column("Peak",            (c, i, r) => imgPeakPixelFlux(r),          tooltip = ItcTableModel.PeakPixelTooltip),
+    Column("S/N Single",      (c, i, r) => imgSingleSNRatio(r)),
+    Column("S/N Total",       (c, i, r) => imgTotalSNRatio (r))
+  )
+
+  def gems(i: String \/ ItcInputs): Option[String] = i.toOption.map { inputs =>
+    val gems = inputs.ins.asInstanceOf[GsaoiParameters].gems
+    f"${gems.avgStrehl}%.2f ${gems.strehlBand}"
+  }
+
 }
 
 
 /** Generic ITC spectroscopy table model. */
 sealed trait ItcSpectroscopyTableModel extends ItcTableModel
 
-class ItcGenericSpectroscopyTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcSpectroscopyTableModel {
+class ItcGenericSpectroscopyTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcInputs], val res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcSpectroscopyTableModel {
   val headers = if (showCoadds) HeadersWithCoadds else Headers
   val results = List(
-    Column("Peak",            (c, r) => spcPeakElectrons(r),          tooltip = "Peak e- per exposure"),
-    Column("S/N Single",      (c, r) => spcPeakSNSingle(r)),
-    Column("S/N Total",       (c, r) => spcPeakSNFinal(r))
+    Column("Peak",            (c, i, r) => spcPeakElectrons(r),          tooltip = "Peak e- per exposure"),
+    Column("S/N Single",      (c, i, r) => spcPeakSNSingle(r)),
+    Column("S/N Total",       (c, i, r) => spcPeakSNFinal(r))
   )
 
 }


### PR DESCRIPTION
GSAOI ITC calculations have been fully functional for a while but the Strehl value was missing. I was not able to get the precise average Strehl value from the Mascot / AGS code in a simple way due to my lack of understanding the code and also because I was very hesitant to change that code even in the slightest bit at such a late stage.

Following Bryan's suggestion I implemented an approximation for the GeMS performance based on this table http://www.gemini.edu/sciops/instruments/gems/gems-performance which should be good enough for now. We can follow up with using the more precise Strehl values at a later stage.

I am aware that this change is a bit a late comer, so I am ok in case people think we should not put that into the release. Andy is going to test it and I will certainly play around with it a bit more, too. We can probably decide tomorrow if it's worth the risk or not.

*HOWEVER* , if we add this, we would have full support for imaging and the only missing bits would be GNIRS and NIFS... just saying.

![image](https://cloud.githubusercontent.com/assets/7856060/7856084/0f8a113e-04c2-11e5-9131-2cb261b9493c.png)
