### PR TITLE
REL-2390: Remove NIRI filters from 2016A PIT

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -34,15 +34,15 @@ object UpConverter {
   }
 
   // Sequence of conversions for proposals from a given semester
-  val from2015B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2016, SemesterOption.A)))
-  val from2015A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2015, SemesterOption.B)))
-  val from2015AToKR:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2015, SemesterOption.A)))
-  val from2014BSV:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.B)))
-  val from2014BToSV:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.B)))
-  val from2014A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.A)))
-  val from2013B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.B)))
-  val from2013A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.A)))
-  val from2012B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2012BTo2013A, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2012, SemesterOption.B)))
+  val from2015B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, LastStepConverter(Semester(2015, SemesterOption.B)))
+  val from2015A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, LastStepConverter(Semester(2015, SemesterOption.A)))
+  val from2015AToKR:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, LastStepConverter(Semester(2015, SemesterOption.A)))
+  val from2014BSV:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, LastStepConverter(Semester(2014, SemesterOption.B)))
+  val from2014BToSV:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.B)))
+  val from2014A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.A)))
+  val from2013B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.B)))
+  val from2013A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.A)))
+  val from2012B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2012BTo2013A, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2012, SemesterOption.B)))
 
   /**
    * Converts one version of a proposal node to the next
@@ -152,7 +152,7 @@ case object SemesterConverter2015BTo2016A extends SemesterConverter {
          }
        }
        // Remove unavailable filters
-       val removedFiltersText = if (filtersToRemove.length == 1) s"filter ${filtersToRemove.map(_.text).head} has been removed" else s"filters ${filtersToRemove.map(_.text).mkString(",")} have been removed."
+       val removedFiltersText = if (filtersToRemove.length == 1) s"filter ${filtersToRemove.map(_.text).head} has been removed" else s"filters ${filtersToRemove.map(_.text).mkString(", ")} have been removed."
        StepResult(s"The unavailable NIRI $removedFiltersText", <niri id={p.attribute("id")}>{SlitTransformer.transform(ns)}</niri>).successNel
     }
   

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -34,15 +34,15 @@ object UpConverter {
   }
 
   // Sequence of conversions for proposals from a given semester
-  val from2015B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, LastStepConverter(Semester(2015, SemesterOption.B)))
-  val from2015A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, LastStepConverter(Semester(2015, SemesterOption.A)))
+  val from2015B:List[SemesterConverter]     = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, LastStepConverter(Semester(2015, SemesterOption.B)))
+  val from2015A:List[SemesterConverter]     = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, LastStepConverter(Semester(2015, SemesterOption.A)))
   val from2015AToKR:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, LastStepConverter(Semester(2015, SemesterOption.A)))
-  val from2014BSV:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, LastStepConverter(Semester(2014, SemesterOption.B)))
+  val from2014BSV:List[SemesterConverter]   = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, LastStepConverter(Semester(2014, SemesterOption.B)))
   val from2014BToSV:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.B)))
-  val from2014A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.A)))
-  val from2013B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.B)))
-  val from2013A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.A)))
-  val from2012B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2012BTo2013A, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2012, SemesterOption.B)))
+  val from2014A:List[SemesterConverter]     = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2014, SemesterOption.A)))
+  val from2013B:List[SemesterConverter]     = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.B)))
+  val from2013A:List[SemesterConverter]     = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2013, SemesterOption.A)))
+  val from2012B:List[SemesterConverter]     = List(SemesterConverterToCurrent, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2012BTo2013A, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, LastStepConverter(Semester(2012, SemesterOption.B)))
 
   /**
    * Converts one version of a proposal node to the next

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -177,7 +177,7 @@ case object SemesterConverter2015ATo2015B extends SemesterConverter {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
           case <fiberMode>{name}</fiberMode> => <fiberMode>{transformFiberMode(name.text)}</fiberMode>
           case <name>{name}</name>           => <name>Graces {transformFiberMode(name.text)}</name>
-          case elem: xml.Elem                => elem.copy(child = elem.child.flatMap(transform _))
+          case elem: xml.Elem                => elem.copy(child = elem.child.flatMap(transform))
           case _                             => n
         }
       }

--- a/bundle/edu.gemini.model.p1/src/main/xjb/Niri.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/Niri.xjb
@@ -52,6 +52,12 @@
             <jxb:bindings node="./xsd:enumeration[@value='Pa(gamma) (1.094 um)']">
                 <jxb:typesafeEnumMember name="NBF_PAGAMMA"/>
             </jxb:bindings>
+            <!--jxb:bindings node="./xsd:enumeration[@value='J-continuum (1.122 um)']">
+                <jxb:typesafeEnumMember name="J_CONTINUUM_122"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='J-continuum (1.207 um)']">
+                <jxb:typesafeEnumMember name="NBF_H"/>
+            </jxb:bindings-->
             <jxb:bindings node="./xsd:enumeration[@value='Pa(beta) (1.282 um)']">
                 <jxb:typesafeEnumMember name="NBF_PABETA"/>
             </jxb:bindings>

--- a/bundle/edu.gemini.model.p1/src/main/xjb/Niri.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/Niri.xjb
@@ -52,12 +52,6 @@
             <jxb:bindings node="./xsd:enumeration[@value='Pa(gamma) (1.094 um)']">
                 <jxb:typesafeEnumMember name="NBF_PAGAMMA"/>
             </jxb:bindings>
-            <jxb:bindings node="./xsd:enumeration[@value='J-continuum (1.122 um)']">
-                <jxb:typesafeEnumMember name="J_CONTINUUM_122"/>
-            </jxb:bindings>
-            <jxb:bindings node="./xsd:enumeration[@value='J-continuum (1.207 um)']">
-                <jxb:typesafeEnumMember name="NBF_H"/> <!-- that's right, NBF_H -->
-            </jxb:bindings>
             <jxb:bindings node="./xsd:enumeration[@value='Pa(beta) (1.282 um)']">
                 <jxb:typesafeEnumMember name="NBF_PABETA"/>
             </jxb:bindings>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -7,6 +7,7 @@ Gemini Phase I Schema Changes
 * Added keyword 'Star formation'
 * Offer Phoenix instrument
 * Added SDSS Magnitude Bands u, g, r, i, z
+* Removed NIRI filters J-cont (1.065 um), J-continuum (1.122 um)
 
 # Version 2015.2.1 - 2015B
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Niri.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Niri.xsd
@@ -48,8 +48,6 @@
             <xsd:enumeration value="Jcont (1.065 um)"/>
             <xsd:enumeration value="HeI (1.083 um)"/>
             <xsd:enumeration value="Pa(gamma) (1.094 um)"/>
-            <xsd:enumeration value="J-continuum (1.122 um)"/>
-            <xsd:enumeration value="J-continuum (1.207 um)"/>
             <xsd:enumeration value="Pa(beta) (1.282 um)"/>
             <xsd:enumeration value="CH4(short) (1.56 um)"/>
             <xsd:enumeration value="H-continuum (1.570 um)"/>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Niri.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Niri.xsd
@@ -48,6 +48,8 @@
             <xsd:enumeration value="Jcont (1.065 um)"/>
             <xsd:enumeration value="HeI (1.083 um)"/>
             <xsd:enumeration value="Pa(gamma) (1.094 um)"/>
+            <!--xsd:enumeration value="J-continuum (1.122 um)"/>
+            <xsd:enumeration value="J-continuum (1.207 um)"/-->
             <xsd:enumeration value="Pa(beta) (1.282 um)"/>
             <xsd:enumeration value="CH4(short) (1.56 um)"/>
             <xsd:enumeration value="H-continuum (1.570 um)"/>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_niri_removed_filters.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_niri_removed_filters.xml
@@ -24,7 +24,7 @@
     <blueprints>
         <niri>
             <niri id="blueprint-0">
-                <name>NIRI Altair Laser Guidestar f/32 (0.02"/pix, 22" FoV) J-continuum (1.122 um)+J-continuum (1.207 um)</name>
+                <name>NIRI Altair Laser Guidestar f/32 (0.02"/pix, 22" FoV) J-continuum (1.122 um)+J-continuum (1.207 um)+HeI (1.083 um)</name>
                 <visitor>false</visitor>
                 <altair>
                     <lgs pwfs1="false" aowfs="false" oiwfs="false"/>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_niri_removed_filters.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_niri_removed_filters.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2015.2.1">
+    <meta band3optionChosen="false"/>
+    <semester year="2015" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <niri>
+            <niri id="blueprint-0">
+                <name>NIRI Altair Laser Guidestar f/32 (0.02"/pix, 22" FoV) J-continuum (1.122 um)+J-continuum (1.207 um)</name>
+                <visitor>false</visitor>
+                <altair>
+                    <lgs pwfs1="false" aowfs="false" oiwfs="false"/>
+                </altair>
+                <camera>f/32 (0.02"/pix, 22" FoV)</camera>
+                <filter>J-continuum (1.122 um)</filter>
+                <filter>J-continuum (1.207 um)</filter>
+                <filter>HeI (1.083 um)</filter>
+            </niri>
+        </niri>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-0"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -644,6 +644,18 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result \\ "graces" must \\("name") \> "Graces 1 fiber (target only, R~67.5k)"
       }
     }
+    "proposal with NIRI blueprints should remove unavailable filters, REL-2390" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_niri_removed_filters.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 4
+          result \\ "niri" must \\("filter") \> "HeI (1.083 um)"
+          result \\ "niri" must not(\\("filter") \> "J-continuum (1.122 um)")
+          result \\ "niri" must not(\\("filter") \> "J-continuum (1.207 um)")
+      }
+    }
   }
 
   def testF2R3KYConversion(xml: Elem) = {

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -654,6 +654,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result \\ "niri" must \\("filter") \> "HeI (1.083 um)"
           result \\ "niri" must not(\\("filter") \> "J-continuum (1.122 um)")
           result \\ "niri" must not(\\("filter") \> "J-continuum (1.207 um)")
+          result \\ "niri" must \\("name") \> "NIRI Altair Laser Guidestar f/32 (0.02\"/pix, 22\" FoV) HeI (1.083 um)"
       }
     }
   }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -59,17 +59,17 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2013A to view the unmodified proposal")
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.meta.band3OptionChosen must beFalse
           proposal.title must beEqualTo("Observation with GSAOI")
           proposal.abstrakt must beEmpty
           proposal.scheduling must beEmpty
           proposal.keywords must beEmpty
-          proposal.investigators.all must have size (1)
+          proposal.investigators.all must have size 1
           proposal.targets must beEmpty
           proposal.conditions must beEmpty
-          proposal.blueprints must have size (1)
-          proposal.observations must have size (1)
+          proposal.blueprints must have size 1
+          proposal.observations must have size 1
           Option(proposal.proposalClass) must beSome
 
           // Check the instruments
@@ -100,7 +100,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2013A to view the unmodified proposal")
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
 
           // Sanity checks
           proposal.meta.band3OptionChosen must beFalse
@@ -108,11 +108,11 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           proposal.abstrakt must beEmpty
           proposal.scheduling must beEmpty
           proposal.keywords must beEmpty
-          proposal.investigators.all must have size (1)
+          proposal.investigators.all must have size 1
           proposal.targets must beEmpty
           proposal.conditions must beEmpty
-          proposal.blueprints must have size (1)
-          proposal.observations must have size (1)
+          proposal.blueprints must have size 1
+          proposal.observations must have size 1
           Option(proposal.proposalClass) must beSome
 
           proposal.schemaVersion must beEqualTo(Proposal.currentSchemaVersion)
@@ -125,7 +125,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
         case StepResult(changes, result) =>
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.tacCategory must beSome(TacCategory.GALACTIC)
       }
     }
@@ -144,7 +144,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
             <attachment>file.pdf</attachment>
           </meta>)
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.meta.band3OptionChosen must beFalse
           proposal.meta.attachment must beSome(new java.io.File("file.pdf"))
       }
@@ -172,7 +172,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
             <keyword>Absorption lines</keyword> <keyword>Herbig-Haro objects</keyword> <keyword>High-redshift</keyword>
           </keywords>)
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.keywords must contain(Keyword.forName("ABSORPTION_LINES"))
           proposal.keywords must contain(Keyword.forName("HERBIG_HARO_OBJECTS"))
           proposal.keywords must contain(Keyword.forName("HIGH_REDSHIFT"))
@@ -187,7 +187,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
             <observation band="Band 1/2"/>
           </observations>)
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.observations.head.enabled must beTrue
       }
     }
@@ -198,7 +198,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
         case StepResult(changes, result) =>
           (result \\ "ngoauthority") must beEmpty
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.proposalClass.itac.map {
             case i: Itac => i.ngoAuthority must beNone
           }
@@ -212,7 +212,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
         case StepResult(changes, result) =>
           (result \\ "ngoauthority") must ==/(<ngoauthority>cl</ngoauthority>)
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.proposalClass.itac.map {
             case i: Itac => i.ngoAuthority must beSome(NgoPartner.CL)
           }
@@ -228,7 +228,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
             <observation enabled="false" band="Band 1/2"/>
           </observations>)
 
-          val proposal = ProposalIo.read(result.toString)
+          val proposal = ProposalIo.read(result.toString())
           proposal.observations.head.enabled must beFalse
       }
     }
@@ -245,10 +245,10 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           changes must contain("NGO acceptance from the United Kingdom has been removed")
 
           // Sanity check
-          ProposalIo.read(result.toString)
+          ProposalIo.read(result.toString())
 
           // ngo is gone
-          result \\ "queue" must not \\ ("ngo")
+          result \\ "queue" must not \\ "ngo"
           // but itac is there
           result \\ "queue" must \\("itac")
           // Check that queue attributes are preserved
@@ -268,7 +268,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           changes must contain("NGO acceptance from the United Kingdom has been removed")
 
           // Sanity check
-          ProposalIo.read(result.toString)
+          ProposalIo.read(result.toString())
 
           // ngo is gone
           result \\ "partner" must have length 1
@@ -293,14 +293,14 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           changes must contain("The United Kingdom was marked as ITAC NGO authority and has been removed")
 
           // Sanity check
-          ProposalIo.read(result.toString)
+          ProposalIo.read(result.toString())
 
           // ngo is gone
           result \\ "partner" must have length 1
           result \\ "queue" must \\("partner") \> "ar"
           // but itac is there
           result \\ "queue" must \\("itac")
-          result \\ "itac" must not \\ ("ngoauthority")
+          result \\ "itac" must not \\ "ngoauthority"
           // Check that queue attributes are preserved
           result must \\("queue", "key" -> "604c87d8-9bf8-96a8-0642-f70604c87d89", "tooOption" -> "None")
       }
@@ -431,11 +431,10 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
 
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
-        case StepResult(changes, result) => {
+        case StepResult(changes, result) =>
           changes must have length 4
           // The texes blueprint must remain
           result must \\("Texes")
-        }
       }
     }
     /*
@@ -505,7 +504,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
 
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
-        case StepResult(changes, result) => {
+        case StepResult(changes, result) =>
           changes must have length 5
           changes must contain("The unavailable Flamingos2 filters F1056 (1.056 um)/F1063 (1.063 um) have been converted to Y (1.020 um).")
           // Check that the centralWavelength node is added
@@ -513,7 +512,6 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result \\ "flamingos2" must \\("name") \>~ ".* Y .1.020 um."
           // The texes blueprint must remain
           result must \\("gmosN")
-        }
       }
     }
     "proposal with F2 R3K+Y longslit must use the filter Y, REL-1282" in {
@@ -531,7 +529,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
 
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
-        case StepResult(changes, result) => {
+        case StepResult(changes, result) =>
           changes must have length 4
           changes must contain("GMOS-N observations without an Altair setting have had Adaptive Optics set to None.")
           // Check that fpu and name are replaced
@@ -540,7 +538,6 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result must \\("altair") \ "none"
           // The texes blueprint must remain
           result must \\("flamingos2")
-        }
       }
     }
     "proposal with GmosN Imaging blueprint and no altair should transform the name to Altair None option, REL-1257" in {


### PR DESCRIPTION
This PR removes two NIRI filters fro the model and adds upconversion code for older proposals
A couple of bugs were fixed on the upconversion code and a few code inspections were fixed