### PR TITLE
REL-2351: target detail enabled state fix

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -118,22 +118,25 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     }
 
     @Override protected void updateEnabledState(boolean enabled) {
-        super.updateEnabledState(enabled);
+        if (enabled != isEnabled()) {
+            setEnabled(enabled);
+            updateEnabledState(getWindow().getComponents(), enabled);
+
+            // Update enabled state for all detail widgets.  The current editor
+            // will have already been updated by the super.updateEnabledState so
+            // update the others.
+            for (final TargetDetailEditor ed : _w.detailEditor.allEditorsJava()) {
+                if (_w.detailEditor.curDetailEdiorJava().forall(cur -> cur != ed)) {
+                    updateEnabledState(new Component[]{ed}, enabled);
+                }
+            }
+        }
 
         final TargetEnvironment env = getDataObject().getTargetEnvironment();
         _w.tag.setEnabled(enabled && env.getBase() != _curPos);
 
         final SPInstObsComp inst = getContextInstrumentDataObject();
         _w.newMenu.setEnabled(enabled && inst != null);
-
-        // Update enabled state for all detail widgets.  The current editor
-        // will have already been updated by the super.updateEnabledState so
-        // update the others.
-        for (final TargetDetailEditor ed : _w.detailEditor.allEditorsJava()) {
-            if (_w.detailEditor.curDetailEdiorJava().forall(cur -> cur != ed)) {
-                updateEnabledState(new Component[] {ed}, enabled);
-            }
-        }
     }
 
     private final ActionListener _tagListener = new ActionListener() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -122,11 +122,15 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             setEnabled(enabled);
             updateEnabledState(getWindow().getComponents(), enabled);
 
-            // Update enabled state for all detail widgets.  The current editor
-            // will have already been updated by the super.updateEnabledState so
-            // update the others.
+            // Update enabled state for all detail widgets.  The current detail
+            // editor will have already been updated by the call to
+            // updateEnabledState above which updates the hierarchy of widgets
+            // rooted in the JPanel containing the target component.  Since the
+            // other detail editors are swapped in when the target type changes,
+            // update them explicitly so they behave as if they were contained
+            // in the panel.
             for (final TargetDetailEditor ed : _w.detailEditor.allEditorsJava()) {
-                if (_w.detailEditor.curDetailEdiorJava().forall(cur -> cur != ed)) {
+                if (_w.detailEditor.curDetailEditorJava().forall(cur -> cur != ed)) {
                     updateEnabledState(new Component[]{ed}, enabled);
                 }
             }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/TargetDetailPanel.scala
@@ -45,7 +45,7 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
 
   def curDetailEditor: Option[TargetDetailEditor] = Option(tde)
 
-  def curDetailEdiorJava: GOption[TargetDetailEditor] = curDetailEditor.asGeminiOpt
+  def curDetailEditorJava: GOption[TargetDetailEditor] = curDetailEditor.asGeminiOpt
 
   val source = new SourceDetailsEditor
   val gfe    = new GuidingFeedbackEditor


### PR DESCRIPTION
This PR fixes a subtle bug in enabled state management for the target detail panel.  Ordinarily enabled state updating is ignored when setting the enabled state to the same value as it was before in order to avoid updating the table of "previous" enabled state values.  You can see this in `OtItemEditor`:

````java
    protected void updateEnabledState(boolean enabled) {
        if (enabled != isEnabled()) {
            setEnabled(enabled);
            updateEnabledState(getWindow().getComponents(), enabled);
        }
    }
````

In the case of `EdCompTargetList` we were ignoring this step in the overridden `updateEnabledState` method.

Unfortunately this fix is not very satisfying.  Enabled state management in the OT needs to be redone from scratch.  The table of all all widget's previous enabled state values is very fragile.