### PR TITLE
REL-2380: fix NPEs when instrument is in conflict folder

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -271,25 +271,25 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
    * angle to be selected in the position angle constraint combo box, and if it is selected but not allowed,
    * resets to FIXED.
    */
-  def updateParallacticControls(): Unit = {
+  def updateParallacticControls(): Unit =
     for {
       p <- ui.parallacticAngleControlsOpt
       e <- editor
-    } yield {
+      o <- Option(e.getContextObservation)
+    } {
       val instrument = e.getDataObject
 
       // Determine if the parallactic angle option can be selected.
       val isParInstAndOk = instrument.isInstanceOf[ParallacticAngleSupport] &&
                            instrument.asInstanceOf[ParallacticAngleSupport].isCompatibleWithMeanParallacticAngleMode
       val canUseAvgPar   = isParInstAndOk &&
-                           !ObsClassService.lookupObsClass(e.getContextObservation).equals(ObsClass.DAY_CAL)
+                           !ObsClassService.lookupObsClass(o).equals(ObsClass.DAY_CAL)
       setOptionEnabled(PosAngleConstraint.PARALLACTIC_ANGLE, canUseAvgPar)
 
       // Now the parallactic angle is in use if it can be used and is selected.
       if (canUseAvgPar && instrument.getPosAngleConstraint.equals(PosAngleConstraint.PARALLACTIC_ANGLE))
         ui.parallacticAngleControlsOpt.foreach(_.ui.relativeTimeMenu.rebuild())
     }
-  }
 
 
   def updateUnboundedControls(): Unit =


### PR DESCRIPTION
When an instrument that features a parallactic angle option finds itself in a conflict folder, bad things happen.  The `ParallacticAngleControls` assume there will always be an observation to work with, but this isn't the case when in a conflict folder.  This PR takes the fact that there may not be a containing observation into account in order to avoid exceptions and strange behavior in the OT.  It isn't ideal because it will in some cases offer widgets that do nothing (and should therefore be disabled) but it avoids the worst problems and people aren't typically editing components in conflict folders anyway.