### PR TITLE
REL-2377: PIT build does not work

### DIFF
--- a/app/all-bundles/build.sbt
+++ b/app/all-bundles/build.sbt
@@ -28,6 +28,7 @@ ocsAppManifest := {
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_phase2_core).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_phase2_core).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_phase2_skeleton_servlet).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_phase2_skeleton_servlet).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_pit).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_pit).value)),
+    BundleSpec((sbt.Keys.name in bundle_edu_gemini_pit_launcher).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_pit_launcher).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_p1monitor).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_p1monitor).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_tools_p1pdfmaker).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_tools_p1pdfmaker).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_pot).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_pot).value)),

--- a/bundle/edu.gemini.pit.launcher/build.sbt
+++ b/bundle/edu.gemini.pit.launcher/build.sbt
@@ -1,0 +1,19 @@
+import OcsKeys._
+
+// note: inter-project dependencies are declared at the top, in projects.sbt
+
+name := "edu.gemini.pit.launcher"
+
+version := pitVersion.value.toOsgiVersion
+
+osgiSettings 
+
+ocsBundleSettings
+
+OsgiKeys.bundleActivator := None
+
+OsgiKeys.bundleSymbolicName := name.value
+
+OsgiKeys.dynamicImportPackage := Seq("")
+
+OsgiKeys.exportPackage := Seq()

--- a/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
+++ b/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
@@ -1,4 +1,4 @@
-package edu.gemini.pit.util
+package edu.gemini.pit.launcher
 
 import java.io.File
 import java.util.Locale

--- a/project/OcsApp.scala
+++ b/project/OcsApp.scala
@@ -138,6 +138,7 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_wdba_xmlrpc_api,
     bundle_edu_gemini_wdba_xmlrpc_server,
     bundle_edu_gemini_pit,
+    bundle_edu_gemini_pit_launcher,
     bundle_edu_gemini_p1monitor,
     bundle_edu_gemini_tools_p1pdfmaker,
     bundle_jsky_app_ot,

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -708,6 +708,12 @@ trait OcsBundle {
       bundle_edu_gemini_spModel_core
     )
 
+  lazy val bundle_edu_gemini_pit_launcher = 
+    project.in(file("bundle/edu.gemini.pit.launcher")).dependsOn(
+      bundle_edu_gemini_pit,
+      bundle_edu_gemini_ags_client_impl
+    )
+
   lazy val bundle_edu_gemini_tools_p1pdfmaker = 
     project.in(file("bundle/edu.gemini.tools.p1pdfmaker")).dependsOn(
       bundle_edu_gemini_model_p1_pdf


### PR DESCRIPTION
PIT Launcher breaks the OSGi dependencies and the PIT distributions don't properly start. In this PR `PITLauncher` is move into its own package to solve this problem.