### PR TITLE
REL-2400: user key program checkout failure

### DIFF
--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
@@ -42,8 +42,7 @@ class Vcs(user: VcsAction[Set[Principal]], server: VcsServer, service: Peer => V
     for {
       p <- Client(peer).checkout(id)
       _ <- checkCancel(cancelled)
-      u <- user
-      _ <- server.add(p, u)
+      _ <- server.add(p)
     } yield p
 
   /** Adds the given program to the remote peer, copying it into the remote

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsServerSpec.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/VcsServerSpec.scala
@@ -116,35 +116,29 @@ class VcsServerSpec extends VcsSpecification {
   }
 
   "add" should {
-    "fail if the user doesn't have access to the program" in withVcs { env =>
-      val user    = Set(ProgramPrincipal(Q3): Principal)
-      val newProg = env.local.newProgram(Q2)
-      forbidden(env.local.server.add(newProg, user))
-    }
-
     "fail if a program with the same key already exists" in withVcs { env =>
       val newProg = env.local.odb.getFactory.createProgram(Key, Q2)
-      val act     = env.local.server.add(newProg, StaffUser)
+      val act     = env.local.server.add(newProg)
       expect(act) { case -\/(KeyAlreadyExists(_, _)) => ok("key exists") }
     }
 
     "fail if a program with the same id already exists" in withVcs { env =>
       val newKey  = new SPNodeKey()
       val newProg = env.local.odb.getFactory.createProgram(newKey, Q1)
-      val act     = env.local.server.add(newProg, StaffUser)
+      val act     = env.local.server.add(newProg)
       expect(act) { case -\/(IdAlreadyExists(_)) => ok("id exists") }
     }
 
     "fail if the new program doesn't have an id" in withVcs { env =>
       val newKey  = new SPNodeKey()
       val newProg = env.local.odb.getFactory.createProgram(newKey, null)
-      val act     = env.local.server.add(newProg, StaffUser)
+      val act     = env.local.server.add(newProg)
       expect(act) { case -\/(MissingId) => ok("missing id") }
     }
 
     "add a new program to the database" in withVcs { env =>
       val newProg = env.local.newProgram(Q2)
-      val act     = env.local.server.add(newProg, StaffUser)
+      val act     = env.local.server.add(newProg)
       act.unsafeRun
 
       env.local.odb.lookupProgram(newProg.getProgramKey) must not beNull


### PR DESCRIPTION
This PR addresses a bug in which a PI with a valid user key cannot checkout his own program.  The `ImplicitPolicy` check for `PiPermission` for a user principal will open the program in the database and check whether it contains a matching email.  For a checkout, the permission check will work fine in the server because the program exists in the remote database.  The client can successfully retrieve the program from the remote database.  If we also check locally though at the point when we're trying to add the program to the local database, It will fail.

The solution is to simply stop checking for permission to add a program to a local database while retaining permission checks if you try to add a program to a remote database.  Adding a program to a remote database continues to require a key that doesn't depend on the content of the program being added which is what we want.