### PR TITLE
REL-2254: Editing is disabled if all submissions failed

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
@@ -145,7 +145,8 @@ class SubmitView(ph: ProblemRobot, newShellHandler: (Model,Option[File]) => Unit
                       val m0 = Model.proposal.set(m, psr.proposal)
                       panel.model = Some(m0)
                       saveHandler()
-                    } else if (errors.nonEmpty) {
+                    }
+                    if (errors.nonEmpty) {
                       // Show prompt with error messages
                       SwingUtilities.invokeLater(new Runnable {
                         override def run() {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
@@ -120,14 +120,12 @@ class SubmitView(ph: ProblemRobot, newShellHandler: (Model,Option[File]) => Unit
       enabled = false
 
       override def refresh(m:Option[SubmitStatus]) {
-
         enabled = ~m.map {
           case _ if tac => false
           case Ready    => true
           case Partial  => true
           case _        => false
         }
-
       }
 
       reactions += {
@@ -135,18 +133,20 @@ class SubmitView(ph: ProblemRobot, newShellHandler: (Model,Option[File]) => Unit
           for (m <- panel.model) {
             if (saveHandler()) {
               GlassLabel.show(panel.peer.getRootPane, "Submitting Proposal...")
-              submitClient.submit(m.proposal) {psr =>
+              submitClient.submit(m.proposal) { psr =>
                 SwingUtilities.invokeLater(new Runnable {
                   def run() {
-                    dsrs = psr.results.map(a => (a.destination, a.result)).toMap
-                    val m0 = Model.proposal.set(m, psr.proposal)
-                    panel.model = Some(m0)
-                    saveHandler()
                     GlassLabel.hide(panel.peer.getRootPane)
 
+                    dsrs = psr.results.map(a => (a.destination, a.result)).toMap
                     val errors = psr.results.map(_.result).filter(!_.isSuccess)
-                    // Show prompt with error messages
-                    if (errors.nonEmpty) {
+
+                    if (errors.size != psr.results.size) {
+                      val m0 = Model.proposal.set(m, psr.proposal)
+                      panel.model = Some(m0)
+                      saveHandler()
+                    } else if (errors.nonEmpty) {
+                      // Show prompt with error messages
                       SwingUtilities.invokeLater(new Runnable {
                         override def run() {
                           new ProposalSubmissionErrorDialog(SubmitStatus.msg(errors)).open(UIElement.wrap(panel.peer.getRootPane))

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
@@ -138,10 +138,11 @@ class SubmitView(ph: ProblemRobot, newShellHandler: (Model,Option[File]) => Unit
                   def run() {
                     GlassLabel.hide(panel.peer.getRootPane)
 
-                    dsrs = psr.results.map(a => (a.destination, a.result)).toMap
+                    val anySuccess = psr.results.exists(_.result.isSuccess)
                     val errors = psr.results.map(_.result).filter(!_.isSuccess)
 
-                    if (errors.size != psr.results.size) {
+                    if (anySuccess) {
+                      // Save the model
                       val m0 = Model.proposal.set(m, psr.proposal)
                       panel.model = Some(m0)
                       saveHandler()


### PR DESCRIPTION
This PR handles a small border case, if all the backends reject a proposal the user should be allowed to keep editing, before the model was marked as submitted
Partially submitted proposals remain as before, they get locked after submission