### PR TITLE
REL-2364 fix A/QR mixup; disable id lookup

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/Horizons.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/Horizons.scala
@@ -82,19 +82,18 @@ object Horizons {
    */
   def lookupConicTargetById(
     name:     String,
-    hObjId:   String,
+    hObjId:   String, // unused for now: see REL-2364
     hObjType: ObjectType,
     date:     Date,
     useCache: Boolean
   ): HorizonsIO[(ConicTarget, Ephemeris)] =
-    lookupConicTargetByName(name, hObjType, date) // RCN: temporary; see REL-2364
-//    for {
-//      _ <- validateName(hObjId)
-//      s <- getService
-//      r <- lookup(s, hObjId, hObjType, date, useCache)
-//      t <- extractConicTarget(r, name)
-//      e <- extractEphemeris(r)
-//    } yield (t, e)
+    for {
+      _ <- validateName(name)
+      s <- getService
+      r <- lookup(s, name, hObjType, date, useCache)
+      t <- extractConicTarget(r, name)
+      e <- extractEphemeris(r)
+    } yield (t, e)
 
   /**
    * Construct a program to look up and construct a new conic target, given a name and an object

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/Horizons.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/Horizons.scala
@@ -87,13 +87,14 @@ object Horizons {
     date:     Date,
     useCache: Boolean
   ): HorizonsIO[(ConicTarget, Ephemeris)] =
-    for {
-      _ <- validateName(hObjId)
-      s <- getService
-      r <- lookup(s, hObjId, hObjType, date, useCache)
-      t <- extractConicTarget(r, name)
-      e <- extractEphemeris(r)
-    } yield (t, e)
+    lookupConicTargetByName(name, hObjType, date) // RCN: temporary; see REL-2364
+//    for {
+//      _ <- validateName(hObjId)
+//      s <- getService
+//      r <- lookup(s, hObjId, hObjType, date, useCache)
+//      t <- extractConicTarget(r, name)
+//      e <- extractEphemeris(r)
+//    } yield (t, e)
 
   /**
    * Construct a program to look up and construct a new conic target, given a name and an object
@@ -154,9 +155,10 @@ object Horizons {
    */
   def extractConicTarget(r: HorizonsReply, name: String): Horizons.HorizonsIO[ConicTarget] =
     HorizonsIO.either {
+      import OrbitalElements.Name, Name._
 
       // Initialize a conic target from the name and reply in scope
-      def init(ct: ConicTarget): Unit = {
+      def init(aq: Name)(ct: ConicTarget): Unit = {
 
         // Set the identifying information
         ct.setName(name)
@@ -167,11 +169,10 @@ object Horizons {
 
         // Set the orbital elements, if any
         if (r.hasOrbitalElements) {
-          import OrbitalElements.Name._
           val es = r.getOrbitalElements
 
           // hm ok the es.getValue things can be null .. check
-          ct.getAQ         .setOrZero(es.getValue(A))
+          ct.getAQ         .setOrZero(es.getValue(aq))
           ct.getEpoch      .setOrZero(es.getValue(EPOCH))
           ct.getEpochOfPeri.setOrZero(es.getValue(TP))
           ct.getANode      .setOrZero(es.getValue(OM))
@@ -192,8 +193,8 @@ object Horizons {
 
       // Construct and initialize a conic target of the appropriate type
       r.getObjectType match {
-        case ObjectType.COMET      => (new ConicTarget(Tag.JPL_MINOR_BODY)   <| init).right
-        case ObjectType.MINOR_BODY => (new ConicTarget(Tag.MPC_MINOR_PLANET) <| init).right
+        case ObjectType.COMET      => (new ConicTarget(Tag.JPL_MINOR_BODY)   <| init(QR)).right
+        case ObjectType.MINOR_BODY => (new ConicTarget(Tag.MPC_MINOR_PLANET) <| init(A)).right
         case _                     => NoMinorBody.left
       }
 


### PR DESCRIPTION
There were two issues reported in [REL-2364](http://jira.gemini.edu:8080/browse/REL-2364):
- The `A` element was mistakenly used for `QR` for comets. This has been fixed.
- Horizons object ids are not stable; they can change and be reassigned as the database is updated. This led to the very strange behavior seen when old targets were pasted into new programs and their (now incorrect) ids were used for "update" operations. This has been fixed by always doing a name lookup. This means that the disambiguation dialog will always appear.