### PR TITLE
OCSADV-366: Unify ITC and core model wavelength bands.

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
@@ -1,15 +1,19 @@
 package edu.gemini.spModel.core
 
-sealed abstract class MagnitudeBand private (val name: String, val wavelengthMidPointNm: Option[Int], val description: Option[String], val defaultSystem: MagnitudeSystem) extends Product with Serializable {
+sealed abstract class MagnitudeBand private (val name: String, val center: Wavelength, val width: Wavelength, val description: Option[String], val defaultSystem: MagnitudeSystem) extends Product with Serializable {
 
-  private def this(name: String, wavelengthMidPointNm: Int) =
-    this(name, Some(wavelengthMidPointNm), None, MagnitudeSystem.VEGA)
+  private def this(name: String, center: Wavelength, width: Wavelength) =
+    this(name, center, width, None, MagnitudeSystem.VEGA)
 
-  private def this(name: String, wavelengthMidPointNm: Int, description: String) =
-    this(name, Some(wavelengthMidPointNm), Some(description), MagnitudeSystem.VEGA)
+  private def this(name: String, center: Wavelength, width: Wavelength, description: String) =
+    this(name, center, width, Some(description), MagnitudeSystem.VEGA)
 
-  private def this(name: String, wavelengthMidPointNm: Int, description: String, defaultMagnitudeSystem: MagnitudeSystem) =
-    this(name, Some(wavelengthMidPointNm), Some(description), defaultMagnitudeSystem)
+  private def this(name: String, center: Wavelength, width: Wavelength, description: String, defaultMagnitudeSystem: MagnitudeSystem) =
+    this(name, center, width, Some(description), defaultMagnitudeSystem)
+
+  val start: Wavelength = center + width / 2
+
+  val end:   Wavelength = center - width / 2
 
 }
 
@@ -18,42 +22,51 @@ object MagnitudeBand {
   // OCSADV-203
   // Class files clobber one another on OS X so names can't differ only in case.
   // We may need to revisit and come up with better names.
-  case object _u extends MagnitudeBand("u", 350, "UV", MagnitudeSystem.AB)
-  case object _g extends MagnitudeBand("g", 475, "green", MagnitudeSystem.AB)
-  case object _r extends MagnitudeBand("r", 630, "red", MagnitudeSystem.AB)
-  case object _i extends MagnitudeBand("i", 780, "far red", MagnitudeSystem.AB)
-  case object _z extends MagnitudeBand("z", 925, "near-infrared", MagnitudeSystem.AB)
+  // Values for Sloan filters (u', g', r', i', z') taken from Fukugita et al. (1996)
+  case object _u extends MagnitudeBand("u", nm(  356), nm(  46), "UV",             MagnitudeSystem.AB)
+  case object _g extends MagnitudeBand("g", nm(  483), nm(  99), "green",          MagnitudeSystem.AB)
+  case object _r extends MagnitudeBand("r", nm(  626), nm(  96), "red",            MagnitudeSystem.AB)
+  case object _i extends MagnitudeBand("i", nm(  767), nm( 106), "far red",        MagnitudeSystem.AB)
+  case object _z extends MagnitudeBand("z", nm(  910), nm( 125), "near-infrared",  MagnitudeSystem.AB)
 
-  case object U  extends MagnitudeBand("U", 365, "ultraviolet")
-  case object B  extends MagnitudeBand("B", 445, "blue")
-  case object G  extends MagnitudeBand("G", 477)
-  case object V  extends MagnitudeBand("V", 551, "visual")
-  case object UC extends MagnitudeBand("UC",610, "UCAC") // unknown FWHM
-  case object R  extends MagnitudeBand("R", 658, "red")
-  case object I  extends MagnitudeBand("I", 806, "infrared")
-  case object Z  extends MagnitudeBand("Z", 913)
-  case object Y  extends MagnitudeBand("Y", 1020)
-  case object J  extends MagnitudeBand("J", 1220)
-  case object H  extends MagnitudeBand("H", 1630)
-  case object K  extends MagnitudeBand("K", 2190)
-  case object L  extends MagnitudeBand("L", 3450)
-  case object M  extends MagnitudeBand("M", 4750)
-  case object N  extends MagnitudeBand("N", 10000)
-  case object Q  extends MagnitudeBand("Q", 16000)
+  case object U  extends MagnitudeBand("U", nm(  360), nm(  75), "ultraviolet")
+  case object B  extends MagnitudeBand("B", nm(  440), nm(  90), "blue")
+  case object G  extends MagnitudeBand("G", nm(  477), nm(   1))                  // TODO: G-band width?
+  case object V  extends MagnitudeBand("V", nm(  550), nm(  85), "visual")
+  case object UC extends MagnitudeBand("UC",nm(  610), nm(  63), "UCAC")
+  case object R  extends MagnitudeBand("R", nm(  670), nm( 100), "red")
+  case object I  extends MagnitudeBand("I", nm(  870), nm( 100), "infrared")
+  case object Z  extends MagnitudeBand("Z", nm(  913), nm(   1))                  // TODO: Z-band width?
+  case object Y  extends MagnitudeBand("Y", nm( 1020), nm( 120))
+  case object J  extends MagnitudeBand("J", nm( 1250), nm( 240))
+  case object H  extends MagnitudeBand("H", nm( 1650), nm( 300))
+  case object K  extends MagnitudeBand("K", nm( 2200), nm( 410))
+  case object L  extends MagnitudeBand("L", nm( 3760), nm( 700))
+  case object M  extends MagnitudeBand("M", nm( 4770), nm( 240))
+  case object N  extends MagnitudeBand("N", nm(10470), nm(5230))
+  case object Q  extends MagnitudeBand("Q", nm(20130), nm(1650))
 
-  case object AP extends MagnitudeBand("AP", None, Some("apparent"), MagnitudeSystem.VEGA)
+  // use V-Band center and width for apparent magnitudes
+  case object AP extends MagnitudeBand("AP", V.center, V.width, Some("apparent"), MagnitudeSystem.VEGA)
 
   val all: List[MagnitudeBand] =
     List(_u, _g, _r, _i, _z, U, B, G, V, UC, R, I, Z, Y, J, H, K, L, M, N, Q, AP)
 
+  // order by central wavelength; make sure that AP always shows up last because it's sort of a special case
   implicit val MagnitudeBandOrder: scalaz.Order[MagnitudeBand] =
-    scalaz.Order.orderBy(_.wavelengthMidPointNm)
+    scalaz.Order.orderBy {
+      case AP   => Wavelength.fromNanometers(Double.MaxValue)
+      case band => band.center
+    }
 
   implicit val MagnitudeBandOrdering: scala.math.Ordering[MagnitudeBand] =
     MagnitudeBandOrder.toScalaOrdering
 
   /** @group Typeclass Instances */
   implicit val equals = scalaz.Equal.equalA[MagnitudeBand]
+
+  // helper to create nanometers
+  private def nm(d: Double) = Wavelength.fromNanometers(d)
 
 }
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Wavelength.scala
@@ -36,6 +36,13 @@ sealed trait Wavelength extends Serializable {
   def *(factor: Double): Wavelength =
     Wavelength.fromNanometers(toNanometers * factor)
 
+  /**
+   * Scalar division.
+   * @group Operations
+   */
+  def /(factor: Double): Wavelength =
+    Wavelength.fromNanometers(toNanometers / factor)
+
   /** @group Overrides */
   final override def toString =
     s"Wavelength(${toNanometers}nm)"


### PR DESCRIPTION
This is a PR I put out there mainly for discussion.

The aim of OCSADV-366 is to get rid of the ITC specific definition of wavelength bands in ```WavebandDefinition``` and replace them with ```MagnitudeBand```s from the core model.

In order to be able to do this I would like to make the following changes, which I put out here for review:

* Bands not only have a center point but also a width. The width of the bands are for example used in ITC to check if filters overlap with source spectras.

* I would also like to make the center and width values mandatory (instead of ```Option```) since a band without center point and width doesn't really make much sense. I spoke with Andy about this, and he agrees that from a domain viewpoint this makes sense and suggested that for apparent magnitudes ```AP``` we could use the values of the visible band ```V```.

* Some of the center values have been changed to the values from ITC. Since currently those values are not used anywhere except for sorting the bands this shouldn't have any impact on the OCS part, however it will keep the results calculated by ITC unchanged.

In addition to those changes I have a question:

What are the ```G``` and ```Z``` bands in the core model ```MagnitudeBand```? When we replace the "old" with the "new" bands in the OT, this means that two additional bands will show up in the OT. Talking with Andy in order to find out the widths of those bands he wasn't quite sure what those bands would refer to and was wondering, if those should actually be ```_g``` and ```_z``` or g' and z'. The center points indicate in this direction and also the fact that when translating those bands to the old model they are mapped to g' and z'. So my question here is, what do we need those bands for and if we can replace ```G``` and ```Z``` with the prime bands ```_g``` and ```_z```? Can anyone shed some light on this?

