### PR TITLE
REL-2355: Change DSSI/TEXES instrument options in the 2016A PIT

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -8,7 +8,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
   var title = "Select Instrument"
   var description = s"The following instruments are available for semester ${sem.year}${sem.half}. See the Gemini website for information on instrument capabilities and configuration options."
 
-  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, /*Texes,*/ Visitor)
+  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Texes, Visitor)
 
   def apply(i:Instrument) = i match {
     case Flamingos2 => Left(inst.Flamingos2())

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -167,8 +167,7 @@ case object SemesterConverter2014BTo2015A extends SemesterConverter {
   val gsSubmission:TransformFunction = {
     case <ngo>{ns @ _*}</ngo> if (ns \\ "partner").text == "gs" => StepResult("Gemini Staff is no longer a valid partner and this time request has been removed", Nil).successNel
   }
-  val texesRemoved = removeBlueprint("texes", "Texes")
-  override val transformers = List(gsSubmission, texesRemoved)
+  override val transformers = List(gsSubmission)
 }
 /**
  * This converter is to current, as a minimum you need to convert a proposal to be the current version and semester

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -8,7 +8,7 @@ class RootSpec extends SpecificationWithJUnit {
 
   "The Root Spec" should {
     "include Gsaoi" in {
-      val root = new Root(Semester(2015, A))
+      val root = new Root(Semester(2016, A))
       root.choices must contain(Instrument.Gsaoi)
     }
     "include Texes" in {
@@ -16,27 +16,27 @@ class RootSpec extends SpecificationWithJUnit {
       root.choices must contain (Instrument.Texes)
     }
     "include Speckles" in {
-      val root = new Root(Semester(2015, A))
+      val root = new Root(Semester(2016, A))
       root.choices must contain (Instrument.Dssi)
     }
     "include Visitor" in {
-      val root = new Root(Semester(2015, B))
+      val root = new Root(Semester(2016, B))
       root.choices must contain(Instrument.Visitor)
     }
     "include Gpi" in {
-      val root = new Root(Semester(2015, A))
+      val root = new Root(Semester(2016, A))
       root.choices must contain(Instrument.Gpi)
     }
     "includes Graces" in {
-      val root = new Root(Semester(2015, A))
+      val root = new Root(Semester(2016, A))
       root.choices must contain(Instrument.Graces)
     }
-    "Michelle has been removed in 2015A" in {
-      val root = new Root(Semester(2015, A))
+    "Michelle has been removed in 2016A" in {
+      val root = new Root(Semester(2016, A))
       root.choices must not contain Instrument.Michelle
     }
-    "T-ReCS has been removed in 2015A" in {
-      val root = new Root(Semester(2015, A))
+    "T-ReCS has been removed in 2016A" in {
+      val root = new Root(Semester(2016, A))
       root.choices must not contain Instrument.Trecs
     }
   }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -12,8 +12,8 @@ class RootSpec extends SpecificationWithJUnit {
       root.choices must contain(Instrument.Gsaoi)
     }
     "include Texes" in {
-      val root = new Root(Semester(2015, A))
-      root.choices must not contain (Instrument.Texes)
+      val root = new Root(Semester(2016, A))
+      root.choices must contain (Instrument.Texes)
     }
     "include Speckles" in {
       val root = new Root(Semester(2015, A))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -426,17 +426,15 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result must \\("gmosN")
       }
     }
-    // Texes and DSSI have been restored, REL-1670
-    "proposal with texes blueprints must be removed, REL-1350, REL-1970" in {
+    "proposal with texes blueprints must be preserved, REL-2308" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_texes.xml")))
 
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) => {
-          changes must have length 5
-          changes must contain("The original proposal contained Texes observations. The instrument is not available and those resources have been removed.")
+          changes must have length 4
           // The texes blueprint must remain
-          result must \\("gmosN")
+          result must \\("Texes")
         }
       }
     }


### PR DESCRIPTION
Enable Texes on the list of supported instruments and do not delete texes proposals on upconversion