### PR TITLE
REL-259: ToO targets must not be allowed in non-ToO proposals (PIT)

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -198,7 +198,10 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
           }
         }
         icons.get(v).map { i =>
-          val label = new Label(v.name, i, Alignment.Left)
+          val label = new Label(v.name, i, Alignment.Left) {
+            if (v == TooType && !isToO)
+              tooltip = "Enable ToO targets by requesting ToO Activation in the Time Requests section"
+          }
           (rb, label)
         }
       }


### PR DESCRIPTION
Small update with a message for the user if the ToO target option is disabled