### PR TITLE
OCSADV-365: Ignore Y and u bands for ITC calculations.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -201,8 +201,10 @@ trait ItcTable extends Table {
       val bands = target.getMagnitudes.toList.asScala.toList.
         filter(_.getBand.getWavelengthMidPoint.isDefined).// ignore bands with unknown wavelengths (currently AP only)
         filterNot(_.getBand == Magnitude.Band.UC).        // ignore UC magnitudes
-        filterNot(_.getBand == Magnitude.Band.AP)         // ignore AP magnitudes
-      if (bands.isEmpty) "No standard magnitudes for target defined; ITC can not use UC and AP magnitudes.".left[Magnitude]
+        filterNot(_.getBand == Magnitude.Band.AP).        // ignore AP magnitudes
+        filterNot(_.getBand == Magnitude.Band.Y).         // ITC currently does not support Y
+        filterNot(_.getBand == Magnitude.Band.u)          // ITC currently does not support u
+      if (bands.isEmpty) "No standard magnitudes for target defined; ITC does not support UC, AP, Y and u magnitudes.".left[Magnitude]
       else closestBand(bands, wl).right[String]
     }
 
@@ -218,7 +220,6 @@ trait ItcTable extends Table {
         case Magnitude.System.Jy    => BrightnessUnit.JY
       }
       val band   = mag.getBand match {
-        case Magnitude.Band.u  => WavebandDefinition.U
         case Magnitude.Band.g  => WavebandDefinition.g
         case Magnitude.Band.r  => WavebandDefinition.r
         case Magnitude.Band.i  => WavebandDefinition.i
@@ -229,7 +230,6 @@ trait ItcTable extends Table {
         case Magnitude.Band.V  => WavebandDefinition.V
         case Magnitude.Band.R  => WavebandDefinition.R
         case Magnitude.Band.I  => WavebandDefinition.I
-        case Magnitude.Band.Y  => WavebandDefinition.z
         case Magnitude.Band.J  => WavebandDefinition.J
         case Magnitude.Band.H  => WavebandDefinition.H
         case Magnitude.Band.K  => WavebandDefinition.K
@@ -238,7 +238,9 @@ trait ItcTable extends Table {
         case Magnitude.Band.N  => WavebandDefinition.N
         case Magnitude.Band.Q  => WavebandDefinition.Q
 
-        // UC and AP are not taken into account for ITC calculations
+        // UC and AP are not taken into account for ITC calculations; Y and u are currently not supported in ITC
+        case Magnitude.Band.u  => throw new Error()
+        case Magnitude.Band.Y  => throw new Error()
         case Magnitude.Band.UC => throw new Error()
         case Magnitude.Band.AP => throw new Error()
       }


### PR DESCRIPTION
One of my shameful moments when integrating the ITC was that I haven't (yet) unified the wavebands used in ITC and the core. Of course - as always - this has now come back to haunt me.

For reasons unknown ITC does not support Y and u bands. In order to deal with this I have translated those bands to other, nearby bands when passing information down from the OT to the ITC. However the preferable way seems to be to ignore those bands when deciding on the magnitude and use other magnitude information.

This PR reflects this change by ignoring magnitudes defined in Y or u and give an error message if no other magnitudes are defined.

And yes, this needs to be cleaned up and those wavelength band definitions need to be unified. But there are only so many hours in a day.