### PR TITLE
REL-2362: Make the two new UCAC4 at Gemini (North|South) catalog entries appear in old locations

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/resources/resources/conf/AstroCat.xml
+++ b/bundle/edu.gemini.catalog/src/main/resources/resources/conf/AstroCat.xml
@@ -17,7 +17,8 @@
 
   <catalog name="PPMXL Catalog at CDS"/>
   <catalog name="2MASS Catalog at CDS"/>
-  <catalog name="UCAC4 Catalog at Gemini"/>
+  <catalog name="UCAC4 Catalog at Gemini North"/>
+  <catalog name="UCAC4 Catalog at Gemini South"/>
   <catalog name="UCAC3 Catalog at CDS"/>
   <catalog name="NOMAD1 catalog at CDS"/>
   <catalog name="GSC-2 at ESO"/>


### PR DESCRIPTION
Split entry in AstroCat.xml to remove the old singular UCAC4 at Gemini entry and replace it with the two UCAC4 entries.

This causes the two entries to appear in the three places required by Bryan's comment on the JIRA task, namely:
1. TPE Catalog -> Catalogs menu
2. Guide Star Selection dialog (manual GS search)
3. Catalog Navigator -> My Catalogs menu