### PR TITLE
REL-2287: Do not allow proposal submission without the full PI name

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Investigator.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Investigator.scala
@@ -54,7 +54,7 @@ object PrincipalInvestigator extends UuidCache[M.PrincipalInvestigator] {
       m.getStatus,
       InstitutionAddress(m.getAddress))
 
-  def empty = apply(UUID.randomUUID(), "", "", Nil, "", InvestigatorStatus.PH_D, InstitutionAddress.empty)
+  def empty = apply(UUID.randomUUID(), "Principal", "Investigator", Nil, "", InvestigatorStatus.PH_D, InstitutionAddress.empty)
 
 }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -445,7 +445,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       })
 
     private val nonUpdatedInvestigatorName = when(p.investigators.pi.firstName === "Principal" && p.investigators.pi.lastName === "Investigator") {
-      new Problem(Severity.Error, s"Please provide PI's full name", "Overview", s.inOverview {
+      new Problem(Severity.Todo, s"Please provide PI's full name", "Overview", s.inOverview {
         _.edit(p.investigators.pi)
       })
     }


### PR DESCRIPTION
Per user request the initial name of the PI is set to 'Principal Investigator'. This will generate an error asking the user to set the real name