### PR TITLE
REL-2356: Add Phoenix to the 2016A PIT resource list

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
@@ -227,6 +227,7 @@
             <xsl:when test="$inst = 'nici'">NICI</xsl:when>
             <xsl:when test="$inst = 'nifs'">NIFS</xsl:when>
             <xsl:when test="$inst = 'niri'">NIRI</xsl:when>
+            <xsl:when test="$inst = 'phoenix'">Phoenix</xsl:when>
             <xsl:when test="$inst = 'dssi'">DSSI</xsl:when>
             <xsl:when test="$inst = 'texes'">Texes</xsl:when>
             <xsl:when test="$inst = 'trecs'">TReCS</xsl:when>
@@ -256,6 +257,7 @@
             <xsl:when test="$inst = 'nici'">Gemini South</xsl:when>
             <xsl:when test="$inst = 'nifs'">Gemini North</xsl:when>
             <xsl:when test="$inst = 'niri'">Gemini North</xsl:when>
+            <xsl:when test="$inst = 'phoenix'">Gemini South</xsl:when>
             <xsl:when test="$inst = 'dssi'">Gemini North</xsl:when>
             <xsl:when test="$inst = 'texes'">Gemini North</xsl:when>
             <xsl:when test="$inst = 'trecs'">Gemini South</xsl:when>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_phoenix.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_phoenix.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2016.1.1">
+    <meta band3optionChosen="false"/>
+    <semester half="A" year="2016"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets>
+        <sidereal epoch="J2000" id="target-0">
+            <name>vega</name>
+            <degDeg>
+                <ra>279.23473479</ra>
+                <dec>38.78368896</dec>
+            </degDeg>
+            <properMotion deltaDec="286.23" deltaRA="200.94"/>
+            <magnitudes>
+                <magnitude system="Vega" band="B">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="V">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="R">0.10000000149011612</magnitude>
+                <magnitude system="Vega" band="J">-0.18000000715255737</magnitude>
+                <magnitude system="Vega" band="H">-0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="K">0.12999999523162842</magnitude>
+            </magnitudes>
+        </sidereal>
+    </targets>
+    <conditions>
+        <condition id="condition-0">
+            <name>CC Any, IQ Any, SB Any/Bright, WV Any</name>
+            <cc>Any</cc>
+            <iq>Any</iq>
+            <sb>Any/Bright</sb>
+            <wv>Any</wv>
+        </condition>
+    </conditions>
+    <blueprints>
+        <phoenix>
+            <Phoenix id="blueprint-0">
+                <name>Phoenix 0.17 arcsec slit H6073</name>
+                <visitor>false</visitor>
+                <fpu>0.17 arcsec slit</fpu>
+                <filter>H6073</filter>
+            </Phoenix>
+        </phoenix>
+    </blueprints>
+    <observations>
+        <observation blueprint="blueprint-0" condition="condition-0" target="target-0" enabled="true" band="Band 1/2">
+            <time units="hr">1.0</time>
+            <meta ck="">
+                <guiding>
+                    <percentage>0</percentage>
+                    <evaluation>Failure</evaluation>
+                </guiding>
+                <visibility>Limited</visibility>
+                <gsa>6</gsa>
+            </meta>
+        </observation>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
@@ -180,6 +180,11 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       // Check that we use the proper public name of GPI
       XML.loadString(result) must (\\("table-cell") \ ("block") \> "GRACES")
     }
+    "present the correct instrument name when using Phoenix, REL-2356" in {
+      val result = transformProposal("proposal_with_phoenix.xml")
+      // Check that we use the proper public name of Phoenix
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Phoenix")
+    }
     "Supports Large Programs, REL-1614" in {
       val result = transformProposal("large_program.xml")
       val proposalXml = XML.loadString(result)
@@ -316,6 +321,11 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       val result = transformProposal("proposal_with_graces.xml", P1PDF.NOAO)
       // Check that GPI is shown in Gemini South
       XML.loadString(result) must (\\("table-cell") \ ("block") \>~ "Gemini North")
+    }
+    "show that Phoenix is in GS, REL-2356" in {
+      val result = transformProposal("proposal_with_phoenix.xml", P1PDF.NOAO)
+      // Check that Phenix is shown in Gemini South
+      XML.loadString(result) must (\\("table-cell") \ ("block") \>~ "Gemini South")
     }
     "show correct Observing Mode for FT, REL-1894" in {
       val result = transformProposal("proposal_fast_turnaround.xml", P1PDF.NOAO)

--- a/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
@@ -35,44 +35,44 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     "include TAC information in case all are approved, REL-677" in {
       val result = transformProposal("proposal_submitted_to_tac_all_approved.xml")
 
-      val accepted = (XML.loadString(result) \\ ("table-row") \ ("table-cell")) collect {
+      val accepted = (XML.loadString(result) \\ "table-row" \ "table-cell") collect {
         case e if e.text.matches( """\s*Accepted\s*""") => true
       }
 
       // Check there is a table
-      XML.loadString(result) must \\("block") \ ("inline") \>~ """\s*TAC information\s*"""
+      XML.loadString(result) must \\("block") \ "inline" \>~ """\s*TAC information\s*"""
       // Check there is three accepted
-      accepted must be size (3)
+      accepted must be size 3
     }
     "include TAC information with accepts and rejects, REL-677" in {
       val result = transformProposal("proposal_submitted_to_tac_one_approved_one_rejected.xml")
 
-      val accepted = (XML.loadString(result) \\ ("table-row") \ ("table-cell")) collect {
+      val accepted = (XML.loadString(result) \\ "table-row" \ "table-cell") collect {
         case e if e.text.matches( """\s*Accepted\s*""") => true
       }
-      val rejected = (XML.loadString(result) \\ ("table-row") \ ("table-cell")) collect {
+      val rejected = (XML.loadString(result) \\ "table-row" \ "table-cell") collect {
         case e if e.text.matches( """\s*Rejected\s*""") => true
       }
 
       // Check there is a table
-      XML.loadString(result) must \\("block") \ ("inline") \>~ """\s*TAC information\s*"""
+      XML.loadString(result) must \\("block") \ "inline" \>~ """\s*TAC information\s*"""
       // Check there is one accepted
-      accepted must be size (1)
+      accepted must be size 1
       // And one rejected
-      rejected must be size (1)
+      rejected must be size 1
     }
     "include TAC information with only one response, REL-677" in {
       val result = transformProposal("proposal_submitted_to_tac_one_decision.xml")
 
-      val accepted = (XML.loadString(result) \\ ("table-row") \ ("table-cell")) collect {
+      val accepted = (XML.loadString(result) \\ "table-row" \ "table-cell") collect {
         case e if e.text.matches( """\s*Accepted\s*""") => true
       }
-      val rejected = (XML.loadString(result) \\ ("table-row") \ ("table-cell")) collect {
+      val rejected = (XML.loadString(result) \\ "table-row" \ "table-cell") collect {
         case e if e.text.matches( """\s*Rejected\s*""") => true
       }
 
       // Check there is a table
-      XML.loadString(result) must \\("block") \ ("inline") \>~ """\s*TAC information\s*"""
+      XML.loadString(result) must \\("block") \ "inline" \>~ """\s*TAC information\s*"""
       // Check there is one accepted
       accepted must be size (1)
       // And none rejected
@@ -82,7 +82,7 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       val result = transformProposal("proposal_submitted_to_tac_no_decisions.xml")
 
       // Check there is no TAC table
-      XML.loadString(result) must not(\\("block") \ ("inline") \>~ """\s*TAC information\s*""")
+      XML.loadString(result) must not(\\("block") \ "inline" \>~ """\s*TAC information\s*""")
     }
     "include TAC partner ranking, REL-677" in {
       val result = transformProposal("proposal_submitted_to_tac_all_approved.xml")
@@ -99,86 +99,86 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     "include text with scheduling requests, REL-687" in {
       val result = transformProposal("proposal_with_schedule.xml")
       val schedRegex = """\s*This proposal has the following scheduling restrictions.*""".r
-      val foundMatches = (XML.loadString(result) \\ ("block")) collect {
+      val foundMatches = (XML.loadString(result) \\ "block") collect {
         case e if schedRegex.findFirstIn(e.text).isDefined => true
       }
       // Check there is a scheduling element
-      XML.loadString(result) must (\\("block") \ ("inline") \>~ """\s*Scheduling Constraints\s*""")
+      XML.loadString(result) must (\\("block") \ "inline" \>~ """\s*Scheduling Constraints\s*""")
       // Check there is a scheduling text
       foundMatches must be size (1)
     }
     "use new text for observations with guiding between 50% and less than 100%, REL-640" in {
       val result = transformProposal("proposal_guiding_caution.xml")
       // Check there is a scheduling element
-      XML.loadString(result) must (\\("block") \ ("inline") \>~ """.*Some PAs do not have suitable guide stars \(\d\d%\).*""")
+      XML.loadString(result) must (\\("block") \ "inline" \>~ """.*Some PAs do not have suitable guide stars \(\d\d%\).*""")
     }
     "use new text for observations with guiding between 0% and less than 50%, REL-640" in {
       val result = transformProposal("proposal_guiding_warning.xml")
       // Check there is a scheduling element
-      XML.loadString(result) must (\\("block") \ ("inline") \>~ """.*Many PAs do not have suitable guide stars \(\d\d%\).*""")
+      XML.loadString(result) must (\\("block") \ "inline" \>~ """.*Many PAs do not have suitable guide stars \(\d\d%\).*""")
     }
     "use new text for observations with guiding equals to 0%, REL-640" in {
       val result = transformProposal("proposal_guiding_bad.xml")
       // Check there is a scheduling element
-      XML.loadString(result) must (\\("block") \ ("inline") \>~ """.*Guiding is problematic \(0%\).*""")
+      XML.loadString(result) must (\\("block") \ "inline" \>~ """.*Guiding is problematic \(0%\).*""")
     }
     "present the correct name when using GSAOI, REL-693" in {
       val result = transformProposal("proposal_with_gsaoi.xml")
       // Check that we use the proper public name of GSOAI
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "GSAOI")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "GSAOI")
     }
     "present the correct name when using Texes, REL-1062" in {
       val result = transformProposal("proposal_with_texes.xml")
       // Check that we use the proper public name of Texes
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Texes")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Texes")
     }
     "present the correct name when using Dssi, REL-1061" in {
       val result = transformProposal("proposal_with_dssi.xml")
       // Check that we use the proper public name of DSSI
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "DSSI")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "DSSI")
     }
     "present the correct name when using Visitor GN, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gn.xml")
       // Check that we use the proper public name of a north visitor
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Visitor - Gemini North - My instrument")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Visitor - Gemini North - My instrument")
     }
     "present the correct name when using Visitor GS, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gs.xml")
       // Check that we use the proper public name of a south visitor
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Visitor - Gemini South - Super Camera")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Visitor - Gemini South - Super Camera")
     }
     "show an ITAC information section if the proposal contains a comment, REL-1165" in {
       val result = transformProposal("proposal_with_itac_comment.xml")
       // Check that we have an ITAC information section with the comment
-      XML.loadString(result) must (\\("block") \ ("inline") \> "ITAC Information")
+      XML.loadString(result) must (\\("block") \ "inline" \> "ITAC Information")
       XML.loadString(result) must \\("block") \>~ "An Itac comment"
     }
     "show an ITAC information section if the proposal contains multiple comments, REL-1165" in {
       val result = transformProposal("proposal_with_itac_and_several_comments.xml")
       // Check that we have an ITAC information section with the comment
-      XML.loadString(result) must (\\("block") \ ("inline") \> "ITAC Information")
+      XML.loadString(result) must (\\("block") \ "inline" \> "ITAC Information")
       XML.loadString(result) must \\("block") \>~ "One Itac comment"
       XML.loadString(result) must \\("block") \>~ "Another itac comment"
     }
     "if there is no ITAC section in the proposal, no ITAC Information section should be included, REL-1165" in {
       val result = transformProposal("proposal_with_gsaoi.xml")
       // Check that there is no ITAC information section
-      XML.loadString(result) must not (\\("block") \ ("inline") \> "ITAC Information")
+      XML.loadString(result) must not (\\("block") \ "inline" \> "ITAC Information")
     }
     "show an ITAC information section if the proposal contains a multiline comment, REL-1165" in {
       val result = transformProposal("proposal_with_itac_and_ntac_comments.xml")
       // Check that we have an ITAC information section with the comment
-      XML.loadString(result) must \\("block") \ ("inline") \> "ITAC Information"
+      XML.loadString(result) must \\("block") \ "inline" \> "ITAC Information"
     }
     "present the correct name when using GPI, REL-1193" in {
       val result = transformProposal("proposal_with_gpi.xml")
       // Check that we use the proper public name of GPI
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "GPI")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "GPI")
     }
     "present the correct name when using GRACES, REL-1356" in {
       val result = transformProposal("proposal_with_graces.xml")
       // Check that we use the proper public name of GPI
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "GRACES")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "GRACES")
     }
     "present the correct instrument name when using Phoenix, REL-2356" in {
       val result = transformProposal("proposal_with_phoenix.xml")
@@ -189,7 +189,7 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       val result = transformProposal("large_program.xml")
       val proposalXml = XML.loadString(result)
       // Check that the Observing Mode is Large Program
-      val largeProgramMode = (proposalXml \\ ("table-cell") \ ("block")) collect {
+      val largeProgramMode = (proposalXml \\ "table-cell" \ "block") collect {
         case e if e.text.matches( """\s*Observing Mode:.Large Program\s*""") => true
       }
       largeProgramMode must be size 1
@@ -244,11 +244,11 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     "include text with scheduling requests, REL-687" in {
       val result = transformProposal("proposal_with_schedule.xml", P1PDF.NOAO)
       val schedRegex = """\s*This proposal has the following scheduling restrictions.*""".r
-      val foundMatches = (XML.loadString(result) \\ ("block")) collect {
+      val foundMatches = (XML.loadString(result) \\ "block") collect {
         case e if schedRegex.findFirstIn(e.text).isDefined => true
       }
       // Check there is a scheduling element
-      XML.loadString(result) must (\\("block") \ ("inline") \>~ """\s*Scheduling Constraints:\s*""")
+      XML.loadString(result) must (\\("block") \ "inline" \>~ """\s*Scheduling Constraints:\s*""")
       // Check there is a scheduling text
       foundMatches must be size (1)
     }
@@ -267,65 +267,65 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     "show that GSAOI is in Gemini South, REL-693" in {
       val result = transformProposal("proposal_with_gsaoi.xml", P1PDF.NOAO)
       // Check that GSAOI is shown in Gemini South
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Gemini South")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini South")
     }
     "show that Texes is in Gemini North, REL-1062" in {
       val result = transformProposal("proposal_with_texes.xml", P1PDF.NOAO)
       // Check that Texes is shown in Gemini North
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Gemini North")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini North")
     }
     "show that Dssi is in Gemini North, REL-1061" in {
       val result = transformProposal("proposal_with_dssi.xml", P1PDF.NOAO)
       // Check that Speckle is shown in Gemini North
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Gemini North")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini North")
     }
     "show that a GN visitor is in Gemini North, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gn.xml", P1PDF.NOAO)
       // Check that Speckle is shown in Gemini North
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Gemini North")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini North")
     }
     "show that a GS visitor is in Gemini North, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gs.xml", P1PDF.NOAO)
       // Check that Speckle is shown in Gemini North
-      XML.loadString(result) must (\\("table-cell") \ ("block") \> "Gemini South")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini South")
     }
     "show an ITAC information section if the proposal contains a comment, REL-1165" in {
       val result = transformProposal("proposal_with_itac_comment.xml", P1PDF.NOAO)
       // Check that we have an ITAC information section with the comment
-      XML.loadString(result) must \\("block") \ ("inline") \>~ "ITAC Information.*"
+      XML.loadString(result) must \\("block") \ "inline" \>~ "ITAC Information.*"
       XML.loadString(result) must \\("block") \>~ "An Itac comment"
     }
     "show an ITAC information section if the proposal contains multiple comment, REL-1165" in {
       val result = transformProposal("proposal_with_itac_and_several_comments.xml", P1PDF.NOAO)
       // Check that we have an ITAC information section with the comment
-      XML.loadString(result) must \\("block") \ ("inline") \>~ "ITAC Information.*"
+      XML.loadString(result) must \\("block") \ "inline" \>~ "ITAC Information.*"
       XML.loadString(result) must \\("block") \>~ "One Itac comment"
       XML.loadString(result) must \\("block") \>~ "Another itac comment"
     }
     "show an ITAC information section if the proposal contains itac and ntac comments, REL-1165" in {
       val result = transformProposal("proposal_with_itac_and_ntac_comments.xml", P1PDF.NOAO)
       // Check that we have an ITAC information section with the comment
-      XML.loadString(result) must (\\("block") \ ("inline") \>~ "ITAC Information:.*")
+      XML.loadString(result) must (\\("block") \ "inline" \>~ "ITAC Information:.*")
     }
     "if there is no ITAC section in the proposal, no ITAC Information section should be included, REL-1165" in {
       val result = transformProposal("proposal_with_gsaoi.xml", P1PDF.NOAO)
       // Check that there is no ITAC information section
-      XML.loadString(result) must not (\\("block") \ ("inline") \> "ITAC Information: ")
+      XML.loadString(result) must not (\\("block") \ "inline" \> "ITAC Information: ")
     }
     "show that GPI is in GS, REL-1193" in {
       val result = transformProposal("proposal_with_gpi.xml", P1PDF.NOAO)
       // Check that GPI is shown in Gemini South
-      XML.loadString(result) must (\\("table-cell") \ ("block") \>~ "Gemini South")
+      XML.loadString(result) must (\\("table-cell") \ "block" \>~ "Gemini South")
     }
     "show that GRACES is in GN, REL-1356" in {
       val result = transformProposal("proposal_with_graces.xml", P1PDF.NOAO)
-      // Check that GPI is shown in Gemini South
-      XML.loadString(result) must (\\("table-cell") \ ("block") \>~ "Gemini North")
+      // Check that Graces is shown in Gemini South
+      XML.loadString(result) must (\\("table-cell") \ "block" \>~ "Gemini North")
     }
     "show that Phoenix is in GS, REL-2356" in {
       val result = transformProposal("proposal_with_phoenix.xml", P1PDF.NOAO)
-      // Check that Phenix is shown in Gemini South
-      XML.loadString(result) must (\\("table-cell") \ ("block") \>~ "Gemini South")
+      // Check that Phoenix is shown in Gemini South
+      XML.loadString(result) must (\\("table-cell") \ "block" \>~ "Gemini South")
     }
     "show correct Observing Mode for FT, REL-1894" in {
       val result = transformProposal("proposal_fast_turnaround.xml", P1PDF.NOAO)
@@ -368,14 +368,12 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     val xslSource = new StreamSource(xslStream)
     val xmlSource = new StreamSource(getClass.getResourceAsStream(proposal))
 
-    val uriResolver = new P1PdfUriResolver
-
     // Setup XSLT
     val factory = TransformerFactory.newInstance()
-    factory.setURIResolver(uriResolver)
+    factory.setURIResolver(P1PdfUriResolver)
 
     val transformer = factory.newTransformer(xslSource)
-    transformer.setURIResolver(uriResolver)
+    transformer.setURIResolver(P1PdfUriResolver)
     template.parameters.foreach(p => transformer.setParameter(p._1, p._2))
 
     val writer = new StringWriter()

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -8,7 +8,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
   var title = "Select Instrument"
   var description = s"The following instruments are available for semester ${sem.year}${sem.half}. See the Gemini website for information on instrument capabilities and configuration options."
 
-  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Texes, Visitor)
+  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, Texes, Visitor)
 
   def apply(i:Instrument) = i match {
     case Flamingos2 => Left(inst.Flamingos2())
@@ -22,6 +22,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
     case Nici       => Left(inst.Nici())
     case Nifs       => Left(inst.Nifs())
     case Niri       => Left(inst.Niri())
+    case Phoenix    => Left(inst.Phoenix())
     case Dssi       => Right(DssiBlueprint())
     case Texes      => Left(inst.Texes())
     case Trecs      => Left(inst.Trecs())

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
@@ -1,0 +1,39 @@
+package edu.gemini.model.p1.dtree.inst
+
+import edu.gemini.model.p1.dtree._
+import edu.gemini.model.p1.immutable._
+
+object Phoenix {
+  def apply() = new FocalPlaneUnitNode
+
+  class FocalPlaneUnitNode extends SingleSelectNode[Unit, PhoenixFocalPlaneUnit, PhoenixFocalPlaneUnit](()) {
+    val title = "Focal Plane Unit"
+    val description = "Select a focal plane unit for your configuration."
+
+    def choices: List[PhoenixFocalPlaneUnit] = PhoenixFocalPlaneUnit.values.toList
+
+    def apply(om: PhoenixFocalPlaneUnit) = Left(new FilterNode(om))
+
+    override def default = Some(PhoenixFocalPlaneUnit.forName("MASK_3"))
+
+    def unapply = {
+      case b: PhoenixBlueprint => b.fpu
+    }
+  }
+
+  class FilterNode(fpu: PhoenixFocalPlaneUnit) extends SingleSelectNode[PhoenixFocalPlaneUnit, PhoenixFilter, PhoenixBlueprint](fpu){
+    def title = "Filter"
+    def description = "Select a filter for your configuration."
+
+    def apply(f: PhoenixFilter) = Right(PhoenixBlueprint(fpu, f))
+
+    override def default = Some(PhoenixFilter.forName("K4396"))
+
+    def unapply = {
+      case b: PhoenixBlueprint => b.filter
+    }
+
+    def choices = PhoenixFilter.values.toList
+  }
+
+}

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/BlueprintBase.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/BlueprintBase.scala
@@ -53,6 +53,9 @@ object BlueprintBase {
     // NIFS
     case b: M.NiriBlueprint                 => NiriBlueprint(b)
 
+    // Phoenix
+    case b: M.PhoenixBlueprint              => PhoenixBlueprint(b)
+
     // Speckle
     case b: M.DssiBlueprint                 => DssiBlueprint(b)
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
@@ -22,7 +22,7 @@ object Instrument {
   case object Graces     extends Instrument(GN, "GRACES")
   case object Gsaoi      extends Instrument(GS, "GSAOI")
   case object Nici       extends Instrument(GS, "NICI")
-//  case object Phoenix    extends Instrument(GS, "Phoenix", "Phoenix, "PHOENIX")
+  case object Phoenix    extends Instrument(GS, "Phoenix", "Phoenix", "PHOENIX")
   case object Trecs      extends Instrument(GS, "TReCS", "T-ReCS", "TReCS")
   case object Visitor    extends Instrument(GS, "Visitor")
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
@@ -1,0 +1,35 @@
+package edu.gemini.model.p1.immutable
+
+import edu.gemini.model.p1.{mutable => M}
+
+object PhoenixBlueprint {
+  def apply(m: M.PhoenixBlueprint): PhoenixBlueprint = new PhoenixBlueprint(m)
+}
+
+case class PhoenixBlueprint(fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) extends GeminiBlueprintBase {
+  def name: String = s"Phoenix ${fpu.value} ${filter.value}"
+
+  def this(m: M.PhoenixBlueprint) = this(
+    m.getFpu,
+    m.getFilter
+  )
+
+  override def instrument: Instrument = Instrument.Gpi
+  override def ao: AoPerspective = AoNone
+
+  def mutable(n: Namer) = {
+    val m = Factory.createPhoenixBlueprint()
+    m.setId(n.nameOf(this))
+    m.setName(name)
+    m.setFpu(fpu)
+    m.setFilter(filter)
+    m
+  }
+
+  def toChoice(n: Namer) = {
+    val m = Factory.createPhoenixBlueprintChoice()
+    m.setPhoenix(mutable(n))
+    m
+  }
+
+}

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
@@ -14,7 +14,7 @@ case class PhoenixBlueprint(fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) e
     m.getFilter
   )
 
-  override def instrument: Instrument = Instrument.Gpi
+  override def instrument: Instrument = Instrument.Phoenix
   override def ao: AoPerspective = AoNone
 
   def mutable(n: Namer) = {

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -322,6 +322,12 @@ package object immutable {
     val BBF_BRACONT = mutable.NiriFilter.NBF_BRACONT
   }
 
+  type PhoenixFocalPlaneUnit = mutable.PhoenixFocalPlaneUnit
+  object PhoenixFocalPlaneUnit extends EnumObject[mutable.PhoenixFocalPlaneUnit]
+
+  type PhoenixFilter = mutable.PhoenixFilter
+  object PhoenixFilter extends EnumObject[mutable.PhoenixFilter]
+
   type GsaoiFilter = mutable.GsaoiFilter
   object GsaoiFilter extends EnumObject[mutable.GsaoiFilter]
 

--- a/bundle/edu.gemini.model.p1/src/main/xjb/Phoenix.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/Phoenix.xjb
@@ -1,0 +1,86 @@
+<jxb:bindings version="2.0"
+              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+              xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <!-- Custom bindings for Phoenix -->
+    <jxb:bindings schemaLocation="../xsd/Phoenix.xsd" node="/xsd:schema">
+        <!-- PhoenixFocalPlaneUnit => PhoenixParams.Mask-->
+        <jxb:bindings node="./xsd:simpleType[@name='PhoenixFocalPlaneUnit']/xsd:restriction">
+            <jxb:bindings node="./xsd:enumeration[@value='0.17 arcsec slit']">
+                <jxb:typesafeEnumMember name="MASK_1"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='0.25 arcsec slit']">
+                <jxb:typesafeEnumMember name="MASK_2"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='0.34 arcsec slit']">
+                <jxb:typesafeEnumMember name="MASK_3"/>
+            </jxb:bindings>
+        </jxb:bindings>
+
+        <!-- PhoenixFilter => PhoenixParams.Filter-->
+        <jxb:bindings node="./xsd:simpleType[@name='PhoenixFilter']/xsd:restriction">
+            <jxb:bindings node="./xsd:enumeration[@value='M1930']">
+                <jxb:typesafeEnumMember name="M1930"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='M2030']">
+                <jxb:typesafeEnumMember name="M2030"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='M2150']">
+                <jxb:typesafeEnumMember name="M2150"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='L2462']">
+                <jxb:typesafeEnumMember name="L2462"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='L2734']">
+                <jxb:typesafeEnumMember name="L2734"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='L3010']">
+                <jxb:typesafeEnumMember name="L3010"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='L3100']">
+                <jxb:typesafeEnumMember name="L3100"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='L3290']">
+                <jxb:typesafeEnumMember name="L3290"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='K4220']">
+                <jxb:typesafeEnumMember name="K4220"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='K4308']">
+                <jxb:typesafeEnumMember name="K4308"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='K4396']">
+                <jxb:typesafeEnumMember name="K4396"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='K4484']">
+                <jxb:typesafeEnumMember name="K4484"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='K4578']">
+                <jxb:typesafeEnumMember name="K4578"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='K4667']">
+                <jxb:typesafeEnumMember name="K4667"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='K4748']">
+                <jxb:typesafeEnumMember name="K4748"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='H6073']">
+                <jxb:typesafeEnumMember name="H6073"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='H6420']">
+                <jxb:typesafeEnumMember name="H6420"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='J7799']">
+                <jxb:typesafeEnumMember name="J7799"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='J8265']">
+                <jxb:typesafeEnumMember name="J8265"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='J9232']">
+                <jxb:typesafeEnumMember name="J9232"/>
+            </jxb:bindings>
+        </jxb:bindings>
+
+    </jxb:bindings>
+
+</jxb:bindings>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -5,6 +5,7 @@ Gemini Phase I Schema Changes
 
 * Offer Flamingos-2 K-long filter
 * Added keyword 'Star formation'
+* Offer Phoenix instrument
 
 # Version 2015.2.1 - 2015B
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Phoenix.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Phoenix.xsd
@@ -1,0 +1,72 @@
+<!--
+  Schema definition for Phoenix blueprints.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:include schemaLocation="Instrument.xsd"/>
+
+    <!-- Options for Phoenix Blueprint. -->
+    <xsd:complexType name="PhoenixBlueprintChoice">
+        <xsd:sequence>
+            <xsd:choice>
+                <xsd:element name="null"    type="PhoenixBlueprintNull"/>
+                <xsd:element name="Phoenix" type="PhoenixBlueprint"/>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- Phoenix null. Empty blueprint, not available in PIT. -->
+    <xsd:complexType name="PhoenixBlueprintNull"/>
+
+    <!--
+      Phoenix Blueprint
+    -->
+    <xsd:complexType name="PhoenixBlueprint">
+        <xsd:complexContent>
+            <xsd:extension base="BlueprintBase">
+                <xsd:sequence>
+                    <xsd:element name="fpu"    type="PhoenixFocalPlaneUnit" maxOccurs="1" minOccurs="0"/>
+                    <xsd:element name="filter" type="PhoenixFilter"         maxOccurs="1" minOccurs="0"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!--
+      Phoenix Focal Plane Unit options
+    -->
+    <xsd:simpleType name="PhoenixFocalPlaneUnit">
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="0.17 arcsec slit"/>
+            <xsd:enumeration value="0.25 arcsec slit"/>
+            <xsd:enumeration value="0.34 arcsec slit"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!--
+      Phoenix Filter options
+    -->
+    <xsd:simpleType name="PhoenixFilter">
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="M1930"/>
+            <xsd:enumeration value="M2030"/>
+            <xsd:enumeration value="M2150"/>
+            <xsd:enumeration value="L2462"/>
+            <xsd:enumeration value="L2734"/>
+            <xsd:enumeration value="L3010"/>
+            <xsd:enumeration value="L3100"/>
+            <xsd:enumeration value="L3290"/>
+            <xsd:enumeration value="K4220"/>
+            <xsd:enumeration value="K4308"/>
+            <xsd:enumeration value="K4396"/>
+            <xsd:enumeration value="K4484"/>
+            <xsd:enumeration value="K4578"/>
+            <xsd:enumeration value="K4667"/>
+            <xsd:enumeration value="K4748"/>
+            <xsd:enumeration value="H6073"/>
+            <xsd:enumeration value="H6420"/>
+            <xsd:enumeration value="J7799"/>
+            <xsd:enumeration value="J8265"/>
+            <xsd:enumeration value="J9232"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Proposal.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Proposal.xsd
@@ -14,6 +14,7 @@
     <xsd:include schemaLocation="Nici.xsd"/>
     <xsd:include schemaLocation="Niri.xsd"/>
     <xsd:include schemaLocation="Nifs.xsd"/>
+    <xsd:include schemaLocation="Phoenix.xsd"/>
     <xsd:include schemaLocation="Subaru.xsd"/>
     <xsd:include schemaLocation="Dssi.xsd"/>
     <xsd:include schemaLocation="Texes.xsd"/>
@@ -126,6 +127,7 @@
             <xsd:element name="nici"       type="NiciBlueprintChoice"/>
             <xsd:element name="nifs"       type="NifsBlueprintChoice"/>
             <xsd:element name="niri"       type="NiriBlueprintChoice"/>
+            <xsd:element name="phoenix"    type="PhoenixBlueprintChoice"/>
             <xsd:element name="subaru"     type="SubaruBlueprint"/>
             <xsd:element name="dssi"       type="DssiBlueprintChoice"/>
             <xsd:element name="texes"      type="TexesBlueprintChoice"/>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_phoenix.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_phoenix.xml
@@ -1,0 +1,39 @@
+<proposal schemaVersion="2016.1.1">
+    <meta band3optionChosen="false"/>
+    <semester half="A" year="2016"/>
+    <title/>
+    <abstract/>
+    <scheduling/>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email/>
+            <address>
+                <institution/>
+                <address/>
+                <country/>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <phoenix>
+            <Phoenix id="blueprint-0">
+                <name>Phoenix 0.17 arcsec slit H6073</name>
+                <visitor>false</visitor>
+                <fpu>0.17 arcsec slit</fpu>
+                <filter>H6073</filter>
+            </Phoenix>
+        </phoenix>
+    </blueprints>
+    <observations>
+        <observation blueprint="blueprint-0" enabled="true" band="Band 1/2"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -31,6 +31,10 @@ class RootSpec extends SpecificationWithJUnit {
       val root = new Root(Semester(2016, A))
       root.choices must contain(Instrument.Graces)
     }
+    "includes Phoenix" in {
+      val root = new Root(Semester(2016, A))
+      root.choices must contain(Instrument.Phoenix)
+    }
     "Michelle has been removed in 2016A" in {
       val root = new Root(Semester(2016, A))
       root.choices must not contain Instrument.Michelle

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
@@ -1,0 +1,25 @@
+package edu.gemini.model.p1.dtree.inst
+
+import edu.gemini.model.p1.mutable.{PhoenixFocalPlaneUnit, PhoenixFilter}
+import org.specs2.mutable.SpecificationWithJUnit
+
+class PhoenixSpec extends SpecificationWithJUnit {
+  "The Phoenix decision tree" should {
+    "includes Phoenix GPU" in {
+      val phoenix = Phoenix()
+      phoenix.title must beEqualTo("Focal Plane Unit")
+      phoenix.choices must have size 3
+      // Check the default
+      phoenix.default should beSome(PhoenixFocalPlaneUnit.MASK_3)
+    }
+    "includes Phoenix filter modes" in {
+      val phoenix = Phoenix()
+      val filterNode = phoenix.apply(PhoenixFocalPlaneUnit.MASK_1).a
+      filterNode.title must beEqualTo("Filter")
+      filterNode.choices must have size 20
+      // Check the default filter
+      filterNode.default must beSome(PhoenixFilter.K4396)
+    }
+  }
+
+}

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PhoenixBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PhoenixBlueprintSpec.scala
@@ -1,0 +1,57 @@
+package edu.gemini.model.p1.immutable
+
+import java.io.InputStreamReader
+
+import edu.gemini.model.p1.{mutable => M}
+import org.specs2.mutable._
+
+import scala.xml.XML
+
+class PhoenixBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
+
+  "The Phoenix Blueprint" should {
+    "has an FPU and a filter" in {
+      // trivial sanity tests
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      blueprint.fpu must beEqualTo(M.PhoenixFocalPlaneUnit.MASK_1)
+      blueprint.filter must beEqualTo(M.PhoenixFilter.H6073)
+    }
+    "never uses Lgs" in {
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      blueprint.ao must beEqualTo(AoNone)
+    }
+    "has an appropriate public name" in {
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      blueprint.name must beEqualTo("Phoenix 0.17 arcsec slit H6073")
+    }
+    "is not a visitor" in {
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      blueprint.visitor must beFalse
+      val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
+
+      val proposal = Proposal.empty.copy(observations = observation :: Nil)
+      val xml = XML.loadString(ProposalIo.writeToString(proposal))
+
+      // verify the blueprint has a false attribute
+      xml must \\("Phoenix") \ "visitor" \> "false"
+    }
+    "export fpu and filter to XML" in {
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
+
+      val proposal = Proposal.empty.copy(observations = observation :: Nil)
+      val xml = XML.loadString(ProposalIo.writeToString(proposal))
+
+      // verify the exported value
+      xml must \\("fpu") \> "0.17 arcsec slit"
+      xml must \\("filter") \> "H6073"
+    }
+    "be possible to deserialize" in {
+      val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix.xml")))
+
+      proposal.blueprints.head.visitor must beFalse
+      proposal.blueprints must beEqualTo(PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073) :: Nil)
+    }
+  }
+
+}

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ProposalSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ProposalSpec.scala
@@ -16,7 +16,7 @@ class ProposalSpec extends SpecificationWithJUnit with SemesterProperties {
     }
     "use a schema version read from System properties" in {
       val proposal = Proposal.empty
-      proposal.schemaVersion must beEqualTo("2015.1.2")
+      proposal.schemaVersion must beEqualTo("2016.1.1")
     }
     "set the band3optionChosen by default to false" in {
       val proposal = Proposal.empty
@@ -59,7 +59,7 @@ class ProposalSpec extends SpecificationWithJUnit with SemesterProperties {
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
       // verify the exported value is set to the current semester
-      xml must \\("proposal", "schemaVersion" -> "2015.1.2")
+      xml must \\("proposal", "schemaVersion" -> "2016.1.1")
     }
     "be able to open latin1 encoded files" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_latin1_encoding.xml")))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/SemesterProperties.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/SemesterProperties.scala
@@ -1,5 +1,5 @@
 package edu.gemini.model.p1.immutable
 
 trait SemesterProperties {
-  System.setProperty("edu.gemini.model.p1.schemaVersion", "2015.1.2")
+  System.setProperty("edu.gemini.model.p1.schemaVersion", "2016.1.1")
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppPreferences.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppPreferences.scala
@@ -3,7 +3,6 @@ package edu.gemini.pit.model
 import edu.gemini.model.p1.pdf.P1PDF
 
 import java.util.prefs.Preferences._
-import scala.collection.JavaConverters._
 import java.util.prefs.{Preferences, PreferenceChangeEvent, PreferenceChangeListener}
 import java.util.logging.{Level, Logger}
 import swing.Swing
@@ -33,7 +32,7 @@ object AppPreferences {
   // PDF pref, getter, setter
   private lazy val pdfPref = getClass.getName + ".pdf"
   private lazy val putPdf = node.put((t:P1PDF.Template) => t.name)(pdfPref) _
-  private def getPdf = node.get((s:String) => P1PDF.templates.asScala.find(_.name == s))(pdfPref)
+  private def getPdf = node.get((s:String) => P1PDF.templates.find(_.name == s))(pdfPref)
 
   // Mode pref, getter, setter
   private lazy val modePref = getClass.getName + ".mode"

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/PdfAction.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/PdfAction.scala
@@ -7,7 +7,6 @@ import edu.gemini.pit.ui.util.{ValueRenderer, Rows, StdModalEditor, Chooser}
 import edu.gemini.ui.workspace.scala.RichShell
 
 import java.util.prefs.Preferences.userNodeForPackage
-import scala.collection.JavaConverters._
 import scala.swing._
 
 object PdfAction {
@@ -59,7 +58,7 @@ class PdfAction(shell: RichShell[Model]) extends ShellAction(shell, "Export as P
       addRow(DontAskCheck)
     }
 
-    object TemplateCombo extends ComboBox(P1PDF.templates.asScala) with ValueRenderer[P1PDF.Template] {
+    object TemplateCombo extends ComboBox(P1PDF.templates) with ValueRenderer[P1PDF.Template] {
       selection.item = tp.template
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/AppPreferencesEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/AppPreferencesEditor.scala
@@ -3,7 +3,6 @@ package edu.gemini.pit.ui.editor
 import edu.gemini.pit.model.AppPreferences
 import edu.gemini.model.p1.pdf.P1PDF
 
-import scala.collection.JavaConverters._
 import edu.gemini.pit.ui.util.{ValueRenderer, Rows, StdModalEditor}
 import swing._
 
@@ -18,7 +17,7 @@ class AppPreferencesEditor private (ps:AppPreferences) extends StdModalEditor[Ap
     addRow(new Label("PIT Mode"), PitModeCombo)
   }
 
-  object PdfTemplateCombo extends ComboBox(P1PDF.templates.asScala) with ValueRenderer[P1PDF.Template] {
+  object PdfTemplateCombo extends ComboBox(P1PDF.templates) with ValueRenderer[P1PDF.Template] {
     selection.item = ps.pdf.getOrElse(P1PDF.DEFAULT)
   }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenix.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenix.java
@@ -44,7 +44,7 @@ public final class InstPhoenix extends SPInstObsComp implements PropertyProvider
     public static final SPComponentType SP_TYPE =
             SPComponentType.INSTRUMENT_PHOENIX;
 
-    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<String, PropertyDescriptor>();
+    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<>();
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     //Properties
@@ -319,7 +319,7 @@ public final class InstPhoenix extends SPInstObsComp implements PropertyProvider
      * queryable configuration parameters.
      */
     public static List getInstConfigInfo() {
-        List<InstConfigInfo> configInfo = new LinkedList<InstConfigInfo>();
+        List<InstConfigInfo> configInfo = new LinkedList<>();
         configInfo.add(new InstConfigInfo(MASK_PROP));
         configInfo.add(new InstConfigInfo(FILTER_PROP));
         return configInfo;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenixCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenixCB.java
@@ -18,7 +18,6 @@ import edu.gemini.pot.sp.ISPObsComponent;
 import java.util.Collection;
 import java.util.Map;
 
-
 /**
  * InstPhoenixCB is the configuration builder for the InstPhoenix data
  * object.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenixNI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenixNI.java
@@ -12,7 +12,6 @@ import edu.gemini.spModel.config.IConfigBuilder;
 import edu.gemini.spModel.gemini.inst.DefaultInstNodeInitializer;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 
-
 /**
  * Initializes <code>{@link ISPObsComponent}</code> nodes of type Phoenix.
  */

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/PhoenixParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/PhoenixParams.java
@@ -21,7 +21,7 @@ public final class PhoenixParams {
     /**
      * Class for Filters.
      */
-    public static enum Filter implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum Filter implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         M1930("M1930"),
         M2030("M2030"),
@@ -65,7 +65,7 @@ public final class PhoenixParams {
 
         private String _displayValue;
 
-        private Filter(String displayValue) {
+        Filter(String displayValue) {
             _displayValue = displayValue;
 
         }
@@ -102,7 +102,7 @@ public final class PhoenixParams {
     /**
      * Masks
      */
-    public static enum Mask implements DisplayableSpType, SequenceableSpType {
+    public enum Mask implements DisplayableSpType, SequenceableSpType {
 
         MASK_1("0.17 arcsec slit", 0.17),
         MASK_2("0.25 arcsec slit", 0.25),
@@ -118,7 +118,7 @@ public final class PhoenixParams {
         private double _slitWidth;
         private String _displayValue;
 
-        private Mask(String displayValue, double slitWidth) {
+        Mask(String displayValue, double slitWidth) {
             _displayValue = displayValue;
             _slitWidth = slitWidth;
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/SeqConfigPhoenixCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/SeqConfigPhoenixCB.java
@@ -25,7 +25,6 @@ public final class SeqConfigPhoenixCB extends HelperSeqCompCB {
         super(seqComp);
     }
 
-
     /**
      * This thisApplyNext overrides the HelperSeqCompCB
      * so that the integration time, exposure time and ncoadds can

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/SeqConfigPhoenixNI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/SeqConfigPhoenixNI.java
@@ -12,9 +12,6 @@ import edu.gemini.pot.sp.ISPFactory;
 
 import edu.gemini.spModel.config.IConfigBuilder;
 
-
-
-
 /**
  * Initializes <code>{@link ISPSeqComponent}</code> nodes.
  */
@@ -31,8 +28,6 @@ public class SeqConfigPhoenixNI implements ISPNodeInitializer {
      */
     public void initNode(ISPFactory factory, ISPNode node)
              {
-        //System.out.println("Initializing a Phoenix Seq Comp");
-
         ISPSeqComponent castNode = (ISPSeqComponent) node;
         if (!castNode.getType().equals(SeqConfigPhoenix.SP_TYPE)) {
             throw new InternalError();

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/phoenix/PhoenixSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/phoenix/PhoenixSpec.scala
@@ -1,0 +1,15 @@
+package edu.gemini.spModel.gemini.phoenix
+
+import edu.gemini.model.p1.immutable.{PhoenixFocalPlaneUnit, PhoenixFilter}
+import org.specs2.mutable.Specification
+
+class PhoenixSpec extends Specification {
+  "Phoenix" should {
+    "Support all phase1 filters" in {
+      PhoenixFilter.values.forall(f => Option(PhoenixParams.Filter.valueOf(f.name)).isDefined) should beTrue
+    }
+    "Support all phase1 fpus" in {
+      PhoenixFocalPlaneUnit.values.forall(f => Option(PhoenixParams.Mask.valueOf(f.name)).isDefined) should beTrue
+    }
+  }
+}

--- a/bundle/edu.gemini.tools.p1pdfmaker/src/main/java/edu/gemini/tools/p1pdfmaker/osgi/Activator.java
+++ b/bundle/edu.gemini.tools.p1pdfmaker/src/main/java/edu/gemini/tools/p1pdfmaker/osgi/Activator.java
@@ -6,14 +6,14 @@ import org.osgi.framework.BundleContext;
 
 public class Activator implements BundleActivator {
 
-	public void start(BundleContext context) throws Exception {
-		System.out.println("edu.gemini.tools.p1pdfmaker started.");
+    public void start(BundleContext context) throws Exception {
+        System.out.println("edu.gemini.tools.p1pdfmaker started.");
         // call the p1pdfmaker main method which will stop the OSGi framework after execution
         P1PdfMaker.main(context);
-	}
+    }
 
-	public void stop(BundleContext context) throws Exception {
-		System.out.println("edu.gemini.tools.p1pdfmaker stopped.");
-	}
-	
+    public void stop(BundleContext context) throws Exception {
+        System.out.println("edu.gemini.tools.p1pdfmaker stopped.");
+    }
+
 }


### PR DESCRIPTION
This PR adds support for creating Phase 1 proposals that use phoenix.

It includes changes to the model, UI support and pdf creation. It also has a test linking the phase 1 model with the OCS model, tests that were desired but couldn't be easily done with the separation of ocs2 and ocs1.5

Aditionally there are set of the usual cosmetic improvements