### PR TITLE
OCSADV-200-R: preparing for OT integration

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/version/VersionMap.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/version/VersionMap.scala
@@ -59,4 +59,16 @@ object VersionMap {
 
   def compare(x: VersionMap, y: VersionMap): VersionComparison =
     VersionComparison(tryCompare(x,y))
+
+  /** Returns a new `VersionMap` with all the keys from both maps and whose
+    * values are the combination of the corresponding `NodeVersions`. In each
+    * case, the combined node versions contains all the keys in either version
+    * vector where the value is the max of the value for that key.
+    *
+    * Intuitively, this method returns the `VersionMap` that results from
+    * synchronizing two program versions with these maps. */
+  def sync(x: VersionMap, y: VersionMap): VersionMap =
+    (x/:y.keySet) { (vm, k) =>
+      vm.updated(k, nodeVersions(x, k).sync(nodeVersions(y, k)))
+    }
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
@@ -22,7 +22,7 @@ import Scalaz._
   * actions that read from and write to programs in the database. It also
   * implements the server side of the [[edu.gemini.sp.vcs2.VcsService]]
   * interface. */
-class VcsServer(odb: IDBDatabaseService, vcsLog: VcsLog) { vs =>
+class VcsServer(odb: IDBDatabaseService) { vs =>
 
   import SPNodeKeyLocks.instance.{readLock, readUnlock, writeLock, writeUnlock}
 
@@ -101,7 +101,7 @@ class VcsServer(odb: IDBDatabaseService, vcsLog: VcsLog) { vs =>
   }
 
   /** Server implementation of `VcsService`. */
-  final class SecureVcsService(user: Set[Principal]) extends VcsService {
+  final class SecureVcsService(user: Set[Principal], vcsLog: VcsLog) extends VcsService {
     def geminiPrincipals: Set[GeminiPrincipal] =
       user.collect { case p: GeminiPrincipal => p }
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Activator.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Activator.scala
@@ -32,14 +32,14 @@ class Activator extends BundleActivator{
     trackers = List(
       track[IDBDatabaseService, KeyChain, VcsLog, List[ServiceRegistration[_]]](ctx) { (odb, auth, log) =>
         // The vcs backend/server implementation itself.
-        val vcsServer = new VcsServer(odb, log)
+        val vcsServer = new VcsServer(odb)
 
         // The public service.
         val props = new util.Hashtable[String, Object]()
         props.put(PUBLISH_TRPC, "true")
         val factory = new SecureServiceFactory[VcsService] {
           def getService(b: Bundle, reg: ServiceRegistration[VcsService], ps: java.util.Set[Principal]): VcsService =
-            new vcsServer.SecureVcsService(ps.asScala.toSet)
+            new vcsServer.SecureVcsService(ps.asScala.toSet, log)
         }
 
         // Register the Vcs client and a secure service factory for making the

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
@@ -9,6 +9,7 @@ import edu.gemini.spModel.core.{Peer, SPProgramID}
 import edu.gemini.util.security.auth.keychain.KeyChain
 
 import java.io.{PrintWriter, StringWriter}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scalaz._
 import Scalaz._
@@ -96,20 +97,20 @@ object Commands {
       runAndFormat(id, peer, vcs.add) { _ => s"Added $id to $peer" }
 
     val checkout: VcsOp = (id, peer) =>
-      runAndFormat(id, peer, vcs.checkout) { _ => s"Checked out $id from $peer" }
+      runAndFormat(id, peer, vcs.checkout(_, _, new AtomicBoolean(false))) { _ => s"Checked out $id from $peer" }
 
     val pull: VcsOp = (id, peer) =>
-      runAndFormat(id, peer, vcs.pull) { updated =>
+      runAndFormat(id, peer, vcs.pull(_, _, new AtomicBoolean(false))) { updated =>
         if (updated) "Updated local program." else "Already up to date."
       }
 
     val push: VcsOp = (id, peer) =>
-      runAndFormat(id, peer, vcs.push) { updated =>
+      runAndFormat(id, peer, vcs.push(_, _, new AtomicBoolean(false))) { updated =>
         if (updated) "Updated remote program." else "Already up to date."
       }
 
     val sync: VcsOp = (id, peer) =>
-      runAndFormat(id, peer, vcs.sync) {
+      runAndFormat(id, peer, vcs.sync(_, _, new AtomicBoolean(false))) {
         case Neither    => "Already up to date."
         case LocalOnly  => "Updated local program."
         case RemoteOnly => "Updated remote program."

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
@@ -101,22 +101,22 @@ object Commands {
 
     val pull: VcsOp = (id, peer) =>
       runAndFormat(id, peer, vcs.pull(_, _, new AtomicBoolean(false))) {
-        case LocalOnly => "Updated local program."
-        case Neither   => "Already up to date."
+        case (LocalOnly,_) => "Updated local program."
+        case (Neither,_  ) => "Already up to date."
       }
 
     val push: VcsOp = (id, peer) =>
       runAndFormat(id, peer, vcs.push(_, _, new AtomicBoolean(false))) {
-        case RemoteOnly  => "Updated remote program."
-        case Neither     => "Already up to date."
+        case (RemoteOnly,_) => "Updated remote program."
+        case (Neither,_   ) => "Already up to date."
       }
 
     val sync: VcsOp = (id, peer) =>
       runAndFormat(id, peer, vcs.sync(_, _, new AtomicBoolean(false))) {
-        case Neither    => "Already up to date."
-        case LocalOnly  => "Updated local program."
-        case RemoteOnly => "Updated remote program."
-        case Both       => "Synchronized."
+        case (Neither,_   ) => "Already up to date."
+        case (LocalOnly,_ ) => "Updated local program."
+        case (RemoteOnly,_) => "Updated remote program."
+        case (Both,_      ) => "Synchronized."
       }
 
     val vcsOps: Map[String, VcsOp] = Map(

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
@@ -1,7 +1,7 @@
 package edu.gemini.sp.vcs2.osgi
 
 import edu.gemini.pot.spdb.IDBDatabaseService
-import edu.gemini.sp.vcs2.ProgramLocation.{Both, RemoteOnly, LocalOnly, Neither}
+import edu.gemini.sp.vcs2.ProgramLocationSet.{Both, RemoteOnly, LocalOnly, Neither}
 import edu.gemini.sp.vcs2._
 import edu.gemini.sp.vcs2.VcsAction._
 import edu.gemini.sp.vcs.reg.VcsRegistrar
@@ -100,13 +100,15 @@ object Commands {
       runAndFormat(id, peer, vcs.checkout(_, _, new AtomicBoolean(false))) { _ => s"Checked out $id from $peer" }
 
     val pull: VcsOp = (id, peer) =>
-      runAndFormat(id, peer, vcs.pull(_, _, new AtomicBoolean(false))) { updated =>
-        if (updated) "Updated local program." else "Already up to date."
+      runAndFormat(id, peer, vcs.pull(_, _, new AtomicBoolean(false))) {
+        case LocalOnly => "Updated local program."
+        case Neither   => "Already up to date."
       }
 
     val push: VcsOp = (id, peer) =>
-      runAndFormat(id, peer, vcs.push(_, _, new AtomicBoolean(false))) { updated =>
-        if (updated) "Updated remote program." else "Already up to date."
+      runAndFormat(id, peer, vcs.push(_, _, new AtomicBoolean(false))) {
+        case RemoteOnly  => "Updated remote program."
+        case Neither     => "Already up to date."
       }
 
     val sync: VcsOp = (id, peer) =>

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeCorrectionSpec.scala
@@ -2,7 +2,6 @@ package edu.gemini.sp.vcs2
 
 import edu.gemini.pot.sp.{Conflict, Conflicts, SPNodeKey}
 import edu.gemini.pot.sp.version._
-import edu.gemini.sp.vcs2.ProgramLocation.{Remote, Local}
 import edu.gemini.spModel.conflict.ConflictFolder
 import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth
@@ -23,10 +22,6 @@ import Scalaz._
 
 class MergeCorrectionSpec extends Specification {
   import NodeDetail._
-
-  val LocalOnly: Set[ProgramLocation]  = Set(Local)
-  val RemoteOnly: Set[ProgramLocation] = Set(Remote)
-  val Both: Set[ProgramLocation]       = Set(Local, Remote)
 
   val lifespanId: LifespanId = LifespanId.random
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TemplateNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TemplateNumberCorrectionSpec.scala
@@ -2,6 +2,7 @@ package edu.gemini.sp.vcs2
 
 
 import edu.gemini.sp.vcs2.ProgramLocation.Remote
+import edu.gemini.sp.vcs2.ProgramLocationSet.{RemoteOnly, LocalOnly, Both}
 import edu.gemini.spModel.template.{TemplateGroup, TemplateFolder}
 import edu.gemini.spModel.util.VersionToken
 
@@ -14,13 +15,13 @@ class TemplateNumberCorrectionSpec extends MergeCorrectionSpec {
   def vt(segs: Int*)(next: Int): VersionToken =
     VersionToken.apply(segs.toArray, next)
 
-  def test(expected: List[VersionToken], merged: (VersionToken, Set[ProgramLocation])*): Boolean = {
+  def test(expected: List[VersionToken], merged: (VersionToken, ProgramLocationSet)*): Boolean = {
     val tgList = merged.map { case (tok,_) => templateGroup(tok).leaf }
 
     val mergeTree = prog.node(Tree.node(templateFolder, tgList.toStream))
 
     val known = merged.unzip._2.zip(tgList.map(_.key)).collect {
-      case (locs, key) if locs.contains(Remote) => key
+      case (locs, key) if locs.toSet.contains(Remote) => key
     }.toSet
 
     def tgNumbers(t: Tree[MergeNode]): List[VersionToken] = {

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsServerSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsServerSpec.scala
@@ -159,7 +159,7 @@ class VcsServerSpec extends VcsSpecification {
       val vm2       = vm.updated(Key, nv2)
       val diffState = DiffState(Key, vm2, Set.empty)
 
-      val svs = new env.local.server.SecureVcsService(StaffUser)
+      val svs = new env.local.server.SecureVcsService(StaffUser, MockVcsLog)
       svs.fetchDiffs(Q1, diffState) match {
         case \/-(pdt) =>
           val mp = pdt.decode.plan
@@ -179,7 +179,7 @@ class VcsServerSpec extends VcsSpecification {
     "do nothing if there are no diffs to store" in withVcs { env =>
       val update = (Unmodified(Key): MergeNode).node()
       val mp     = MergePlan(update, Set.empty)
-      val svs    = new env.local.server.SecureVcsService(StaffUser)
+      val svs    = new env.local.server.SecureVcsService(StaffUser, MockVcsLog)
       svs.storeDiffs(Q1, mp.encode) match {
         case \/-(false) => ok("ok, nothing done")
         case \/-(true)  => ko("updated anyway")
@@ -196,7 +196,7 @@ class VcsServerSpec extends VcsSpecification {
       val update = MergeNode.modified(Key, nv, dob, NodeDetail.Empty, Conflicts.EMPTY).node()
       val mp     = MergePlan(update, Set.empty)
 
-      val svs = new env.local.server.SecureVcsService(StaffUser)
+      val svs = new env.local.server.SecureVcsService(StaffUser, MockVcsLog)
       svs.storeDiffs(Q1, mp.encode) match {
         case \/-(true)  => env.local.progTitle must_== "The Myth of Sisyphus"
         case \/-(false) => ko("update ignored")
@@ -215,7 +215,7 @@ class VcsServerSpec extends VcsSpecification {
       val update = MergeNode.modified(Key, nv, dob, NodeDetail.Empty, con).node()
       val mp     = MergePlan(update, Set.empty)
 
-      val svs = new env.local.server.SecureVcsService(StaffUser)
+      val svs = new env.local.server.SecureVcsService(StaffUser, MockVcsLog)
       svs.storeDiffs(Q1, mp.encode) match {
         case \/-(true)        => ko("conflict ignored")
         case \/-(false)       => ko("update and conflict ignored")

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsSpec.scala
@@ -1,6 +1,7 @@
 package edu.gemini.sp.vcs2
 
 
+import edu.gemini.sp.vcs2.ProgramLocationSet.{RemoteOnly, LocalOnly, Neither, Both}
 import edu.gemini.sp.vcs2.VcsAction._
 import edu.gemini.sp.vcs2.VcsFailure.NeedsUpdate
 import edu.gemini.spModel.core.SPProgramID
@@ -95,7 +96,7 @@ class VcsSpec extends VcsSpecification {
 
     "do nothing if the local version is the same" in withVcs { env =>
       expect(env.local.superStaffVcs.pull(Q1, DummyPeer, notCancelled)) {
-        case \/-(false) => ok("")
+        case \/-(Neither) => ok("")
       }
     }
 
@@ -103,7 +104,7 @@ class VcsSpec extends VcsSpecification {
       env.local.progTitle = "The Myth of Sisyphus"
 
       expect(env.local.superStaffVcs.pull(Q1, DummyPeer, notCancelled)) {
-        case \/-(false) => ok("")
+        case \/-(Neither) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
 
@@ -111,7 +112,7 @@ class VcsSpec extends VcsSpecification {
       env.remote.progTitle = "The Myth of Sisyphus"
 
       expect(env.local.superStaffVcs.pull(Q1, DummyPeer, notCancelled)) {
-        case \/-(true) => ok("")
+        case \/-(LocalOnly) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
 
@@ -147,7 +148,7 @@ class VcsSpec extends VcsSpecification {
 
     "do nothing if the local version is the same" in withVcs { env =>
       expect(env.local.superStaffVcs.push(Q1, DummyPeer, notCancelled)) {
-        case \/-(false) => ok("")
+        case \/-(Neither) => ok("")
       }
     }
 
@@ -163,7 +164,7 @@ class VcsSpec extends VcsSpecification {
       env.local.progTitle = "The Myth of Sisyphus"
 
       expect(env.local.superStaffVcs.push(Q1, DummyPeer, notCancelled)) {
-        case \/-(true) => ok("")
+        case \/-(RemoteOnly) => ok("")
       } and (env.remote.progTitle must_== "The Myth of Sisyphus")
     }
 
@@ -202,7 +203,7 @@ class VcsSpec extends VcsSpecification {
 
       "do nothing if both versions are the same" in withVcs { env =>
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(ProgramLocation.Neither) => ok("")
+          case \/-(Neither) => ok("")
         }
       }
 
@@ -210,7 +211,7 @@ class VcsSpec extends VcsSpecification {
         env.remote.progTitle = "The Myth of Sisyphus"
 
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(ProgramLocation.LocalOnly) => ok("")
+          case \/-(LocalOnly) => ok("")
         } and (env.local.progTitle must_== "The Myth of Sisyphus")
       }
 
@@ -218,7 +219,7 @@ class VcsSpec extends VcsSpecification {
         env.local.progTitle = "The Myth of Sisyphus"
 
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(ProgramLocation.RemoteOnly) => ok("")
+          case \/-(RemoteOnly) => ok("")
         } and (env.remote.progTitle must_== "The Myth of Sisyphus")
       }
 
@@ -230,7 +231,7 @@ class VcsSpec extends VcsSpecification {
         env.remote.prog.addObsComponent(note)
 
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(ProgramLocation.Both) => ok("")
+          case \/-(Both) => ok("")
         } and (env.remote.prog.getGroups.get(0).getNodeKey must_== group.getNodeKey) and
           (env.local.prog.getObsComponents.get(0).getNodeKey must_== note.getNodeKey)
       }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsSpec.scala
@@ -1,6 +1,7 @@
 package edu.gemini.sp.vcs2
 
 
+import edu.gemini.pot.sp.version.VersionMap
 import edu.gemini.sp.vcs2.ProgramLocationSet.{RemoteOnly, LocalOnly, Neither, Both}
 import edu.gemini.sp.vcs2.VcsAction._
 import edu.gemini.sp.vcs2.VcsFailure.NeedsUpdate
@@ -96,7 +97,7 @@ class VcsSpec extends VcsSpecification {
 
     "do nothing if the local version is the same" in withVcs { env =>
       expect(env.local.superStaffVcs.pull(Q1, DummyPeer, notCancelled)) {
-        case \/-(Neither) => ok("")
+        case \/-((Neither,_)) => ok("")
       }
     }
 
@@ -104,7 +105,7 @@ class VcsSpec extends VcsSpecification {
       env.local.progTitle = "The Myth of Sisyphus"
 
       expect(env.local.superStaffVcs.pull(Q1, DummyPeer, notCancelled)) {
-        case \/-(Neither) => ok("")
+        case \/-((Neither,_)) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
 
@@ -112,7 +113,7 @@ class VcsSpec extends VcsSpecification {
       env.remote.progTitle = "The Myth of Sisyphus"
 
       expect(env.local.superStaffVcs.pull(Q1, DummyPeer, notCancelled)) {
-        case \/-(LocalOnly) => ok("")
+        case \/-((LocalOnly,_)) => ok("")
       } and (env.local.progTitle must_== "The Myth of Sisyphus")
     }
 
@@ -148,7 +149,7 @@ class VcsSpec extends VcsSpecification {
 
     "do nothing if the local version is the same" in withVcs { env =>
       expect(env.local.superStaffVcs.push(Q1, DummyPeer, notCancelled)) {
-        case \/-(Neither) => ok("")
+        case \/-((Neither,_)) => ok("")
       }
     }
 
@@ -164,7 +165,7 @@ class VcsSpec extends VcsSpecification {
       env.local.progTitle = "The Myth of Sisyphus"
 
       expect(env.local.superStaffVcs.push(Q1, DummyPeer, notCancelled)) {
-        case \/-(RemoteOnly) => ok("")
+        case \/-((RemoteOnly,_)) => ok("")
       } and (env.remote.progTitle must_== "The Myth of Sisyphus")
     }
 
@@ -179,7 +180,7 @@ class VcsSpec extends VcsSpecification {
     // TODO: pending tests with conflicts, which must be rejected
   }
 
-  def syncFragments(name: String, syncMethod: (Vcs, SPProgramID) => VcsAction[ProgramLocationSet]): Fragments = {
+  def syncFragments(name: String, syncMethod: (Vcs, SPProgramID) => VcsAction[(ProgramLocationSet,VersionMap)]): Fragments = {
     name should {
       "fail if the indicated program doesn't exist locally" in withVcs { env =>
         env.remote.addNewProgram(Q2)
@@ -203,7 +204,7 @@ class VcsSpec extends VcsSpecification {
 
       "do nothing if both versions are the same" in withVcs { env =>
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(Neither) => ok("")
+          case \/-((Neither,_)) => ok("")
         }
       }
 
@@ -211,7 +212,7 @@ class VcsSpec extends VcsSpecification {
         env.remote.progTitle = "The Myth of Sisyphus"
 
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(LocalOnly) => ok("")
+          case \/-((LocalOnly,_)) => ok("")
         } and (env.local.progTitle must_== "The Myth of Sisyphus")
       }
 
@@ -219,7 +220,7 @@ class VcsSpec extends VcsSpecification {
         env.local.progTitle = "The Myth of Sisyphus"
 
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(RemoteOnly) => ok("")
+          case \/-((RemoteOnly,_)) => ok("")
         } and (env.remote.progTitle must_== "The Myth of Sisyphus")
       }
 
@@ -231,7 +232,7 @@ class VcsSpec extends VcsSpecification {
         env.remote.prog.addObsComponent(note)
 
         expect(syncMethod(env.local.superStaffVcs, Q1)) {
-          case \/-(Both) => ok("")
+          case \/-((Both,_)) => ok("")
         } and (env.remote.prog.getGroups.get(0).getNodeKey must_== group.getNodeKey) and
           (env.local.prog.getObsComponents.get(0).getNodeKey must_== note.getNodeKey)
       }


### PR DESCRIPTION
When I started looking into OT / VCS integration I realized I would need a few changes in the new vcs code.  The intention is for the OT to mostly work with the API provided by `edu.gemini.sp.vcs2.Vcs` which has methods for performing checkouts, adds, and syncs.  Unfortunately though,

1. It was missing a `version` method to simply fetch the current `VersionMap` from the remote peer.

2. It provided no way to cancel an ongoing sync or checkout operation.  Since a `VcsAction` is simply an `EitherT[Task, VcsFailure, A]`, I could just extract the `Task`, fork it into a new thread and call `runAsyncInterruptibly`.  I wanted more control over where the interrupt would happen though to make sure that I don't somehow half-commit any updates. I used the same API as `runAsyncInterruptibly` and just check an `AtomicBoolean` at key places.

Also, this PR

* pimps in a `forkAsync` method for `VcsAction` to simplify running the action in a separate thread

* changes the `VcsServer` constructor so that there's no need to have a `VcsLog` unless you also need to make a `SecureVcsService`

This may be terrible.  Suggestions for improvement would be extremely welcome.