### PR TITLE
REL-2362: UCAC4 at Gemini fix

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/resources/jsky/catalog/osgi/skycat.cfg
+++ b/bundle/edu.gemini.catalog/src/main/resources/jsky/catalog/osgi/skycat.cfg
@@ -205,15 +205,27 @@ copyright:      Third U.S. Naval Observatory CCD Astrograph Catalog (UCAC3): on-
 skyobj_factory: edu.gemini.catalog.skycat.binding.skyobj.Ucac3SkyObjectFactory
 
 serv_type:      catalog
-long_name:      UCAC4 Catalog at Gemini
-short_name:     UCAC4
-url:            https://gnodbtest2.gemini.edu:8443/votable?ra=%ra&dec=%dec&r1=%r1&r2=%r2&%BANDmagLL=%m1&%BANDmagHL=%m2&max=%n&%cond(..)
+long_name:      UCAC4 Catalog at Gemini North
+short_name:     UCAC4@GN
+url:            https://gnodb.gemini.edu:8443/votable?ra=%ra&dec=%dec&r1=%r1&r2=%r2&%BANDmagLL=%m1&%BANDmagHL=%m2&max=%n&%cond(..)
 symbol:         UC {circle red {} {} {} {${UC} > 0.}} {{(25-${UC})/2.} {}}
 search_cols:    UCmag {Brightest (min UC)} {Faintest (max UC)} : Bmag {Brightest (min Bmag)} {Faintest (max Bmag)} : Vmag {Brightest (min Vmag)} {Faintest (max Vmag)} : gmag {Brightest (min gmag)} {Faintest (max gmag)} : rmag {Brightest (min rmag)} {Faintest (max rmag)} : imag {Brightest (min imag)} {Faintest (max imag)} : Jmag {Brightest (min Jmag)} {Faintest (max Jmag)} : Hmag {Brightest (min Hmag)} {Faintest (max Hmag) : Kmag {Brightest (min Kmag)} {Faintest (max Kmag)}}
 sort_cols:      UC
 sort_order:     increasing
 copyright:      Fourth U.S. Naval Observatory CCD Astrograph Catalog (UCAC4): on-line at Gemini
 skyobj_factory: edu.gemini.catalog.skycat.binding.skyobj.Ucac4SkyObjectFactory
+
+serv_type:      catalog
+long_name:      UCAC4 Catalog at Gemini South
+short_name:     UCAC4@GS
+url:            https://gsodb.gemini.edu:8443/votable?ra=%ra&dec=%dec&r1=%r1&r2=%r2&%BANDmagLL=%m1&%BANDmagHL=%m2&max=%n&%cond(..)
+symbol:         UC {circle red {} {} {} {${UC} > 0.}} {{(25-${UC})/2.} {}}
+search_cols:    UCmag {Brightest (min UC)} {Faintest (max UC)} : Bmag {Brightest (min Bmag)} {Faintest (max Bmag)} : Vmag {Brightest (min Vmag)} {Faintest (max Vmag)} : gmag {Brightest (min gmag)} {Faintest (max gmag)} : rmag {Brightest (min rmag)} {Faintest (max rmag)} : imag {Brightest (min imag)} {Faintest (max imag)} : Jmag {Brightest (min Jmag)} {Faintest (max Jmag)} : Hmag {Brightest (min Hmag)} {Faintest (max Hmag) : Kmag {Brightest (min Kmag)} {Faintest (max Kmag)}}
+sort_cols:      UC
+sort_order:     increasing
+copyright:      Fourth U.S. Naval Observatory CCD Astrograph Catalog (UCAC4): on-line at Gemini
+skyobj_factory: edu.gemini.catalog.skycat.binding.skyobj.Ucac4SkyObjectFactory
+
 
 serv_type:      catalog
 long_name:      PPMXL Catalog at Gemini


### PR DESCRIPTION
Previously, UCAC4 at Gemini queried gnodbtest2, which was not the desired behaviour.

Separated UCAC4 at Gemini into two catalogs (one for north, which now queries gnodb, and one for south, which now queries gsodb).