### PR TITLE
OCSADV-200: small bugfix for sync history of new programs

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EdProgramHelper.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EdProgramHelper.scala
@@ -77,8 +77,10 @@ object EdProgramHelper {
     update(Nil)
 
     for {
-      pid    <- Option(ed.getProgram).map(_.getProgramID)
+      prog   <- Option(ed.getProgram)
+      pid    <- Option(prog.getProgramID)
       client <- VcsOtClient.ref
+      _      <- client.peer(pid)
     } client.log(pid, 0, 100).forkAsync {
       case \/-((es, more)) =>
         Log.info(s"Got ${es.length} history items for $pid, more == $more")


### PR DESCRIPTION
Corrects a bad assumption that programs will always have a program id, and that programs which have an ID also have a known peer with which to sync.  This was more or less harmless but could generate a confusing log message when viewing the root science program node in the OT.