### PR TITLE
REL-2352: Add SDSS filter to target bandpass list in PIT

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -351,6 +351,11 @@ package object immutable {
 
   // Bands that are on the phase1 model
   val allowedBands = List(
+    MagnitudeBand._u,
+    MagnitudeBand._g,
+    MagnitudeBand._r,
+    MagnitudeBand._i,
+    MagnitudeBand._z,
     MagnitudeBand.U,
     MagnitudeBand.B,
     MagnitudeBand.V,
@@ -368,6 +373,11 @@ package object immutable {
 
   implicit class MagnitudeBandOps(val band: MagnitudeBand) extends AnyVal {
     def mutable: M.MagnitudeBand = band match {
+      case MagnitudeBand._u => M.MagnitudeBand._u
+      case MagnitudeBand._g => M.MagnitudeBand._g
+      case MagnitudeBand._r => M.MagnitudeBand._r
+      case MagnitudeBand._i => M.MagnitudeBand._i
+      case MagnitudeBand._z => M.MagnitudeBand._z
       case MagnitudeBand.U  => M.MagnitudeBand.U
       case MagnitudeBand.B  => M.MagnitudeBand.B
       case MagnitudeBand.V  => M.MagnitudeBand.V
@@ -396,6 +406,11 @@ package object immutable {
 
   implicit class MutableMagnitudeBandOps(val band: M.MagnitudeBand) extends AnyVal {
     def toBand: MagnitudeBand = band match {
+      case M.MagnitudeBand._u => MagnitudeBand._u
+      case M.MagnitudeBand._g => MagnitudeBand._g
+      case M.MagnitudeBand._r => MagnitudeBand._r
+      case M.MagnitudeBand._i => MagnitudeBand._i
+      case M.MagnitudeBand._z => MagnitudeBand._z
       case M.MagnitudeBand.U  => MagnitudeBand.U
       case M.MagnitudeBand.B  => MagnitudeBand.B
       case M.MagnitudeBand.V  => MagnitudeBand.V

--- a/bundle/edu.gemini.model.p1/src/main/xjb/MagnitudeBand.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/MagnitudeBand.xjb
@@ -1,0 +1,29 @@
+<jxb:bindings version="2.0"
+              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+              xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <!-- Custom bindings for magnitude bands, special cases for SDSS bands-->
+    <jxb:bindings schemaLocation="../xsd/Target.xsd" node="/xsd:schema">
+
+        <!-- SDSS Bands need a special mapping, otherwise they collide with the bands with a capital letter -->
+        <jxb:bindings node="./xsd:simpleType[@name='MagnitudeBand']/xsd:restriction">
+            <jxb:bindings node="./xsd:enumeration[@value='u']">
+                <jxb:typesafeEnumMember name="_u"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='g']">
+                <jxb:typesafeEnumMember name="_g"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='r']">
+                <jxb:typesafeEnumMember name="_r"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='i']">
+                <jxb:typesafeEnumMember name="_i"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='z']">
+                <jxb:typesafeEnumMember name="_z"/>
+            </jxb:bindings>
+        </jxb:bindings>
+
+    </jxb:bindings>
+
+</jxb:bindings>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -6,6 +6,7 @@ Gemini Phase I Schema Changes
 * Offer Flamingos-2 K-long filter
 * Added keyword 'Star formation'
 * Offer Phoenix instrument
+* Added SDSS Magnitude Bands u, g, r, i, z
 
 # Version 2015.2.1 - 2015B
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Target.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Target.xsd
@@ -220,6 +220,51 @@
     -->
     <xsd:simpleType name="MagnitudeBand">
         <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="u">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <desc>UV</desc>
+                        <nm>365</nm>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+
+            <xsd:enumeration value="g">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <desc>green</desc>
+                        <nm>483</nm>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+
+            <xsd:enumeration value="r">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <desc>red</desc>
+                        <nm>626</nm>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+
+            <xsd:enumeration value="i">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <desc>far red</desc>
+                        <nm>767</nm>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+
+            <xsd:enumeration value="z">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <desc>near infrared</desc>
+                        <nm>910</nm>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+
             <xsd:enumeration value="U">
                 <xsd:annotation>
                     <xsd:appinfo>

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Ned.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Ned.scala
@@ -30,21 +30,21 @@ class Ned private (val host: String) extends VOTableCatalog {
   def decode(vot: VOTable): Seq[I.Target] = for {
 
     // In the List monad here, eventually iterating rows
-    resource <- vot.resources
+    resource                                <- vot.resources
     table @ Table("NED_MainTable", _, _, _) <- resource.tables
-    row <- table.data.tableData.rows
+    row                                     <- table.data.tableData.rows
     kvs = table.fields.zip(row)
 
     // Local find function
     find = (s: String) => kvs.find(_._1.ucd == Some(s)).map(_._2)
 
     // Switch to Option here to pull out data
-    epoch <- vot.definitions.map(_.cooSys.id) collect {
-      case "J2000" => M.CoordinatesEpoch.J_2000
-    }
-    name <- find("meta.id;meta.main")
-    ra <- find("pos.eq.ra;meta.main").flatMap(_.toDoubleOption)
-    dec <- find("pos.eq.dec;meta.main").flatMap(_.toDoubleOption)
+    epoch                                   <- vot.definitions.map(_.cooSys.id) collect {
+                                                case "J2000" => M.CoordinatesEpoch.J_2000
+                                              }
+    name                                    <- find("meta.id;meta.main")
+    ra                                      <- find("pos.eq.ra;meta.main").flatMap(_.toDoubleOption)
+    dec                                     <- find("pos.eq.dec;meta.main").flatMap(_.toDoubleOption)
 
   } yield I.SiderealTarget(UUID.randomUUID(), name, I.DegDeg(ra, dec), epoch, None, List())
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
@@ -33,43 +33,43 @@ class Simbad private (val host:String) extends VOTableCatalog {
 
   def decode(vot:VOTable):Seq[I.Target] = for {
 
-  // In the List monad here, eventually iterating rows
-    resource <- vot.resources
-    table@Table("simbad", _, _, _) <- resource.tables
-    row <- table.data.tableData.rows
+    // In the List monad here, eventually iterating rows
+    resource                         <- vot.resources
+    table @ Table("simbad", _, _, _) <- resource.tables
+    row                              <- table.data.tableData.rows
     kvs = table.fields.zip(row)
 
     // Local find function
-    str = (s:String) => kvs.find(_._1.ucd.exists(_.toLowerCase == s.toLowerCase)).map(_._2)
-    num = (s:String) => str(s).flatMap(_.toDoubleOption)
+    str                                = (s:String) => kvs.find(_._1.ucd.exists(_.toLowerCase == s.toLowerCase)).map(_._2)
+    num                                = (s:String) => str(s).flatMap(_.toDoubleOption)
 
     // Switch to Option here to pull out data
-    epoch <- vot.definitions.map(_.cooSys.epoch).map {
-      case "J2000" => I.CoordinatesEpoch.J_2000
-      case s       => I.CoordinatesEpoch.forName(s)
-    }
-    name <- str("meta.id;meta.main")
-    ra <- num("pos.eq.ra;meta.main")
-    dec <- num("pos.eq.dec;meta.main")
+    epoch                             <- vot.definitions.map(_.cooSys.epoch).map {
+                                          case "J2000" => I.CoordinatesEpoch.J_2000
+                                          case s       => I.CoordinatesEpoch.forName(s)
+                                        }
+    name                              <- str("meta.id;meta.main")
+    ra                                <- num("pos.eq.ra;meta.main")
+    dec                               <- num("pos.eq.dec;meta.main")
 
     // Mags get pulled out into a list
-    mags = for {
-      (k, Some(v)) <- Map(
-        MagnitudeBand.U -> num("phot.mag;em.opt.U"),
-        MagnitudeBand.V -> num("phot.mag;em.opt.V"),
-        MagnitudeBand.B -> num("phot.mag;em.opt.B"),
-        MagnitudeBand.R -> num("phot.mag;em.opt.R"),
-        MagnitudeBand.J -> num("phot.mag;em.ir.J"),
-        MagnitudeBand.H -> num("phot.mag;em.ir.H"),
-        MagnitudeBand.K -> num("phot.mag;em.ir.K"))
-    // TODO: more passbands
-    } yield new Magnitude(v, k, MagnitudeSystem.VEGA) // TODO
+    mags                               = for {
+                                            (k, Some(v)) <- Map(
+                                              MagnitudeBand.U -> num("phot.mag;em.opt.U"),
+                                              MagnitudeBand.V -> num("phot.mag;em.opt.V"),
+                                              MagnitudeBand.B -> num("phot.mag;em.opt.B"),
+                                              MagnitudeBand.R -> num("phot.mag;em.opt.R"),
+                                              MagnitudeBand.J -> num("phot.mag;em.ir.J"),
+                                              MagnitudeBand.H -> num("phot.mag;em.ir.H"),
+                                              MagnitudeBand.K -> num("phot.mag;em.ir.K"))
+                                              // TODO: more passbands
+                                          } yield new Magnitude(v, k, MagnitudeSystem.VEGA)
 
     // Proper Motion
-    pm = for {
-      dRa <- num("pos.pm;pos.eq.ra")
-      dDec <- num("pos.pm;pos.eq.dec")
-    } yield I.ProperMotion(dRa, dDec) // TODO: are these correct?
+    pm                                = for {
+                                          dRa  <- num("pos.pm;pos.eq.ra")
+                                          dDec <- num("pos.pm;pos.eq.dec")
+                                        } yield I.ProperMotion(dRa, dDec) // TODO: are these correct?
 
   } yield I.SiderealTarget(UUID.randomUUID(), cleanName(name), I.DegDeg(ra, dec), epoch, pm, mags.toList)
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
@@ -29,7 +29,7 @@ object Simbad extends Catalog with App {
 
 class Simbad private (val host:String) extends VOTableCatalog {
 
-  def url(id:String) = new URL("http://%s/simbad/sim-id?output.format=VOTABLE&Ident=%s".format(host, urlencode(id, "UTF-8")))
+  def url(id:String) = new URL(s"http://$host/simbad/sim-id?output.format=VOTABLE&Ident=${urlencode(id, "UTF-8")}")
 
   def decode(vot:VOTable):Seq[I.Target] = for {
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
@@ -42,6 +42,9 @@ class Simbad private (val host:String) extends VOTableCatalog {
     // Local find function
     str                               = (s:String) => kvs.find(_._1.ucd.exists(_.toLowerCase == s.toLowerCase)).map(_._2)
     num                               = (s:String) => str(s).flatMap(_.toDoubleOption)
+    // Find magnitudes checking ucd and field name
+    magStr                            = (b: String, s:String) => kvs.find(i => i._1.ucd.exists(_.toLowerCase == s.toLowerCase) && i._1.id.endsWith(b)).map(_._2)
+    magNum                            = (b: MagnitudeBand, s:String) => magStr(b.name, s).flatMap(_.toDoubleOption)
 
     // Switch to Option here to pull out data
     epoch                            <- vot.definitions.map(_.cooSys.epoch).map {
@@ -55,14 +58,18 @@ class Simbad private (val host:String) extends VOTableCatalog {
     // Mags get pulled out into a list
     mags                              = for {
                                            (k, Some(v)) <- Map(
-                                             MagnitudeBand.U -> num("phot.mag;em.opt.U"),
-                                             MagnitudeBand.V -> num("phot.mag;em.opt.V"),
-                                             MagnitudeBand.B -> num("phot.mag;em.opt.B"),
-                                             MagnitudeBand.R -> num("phot.mag;em.opt.R"),
-                                             MagnitudeBand.J -> num("phot.mag;em.ir.J"),
-                                             MagnitudeBand.H -> num("phot.mag;em.ir.H"),
-                                             MagnitudeBand.K -> num("phot.mag;em.ir.K"))
-                                            // TODO: more passbands
+                                             MagnitudeBand._u -> magNum(MagnitudeBand._u, "phot.mag;em.opt.U"),
+                                             MagnitudeBand._g -> magNum(MagnitudeBand._g, "phot.mag;em.opt.B"),
+                                             MagnitudeBand._r -> magNum(MagnitudeBand._r, "phot.mag;em.opt.R"),
+                                             MagnitudeBand._i -> magNum(MagnitudeBand._i, "phot.mag;em.opt.I"),
+                                             MagnitudeBand._z -> magNum(MagnitudeBand._z, "phot.mag;em.opt.I"),
+                                             MagnitudeBand.U  -> magNum(MagnitudeBand.U, "phot.mag;em.opt.U"),
+                                             MagnitudeBand.V  -> magNum(MagnitudeBand.V, "phot.mag;em.opt.V"),
+                                             MagnitudeBand.B  -> magNum(MagnitudeBand.B, "phot.mag;em.opt.B"),
+                                             MagnitudeBand.R  -> magNum(MagnitudeBand.R, "phot.mag;em.opt.R"),
+                                             MagnitudeBand.J  -> magNum(MagnitudeBand.J, "phot.mag;em.ir.J"),
+                                             MagnitudeBand.H  -> magNum(MagnitudeBand.H, "phot.mag;em.ir.H"),
+                                             MagnitudeBand.K  -> magNum(MagnitudeBand.K, "phot.mag;em.ir.K"))
                                          } yield new Magnitude(v, k, k.defaultSystem)
 
     // Proper Motion

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/VOTableCatalog.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/VOTableCatalog.scala
@@ -26,7 +26,7 @@ trait VOTableCatalog extends Catalog {
         // Parse the URL data into a VOTable
         val vot = VOTable(conn.getInputStream)
         val ts = decode(vot)
-        if (!ts.isEmpty) f(Success(ts.toList, Nil)) else f(NotFound(id))
+        if (ts.nonEmpty) f(Success(ts.toList, Nil)) else f(NotFound(id))
 
       } catch {
         case e:IOException =>

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SynchronousLookup2.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SynchronousLookup2.scala
@@ -32,7 +32,7 @@ class SynchronousLookup2 private (targetName:String) extends ModalEditor[Target]
   val m = (Model.proposal andThen Proposal.targets).set(Model.empty, List(t))
 
   // Order here is significant
-  handler.reset
+  handler.reset()
   handler.bind(Some(m), done)
   handler.lookup(t)
 
@@ -68,9 +68,8 @@ class SynchronousLookup2 private (targetName:String) extends ModalEditor[Target]
   }
 
   def listener(state:CatalogRobot#State) {
-    state.headOption.map {
-      case (t, s) => s match {
-
+    state.headOption.foreach {
+      case (_, s) => s match {
         case Some(f) =>
           Contents.msg.text = f match {
             case Offline     => "Server(s) offline."
@@ -79,12 +78,10 @@ class SynchronousLookup2 private (targetName:String) extends ModalEditor[Target]
           }
           Contents.msg.foreground = Color.RED
           Contents.spinner.visible = false
-
         case None =>
           Contents.msg.foreground = Color.BLACK
           Contents.msg.text = "Searching..."
           Contents.spinner.visible = true
-
       }
     }
   }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -328,7 +328,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
       private val mag = sidereal.magnitudes.find(_.band == band)
 
       // The checkbox
-      val check = new CheckBox(band.toString) {
+      val check = new CheckBox(band.name) {
         selected = mag.isDefined
         enabled = canEdit
       }
@@ -344,7 +344,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
 
       // The system combo
       val combo = new ComboBox(MagnitudeSystem.all.toSeq) {
-        val magDefault = MagnitudeSystem.all.toSeq.head
+        val magDefault = band.defaultSystem
         val magSys = mag.map(_.system).getOrElse(magDefault)
         enabled = mag.isDefined && canEdit
         selection.item = magSys

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -315,7 +315,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
 
       // Add a set of three controls for each magnitude band.
       magControls.foreach {mc =>
-        addRow(mc.check, mc.text, mc.combo)
+        addRow(mc.check, mc.text, mc.system)
       }
 
     })
@@ -343,7 +343,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
       }
 
       // The system combo
-      val combo = new ComboBox(MagnitudeSystem.all.toSeq) {
+      val system = new ComboBox(MagnitudeSystem.all.toSeq) {
         val magDefault = band.defaultSystem
         val magSys = mag.map(_.system).getOrElse(magDefault)
         enabled = mag.isDefined && canEdit
@@ -356,7 +356,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
       // Get the edited magnitude, if any
       def magnitude = check.selected match {
         case false => None
-        case true  => Some(new Magnitude(text.text.toFloat, band, combo.selection.item))
+        case true  => Some(new Magnitude(text.text.toFloat, band, system.selection.item))
       }
 
     }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetExporter.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetExporter.scala
@@ -16,7 +16,7 @@ object TargetExporter {
   def isExportable(target: Target) = ExportType(target).isDefined
 
   def open(parent: UIElement, targets: List[Target]) {
-    (new TargetExporter(parent, targets)).open()
+    new TargetExporter(parent, targets).open()
   }
 
   sealed trait ExportType {
@@ -42,7 +42,7 @@ object TargetExporter {
     }
 
     def options(ts: List[Target]): Set[ExportType] =
-      (for { Some(et) <- ts.map(apply(_)) } yield et).toSet
+      (for { Some(et) <- ts.map(apply) } yield et).toSet
   }
 
   case class ExportPreferences(exportType: ExportType, fileType: FileType)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/CatalogRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/CatalogRobot.scala
@@ -3,7 +3,6 @@ package edu.gemini.pit.ui.robot
 import edu.gemini.model.p1.immutable._
 import edu.gemini.pit.ui.util.{BooleanToolPreference, PreferenceManager}
 import edu.gemini.pit.catalog._
-import edu.gemini.pit.catalog._
 import BooleanToolPreference.{SIMBAD, NED, HORIZONS}
 import java.awt.Component
 import javax.swing.JOptionPane
@@ -37,7 +36,7 @@ class CatalogRobot(parent: Component) extends Robot {
       // Take the opportunity to remove state for targets that are no longer part of the model.
       // This won't amount to a big leak but we might as well clean it up.
       val ts = targetLens.get(m)
-      state = state -- (state.keys.filterNot(ts.contains))
+      state = state -- state.keys.filterNot(ts.contains)
 
     }
   }
@@ -75,7 +74,6 @@ class CatalogRobot(parent: Component) extends Robot {
           // Several choices. Let the user select one.
           case Success(ts, choices) => disambiguate(semesterLens.get(m), t.name, ts, choices) match {
             case None =>
-
               // User selected cancel. Remove t wherever it occurs. Note that the model might have
               // changed so be sure to fetch it again rather than using the outer 'm'
               model.foreach {
@@ -84,20 +82,17 @@ class CatalogRobot(parent: Component) extends Robot {
                   model = Some(targetLens.set(m, ts.filterNot(_ == t)))
               }
 
-            case Some(Left(t0)) =>
-
+            case Some(Left(t0))     =>
               // User selected one item, so pass it to our handler above
               callback(t)(Success(List(t0), Nil))
 
             case Some(Right(retry)) =>
-
               // User selected a retry option, so evaluate it
               retry(callback(t))
 
           }
 
           case fail: Failure =>
-
             // Record the failure, and we're done
             state = state + (t -> Some(fail))
 
@@ -108,15 +103,15 @@ class CatalogRobot(parent: Component) extends Robot {
 
   // Because copy isn't polymorphic
   private def rename(t: Target, newName: String) = t match {
-    case t: TooTarget => t.copy(name = newName)
-    case t: SiderealTarget => t.copy(name = newName)
+    case t: TooTarget         => t.copy(name = newName)
+    case t: SiderealTarget    => t.copy(name = newName)
     case t: NonSiderealTarget => t.copy(name = newName)
   }
 
   // Because copy isn't polymorphic
   private def withUuid(t: Target, uuid: UUID) = t match {
-    case t: TooTarget => t.copy(uuid = uuid)
-    case t: SiderealTarget => t.copy(uuid = uuid)
+    case t: TooTarget         => t.copy(uuid = uuid)
+    case t: SiderealTarget    => t.copy(uuid = uuid)
     case t: NonSiderealTarget => t.copy(uuid = uuid)
   }
 
@@ -126,9 +121,9 @@ class CatalogRobot(parent: Component) extends Robot {
 
     implicit object Ord extends Ordering[E] {
       def compare(a0: E, b0: E): Int = (a0, b0) match {
-        case (Left(a), Left(b)) => a.name.compareTo(b.name)
-        case (Right(a), Left(b)) => a.name.compareTo(b.name)
-        case (Left(a), Right(b)) => a.name.compareTo(b.name)
+        case (Left(a), Left(b))   => a.name.compareTo(b.name)
+        case (Right(a), Left(b))  => a.name.compareTo(b.name)
+        case (Left(a), Right(b))  => a.name.compareTo(b.name)
         case (Right(a), Right(b)) => a.name.compareTo(b.name)
       }
     }
@@ -139,13 +134,13 @@ class CatalogRobot(parent: Component) extends Robot {
         case Left(target: SiderealTarget) =>
           target.coords(sem.midPoint).map(_.toDegDeg) match {
             case Some(dd) => "%s (%s, %s) %s".format(target.name, dd.ra, dd.dec, target.magnitudes.map(_.band).mkString(" "))
-            case None => "%s (--, --) %s".format(target.name, target.magnitudes.map(_.band).mkString(" "))
+            case None     => "%s (--, --) %s".format(target.name, target.magnitudes.map(_.band).mkString(" "))
           }
 
         case Left(target: NonSiderealTarget) =>
           target.coords(sem.midPoint).map(_.toDegDeg) match {
             case Some(dd) => "%s (%s, %s)".format(target.name, dd.ra, dd.dec)
-            case None => "%s (--, --)".format(target.name)
+            case None     => "%s (--, --)".format(target.name)
           }
 
         case Left(target: TooTarget) => "???" // can't happen
@@ -157,7 +152,7 @@ class CatalogRobot(parent: Component) extends Robot {
 
     val all: Seq[E] = ts.map(Left(_): E) ++ cs.map(Right(_): E)
 
-    val pts = all.sorted.map(PickerTarget(_))
+    val pts = all.sorted.map(PickerTarget)
 
     Option(JOptionPane.showInputDialog(
       parent,
@@ -166,7 +161,7 @@ class CatalogRobot(parent: Component) extends Robot {
       JOptionPane.QUESTION_MESSAGE,
       null,
       pts.toArray,
-      pts(0))).map(_.asInstanceOf[PickerTarget]).map(_.item)
+      pts.head)).map(_.asInstanceOf[PickerTarget]).map(_.item)
   }
 
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/CatalogRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/CatalogRobot.scala
@@ -25,7 +25,7 @@ class CatalogRobot(parent: Component) extends Robot {
   def lookup(t: Target) {
     checkThread()
     if (t.isEmpty && !state.contains(t)) {
-      logger.info("Performing catalog lookup for '%s'".format(t.name))
+      logger.info(s"Performing catalog lookup for '${t.name}'")
       catalog.find(t.name)(callback(t))
     }
   }
@@ -89,7 +89,6 @@ class CatalogRobot(parent: Component) extends Robot {
             case Some(Right(retry)) =>
               // User selected a retry option, so evaluate it
               retry(callback(t))
-
           }
 
           case fail: Failure =>
@@ -133,14 +132,14 @@ class CatalogRobot(parent: Component) extends Robot {
 
         case Left(target: SiderealTarget) =>
           target.coords(sem.midPoint).map(_.toDegDeg) match {
-            case Some(dd) => "%s (%s, %s) %s".format(target.name, dd.ra, dd.dec, target.magnitudes.map(_.band).mkString(" "))
-            case None     => "%s (--, --) %s".format(target.name, target.magnitudes.map(_.band).mkString(" "))
+            case Some(dd) => s"${target.name} (${dd.ra}, ${dd.dec}) ${target.magnitudes.map(_.band).mkString(" ")}"
+            case None     => s"${target.name} (--, --) ${target.magnitudes.map(_.band).mkString(" ")}"
           }
 
         case Left(target: NonSiderealTarget) =>
           target.coords(sem.midPoint).map(_.toDegDeg) match {
-            case Some(dd) => "%s (%s, %s)".format(target.name, dd.ra, dd.dec)
-            case None     => "%s (--, --)".format(target.name)
+            case Some(dd) => s"${target.name} (${dd.ra}, ${dd.dec})"
+            case None     => s"${target.name} (--, --)"
           }
 
         case Left(target: TooTarget) => "???" // can't happen
@@ -156,12 +155,14 @@ class CatalogRobot(parent: Component) extends Robot {
 
     Option(JOptionPane.showInputDialog(
       parent,
-      "Your search for \"%s\" yielded several possible targets.\nPlease select the one you intended:".format(name),
+      s"""Your search for "$name" yielded several possible targets.\nPlease select the one you intended:""",
       "Multiple Targets Found",
       JOptionPane.QUESTION_MESSAGE,
       null,
       pts.toArray,
-      pts.head)).map(_.asInstanceOf[PickerTarget]).map(_.item)
+      pts.head)).collect {
+        case pt: PickerTarget => pt.item
+      }
   }
 
 }


### PR DESCRIPTION
This PR adds the SDSS bandpasses (u, g, r, i, z) to the PIT and it allows the user to enter them on the UI.
The Simbad queries were expanded to support those bands too. I couldn't find good documentation on Simbad's votable format so I followed the result of a sample

http://simbad.u-strasbg.fr/simbad/sim-id?Ident=SDSS+J082354.96%2B280621.6

The Magnitude editor now looks like this:
![screenshot 2015-06-22 10 04 32](https://cloud.githubusercontent.com/assets/3615303/8282328/2e7024a4-18c6-11e5-86b7-3e23ef0cf7e6.png)
