### PR TITLE
OCSADV-200-S: Initial OT Integration + Merge Tweaks

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflict.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflict.java
@@ -35,6 +35,10 @@ public final class Conflict {
         }
 
         public abstract void accept(NoteVisitor v);
+
+        @Override public String toString() {
+            return getClass().getSimpleName() + ": " + getNodeKey();
+        }
     }
 
     /**
@@ -86,6 +90,10 @@ public final class Conflict {
         }
 
         public void accept(NoteVisitor v) { v.visitMoved(this); }
+
+        @Override public final String toString() {
+            return super.toString() + " to " + getDestinationKey();
+        }
     }
 
     /**
@@ -95,9 +103,7 @@ public final class Conflict {
      * note.
      */
     public static final class ResurrectedLocalDelete extends Note {
-        public ResurrectedLocalDelete(SPNodeKey node) {
-            super(node);
-        }
+        public ResurrectedLocalDelete(SPNodeKey node) { super(node); }
 
         public void accept(NoteVisitor v) { v.visitResurrectedLocalDelete(this);}
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflicts.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/Conflicts.java
@@ -57,6 +57,10 @@ public final class Conflicts implements Serializable {
         return dataObjectConflict.isEmpty() && (notes.size() == 0);
     }
 
+    public boolean nonEmpty() {
+        return !isEmpty();
+    }
+
     public Conflicts merge(Conflicts that) {
         if (that.isEmpty()) return this;
         if (this.isEmpty()) return that;
@@ -71,5 +75,11 @@ public final class Conflicts implements Serializable {
         final ImList<Conflict.Note> mergedNotes = oldNotes.append(that.notes);
 
         return Conflicts.apply(mergedDoc, mergedNotes);
+    }
+
+    @Override public String toString() {
+        final String ds = dataObjectConflict.map(DataObjectConflict::toString).getOrElse("No data object conflict");
+        final String ns = notes.mkString("Notes: {", ",", "}");
+        return "Conflicts: " + ds + ", " + ns;
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/DataObjectConflict.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/DataObjectConflict.java
@@ -28,4 +28,8 @@ public final class DataObjectConflict implements Serializable {
         this.perspective = p;
         this.dataObject  = o;
     }
+
+    @Override public String toString() {
+        return "DataObjectConflict: " + perspective;
+    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/DocumentData.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/DocumentData.java
@@ -88,7 +88,8 @@ public class DocumentData implements Serializable {
 
             // Avoid counting changes to temporary nodes as modifications.
             // Temporary nodes that never get added to the program shouldn't
-            // be recorded in the version map. Sorry.
+            // be recorded in the version map.  See the corresponding hack in
+            // MemAbstractBase.attachTo().  Sorry.
             if (!vector.isEmpty() || (node.getParent() != null) || (node instanceof ISPRootNode)) {
                 return vector.incr(lifespanId);
             } else {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/DocumentData.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/DocumentData.java
@@ -88,8 +88,7 @@ public class DocumentData implements Serializable {
 
             // Avoid counting changes to temporary nodes as modifications.
             // Temporary nodes that never get added to the program shouldn't
-            // be recorded in the version map.  See the corresponding hack in
-            // MemAbstractBase.attachTo().  Sorry.
+            // be recorded in the version map. Sorry.
             if (!vector.isEmpty() || (node.getParent() != null) || (node instanceof ISPRootNode)) {
                 return vector.incr(lifespanId);
             } else {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemAbstractBase.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemAbstractBase.java
@@ -212,18 +212,8 @@ public abstract class MemAbstractBase implements ISPNode, Serializable {
      */
     protected void attachTo(MemAbstractContainer node) throws SPNodeNotLocalException, SPTreeStateException {
         _setParent(node);
-//        markModified();  moving a child impacts the old and new parents, but not the child
-        if (node != null) node.markModified();
-
-        // Add this node to the map if it wasn't there previously.  This
-        // awful hack was put into place to allow us to create temporary
-        // nodes that never get added to the program and yet not pollute the
-        // version map.  We use this to run the validity checker "can add"
-        // with temporary throw-away nodes.
-        //
-        // See DocumentData.markModified for the corresponding
-        // hack in markModified for nodes without parents. Sorry. :/
-        if (!getDocumentData().containsVersion(getNodeKey())) {
+        if (node != null) {
+            node.markModified();
             markModified();
         }
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemAbstractBase.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemAbstractBase.java
@@ -212,8 +212,18 @@ public abstract class MemAbstractBase implements ISPNode, Serializable {
      */
     protected void attachTo(MemAbstractContainer node) throws SPNodeNotLocalException, SPTreeStateException {
         _setParent(node);
-        if (node != null) {
-            node.markModified();
+//        markModified();  moving a child impacts the old and new parents, but not the child
+        if (node != null) node.markModified();
+
+        // Add this node to the map if it wasn't there previously.  This
+        // awful hack was put into place to allow us to create temporary
+        // nodes that never get added to the program and yet not pollute the
+        // version map.  We use this to run the validity checker "can add"
+        // with temporary throw-away nodes.
+        //
+        // See DocumentData.markModified for the corresponding
+        // hack in markModified for nodes without parents. Sorry. :/
+        if (!getDocumentData().containsVersion(getNodeKey())) {
             markModified();
         }
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/version/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/version/package.scala
@@ -1,6 +1,6 @@
 package edu.gemini.pot.sp
 
-import edu.gemini.shared.util.VersionVector
+import edu.gemini.shared.util.{VersionComparison, VersionVector}
 
 import java.nio.ByteBuffer
 import java.util.UUID
@@ -25,6 +25,14 @@ package object version {
   val EmptyVersionMap: VersionMap = Map.empty
 
   def nodeVersions(vm: VersionMap, k: SPNodeKey): NodeVersions = vm.getOrElse(k, EmptyNodeVersions)
+
+  implicit class NodeVersionsOps(nv: NodeVersions) {
+    def updates(that: NodeVersions): Boolean =
+      nv.compare(that) match {
+        case VersionComparison.Newer | VersionComparison.Conflicting => true
+        case VersionComparison.Older | VersionComparison.Same        => false
+      }
+  }
 
   private def children(n: ISPNode): List[ISPNode] = n match {
     case c: ISPContainerNode => c.getChildren.asScala.toList

--- a/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/VcsRegistrar.scala
+++ b/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/VcsRegistrar.scala
@@ -7,7 +7,7 @@ import edu.gemini.spModel.core.Peer
  * A service that provides persistent/mutable mapping between program ids and
  * VCS server locations.
  */
-trait VcsRegistrar {
+trait VcsRegistrar extends scala.collection.mutable.Publisher[VcsRegistrationEvent] {
   def allRegistrations: Map[SPProgramID, Peer]
   def registration(id: SPProgramID): Option[Peer]
   def register(id: SPProgramID, loc: Peer): Unit

--- a/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/VcsRegistrationSubscriber.scala
+++ b/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/VcsRegistrationSubscriber.scala
@@ -1,5 +1,0 @@
-package edu.gemini.sp.vcs.reg
-
-trait VcsRegistrationSubscriber {
-  def notify(evt: VcsRegistrationEvent, pub: VcsRegistrar)
-}

--- a/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/osgi/Activator.scala
+++ b/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/osgi/Activator.scala
@@ -1,35 +1,24 @@
 package edu.gemini.sp.vcs.reg.osgi
 
-import edu.gemini.sp.vcs.reg.{VcsRegistrationSubscriber, VcsRegistrar}
+import edu.gemini.sp.vcs.reg.VcsRegistrar
 import edu.gemini.sp.vcs.reg.impl.VcsRegistrarImpl
-import edu.gemini.util.osgi.Tracker._
 
 import org.osgi.framework.{ServiceRegistration, BundleActivator, BundleContext}
-import org.osgi.util.tracker.ServiceTracker
 import java.io.File
 import java.util.logging.Logger
 
 class Activator extends BundleActivator {
   private var reg: ServiceRegistration[VcsRegistrar] = null
-  private var tracker: ServiceTracker[_,_] = null
   private var vcsReg: VcsRegistrarImpl = null
 
   override def start(ctx: BundleContext) {
     vcsReg = new VcsRegistrarImpl(Activator.getStorageFile(ctx))
     reg = ctx.registerService(classOf[VcsRegistrar], vcsReg, null)
-
-    tracker = track[VcsRegistrationSubscriber, VcsRegistrationSubscriber](ctx) { sub =>
-      vcsReg.subscribe(sub)
-      sub
-    } { vcsReg.unsubscribe }
-    tracker.open()
   }
 
   override def stop(ctx: BundleContext) {
     reg.unregister()
     reg = null
-    tracker.close()
-    tracker = null
   }
 }
 

--- a/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/osgi/Activator.scala
+++ b/bundle/edu.gemini.sp.vcs.reg/src/main/scala/edu/gemini/sp/vcs/reg/osgi/Activator.scala
@@ -8,17 +8,18 @@ import java.io.File
 import java.util.logging.Logger
 
 class Activator extends BundleActivator {
-  private var reg: ServiceRegistration[VcsRegistrar] = null
-  private var vcsReg: VcsRegistrarImpl = null
+  private var reg: Option[ServiceRegistration[VcsRegistrar]] = None
+  private var vcsReg: Option[VcsRegistrarImpl] = None
 
   override def start(ctx: BundleContext) {
-    vcsReg = new VcsRegistrarImpl(Activator.getStorageFile(ctx))
-    reg = ctx.registerService(classOf[VcsRegistrar], vcsReg, null)
+    vcsReg = Some(new VcsRegistrarImpl(Activator.getStorageFile(ctx)))
+    reg    = vcsReg.map { r => ctx.registerService(classOf[VcsRegistrar], r, null) }
   }
 
   override def stop(ctx: BundleContext) {
-    reg.unregister()
-    reg = null
+    reg.foreach(_.unregister())
+    reg    = None
+    vcsReg = None
   }
 }
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeCorrection.scala
@@ -17,7 +17,8 @@ object MergeCorrection {
   def apply(mc: MergeContext): CorrectionAction =
     (mp: MergePlan, hasPermission: PermissionCheck) =>
       for {
-        prm <- ObsPermissionCorrection(mc)(mp, hasPermission)
+        res <- ObsResurrectionCorrection(mc)(mp).liftVcs
+        prm <- ObsPermissionCorrection(mc)(res, hasPermission)
         on  <- ObsNumberCorrection(mc)(prm).liftVcs
         tn  <- TemplateNumberingCorrection(mc)(on).liftVcs
         v   <- ValidityCorrection(mc)(tn).liftVcs

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
@@ -156,6 +156,9 @@ object MergeNode {
         case m: Modified => Tree.node(f(m): MergeNode, t.subForest).right
         case _           => TryVcs.fail(s"Expected Modified label for $key")
       }
+
+    def incr(lifespanId: LifespanId): TryVcs[Tree[MergeNode]] =
+      mModifyLabel(m => m.copy(nv = m.nv.incr(lifespanId)))
   }
 
   implicit class MergeZipperOps(z: TreeLoc[MergeNode]) {

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
@@ -79,8 +79,11 @@ object MergeNode {
 
   implicit class TreeOps[A](t: Tree[A]) {
     /** A `foldRight` with strict evaluation of the `B` value of `f`. */
-    def sFoldRight[B](z: => B)(f: (A, B) => B): B =
-      t.foldRight(z) { (a, b) => f(a,b) }
+    def sFoldRight[B](z: B)(f: (A, B) => B): B =
+      foldTree(z)((t0, b) => f(t0.rootLabel, b))
+
+    // more problems with foldRight.  throws stack overflow for giant programs
+//      t.foldRight(z) { (a, b) => f(a,b) }
 
     // TODO: what's the proper way to do this?
     /** A fold that provides access to the children. */

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
@@ -8,6 +8,7 @@ import edu.gemini.spModel.conflict.ConflictFolder
 import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.rich.pot.sp._
 
+import scala.annotation.tailrec
 import scalaz._
 import Scalaz._
 
@@ -88,6 +89,7 @@ object MergeNode {
     // TODO: what's the proper way to do this?
     /** A fold that provides access to the children. */
     def foldTree[B](z: B)(f: (Tree[A], B) => B): B = {
+      @tailrec
       def go(rem: List[Tree[A]], res: B): B =
         rem match {
           case Nil        => res

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergeNode.scala
@@ -31,6 +31,9 @@ final case class Modified(key: SPNodeKey,
                           detail: NodeDetail,
                           conflicts: Conflicts) extends MergeNode {
 
+  def this(n: ISPNode) =
+    this(n.key, n.getVersion, n.getDataObject, NodeDetail(n), n.getConflicts)
+
   def withDataObjectConflict(dob: ISPDataObject): Modified = {
     val doc = new DataObjectConflict(DataObjectConflict.Perspective.LOCAL, dob)
     copy(conflicts = conflicts.withDataObjectConflict(doc))
@@ -69,8 +72,7 @@ object MergeNode {
   def modified(key: SPNodeKey, nv: NodeVersions, dob: ISPDataObject, detail: NodeDetail, conflicts: Conflicts): MergeNode =
     Modified(key, nv, dob, detail, conflicts)
 
-  def modified(n: ISPNode): MergeNode =
-    Modified(n.key, n.getVersion, n.getDataObject, NodeDetail(n), n.getConflicts)
+  def modified(n: ISPNode): MergeNode = new Modified(n)
 
   def modifiedTree(root: ISPNode): Tree[MergeNode] =
     Tree.node(modified(root), root.children.map(modifiedTree).toStream)

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
@@ -42,7 +42,7 @@ case class MergePlan(update: Tree[MergeNode], delete: Set[Missing]) {
   def vm(vm0: VersionMap): VersionMap = {
     // Extract the updates to the VersionMap from the MergePlan.
     val vmUpdates: VersionMap = {
-      val vm0 = update.foldRight(Map.empty[SPNodeKey, NodeVersions]) { (mn, m) =>
+      val vm0 = update.sFoldRight(Map.empty[SPNodeKey, NodeVersions]) { (mn, m) =>
         mn match {
           case Modified(k, nv, _, _, _) => m.updated(k, nv)
           case _                        => m

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
@@ -35,7 +35,11 @@ case class MergePlan(update: Tree[MergeNode], delete: Set[Missing]) {
 
   /** Gets the `VersionMap` of the provided program as it will be after the
     * updates in this plan have been applied. */
-  def vm(p: ISPProgram): VersionMap = {
+  def vm(p: ISPProgram): VersionMap = vm(p.getVersions)
+
+  /** Gets the `VersionMap` with any modifications required that will be made
+    * by this merge plan. */
+  def vm(vm0: VersionMap): VersionMap = {
     // Extract the updates to the VersionMap from the MergePlan.
     val vmUpdates: VersionMap = {
       val vm0 = update.foldRight(Map.empty[SPNodeKey, NodeVersions]) { (mn, m) =>
@@ -47,8 +51,9 @@ case class MergePlan(update: Tree[MergeNode], delete: Set[Missing]) {
       (vm0/:delete) { case (vm1, Missing(k, nv)) => vm1.updated(k, nv) }
     }
 
-    p.getVersions ++ vmUpdates
+    vm0 ++ vmUpdates
   }
+
 
   /** Compares the version information in this merge plan with the given
     * version map.  The assumption here is that any unmodified parts of the

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsPermissionCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsPermissionCorrection.scala
@@ -130,7 +130,7 @@ class ObsPermissionCorrection(
       cf0   <- p2.getOrCreateConflictFolder(lifespanId, nodeMap)
       cf1   <- cf0.incr(lifespanId)
       lobs0 <- restoreLocal(cf1, localObs, remoteDiffs.plan.vm(local), obsNumber)
-      lobs1 <- lobs0.addConflictNote(new UpdatePermissionFail(lobs0.key))
+      lobs1 <- lobs0.addConflictNote(new UpdatePermissionFail(k))
       resurrectedKeys = robs.tree.keySet ++ lobs1.tree.keySet
     } yield MergePlan(lobs1.toTree, mp.delete.filterNot(m => resurrectedKeys.contains(m.key)))
   }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsResurrectionCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsResurrectionCorrection.scala
@@ -1,0 +1,74 @@
+package edu.gemini.sp.vcs2
+
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.pot.sp.version.EmptyNodeVersions
+import edu.gemini.sp.vcs2.MergeCorrection.CorrectionFunction
+import edu.gemini.spModel.rich.pot.sp.SpNodeKeyEqual
+
+import scalaz._
+import Scalaz._
+
+case class ObsResurrectionCorrection(mc: MergeContext) extends CorrectionFunction {
+
+  val lifespanId = mc.local.prog.getLifespanId
+
+  override def apply(mp: MergePlan): TryVcs[MergePlan] = {
+    val obsKeys = mp.update.foldObservations(Set.empty[SPNodeKey]) { (mod, _, _, s) => s + mod.key }
+    val remKeys = obsKeys.filter { k => mc.local.isDeleted(k) && mc.remote.isPresent(k) }
+    val locKeys = obsKeys.filter { k => mc.local.isPresent(k) && mc.remote.isDeleted(k) }
+
+    for {
+      mp0 <- (mp.right[VcsFailure]/:remKeys)  { (mpx, k) => mpx.flatMap(completeRemote(mc, _, k)) }
+      mp1 <- (mp0.right[VcsFailure]/:locKeys) { (mpx, k) => mpx.flatMap(completeLocal(mc, _, k))  }
+    } yield mp1
+  }
+
+  def completeRemote(mc: MergeContext, mp: MergePlan, obsKey: SPNodeKey): TryVcs[MergePlan] =
+    for {
+      obs      <- mp.update.focus(obsKey)
+      children <- mc.remote.get(obsKey).map(_.subForest).toTryVcs("Couldn't find resurrected remote observation")
+      upd      <- complete(mc, mp, obs, children)
+    } yield mp.copy(update = upd.toTree)
+
+  def completeLocal(mc: MergeContext, mp: MergePlan, obsKey: SPNodeKey): TryVcs[MergePlan] =
+    for {
+      obs      <- mp.update.focus(obsKey)
+      lobs     <- mc.local.get(obsKey).toTryVcs("Couldn't find resurrected local observation")
+      children = MergeNode.modifiedTree(lobs).subForest
+      upd      <- complete(mc, mp, obs, children)
+    } yield mp.copy(update = upd.toTree)
+
+  def complete(mc: MergeContext, mp: MergePlan, loc: TreeLoc[MergeNode], children: Stream[Tree[MergeNode]]): TryVcs[TreeLoc[MergeNode]] = {
+    val usedKeys = mp.update.keySet
+
+    val resurrectedChildren = loc.tree.subForest.map { child => child.key -> child }.toMap
+
+    // Strip the node of all children.
+    val loc2 = loc.modifyTree { t => Tree(t.rootLabel) }
+
+    // Add children back, one at a time.  If it is a resurrected child, we can
+    // add it straight away.  If it was deleted but not present anywhere else,
+    // it can also be added.  Otherwise it was moved somewhere else in the tree
+    // so we have to duplicate it.
+    val loc3 = (children :\ \/.right[VcsFailure, TreeLoc[MergeNode]](loc2)) { (c,tl) =>
+      tl.flatMap { l =>
+        val origChildKey = c.key
+        val c2 = resurrectedChildren.getOrElse(origChildKey, {
+          if (!usedKeys(origChildKey)) Tree(c.rootLabel)
+          else Tree(c.rootLabel match { // Duplicate child with a new node key.
+            case m: Modified => m.copy(key = new SPNodeKey(), nv = EmptyNodeVersions.incr(lifespanId))
+            case u           => u
+          })
+        })
+
+        for {
+          l0 <- if (origChildKey =/= c2.key) l.incr(lifespanId) else TryVcs(l)
+          l1 <- complete(mc, mp, l0.insertDownFirst(c2), c.subForest)
+        } yield l1
+      }
+    }
+
+    loc3.flatMap(_.parent.toTryVcs("Replace node has no parent"))
+  }
+
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/PreliminaryMerge.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/PreliminaryMerge.scala
@@ -17,7 +17,7 @@ object PreliminaryMerge {
 
   def merge(mc: MergeContext): TryVcs[MergePlan] =
     tree(mc).map { t =>
-      val mergedKeys  = t.foldRight(Set.empty[SPNodeKey]) { (mn, s) => s + mn.key }
+      val mergedKeys  = t.sFoldRight(Set.empty[SPNodeKey]) { (mn, s) => s + mn.key }
       val allKeys     = mc.remote.diffMap.keySet ++ mc.remote.plan.delete.map(_.key)
       val deletedKeys = allKeys &~ mergedKeys
       val allMissing  = deletedKeys.map { k => Missing(k, mc.local.version(k).sync(mc.remote.version(k))) }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/SortHeuristic.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/SortHeuristic.scala
@@ -1,0 +1,71 @@
+package edu.gemini.sp.vcs2
+
+import scala.annotation.tailrec
+
+/** A heuristic for sorting an unordered merged list derived from two sorted
+  * source lists. */
+private[vcs2] object SortHeuristic {
+
+  /** Produces a list sort function from a pair of "guideline" sorted lists.
+    * Given a preferred key order (which may not contain all the elements of the
+    * eventual input list), and an alternate key order (which also may not
+    * contain all the elements of the eventual input list) produce a sort
+    * function that takes an input list and sorts it trying to respect the
+    * preferred and alternate orderings.
+    *
+    * This is loosely worded because there is no clear best result in all cases.
+    * The intuition is that `preferred` and `alternate` are usually roughly the
+    * same, give or take an element or two with some possible rearrangements.
+    * The input list for the returned sort function represents a merge of the
+    * preferred and alternate lists.  Its elements map to keys that should be in
+    * one or the other (or both) of `preferred` and `alternate`.
+    *
+    * The laws, if you will, are that
+    *
+    * (a) all input elements mapping to keys in `preferred` must appear in the
+    *     same relative order as they appear in `preferred`
+    *
+    * (b) all input elements mapping to keys that appear exclusively in
+    *     `alternative` (i.e., not in `preferred`) should be placed behind the
+    *     closest predecessor in `alternative` that is also in `input`
+    *
+    * @param preferred keys in preferred order
+    * @param alternate keys in alternate order
+    *
+    * @param kf key function, extracts a unique key from an A
+    *
+    * @tparam A element type of input list
+    * @tparam K type of key in `preferred` and `alternate`
+    *
+    * @return a "reasonably" sorted list according to the description above
+    */
+  def sort[A,K](input: List[A], preferred: List[K], alternate: List[K])(kf: A => K): List[A] = {
+    val pMap = preferred.zipWithIndex.toMap
+
+    // First sort (reversed) all the elements that are in `preferred`.
+    val (found, missing) = input.partition(a => pMap.contains(kf(a)))
+    val revSort          = found.sortBy(a => -pMap(kf(a)))
+
+    // Get map of K -> List[K] of predecessors in the alternative list.
+    // For example, given 'a', 'b', 'c':
+    //    'a' -> []
+    //    'b' -> ['a']
+    //    'c' -> ['b', 'a']
+    lazy val altRev      = alternate.reverse
+    lazy val altPreds    = altRev.zip(altRev.tails.drop(1).toIterable).toMap
+
+    @tailrec
+    def insert(as: List[A], a: A, predecessors: List[K]): List[A] =
+      predecessors match {
+        case Nil     => as :+ a
+        case p :: ps =>
+          val (suffix, prefix) = as.span(kf(_) != p)
+          if (prefix.nonEmpty) suffix ++ (a :: prefix)
+          else insert(as, a, ps) // go fish
+      }
+
+    // Fold all the missing elements into the reverse sorted list, then finally
+    // reverse the result to get the desired order.
+    (revSort/:missing) { (as,a) => insert(as, a, altPreds.getOrElse(kf(a), Nil)) }.reverse
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
@@ -48,11 +48,12 @@ class Vcs(user: VcsAction[Set[Principal]], server: VcsServer, service: Peer => V
 
   /** Adds the given program to the remote peer, copying it into the remote
     * database. */
-  def add(id: SPProgramID, peer: Peer): VcsAction[Unit] =
+  def add(id: SPProgramID, peer: Peer): VcsAction[VersionMap] =
     for {
       p <- server.lookup(id)
+      vm = p.getVersions
       _ <- Client(peer).add(p)
-    } yield ()
+    } yield vm
 
   // pull0 is shared by `pull` and `sync`, since the first half of a sync is
   // to merge in changes from the remote peer.  The local merge is only

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
@@ -144,7 +144,7 @@ class Vcs(user: VcsAction[Set[Principal]], server: VcsServer, service: Peer => V
 
         case MergeEval(diffs, lvm, rvm, _, true)  =>
           client.storeDiffs(id, diffs).map { updated =>
-            if (updated) (s0 + Remote, VersionMap.sync(lvm, rvm)) else (s0, rvm)
+            if (updated) (s0 + Remote, eval.plan.vm(rvm)) else (s0, rvm)
           }
       }
     } yield res

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -715,49 +715,7 @@ class MergeTest extends JUnitSuite {
         expected == actual
       }
     ),
-
-    ("Conflicts are added when a remotely deleted node is replaced",
-      (start, local, remote, pc) => {
-        // allReplaced is all keys of nodes that were replaced.  we just want
-        // the root of an replaced subtree, so we filter it
-        val allReplaced = pc.mergePlan.update.keySet & pc.remote.deletedKeys
-        val expected    = allReplaced.filterNot { k =>
-          pc.mergeContext.local.parent(k).exists(allReplaced.contains)
-        }
-
-        val actual = pc.mergePlanConflictKeys((con: Conflicts, k: SPNodeKey) =>
-          con.notes.contains(new ReplacedRemoteDelete(k))
-        )
-
-        if (expected != actual) {
-          Console.err.println("expected: " + expected.toList.sorted.mkString(", "))
-          Console.err.println("actual..: " + actual.toList.sorted.mkString(", "))
-        }
-
-        expected == actual
-      }
-    ),
-
-    ("Conflicts are added when a locally deleted node is resurrected",
-      (start, local, remote, pc) => {
-        val allResurrected = pc.mergePlan.update.keySet & pc.local.deletedKeys
-        val expected       = allResurrected.filterNot { k =>
-          pc.mergeContext.remote.parent(k).exists(allResurrected.contains)
-        }
-
-        val actual = pc.mergePlanConflictKeys((con: Conflicts, k: SPNodeKey) =>
-          con.notes.contains(new ResurrectedLocalDelete(k))
-        )
-
-        if (expected != actual) {
-          Console.err.println("expected: " + expected.toList.sorted.mkString(", "))
-          Console.err.println("actual..: " + actual.toList.sorted.mkString(", "))
-        }
-
-        expected == actual
-      }
-    ),
-
+  
     ("Conflicts are added for conflicting moves",
       (start, local, remote, pc) => {
         val mergeParents = pc.mergePlan.update.foldTree(Map.empty[SPNodeKey, SPNodeKey]) { (p,m) =>

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -360,10 +360,8 @@ class MergeTest extends JUnitSuite {
           val remoteMax = remoteOnly.keySet.max
 
           ObsNumberCorrection(pc.mergeContext).apply(pc.mergePlan) match {
-            case -\/(VcsFailure.Unmergeable(msg)) =>
-              // This might start to fail if we update the generator to produce
-              // events or datasets in observation exec logs.
-              Console.err.println(s"Unmergeable: $msg")
+            case -\/(f) =>
+              Console.err.println(VcsFailure.explain(f, start.getProgramID, "", None))
               false
 
             case \/-(mp) =>

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -258,28 +258,28 @@ class MergeTest extends JUnitSuite {
       }
     ),
 
-//    ("a locally deleted node inside a remotely edited parent must be present in the merged program",
-//      (start, local, remote, pc) => {
-//        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
-//        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
-//          pc.remote.isParentEdited(pc.remote.nodeMap(k))
-//        }
-//
-//        emptySet(pc, inEditedRemoteParent &~ pc.mergeMap.keySet)
-//      }
-//    ),
+    ("a locally deleted node inside a remotely edited parent must be present in the merged program",
+      (start, local, remote, pc) => {
+        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
+        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
+          pc.remote.isParentEdited(pc.remote.nodeMap(k))
+        }
 
-//    ("a locally resurrected node not inside a remotely edited parent must contain a node that is remotely edited",
-//      (start, local, remote, pc) => {
-//        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
-//        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
-//          pc.remote.isParentEdited(pc.remote.nodeMap(k))
-//        }
-//
-//        val locallyResurrected = (pc.local.deletedKeys & pc.mergeMap.keySet) &~ inEditedRemoteParent
-//        emptySet(pc, locallyResurrected.map(pc.remote.nodeMap.apply).filterNot(pc.remote.containsRemotelyEditedNode))
-//      }
-//    ),
+        emptySet(pc, inEditedRemoteParent &~ pc.mergeMap.keySet)
+      }
+    ),
+
+    ("a locally resurrected node not inside a remotely edited parent must contain a node that is remotely edited",
+      (start, local, remote, pc) => {
+        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
+        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
+          pc.remote.isParentEdited(pc.remote.nodeMap(k))
+        }
+
+        val locallyResurrected = (pc.local.deletedKeys & pc.mergeMap.keySet) &~ inEditedRemoteParent
+        emptySet(pc, locallyResurrected.map(pc.remote.nodeMap.apply).filterNot(pc.remote.containsRemotelyEditedNode))
+      }
+    ),
 
     ("a locally deleted node whose remote version contains no updates must stay deleted",
       (start, local, remote, pc) => {

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -264,8 +264,16 @@ class MergeTest extends JUnitSuite {
 
         def matches(merged: Tree[MergeNode], n: ISPNode): Boolean = {
           val dobMatches = merged.rootLabel match {
-            case Modified(_,_,dob,_,_) => DOB.same(dob, n.getDataObject)
-            case Unmodified(k)         => k == n.key
+            case Modified(_,_,dob,_,_) =>
+              // Usually the data objects are the same.  If a child is moved
+              // locally and then the parent is deleted locally and yet edited
+              // remotely though, the edited child is recalled in the
+              // resurrected observation.  We'll just make sure that the same
+              // type of data object is found and not that they are identical.
+              dob.getClass.getName == n.getDataObject.getClass.getName
+              
+            case Unmodified(k)         =>
+              k == n.key
           }
 
           dobMatches && {

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -248,28 +248,28 @@ class MergeTest extends JUnitSuite {
       }
     ),
 
-    ("a locally deleted node inside a remotely edited parent must be present in the merged program",
-      (start, local, remote, pc) => {
-        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
-        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
-          pc.remote.isParentEdited(pc.remote.nodeMap(k))
-        }
+//    ("a locally deleted node inside a remotely edited parent must be present in the merged program",
+//      (start, local, remote, pc) => {
+//        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
+//        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
+//          pc.remote.isParentEdited(pc.remote.nodeMap(k))
+//        }
+//
+//        emptySet(pc, inEditedRemoteParent &~ pc.mergeMap.keySet)
+//      }
+//    ),
 
-        emptySet(pc, inEditedRemoteParent &~ pc.mergeMap.keySet)
-      }
-    ),
-
-    ("a locally resurrected node not inside a remotely edited parent must contain a node that is remotely edited",
-      (start, local, remote, pc) => {
-        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
-        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
-          pc.remote.isParentEdited(pc.remote.nodeMap(k))
-        }
-
-        val locallyResurrected = (pc.local.deletedKeys & pc.mergeMap.keySet) &~ inEditedRemoteParent
-        emptySet(pc, locallyResurrected.map(pc.remote.nodeMap.apply).filterNot(pc.remote.containsRemotelyEditedNode))
-      }
-    ),
+//    ("a locally resurrected node not inside a remotely edited parent must contain a node that is remotely edited",
+//      (start, local, remote, pc) => {
+//        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
+//        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
+//          pc.remote.isParentEdited(pc.remote.nodeMap(k))
+//        }
+//
+//        val locallyResurrected = (pc.local.deletedKeys & pc.mergeMap.keySet) &~ inEditedRemoteParent
+//        emptySet(pc, locallyResurrected.map(pc.remote.nodeMap.apply).filterNot(pc.remote.containsRemotelyEditedNode))
+//      }
+//    ),
 
     ("a locally deleted node whose remote version contains no updates must stay deleted",
       (start, local, remote, pc) => {

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -105,14 +105,13 @@ class MergeTest extends JUnitSuite {
     // Find all the merge plan node keys with a particular type of conflict.
     // Note, the corrected merge plan may have different/fewer conflicts since
     // obs permission correction will reset inappropriately edited observations.
-    def mergePlanConflictKeys(p: (Conflicts, SPNodeKey) => Boolean ): Set[SPNodeKey] = {
+    def mergePlanConflictKeys(p: (Conflicts, SPNodeKey) => Boolean ): Set[SPNodeKey] =
       mergePlan.update.sFoldRight(Set.empty[SPNodeKey]) { (mn, s) =>
         mn match {
           case Modified(k, _, _, _, con) if p(con, k) => s + k
-          case _ => s
+          case _                                      => s
         }
       }
-    }
 
     val obsEditsTry = ObsEdit.all(lp, diffs)
     val obsEdits    = obsEditsTry match {

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/ObsNumberCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/ObsNumberCorrectionSpec.scala
@@ -4,7 +4,7 @@ import edu.gemini.pot.sp.{SPObservationID, SPNodeKey}
 import edu.gemini.sp.vcs2.NodeDetail.Obs
 import edu.gemini.sp.vcs2.ProgramLocation.{Local, Remote}
 import edu.gemini.sp.vcs2.ProgramLocationSet.{RemoteOnly, LocalOnly, Both}
-import edu.gemini.sp.vcs2.VcsFailure.Unmergeable
+import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.event.SlewEvent
 import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.obslog.ObsExecLog
@@ -152,8 +152,8 @@ class ObsNumberCorrectionSpec extends MergeCorrectionSpec {
       val expected  = p.node(renumberedLocal.leaf, oRemote.leaf)
 
       onc(plan) match {
-        case -\/(Unmergeable(msg)) => failure(msg)
-        case \/-(mp)               => mp.update must correspondTo(expected)
+        case -\/(f)   => failure(VcsFailure.explain(f, SPProgramID.toProgramID("GS-2016A-Q-1"), "", None))
+        case \/-(mp)  => mp.update must correspondTo(expected)
       }
     }
   }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/ObsPermissionCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/ObsPermissionCorrectionSpec.scala
@@ -31,7 +31,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
       afterPull(env, PiUserPrincipal) {
         localIs(PI_TO_COMPLETE, obsKey, env) and
           (env.local.nodeVersions(obsKey) must_== initialVersion.incr(env.local.lifespanId)) and
-          localHasNote(new CreatePermissionFail(obsKey), env)
+          localHasNote(obsKey, new CreatePermissionFail(obsKey), env)
       }
     }
 
@@ -58,7 +58,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
       afterPull(env, PiUserPrincipal) {
         (env.local.prog.children.exists(_.key == ObsKey) must beTrue) and
           (env.local.prog.getVersion must_== initialVersion.incr(env.local.lifespanId)) and
-          localHasNote(new DeletePermissionFail(ObsKey), env)
+          localHasNote(ObsKey, new DeletePermissionFail(ObsKey), env)
       }
     }
 
@@ -89,7 +89,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
       // sync and see it has been resurrected
       afterPull(env, PiUserPrincipal) {
         (env.local.prog.children.exists(_.key == obsKey) must beTrue) and
-          localHasNote(new DeletePermissionFail(obsKey), env)
+          localHasNote(obsKey, new DeletePermissionFail(obsKey), env)
       }
     }
 
@@ -118,7 +118,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
           (restoredNote.getDataObject.getTitle must_== "abc") and
           (dupNote.key must_!= noteKey) and
           (dupNote.getDataObject.getTitle must_== "123") and
-          localHasNote(new DeletePermissionFail(ObsKey), env)
+          localHasNote(ObsKey, new DeletePermissionFail(ObsKey), env)
       }
     }
 
@@ -152,7 +152,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
       env.local.setObsPhase2Status(ObsKey, PHASE_2_COMPLETE)
       afterPull(env, PiUserPrincipal) {
         localIs(PI_TO_COMPLETE, ObsKey, env) and
-        localHasNote(new UpdatePermissionFail(ObsKey), env)
+        localHasNote(ObsKey, new UpdatePermissionFail(ObsKey), env)
       }
     }
 
@@ -178,7 +178,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
           (localNote.exists(_.key == noteKey) must beTrue) and
           localIs(PHASE_2_COMPLETE, ObsKey, env) and
           localIs(PI_TO_COMPLETE, localObs.key, env) and
-          localHasNote(new UpdatePermissionFail(localObs.key), env)
+          localHasNote(localObs.key, new UpdatePermissionFail(ObsKey), env)
       }
     }
 
@@ -227,7 +227,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
           (newNote.getVersion must_== EmptyNodeVersions.incr(env.local.prog.getLifespanId)) and
           (env.local.descendant(noteKey).getDataObject.getTitle must_== "123") and
           (newNote.getDataObject.getTitle must_== "foo") and
-          localHasNote(new UpdatePermissionFail(localObs.key), env)
+          localHasNote(localObs.key, new UpdatePermissionFail(ObsKey), env)
       }
     }
 
@@ -250,7 +250,7 @@ class ObsPermissionCorrectionSpec extends VcsSpecification {
         (env.local.obs(ObsKey).getObservationNumber must_== 1) and
           (env.local.obs(newObsKey).getObservationNumber must_== 2) and
           (obs3.getObservationNumber must_== 3) and
-          localHasNote(new UpdatePermissionFail(obs3.key), env)
+          localHasNote(obs3.key, new UpdatePermissionFail(ObsKey), env)
       }
     }
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/SortSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/SortSpec.scala
@@ -1,0 +1,79 @@
+package edu.gemini.sp.vcs2
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Gen
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object SortSpec extends Specification with ScalaCheck {
+  case class Test(merged: List[Char], preferred: List[Char], alternate: List[Char]) {
+    val sorted = SortHeuristic.sort(merged, preferred, alternate)(identity)
+
+    override def toString: String =
+      s"""----------
+         |Merged...: ${merged.mkString}
+         |Preferred: ${preferred.mkString}
+         |Alternate: ${alternate.mkString}
+         |Sorted...: ${sorted.mkString}
+       """.stripMargin
+  }
+
+  val genTest = for {
+    p <- Gen.listOf(Gen.alphaChar)
+    a <- Gen.listOf(Gen.alphaChar)
+    m <- Gen.someOf(p ++ a)
+  } yield Test(m.toList.distinct, p.toList.distinct, a.toList.distinct)
+
+  // checks whether l is in order with respect to orderedList and contains no
+  // characters not contained in orderedList (though orderedList might contain
+  // characters not in l)
+  def isOrdered(l: List[Char], orderedList: List[Char]): Boolean = {
+    val order   = orderedList.zipWithIndex.toMap
+    val indices = l.map(c => order.getOrElse(c, -1))
+    indices == indices.sorted && !indices.contains(-1)
+  }
+
+
+  "sort" should {
+    "not add or remove anything" !
+      forAll(genTest) { t => t.sorted.toSet == t.merged.toSet }
+
+    "respect preferred order" !
+      forAll(genTest) { t => isOrdered(t.sorted.filter(t.preferred.contains), t.preferred) }
+
+    "respect alternate order" !
+      forAll(genTest) { t =>
+        val isPref = t.preferred.toSet
+
+        def part(l: List[Char]): List[List[Char]] =
+          (l:\List(List.empty[Char])) { case (c, res) =>
+            if (isPref(c))
+              res match {
+                case Nil :: _ => res
+                case _        => Nil :: res
+              }
+            else (c :: res.head) :: res.tail
+          }
+
+        part(t.sorted).forall { isOrdered(_,t.alternate) }
+      }
+
+    "place alternate chars close to preceding character in alternate order" !
+      forAll(genTest) { t =>
+        val isPref    = t.preferred.toSet
+        val isMissing = (isPref ++ t.alternate.toSet) &~ t.merged.toSet
+
+        def preds(l: List[Char]): Map[Char, List[Char]] = {
+          val rev  = l.reverse
+          rev.zip(rev.tails.drop(1).toIterable).toMap
+        }
+
+        val altPreds  = preds(t.alternate)
+        val sortPreds = preds(t.sorted)
+
+        t.sorted.forall { c =>
+          isPref(c) || (sortPreds(c).headOption == altPreds(c).dropWhile(isMissing).headOption)
+        }
+      }
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TestEnv.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TestEnv.scala
@@ -246,6 +246,7 @@ trait VcsSpecification extends Specification {
     else {
       t match {
         case -\/(VcsException(ex)) => ex.printStackTrace()
+        case _                     => // ignore, report the error below
       }
       ko("unexpected result: " + t)
     }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TestEnv.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TestEnv.scala
@@ -266,7 +266,7 @@ trait VcsSpecification extends Specification {
       case -\/(VcsException(rte: RuntimeException)) => rte.getMessage must_== msg
     }
 
-  def localHasNote(n: Conflict.Note, env: TestEnv): MatchResult[_] =
-    env.local.descendant(n.getNodeKey).getConflicts.notes.asScalaList.contains(n) must beTrue
+  def localHasNote(k: SPNodeKey, n: Conflict.Note, env: TestEnv): MatchResult[_] =
+    env.local.descendant(k).getConflicts.notes.asScalaList.contains(n) must beTrue
 
 }

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/ValidityCorrectionSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/ValidityCorrectionSpec.scala
@@ -3,7 +3,7 @@ package edu.gemini.sp.vcs2
 import edu.gemini.pot.sp.Conflict.ConstraintViolation
 import edu.gemini.pot.sp.SPNodeKey
 import edu.gemini.pot.spdb.DBLocalDatabase
-import edu.gemini.sp.vcs2.VcsFailure.Unmergeable
+import edu.gemini.spModel.core.SPProgramID
 import org.specs2.matcher.MatchResult
 
 import scalaz._
@@ -14,8 +14,8 @@ class ValidityCorrectionSpec extends MergeCorrectionSpec {
 
   private def test(start: Tree[MergeNode], expected: Tree[MergeNode], vc: ValidityCorrection = validityCorrection): MatchResult[Tree[MergeNode]] =
     vc.apply(plan(start)) match {
-      case -\/(Unmergeable(msg)) => failure(msg)
-      case \/-(mp)               => mp.update must correspondTo(expected)
+      case -\/(f)   => failure(VcsFailure.explain(f, SPProgramID.toProgramID("GS-2016A-Q-1"), "", None))
+      case \/-(mp)  => mp.update must correspondTo(expected)
     }
 
   "ValidityCorrection" should {

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsServerSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsServerSpec.scala
@@ -48,7 +48,7 @@ class VcsServerSpec extends VcsSpecification {
 
   "write" should {
     def dummyWrite(env: TestEnv, pid: SPProgramID, user: Set[Principal]): VcsAction[Boolean] =
-      env.local.server.write[Boolean](pid, user, _ => VcsAction(true), identity, (_,_,_) => VcsAction(true))
+      env.local.server.write[Boolean](pid, user, _ => VcsAction(true), identity, (_,_,_) => VcsAction.unit)
 
     "fail if the program id doesn't exist in the database" in withVcs { env =>
       notFound(dummyWrite(env, Q2, StaffUser), Q2)
@@ -62,7 +62,7 @@ class VcsServerSpec extends VcsSpecification {
       val act = env.local.server.write[Boolean](Q1, StaffUser,
         _ => throw new RuntimeException("handle me"),
         identity,
-        (_,_,_) => VcsAction(true))
+        (_,_,_) => VcsAction.unit)
       exception(act, "handle me")
     }
 
@@ -70,7 +70,7 @@ class VcsServerSpec extends VcsSpecification {
       val act = env.local.server.write[Boolean](Q1, StaffUser,
         _ => VcsAction(true),
         _ => throw new RuntimeException("handle me"),
-        (_,_,_) => VcsAction(true))
+        (_,_,_) => VcsAction.unit)
       exception(act, "handle me")
     }
 

--- a/bundle/jsky.app.ot.testlauncher/src/main/scala/jsky/app/ot/testlauncher/TestLauncher.scala
+++ b/bundle/jsky.app.ot.testlauncher/src/main/scala/jsky/app/ot/testlauncher/TestLauncher.scala
@@ -2,6 +2,8 @@ package jsky.app.ot.testlauncher
 
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.qv.plugin.{QvTool, ShowQvToolAction}
+import edu.gemini.sp.vcs2.{VcsServer, Vcs}
+import jsky.app.ot.vcs2.VcsOtClient
 import jsky.app.ot.viewer.plugin.PluginRegistry
 
 import scalaz._, Scalaz._
@@ -33,6 +35,10 @@ object TestLauncher extends App {
   SkycatConfigFile.setConfigFile(classOf[SkycatConfigFile].getResource("/jsky/catalog/osgi/skycat.cfg"))
   ViewerService.instance = Some(new ViewerService(odb, reg))
   VcsGui.registrar = Some(reg)
+
+  val vcsServer   = new VcsServer(odb)
+  val vcs         = Vcs(keys, vcsServer)
+  VcsOtClient.ref = Some(VcsOtClient(vcs, reg))
 
   // Register Plugins
   PluginRegistry.add(new ShowVisitLogAction())

--- a/bundle/jsky.app.ot/build.sbt
+++ b/bundle/jsky.app.ot/build.sbt
@@ -31,6 +31,7 @@ OsgiKeys.privatePackage := Seq(
   "edu.gemini.shared.cat.*",
   "jsky.app.jskycat.*",
   "jsky.app.ot.vcs.*",
+  "jsky.app.ot.vcs2.*",
   "jsky.app.ot",
   "jsky.app.ot.ags",
   "jsky.app.ot.editor.*",
@@ -62,7 +63,7 @@ OsgiKeys.bundleActivator := Some("jsky.app.ot.osgi.Activator")
 
 OsgiKeys.bundleSymbolicName := name.value
 
-OsgiKeys.additionalHeaders += 
+OsgiKeys.additionalHeaders +=
   ("Import-Package" -> "!Acme.JPM.Encoders,!com.sun.*.jpeg,!sun.*,*")
 
 OsgiKeys.dynamicImportPackage := Seq("*") // hmm
@@ -140,4 +141,4 @@ OsgiKeys.exportPackage := Seq(
   "jsky.science.util",
   "jsky.science.util.gui")
 
-        
+

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
@@ -20,6 +20,7 @@ public final class SPViewerActions {
     public final AbstractViewerAction vcsUpdateAction;
     public final AbstractViewerAction vcsCommitAction;
     public final AbstractViewerAction vcsSyncAction;
+    public final AbstractViewerAction vcs2SyncAction;
     public final AbstractViewerAction syncAllAction;
     public final AbstractViewerAction conflictPrevAction;
     public final AbstractViewerAction conflictNextAction;
@@ -133,8 +134,9 @@ public final class SPViewerActions {
         // VCS Actions
         vcsUpdateAction = new VcsUpdateAction(viewer);
         vcsCommitAction = new VcsCommitAction(viewer);
-        vcsSyncAction = new VcsSyncAction(viewer);
-        syncAllAction = new SyncAllAction(viewer);
+        vcsSyncAction   = new VcsSyncAction(viewer);
+        vcs2SyncAction  = new jsky.app.ot.vcs2.VcsSyncAction(viewer);
+        syncAllAction   = new SyncAllAction(viewer);
 
         // General Edit Actions
         cutAction = new CutAction(viewer);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
@@ -82,6 +82,7 @@ final class SPViewerMenuBar extends JMenuBar {
         menu.add(new ImportAction(_viewer));
         menu.add(new ExportAction(_viewer));
         menu.add(_viewer._actions.vcsSyncAction);
+        menu.add(_viewer._actions.vcs2SyncAction);
         menu.add(_viewer._actions.syncAllAction);
         menu.addSeparator();
         menu.add(new FetchLibrariesAction(_viewer));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerToolBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerToolBar.java
@@ -65,12 +65,8 @@ public final class SPViewerToolBar extends JToolBar {
 
         add(viewer._actions.conflictNextAction);
         add(viewer._actions.vcsSyncAction);
+        add(viewer._actions.vcs2SyncAction);
         super.addSeparator();
-
-// RCN: this button is dumb, so I'm not putting it on the toolbar anymore.
-// we'll see if anyone notices.
-//        add(makeEnableEditButton());
-
     }
 
     public boolean isShowPictures() {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsGui.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsGui.scala
@@ -1,11 +1,9 @@
 package jsky.app.ot.vcs
 
 import edu.gemini.sp.vcs.{TrpcVcsServer, VcsServer}
-import edu.gemini.sp.vcs.reg.{VcsRegistrationSubscriber, VcsRegistrar}
+import edu.gemini.sp.vcs.reg.VcsRegistrar
 import edu.gemini.spModel.core.{Peer, SPProgramID}
 import edu.gemini.pot.sp.{ISPNode, ISPProgram}
-import scala.swing.{Publisher, Swing}
-import scala.swing.event.Event
 import jsky.app.ot.OT
 
 /**
@@ -13,7 +11,7 @@ import jsky.app.ot.OT
  * particular program ids.  Publishes VcsGui.VcsRegistrationEvent as a Swing
  * Event.
  */
-object VcsGui extends VcsRegistrationSubscriber with Publisher {
+object VcsGui {
   private var reg: Option[VcsRegistrar] = None
 
   def registrar: Option[VcsRegistrar] = reg
@@ -63,9 +61,4 @@ object VcsGui extends VcsRegistrationSubscriber with Publisher {
       } yield ProgramVcsServer(p, srv)
     case _             => Left(VcsServerNotFound("Not a Science Program", NotScience))
   }
-
-  case class VcsRegistrationEvent(pid: SPProgramID, peer: Option[Peer]) extends Event
-
-  def notify(evt: edu.gemini.sp.vcs.reg.VcsRegistrationEvent, pub: VcsRegistrar): Unit =
-    Swing.onEDT { publish(VcsRegistrationEvent(evt.pid, evt.peer)) }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsProgressDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsProgressDialog.scala
@@ -17,7 +17,6 @@ import scala.swing.GridBagPanel.Fill._
 import scala.swing.Swing._
 
 import java.awt.Color
-import javax.security.auth.Subject
 import javax.swing.UIManager
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsOtClient.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsOtClient.scala
@@ -1,0 +1,71 @@
+package jsky.app.ot.vcs2
+
+import edu.gemini.pot.sp.ISPProgram
+import edu.gemini.pot.sp.version.VersionMap
+import edu.gemini.sp.vcs.log.VcsEventSet
+import edu.gemini.sp.vcs.reg.VcsRegistrar
+import edu.gemini.sp.vcs2._
+import edu.gemini.spModel.core.{Peer, SPProgramID}
+import jsky.app.ot.vcs.vm.VmStore
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.swing.Swing
+
+object VcsOtClient {
+  private var client: Option[VcsOtClient] = None
+
+  def ref: Option[VcsOtClient] = client
+
+  def ref_=(c: Option[VcsOtClient]): Unit = {
+    client = c
+  }
+}
+
+/** Provides a simplified VCS API for the OT that Wraps the raw `Vcs` API to
+  * handle peer lookup from the `VcsRegistrar` and update the `VmStore` map
+  * with sync results. */
+case class VcsOtClient(vcs: Vcs, reg: VcsRegistrar) {
+
+  def peer(id: SPProgramID): Option[Peer] = reg.registration(id)
+  def peerOrNull(id: SPProgramID): Peer   = reg.registrationOrNull(id)
+
+  def checkout(id: SPProgramID, peer: Peer, cancelled: AtomicBoolean): VcsAction[ISPProgram] =
+    for {
+      p <- vcs.checkout(id, peer, cancelled)
+      _ <- VcsAction(reg.register(id, peer))
+    } yield vmStore(id, p)(_.getVersions)
+
+  def add(id: SPProgramID, peer: Peer): VcsAction[VersionMap] =
+    for {
+      vm <- vcs.add(id, peer)
+      _  <- VcsAction(reg.register(id, peer))
+    } yield vmStore(id, vm)(identity)
+
+  private def lookupAndThen[A](id: SPProgramID)(f: (Vcs, Peer) => VcsAction[A]): VcsAction[A] =
+    for {
+      p <- peer(id).toTryVcs(s"Program '$id' has not been checked out of any database.").liftVcs
+      a <- f(vcs, p)
+    } yield a
+
+  private def recording[A](id: SPProgramID)(f: (Vcs, Peer) => VcsAction[A])(g: A => VersionMap): VcsAction[A] =
+    lookupAndThen(id)(f).map(vmStore(id, _)(g))
+
+  def version(id: SPProgramID): VcsAction[VersionMap] =
+    recording(id)(_.version(id, _))(identity)
+
+  def pull(id: SPProgramID, cancelled: AtomicBoolean): VcsAction[(PullResult, VersionMap)] =
+    recording(id)(_.pull(id, _, cancelled))(_._2)
+
+  def sync(id: SPProgramID, cancelled: AtomicBoolean): VcsAction[(ProgramLocationSet, VersionMap)] =
+    recording(id)(_.retrySync(id, _, cancelled, 10))(_._2)
+
+  def log(id: SPProgramID, offset: Int, length: Int): VcsAction[(List[VcsEventSet], Boolean)] =
+    lookupAndThen(id)(_.log(id, _, offset, length))
+
+  // Performs the side-effect of updating the map from id to VersionMap.
+  private def vmStore[A](id: SPProgramID, a: A)(f: A => VersionMap): A = {
+    Swing.onEDT { VmStore.update(id, f(a)) }
+    a
+  }
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsSyncAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsSyncAction.scala
@@ -1,0 +1,84 @@
+package jsky.app.ot.vcs2
+
+import edu.gemini.sp.vcs.ProgramStatus
+import edu.gemini.sp.vcs.ProgramStatus.{PendingCheckIn, PendingSync, PendingUpdate, Unknown}
+import edu.gemini.spModel.core.{Peer, SPProgramID}
+import edu.gemini.util.security.auth.keychain.Action._
+
+
+import jsky.app.ot.OT
+import jsky.app.ot.vcs.{VcsPeerSelectionDialog, VcsIcon, VcsStateEvent}
+import jsky.app.ot.viewer.SPViewer
+import jsky.app.ot.viewer.action.{AbstractVcsAction, AbstractViewerAction}
+import jsky.app.ot.viewer.action.AbstractVcsAction.scalaComponent
+
+import java.awt.event.{ActionEvent, KeyEvent}
+import javax.swing.Action._
+import javax.swing.Icon
+
+import scala.swing.{Component, Reactor}
+
+import scalaz.\/
+import scalaz.syntax.std.option._
+
+final class VcsSyncAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Sync changes to this program with the database", VcsIcon.UpToDate) with Reactor {
+  putValue(AbstractViewerAction.SHORT_NAME, "New Sync")
+  putValue(SHORT_DESCRIPTION, "Sync program with any changes from the database.")
+  putValue(ACCELERATOR_KEY, AbstractVcsAction.keystroke(KeyEvent.VK_S))
+
+  private def pid: Option[SPProgramID] =
+    for {
+      r <- Option(viewer.getRoot)
+      p <- Option(r.getProgramID)
+    } yield p
+
+  private def peer: Option[Peer] =
+    for {
+      pd <- pid
+      c  <- VcsOtClient.ref
+      pr <- c.peer(pd)
+    } yield pr
+
+  protected def allPeers: List[Peer] =
+    OT.getKeyChain.peers.unsafeRun.fold(_ => Nil, _.toList)
+
+  private def promptAndSetPeer(c: Option[Component]): Option[Peer] = {
+    pid.foreach { p => VcsPeerSelectionDialog.promptAndSet(c, p, allPeers) }
+    peer
+  }
+
+  private def isShowIcons: Boolean =
+    \/.fromTryCatch(viewer.getParentFrame.getToolBar.isShowPictures) | true
+
+  listenTo(viewer.getVcsStateTracker)
+
+  reactions += {
+    case VcsStateEvent(pid, peer, status, conflicts) =>
+      def iconFor(s: ProgramStatus): Option[Icon] = s match {
+        case Unknown        => Some(VcsIcon.BrokenLink)
+        case PendingSync    => Some(VcsIcon.PendingSync)
+        case PendingUpdate  => Some(VcsIcon.PendingUpdate)
+        case PendingCheckIn => Some(VcsIcon.PendingCheckIn)
+        case _              => None
+      }
+
+      val newIcon = pid.flatMap { p =>
+        peer.fold(Option(VcsIcon.NoPeer: Icon)) { _ => iconFor(status) }
+      } | VcsIcon.UpToDate
+
+      if (isShowIcons) putValue(SMALL_ICON, newIcon)
+
+      setEnabled(pid.isDefined && conflicts.isEmpty)
+  }
+
+  override def computeEnabledState =
+    pid.isDefined && allPeers.size > 0 && viewer.getVcsStateTracker.conflicts.isEmpty
+
+  def actionPerformed(evt: ActionEvent): Unit =
+    for {
+      pd  <- pid
+      cl  <- VcsOtClient.ref
+      comp = scalaComponent(evt)
+      pr  <- peer orElse promptAndSetPeer(comp)
+    } VcsSyncDialog.open(pd, cl, comp)
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsSyncDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsSyncDialog.scala
@@ -46,13 +46,13 @@ object VcsSyncDialog {
 
   // Make a multi-line label by doctoring a JTextArea until it works more or
   // less like a text label.
-  private def makeNote(rows: Int, cols: Int, text: String): TextArea =
+  private def makeNote(rows: Int, cols: Int, text0: String): TextArea =
     new TextArea(rows, cols) {
       editable = false
       opaque   = false
       lineWrap = true
       wordWrap = true
-      text     = text
+      text     = text0
       peer.setHighlighter(null)
     }
 
@@ -73,7 +73,7 @@ class VcsSyncDialog(pid: SPProgramID, client: VcsOtClient, comp: Option[Componen
 
   object statusIcon extends Label { icon = Resources.getIcon("spinner16.gif") }
 
-  val statusMsg = makeNote(1, 35, "")
+  val statusMsg = makeNote(1, 35, s"Synchronizing $pid ...")
 
   object resolveButton extends Button("Accept All Remote") {
     visible = false

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsSyncDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs2/VcsSyncDialog.scala
@@ -1,0 +1,190 @@
+package jsky.app.ot.vcs2
+
+import edu.gemini.pot.client.SPDB
+import edu.gemini.pot.sp.version.VersionMap
+import edu.gemini.sp.vcs2.VcsFailure.{NotFound, HasConflict, Cancelled}
+import edu.gemini.sp.vcs2._
+import edu.gemini.sp.vcs2.VcsAction.VcsActionOps
+import edu.gemini.spModel.core.SPProgramID
+import jsky.app.ot.util.Resources
+import jsky.app.ot.viewer.action.ResolveConflictsAction
+
+import java.awt.Color
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.swing.UIManager
+
+import scala.swing._
+import scala.swing.GridBagPanel.Anchor.West
+import scala.swing.GridBagPanel.Fill.Horizontal
+import scala.swing.Swing._
+import scala.swing.event.ActionEvent
+
+import scalaz._
+import Scalaz._
+
+
+object VcsSyncDialog {
+  val ConflictMessage =
+    """Your program contains edits that conflict with the database.  Press
+      |'Accept All Remote' to automatically accept all the remote changes, or
+      |'Cancel and Review' to review the conflicts.
+    """.stripMargin.map(c => (c === '\n').fold(' ', c))
+
+  def open(pid: SPProgramID, client: VcsOtClient, comp: Option[Component]): TryVcs[(ProgramLocationSet, VersionMap)] = {
+    val d = new VcsSyncDialog(pid, client, comp)
+    d.title = s"Sync $pid"
+    d.pack()
+    d.setLocationRelativeTo(comp.orNull)
+    d.visible = true
+    d.result | VcsFailure.Cancelled.left
+  }
+
+  private def warn(parent: Option[Component], title: String, message: String) {
+    Dialog.showMessage(parent = parent.orNull, message = message, title = title,
+                       messageType = Dialog.Message.Error)
+  }
+
+  // Make a multi-line label by doctoring a JTextArea until it works more or
+  // less like a text label.
+  private def makeNote(rows: Int, cols: Int, text: String): TextArea =
+    new TextArea(rows, cols) {
+      editable = false
+      opaque   = false
+      lineWrap = true
+      wordWrap = true
+      text     = text
+      peer.setHighlighter(null)
+    }
+
+  private lazy val separatorBorder =
+    CompoundBorder(MatteBorder(1, 0, 0, 0, Color.LIGHT_GRAY), EmptyBorder(10, 0 , 0, 0))
+}
+
+class VcsSyncDialog(pid: SPProgramID, client: VcsOtClient, comp: Option[Component]) extends Dialog { dialog =>
+
+  import VcsSyncDialog._
+
+  modal         = true
+  resizable     = false
+
+  var result: Option[TryVcs[(ProgramLocationSet, VersionMap)]] = None
+
+  val cancelled: AtomicBoolean = new AtomicBoolean(false)
+
+  object statusIcon extends Label { icon = Resources.getIcon("spinner16.gif") }
+
+  val statusMsg = makeNote(1, 35, "")
+
+  object resolveButton extends Button("Accept All Remote") {
+    visible = false
+  }
+
+  object closeButton extends Button("Cancel") {
+    reactions += {
+      case e: ActionEvent =>
+        enabled = false
+        cancelled.set(true)
+        closeAndDispose(-\/(Cancelled))
+    }
+  }
+
+  def closeAndDispose(res: TryVcs[(ProgramLocationSet, VersionMap)]): Unit = {
+    result = Some(res)
+    close()
+    dispose()
+  }
+
+  val handleResult: TryVcs[(ProgramLocationSet, VersionMap)] => Unit = {
+    case \/-(a)           =>
+      closeAndDispose(\/-(a))
+
+    case -\/(Cancelled)   =>
+      closeAndDispose(-\/(Cancelled))
+
+    case -\/(NotFound(_)) =>
+      client.peer(pid).foreach { peer =>
+        client.add(pid, peer).forkAsync(vm => Swing.onEDT(handleResult(vm.map((ProgramLocationSet.RemoteOnly, _)))))
+      }
+
+    case -\/(HasConflict) =>
+      Option(SPDB.get().lookupProgramByID(pid)).foreach { p =>
+        statusIcon.icon  = UIManager.getIcon("OptionPane.warningIcon")
+        statusMsg.rows   = 4
+        statusMsg.text   = ConflictMessage
+        closeButton.text = "Cancel and Review"
+
+        resolveButton.visible = true
+        resolveButton.reactions += {
+          case _: ActionEvent =>
+            ResolveConflictsAction.resolveAll(p)
+            closeAndDispose(-\/(HasConflict))
+
+            // Try again but let this instance die
+            Swing.onEDT { VcsSyncDialog.open(pid, client, comp) }
+        }
+
+        dialog.pack()
+      }
+
+    case -\/(failure)     =>
+      statusIcon.icon  = UIManager.getIcon("OptionPane.warningIcon")
+      statusMsg.text   = VcsFailure.explain(failure, pid, "sync", client.peer(pid))
+      closeButton.text = "Ok"
+      closeButton.reactions += { case _: ActionEvent => closeAndDispose(-\/(failure)) }
+  }
+
+  object statusPanel extends GridBagPanel {
+    layout(statusIcon) = new Constraints() {
+      gridx  = 0
+      gridy  = 0
+      anchor = West
+    }
+
+    layout(statusMsg) = new Constraints() {
+      gridx   = 1
+      anchor  = West
+      fill    = Horizontal
+      weightx = 1.0
+      insets  = new Insets(0,5,0,0)
+    }
+  }
+
+  object buttonPanel extends GridBagPanel {
+    border = separatorBorder
+
+    layout(HGlue) = new Constraints() {
+      gridx   = 0
+      weightx = 1.0
+      fill    = Horizontal
+    }
+
+    layout(resolveButton) = new Constraints() {
+      gridx  = 1
+      insets = new Insets(0,0,0,5)
+    }
+
+    layout(closeButton) = new Constraints() {
+      gridx = 2
+    }
+  }
+
+  contents = new GridBagPanel {
+    border = EmptyBorder(20,10,10,10)
+
+    layout(statusPanel) = new Constraints() {
+      gridy  = 0
+      anchor = West
+    }
+
+    layout(buttonPanel) = new Constraints() {
+      gridy   = 1
+      fill    = Horizontal
+      weightx = 1.0
+      insets  = new Insets(10,0,0,0)
+    }
+  }
+
+  peer.getRootPane.setDefaultButton(closeButton.peer)
+
+  client.sync(pid, cancelled).forkAsync(r => Swing.onEDT(handleResult(r)))
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/VcsSyncAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/VcsSyncAction.scala
@@ -11,19 +11,16 @@ import javax.swing.Icon
 import javax.swing.Action.{ACCELERATOR_KEY, SHORT_DESCRIPTION, SMALL_ICON}
 import scala.util.Try
 
-//import scala.concurrent._
-//import scala.concurrent.ExecutionContext.Implicits.global
-
 import scala.swing.Reactor
 
-//import java.util.UUID
+// NOTE: This class is slated for deletion in favor of vcs2.VcsSyncAction..
 
 /**
  * Updates program from the remote database and then commits local changes if
  * there were no conflicts.
  */
 final class VcsSyncAction(viewer: SPViewer) extends AbstractVcsAction(viewer, "Sync changes to this program with the database", VcsIcon.UpToDate, VcsSyncOp) with Reactor {
-  putValue(AbstractViewerAction.SHORT_NAME, "Sync")
+  putValue(AbstractViewerAction.SHORT_NAME, "Old Sync")
   putValue(SHORT_DESCRIPTION, "Sync program with any changes from the database.")
   putValue(ACCELERATOR_KEY, AbstractVcsAction.keystroke(KeyEvent.VK_S))
 
@@ -34,56 +31,22 @@ final class VcsSyncAction(viewer: SPViewer) extends AbstractVcsAction(viewer, "S
   reactions += {
     case VcsStateEvent(pid, peer, status, conflicts) =>
       def iconFor(s: ProgramStatus): Option[Icon] = s match {
-        case Unknown => Some(VcsIcon.BrokenLink)
-        case PendingSync => Some(VcsIcon.PendingSync)
-        case PendingUpdate => Some(VcsIcon.PendingUpdate)
+        case Unknown        => Some(VcsIcon.BrokenLink)
+        case PendingSync    => Some(VcsIcon.PendingSync)
+        case PendingUpdate  => Some(VcsIcon.PendingUpdate)
         case PendingCheckIn => Some(VcsIcon.PendingCheckIn)
-        case _ => None
+        case _              => None
       }
 
-      val newIcon = pid.flatMap {
-        p =>
-          peer.fold[Option[Icon]](Some(VcsIcon.NoPeer)) {
-            _ => iconFor(status)
-          }
+      val newIcon = pid.flatMap { p =>
+        peer.fold[Option[Icon]](Some(VcsIcon.NoPeer)) { _ => iconFor(status) }
       }.getOrElse(VcsIcon.UpToDate)
 
-      //      val oldIcon = getValue(SMALL_ICON).asInstanceOf[Icon]
-      //      val eventId = UUID.randomUUID
-      //      putValue("EventId", eventId)
       if (isShowIcons) putValue(SMALL_ICON, newIcon)
-      //      if ((oldIcon == VcsIcon.UpToDate) && (newIcon == VcsIcon.PendingSync)) {
-      //        // animate the transition from up-to-date to pending
-      //        flashIcon(eventId, VcsIcon.SyncFlash, newIcon)
-      //      }
 
       setEnabled(pid.isDefined && conflicts.isEmpty)
   }
 
   override def computeEnabledState =
     super.computeEnabledState && viewer.getVcsStateTracker.conflicts.isEmpty
-
-  /*
-  private def flashIcon(eventId: UUID, from: Icon, to: Icon): Unit = {
-    val delay      = 200
-    val cycleCount = 2
-
-    def updateIcon(icon: Icon) = Swing.onEDTWait {
-      if (getValue("EventId") == eventId) putValue(SMALL_ICON, icon)
-    }
-
-    def cycle(count: Int): Unit = {
-      if (count > 0) {
-        Thread.sleep(delay)
-        updateIcon(from)
-        Thread.sleep(delay)
-        updateIcon(to)
-        cycle(count - 1)
-      }
-    }
-
-    future { cycle(cycleCount) }
-  }
-  */
-
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/OpenDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/OpenDialog.scala
@@ -7,21 +7,22 @@ import edu.gemini.shared.gui.SizePreference
 import edu.gemini.shared.util.immutable.ApplyOp
 import edu.gemini.sp.vcs.ProgramStatus.{PendingCheckIn, PendingSync}
 import edu.gemini.sp.vcs.reg.VcsRegistrar
-import edu.gemini.sp.vcs.{OldVcsFailure, VcsServer, VersionControlSystem}
+import edu.gemini.sp.vcs2.VcsAction._
+import edu.gemini.sp.vcs2.VcsFailure
 import edu.gemini.spModel.core.{Peer, SPProgramID}
 import edu.gemini.spModel.util.DBProgramInfo
 import edu.gemini.util.security.auth.keychain.Action._
 import edu.gemini.util.security.auth.keychain.{Key, KeyChain, Action => KAction}
 import edu.gemini.util.security.auth.ui.{AuthDialog, CloseOnEsc, Instructions}
-import edu.gemini.util.trpc.client.TrpcClient
 import jsky.app.ot.OT
 import jsky.app.ot.util.Resources
-import jsky.app.ot.vcs.vm.VmStore
+import jsky.app.ot.vcs2.VcsOtClient
 import jsky.app.ot.viewer.DBProgramChooserFilter
 
 import java.awt
 import java.awt.Color
 import java.awt.event.{MouseAdapter, MouseEvent}
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing
 import javax.swing._
 import javax.swing.event.{ListSelectionEvent, ListSelectionListener, TableModelEvent}
@@ -58,28 +59,27 @@ object OpenDialog {
     update(db, pid, peer, Component.wrap(parent), vcs).orNull
 
   def checkout(db: IDBDatabaseService, pid: SPProgramID, peer: Peer, parent: Component, vcs: VcsRegistrar): Option[ISPProgram] =
-    vcsOp(db, pid, peer, parent, vcs, "checkout") { _.checkout(pid) }
+    vcs2Op(db, pid, peer, parent, vcs, "checkout") { _.checkout(pid, peer, new AtomicBoolean(false)).unsafeRun }
 
   def update(db: IDBDatabaseService, pid: SPProgramID, peer: Peer, parent: Component, vcs: VcsRegistrar): Option[ISPProgram] =
-    vcsOp(db, pid, peer, parent, vcs, "update") { _.update(pid, currentUser) }
+    vcs2Op(db, pid, peer, parent, vcs, "pull") { _.pull(pid, new AtomicBoolean(false)).unsafeRun.as(db.lookupProgramByID(pid)) }
 
-  private def vcsOp(db: IDBDatabaseService, pid: SPProgramID, peer: Peer, parent: Component, vcs: VcsRegistrar, opName: String)(op: VersionControlSystem => OldVcsFailure \/ ISPProgram): Option[ISPProgram] = {
-    import edu.gemini.sp.vcs.OldVcsFailure._
-
+  private def vcs2Op(db: IDBDatabaseService, pid: SPProgramID, peer: Peer, parent: Component, vcs: VcsRegistrar, opName: String)(op: VcsOtClient => VcsFailure \/ ISPProgram): Option[ISPProgram] = {
     def success(p: ISPProgram): Option[ISPProgram] = {
       vcs.register(p.getProgramID, peer)
       Some(p)
     }
 
-    def fail(f: OldVcsFailure): Option[ISPProgram] = {
-      val msg = OldVcsFailure.explain(f, pid, opName, Some(peer))
+    def fail(f: VcsFailure): Option[ISPProgram] = {
+      val msg = VcsFailure.explain(f, pid, opName, Some(peer))
       Dialog.showMessage(parent, msg, "Error", Dialog.Message.Error)
       None
     }
 
-    TrpcClient(peer).withKeyChain(OT.getKeyChain) { r =>
-      op(VersionControlSystem(db, r[VcsServer])).fold(fail, success)
-    }.fold(e => fail(OldVcsException(e)), identity)
+    for {
+      client <- VcsOtClient.ref
+      prog   <- op(client).fold(fail, success)
+    } yield prog
   }
 }
 
@@ -248,37 +248,22 @@ class OpenDialog private(db: IDBDatabaseService, auth: KeyChain, vcs: VcsRegistr
       }
     }
 
-    //    lazy val ImportAction = Action("Import...") {
-    //      new OpenActions.ImportAction() {
-    //        override def openedProgram(p:ISPNode) {
-    //          Contents.ProgTable.refreshLocal()
-    //        }
-    //      }
-    //    }
-
     lazy val CheckoutAction = Action("Checkout") {
-      import edu.gemini.sp.vcs.OldVcsFailure._
-
-      def success(loc: Peer)(p: ISPProgram) {
+      def success(loc: Peer)(p: ISPProgram): Unit = {
         vcs.register(p.getProgramID, loc)
-        VmStore.update(p.getProgramID, p.getVersions)
         Contents.ProgTable.refresh(full = false)
         updateStorage()
       }
 
-      def fail(info: DBProgramInfo, loc: Peer)(f: OldVcsFailure) {
-        val msg = OldVcsFailure.explain(f, info.programID, "checkout", Some(loc))
+      def fail(info: DBProgramInfo, loc: Peer)(f: VcsFailure): Unit = {
+        val msg = VcsFailure.explain(f, info.programID, "checkout", Some(loc))
         Dialog.showMessage(Contents, msg, "Error", Dialog.Message.Error)
       }
 
-      Contents.ProgTable.selectedRemote.foreach {
-        case (info, loc) =>
-          TrpcClient(loc.host, loc.port).withKeyChain(OT.getKeyChain) { r =>
-            val remote = VersionControlSystem(db, r[VcsServer])
-            remote.checkout(info.programID).fold(fail(info, loc), success(loc))
-          }.fold(e => fail(info, loc)(OldVcsException(e)), identity)
-      }
-
+      for {
+        (info, loc) <- Contents.ProgTable.selectedRemote
+        client      <- VcsOtClient.ref
+      } client.checkout(info.programID, loc, new AtomicBoolean(false)).unsafeRun.fold(fail(info,loc), success(loc))
     }
 
     def isRemote(p: ISPProgram): Boolean =


### PR DESCRIPTION
This PR was ostensibly about integrating the new sync algorithm with the OT.  The beginning of that process is included in the form of a "New Sync" button which has been placed alongside the existing but renamed "Old Sync".  This is a temporary arrangement until the old merge algorithm and related OT code are removed.  In the meantime there is some code duplication but testers will be able to try each version side by side and see how they differ.

![syncbuttons](https://cloud.githubusercontent.com/assets/4906023/8259879/4e9ffec0-1696-11e5-9c4d-dfe157d340e4.png)

Most of the work that went into this PR is unrelated to the OT and rather deals with bug fixes and improvements for the sync algorithm.  These include:

* A bug fix in which the children of a node would be rearranged upon sync (and yet have identical version numbers).  For this an improved sort was added in `edu.gemini.sp.vcs2.SortHeuristic` which tries to combine two independently edited lists in a way that isn't too crazy.

* A merge correction that completes resurrected observations so that they don't come back to life in an invalid state and missing descendants.

* Turning off observation resurrection conflict notes, since I can't see a good way to add them and they may not be that useful anyway.  (Will consult with Andy/Bryan.)