### PR TITLE
REL-2356: Add Phoenix to the 2016A PIT resource list

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
@@ -21,13 +21,13 @@ object Phoenix {
     }
   }
 
-  class FilterNode(fpu: PhoenixFocalPlaneUnit) extends SingleSelectNode[PhoenixFocalPlaneUnit, PhoenixFilter, PhoenixBlueprint](fpu){
+  class FilterNode(fpu: PhoenixFocalPlaneUnit) extends MultiSelectNode[PhoenixFocalPlaneUnit, PhoenixFilter, PhoenixBlueprint](fpu){
     def title = "Filter"
     def description = "Select a filter for your configuration."
 
-    def apply(f: PhoenixFilter) = Right(PhoenixBlueprint(fpu, f))
+    def apply(f: List[PhoenixFilter]) = Right(PhoenixBlueprint(fpu, f))
 
-    override def default = Some(PhoenixFilter.forName("K4396"))
+    override def default = Some(List(PhoenixFilter.forName("K4396")))
 
     def unapply = {
       case b: PhoenixBlueprint => b.filter

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
@@ -1,17 +1,18 @@
 package edu.gemini.model.p1.immutable
 
 import edu.gemini.model.p1.{mutable => M}
+import scala.collection.JavaConverters._
 
 object PhoenixBlueprint {
   def apply(m: M.PhoenixBlueprint): PhoenixBlueprint = new PhoenixBlueprint(m)
 }
 
-case class PhoenixBlueprint(fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) extends GeminiBlueprintBase {
-  def name: String = s"Phoenix ${fpu.value} ${filter.value}"
+case class PhoenixBlueprint(fpu: PhoenixFocalPlaneUnit, filter: List[PhoenixFilter]) extends GeminiBlueprintBase {
+  def name: String = s"Phoenix ${fpu.value} ${filter.map(_.value).mkString(", ")}"
 
   def this(m: M.PhoenixBlueprint) = this(
     m.getFpu,
-    m.getFilter
+    m.getFilter.asScala.toList
   )
 
   override def instrument: Instrument = Instrument.Phoenix
@@ -22,7 +23,8 @@ case class PhoenixBlueprint(fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) e
     m.setId(n.nameOf(this))
     m.setName(name)
     m.setFpu(fpu)
-    m.setFilter(filter)
+    m.getFilter.clear()
+    filter.foreach(m.getFilter.add)
     m
   }
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Phoenix.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Phoenix.xsd
@@ -24,8 +24,8 @@
         <xsd:complexContent>
             <xsd:extension base="BlueprintBase">
                 <xsd:sequence>
-                    <xsd:element name="fpu"    type="PhoenixFocalPlaneUnit" maxOccurs="1" minOccurs="0"/>
-                    <xsd:element name="filter" type="PhoenixFilter"         maxOccurs="1" minOccurs="0"/>
+                    <xsd:element name="fpu"    type="PhoenixFocalPlaneUnit" maxOccurs="1"         minOccurs="0"/>
+                    <xsd:element name="filter" type="PhoenixFilter"         maxOccurs="unbounded" minOccurs="0"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_phoenix.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_phoenix.xml
@@ -23,10 +23,11 @@
     <blueprints>
         <phoenix>
             <Phoenix id="blueprint-0">
-                <name>Phoenix 0.17 arcsec slit H6073</name>
+                <name>Phoenix 0.17 arcsec slit H6073, H6420</name>
                 <visitor>false</visitor>
                 <fpu>0.17 arcsec slit</fpu>
                 <filter>H6073</filter>
+                <filter>H6420</filter>
             </Phoenix>
         </phoenix>
     </blueprints>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
@@ -18,7 +18,7 @@ class PhoenixSpec extends SpecificationWithJUnit {
       filterNode.title must beEqualTo("Filter")
       filterNode.choices must have size 20
       // Check the default filter
-      filterNode.default must beSome(PhoenixFilter.K4396)
+      filterNode.default must beSome(List(PhoenixFilter.K4396))
     }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PhoenixBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PhoenixBlueprintSpec.scala
@@ -12,20 +12,20 @@ class PhoenixBlueprintSpec extends SpecificationWithJUnit with SemesterPropertie
   "The Phoenix Blueprint" should {
     "has an FPU and a filter" in {
       // trivial sanity tests
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, List(M.PhoenixFilter.H6073))
       blueprint.fpu must beEqualTo(M.PhoenixFocalPlaneUnit.MASK_1)
-      blueprint.filter must beEqualTo(M.PhoenixFilter.H6073)
+      blueprint.filter must beEqualTo(List(M.PhoenixFilter.H6073))
     }
     "never uses Lgs" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, List(M.PhoenixFilter.H6073))
       blueprint.ao must beEqualTo(AoNone)
     }
     "has an appropriate public name" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, List(M.PhoenixFilter.H6073))
       blueprint.name must beEqualTo("Phoenix 0.17 arcsec slit H6073")
     }
     "is not a visitor" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, List(M.PhoenixFilter.H6073))
       blueprint.visitor must beFalse
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
@@ -36,7 +36,7 @@ class PhoenixBlueprintSpec extends SpecificationWithJUnit with SemesterPropertie
       xml must \\("Phoenix") \ "visitor" \> "false"
     }
     "export fpu and filter to XML" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, List(M.PhoenixFilter.H6073))
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
       val proposal = Proposal.empty.copy(observations = observation :: Nil)
@@ -46,11 +46,23 @@ class PhoenixBlueprintSpec extends SpecificationWithJUnit with SemesterPropertie
       xml must \\("fpu") \> "0.17 arcsec slit"
       xml must \\("filter") \> "H6073"
     }
+    "export fpu and multiple filters to XML" in {
+      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, List(M.PhoenixFilter.H6073, M.PhoenixFilter.H6420))
+      val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
+
+      val proposal = Proposal.empty.copy(observations = observation :: Nil)
+      val xml = XML.loadString(ProposalIo.writeToString(proposal))
+
+      // verify the exported value
+      xml must \\("fpu") \> "0.17 arcsec slit"
+      xml must \\("filter") \> "H6073"
+      xml must \\("filter") \> "H6420"
+    }
     "be possible to deserialize" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix.xml")))
 
       proposal.blueprints.head.visitor must beFalse
-      proposal.blueprints must beEqualTo(PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073) :: Nil)
+      proposal.blueprints must beEqualTo(PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, List(M.PhoenixFilter.H6073, M.PhoenixFilter.H6420)) :: Nil)
     }
   }
 


### PR DESCRIPTION
On the first RC, Phoenix can only support a single filter, but it should have support for multiple ones. This PR changes the schema to support multiple filters