### PR TITLE
REL-2284: Non-sidereal targets should not produce RA visibility errors

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -331,18 +331,17 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       )
 
     private lazy val badVisibility = for {
-      o @ Observation(Some(_), Some(_), Some(_), Some(_), _) <- p.observations
-      v <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
+      o @ Observation(Some(_), Some(_), Some(t), Some(_), _) <- p.observations
+      v                                                      <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
       if v == TargetVisibility.Bad
     } yield new Problem(Severity.Error,
-        visibilityMessage("Target is inaccessible at %s during %s.  Consider an alternative.", p.semester, o),
+        visibilityMessage("Target is inaccessible at %s during %s. Consider an alternative.", p.semester, o),
         "Observations",
         indicateObservation(o))
 
-
     private lazy val iffyVisibility = for {
       o @ Observation(Some(_), Some(_), Some(_), Some(_), _) <- p.observations
-      v <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
+      v                                                      <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
       if v == TargetVisibility.Limited
     } yield new Problem(Severity.Warning,
         visibilityMessage("Target has limited visibility at %s during %s.", p.semester, o),


### PR DESCRIPTION
In this PR, RA errors for non-sidereal targets get reduced severity. The change is made at the calculation level so it is reflected on `ProblemRobot` and the `Visibility` indicator