### PR TITLE
OCSADV-363: Disable ITC panels for GNIRS and NIFS

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -120,7 +120,7 @@ class ItcImagingPanel(val owner: EdIteratorFolder) extends ItcPanel {
     case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
     case SPComponentType.INSTRUMENT_GMOS        => true
     case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
-    case SPComponentType.INSTRUMENT_GSAOI       => false // will add support at a later stage
+    case SPComponentType.INSTRUMENT_GSAOI       => true
     case SPComponentType.INSTRUMENT_MICHELLE    => false // may or may not be supported in OT at some point
     case SPComponentType.INSTRUMENT_NIRI        => true
     case SPComponentType.INSTRUMENT_TRECS       => false // may or may not be supported in OT at some point

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -120,10 +120,10 @@ class ItcImagingPanel(val owner: EdIteratorFolder) extends ItcPanel {
     case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
     case SPComponentType.INSTRUMENT_GMOS        => true
     case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
-    case SPComponentType.INSTRUMENT_GSAOI       => true
-    case SPComponentType.INSTRUMENT_MICHELLE    => true
+    case SPComponentType.INSTRUMENT_GSAOI       => false // will add support at a later stage
+    case SPComponentType.INSTRUMENT_MICHELLE    => false // may or may not be supported in OT at some point
     case SPComponentType.INSTRUMENT_NIRI        => true
-    case SPComponentType.INSTRUMENT_TRECS       => true
+    case SPComponentType.INSTRUMENT_TRECS       => false // may or may not be supported in OT at some point
     case _                                      => false
   }
 }
@@ -152,11 +152,11 @@ class ItcSpectroscopyPanel(val owner: EdIteratorFolder) extends ItcPanel {
     case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
     case SPComponentType.INSTRUMENT_GMOS        => true
     case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
-    case SPComponentType.INSTRUMENT_GNIRS       => true
-    case SPComponentType.INSTRUMENT_MICHELLE    => true
-    case SPComponentType.INSTRUMENT_NIFS        => true
+    case SPComponentType.INSTRUMENT_GNIRS       => false // will add support at later stage
+    case SPComponentType.INSTRUMENT_MICHELLE    => false // may or may not be supported in OT at some point
+    case SPComponentType.INSTRUMENT_NIFS        => false // will add support at later stage
     case SPComponentType.INSTRUMENT_NIRI        => true
-    case SPComponentType.INSTRUMENT_TRECS       => true
+    case SPComponentType.INSTRUMENT_TRECS       => false // may or may not be supported in OT at some point
     case _                                      => false
   }
 }


### PR DESCRIPTION
GNIRS and NIFS ITC support is not fully finished yet and will be added at a later stage. This PR simply hides the ITC panels for those instruments.

ITC support for Michelle and TReCS has also been disabled. Potentially ITC for these legacy instruments will never be supported in the OT; they are (still) supported in the web app.