### PR TITLE
REL-2260, REL-2360, REL-2361: old calendar widget bugs

### DIFF
--- a/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/calendar/CalendarMonth.java
+++ b/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/calendar/CalendarMonth.java
@@ -1748,6 +1748,16 @@ public class CalendarMonth extends JLabel implements MouseInputListener, KeyList
      * @param c Calendar specifying the date.
      */
     public void setDate(YearMonthDay ymd) {
+        // Some mumbo-jumbo to setup the calendar as if it were clicked by the
+        // user.
+        _from = new MonthYear(ymd.year, ymd.month);
+        _to   = new MonthYear(ymd.year, ymd.month);
+        setMovingModel();
+        displayChanged();
+        fireActionEvent(ACTION_CLICK);
+
+        // Now the dayIndex relative to the (possibly) newly selected month
+        // will be correct so update the selection.
         int index = dayIndex(ymd);
         getSelectionModel().setSelectionInterval(index, index);
         if (getSelectionMode() == ListSelectionModel.SINGLE_SELECTION) {
@@ -1771,12 +1781,7 @@ public class CalendarMonth extends JLabel implements MouseInputListener, KeyList
      * Convenience method to get the selected day if any.
      */
     public YearMonthDay getDate() {
-        int index = getSelectionModel().getAnchorSelectionIndex();
-        if (getSelectionModel().isSelectedIndex(index)) {
-            return dateFromIndex(index);
-        } else {
-            return null;
-        }
+        return _movingModelDate;
     }
 
     public void mouseClicked(MouseEvent event) {

--- a/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/calendar/JCalendar.java
+++ b/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/calendar/JCalendar.java
@@ -428,8 +428,6 @@ public class JCalendar extends JPanel implements ActionListener, CalendarDisplay
         c.set(c.YEAR, ymd.year);
         c.set(c.MONTH, ymd.month);
         c.set(c.DAY_OF_MONTH, ymd.day);
-        if (c == null)
-            return null;
         return c.getTime();
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
@@ -109,10 +109,9 @@ abstract class ValidAtEditor[A <: ITarget](empty: A) extends TelescopePosEditor 
     node = node0
     nonreentrant {
       val nst = spt.getTarget.asInstanceOf[NonSiderealTarget]
-      Option(nst.getDateForPosition).foreach { d =>
-        calendar.setDate(d)
-        timeConfig.setTime(d)
-      }
+      val d   = Option(nst.getDateForPosition) | new java.util.Date
+      calendar.setDate(d)
+      timeConfig.setTime(d)
     }
   }
 
@@ -128,15 +127,16 @@ abstract class ValidAtEditor[A <: ITarget](empty: A) extends TelescopePosEditor 
   ///
 
   /** A program that returns the editor's current date and time. */
-  def dateTime: HorizonsIO[Date] = {
-    val cal = Calendar.getInstance(UTC)
-    cal.setTimeZone(calendar.getTimeZone)
-    cal.setTime(calendar.getDate)
-    cal.set(Calendar.HOUR_OF_DAY, timeConfig.textDoc.getHoursField)
-    cal.set(Calendar.MINUTE,      timeConfig.textDoc.getMinutesField)
-    cal.set(Calendar.SECOND,      timeConfig.textDoc.getSecondsField)
-    HorizonsIO.delay(cal.getTime)
-  }
+  def dateTime: HorizonsIO[Date] =
+    HorizonsIO.delay {
+      val cal = Calendar.getInstance(UTC)
+      cal.setTimeZone(calendar.getTimeZone)
+      cal.setTime(calendar.getDate)
+      cal.set(Calendar.HOUR_OF_DAY, timeConfig.textDoc.getHoursField)
+      cal.set(Calendar.MINUTE, timeConfig.textDoc.getMinutesField)
+      cal.set(Calendar.SECOND, timeConfig.textDoc.getSecondsField)
+      cal.getTime
+    }
 
   /** A program that returns the editor's current target. */
   val target: HorizonsIO[A] =


### PR DESCRIPTION
There are a number of related bugs that appear when selecting calendar dates for non-sidereal coordinate lookups.  This code uses an ancient, complex calendar widget that should be retired.  The fundamental problem is that calling `setDate(d)` on a `JCalendar` instance immediately followed by `getDate` does not produce the value `d` unless it happens to be a date in the *same month* that is being displayed.

The "solution" was to examine the actions that take place in response to the user clicking to advance the month and doing corresponding actions in `setDate`.  Finally `getDate` was changed to simply return the date that was previously set.