### PR TITLE
REL-1803: cache P2 check results

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/NodeValueCache.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/NodeValueCache.scala
@@ -3,24 +3,35 @@ package edu.gemini.spModel.util
 import edu.gemini.pot.sp.{ISPNode, SPNodeKey}
 import edu.gemini.pot.sp.version.nodeChecksum
 
-object NodeValueCache {
-  type CacheMap[A] = Map[SPNodeKey, (Long, A)]
-  def empty[A]: NodeValueCache[A] = NodeValueCache(Map.empty[SPNodeKey, (Long, A)])
+/** Provides fast lookup of values that depend upon the state of `ISPNode`s,
+  * avoiding recalculation unless the subtree rooted at the node has changed
+  * since the last time the value was calculated. */
+sealed trait NodeValueCache[A] {
+
+  /** Get the value associated with the node, returning the previously cached
+    * value if available and if the node has not been modified.  Otherwise
+    * calculates the value with the provided function and caches it for the
+    * next lookup. */
+  def get(n: ISPNode)(a: ISPNode => A): (A, NodeValueCache[A])
 }
 
-import NodeValueCache._
+object NodeValueCache {
 
-case class NodeValueCache[A](m: CacheMap[A]) {
-  def get(n: ISPNode): (Option[A], NodeValueCache[A]) =
-    m.get(n.getNodeKey).fold((Option.empty[A], this)) { case (check, value) =>
-      val curCheck = nodeChecksum(n)
-      if (curCheck == check) (Some(value), this)  // hit
-      else (None, copy(m = m - n.getNodeKey))     // miss, node has been edited
+  def empty[A]: NodeValueCache[A] = Impl[A](Map.empty[SPNodeKey, (Long, A)])
+
+  private final case class Impl[A](m: Map[SPNodeKey, (Long, A)]) extends NodeValueCache[A] {
+    def get(n: ISPNode)(a: ISPNode => A): (A, NodeValueCache[A]) = {
+      val k  = n.getNodeKey
+      val cs = nodeChecksum(n)
+
+      def add: (A, NodeValueCache[A]) = {
+        val aVal = a(n)
+        (aVal, Impl(m.updated(k, (cs, aVal))))
+      }
+
+      m.get(k).fold(add) { case (check, aVal) =>
+        if (cs == check) (aVal, this) else add
+      }
     }
-
-  def put(n: ISPNode)(a: ISPNode => A): (A, NodeValueCache[A]) = {
-    val check = nodeChecksum(n)
-    val aVal  = a(n)
-    (aVal, copy(m = m.updated(n.getNodeKey, (check, aVal))))
   }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/P2CheckerCowboy.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/P2CheckerCowboy.java
@@ -23,14 +23,10 @@ import java.util.logging.Logger;
 final class P2CheckerCowboy {
     private static final Logger LOG = Logger.getLogger(P2CheckerCowboy.class.getName());
 
-    static P2CheckerCowboy INSTANCE = new P2CheckerCowboy();
-
-    private P2CheckerCowboy() {
-    }
-
+    private final P2Checker _checker = new P2Checker();
 
     void check(ISPNode node, SPTree tree, AgsMagnitude.MagnitudeTable mt)  {
-        IP2Problems probs = P2Checker.getInstance().check(node, mt);
+        final IP2Problems probs = _checker.check(node, mt);
         if (probs == null) return;
 
         // if an observation or greater, clear everything below this node

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
@@ -114,6 +114,8 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
 
     private final Map<SPNodeKey, SPTree.StateSnapshot> treeSnapshots = new HashMap<>();
 
+    private final P2CheckerCowboy _checker = new P2CheckerCowboy();
+
     public static List<SPViewer> instances() {
         return new ArrayList<>(_orderedInstances);
     }
@@ -556,7 +558,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
                     if (OTOptions.isCheckingEngineEnabled() && (treeNode != null) && (node instanceof ISPProgramNode)) {
                         final NodeData viewable = (NodeData) treeNode.getUserObject();
                         if ((viewable != null) && !viewable.isCheckedForProblems()) {
-                            P2CheckerCowboy.INSTANCE.check(node, getTree(), OT.getMagnitudeTable());
+                            _checker.check(node, getTree(), OT.getMagnitudeTable());
                         }
                     }
 
@@ -644,7 +646,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
             if (dataObj instanceof ObsExecLog) return;
             if (dataObj instanceof SPNote) return;
 
-            P2CheckerCowboy.INSTANCE.check(nodeChanged, getTree(), OT.getMagnitudeTable()); // REL-337
+            _checker.check(nodeChanged, getTree(), OT.getMagnitudeTable()); // REL-337
 
             //update the problem viewer window
             _problemViewer.update();
@@ -724,7 +726,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
                 root.addPropertyChangeListener(ISPProgram.DATA_OBJECT_KEY, authListener);
 
                 if (getRoot() != null && OTOptions.isCheckingEngineEnabled()) {
-                    P2CheckerCowboy.INSTANCE.check(getRoot(), getTree(), OT.getMagnitudeTable());
+                    _checker.check(getRoot(), getTree(), OT.getMagnitudeTable());
                 }
             }
 
@@ -1032,7 +1034,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
     /** Checks the entire program looking for potential problems. */
     public void checkCurrentProgram() {
         if (getRoot() != null) {
-            P2CheckerCowboy.INSTANCE.check(getRoot(), getTree(), OT.getMagnitudeTable());
+            _checker.check(getRoot(), getTree(), OT.getMagnitudeTable());
             getTree().repaint();
             //set the problem viewer to watch the current selected node
             _problemViewer.setNodeData(getTree().getViewable());


### PR DESCRIPTION
This PR is aimed at speeding up the time it takes to recover from synchronization of large programs.  In particular it caches P2 check results for observations and avoids recalculating them unless something in the observation actually changes.   It makes the determination that something has changed by comparing a hash of the node version information used by the sync algorithm.

This change would introduce mutable state (the cache) in `P2Checker` so I changed it to have one instance per `SPViewer` instead of a singleton shared across all viewers.  Cache cleanup happens automatically when the viewer switches to view a new program and runs a P2 check for it.

A lot more could be done to speed up P2 checking in general but for the specific case of recovering from a sync, the cache is quite effective.