### PR TITLE
REL-2372: Prepare PIT 2016A

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -30,7 +30,6 @@ def common(pv: Version) = AppConfig(
   vmargs = List(
     "-Xmx512M",
     "-Dedu.gemini.ui.workspace.impl.Workspace.fonts.shrunk=true",
-    "-Dedu.gemini.pit.test=true",
     "-Dfile.encoding=UTF-8"
   ),
   props = Map(

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 0)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.model.p1.submit/src/main/scala/edu/gemini/model/p1/submit/package.scala
+++ b/bundle/edu.gemini.model.p1.submit/src/main/scala/edu/gemini/model/p1/submit/package.scala
@@ -19,8 +19,8 @@ package object submit {
     Map(LargeProgram -> url("large_program"), FastTurnaroundProgram -> url("fast_turnaround"))
   }
 
-  val productionSubmissionUrls: Map[SubmitDestination, String] = submissionUrls("http://phase1.cl.gemini.edu/cgi-bin/backend/production")
+  val productionSubmissionUrls: Map[SubmitDestination, String] = submissionUrls("http://hbfphase1-lv1.hi.gemini.edu/cgi-bin/backend/production")
 
-  val testSubmissionUrls: Map[SubmitDestination, String] = submissionUrls("http://phase1.cl.gemini.edu/cgi-bin/backend/test")
+  val testSubmissionUrls: Map[SubmitDestination, String] = submissionUrls("http://hbfphase1-lv1.hi.gemini.edu/cgi-bin/backend/test")
 
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
@@ -1,6 +1,7 @@
 package edu.gemini.pit.ui.view.submit
 
 import edu.gemini.model.p1.immutable._
+import edu.gemini.shared.gui.GlassLabel
 import scala.swing._
 import event.ButtonClicked
 import Swing._
@@ -11,7 +12,7 @@ import edu.gemini.pit.ui.robot.ProblemRobot.Problem
 import BorderPanel.Position._
 import java.awt.{Font, Color}
 import edu.gemini.pit.ui.view.partner.PartnersFlags
-import edu.gemini.pit.ui.util.{ProposalSubmissionErrorDialog, GlassLabel, SharedIcons, Rows}
+import edu.gemini.pit.ui.util.{ProposalSubmissionErrorDialog, SharedIcons, Rows}
 import edu.gemini.model.p1.submit.{SubmitResult, SubmitDestination, SubmitClient}
 import java.io.File
 import edu.gemini.pit.ui.robot.ProblemRobot

--- a/bundle/edu.gemini.shared.gui/build.sbt
+++ b/bundle/edu.gemini.shared.gui/build.sbt
@@ -25,12 +25,6 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.shared.gui",
   "edu.gemini.shared.gui.bean",
   "edu.gemini.shared.gui.calendar",
-  "edu.gemini.shared.gui.dialog",
-  "edu.gemini.shared.gui.dialog.canned",
   "edu.gemini.shared.gui.textComponent",
-  "edu.gemini.shared.gui.goodies",
   "edu.gemini.shared.gui.monthview",
-  "edu.gemini.shared.gui.propertyCtrl",
   "edu.gemini.shared.gui.text")
-
-        

--- a/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/GlassLabel.java
+++ b/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/GlassLabel.java
@@ -1,4 +1,4 @@
-package edu.gemini.pit.ui.util;
+package edu.gemini.shared.gui;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -715,6 +715,7 @@ trait OcsBundle {
       bundle_edu_gemini_model_p1_targetio,
       bundle_edu_gemini_model_p1_visibility,
       bundle_edu_gemini_ui_workspace,
+      bundle_edu_gemini_shared_gui,
       bundle_edu_gemini_util_pdf,
       bundle_edu_gemini_spModel_core
     )


### PR DESCRIPTION
Set the PIT to use non-test mode and use of the HBF based backend.

I also have in this PR moving `GlassLabel` from `edu.gemini.pit` to the bundle `edu.gemini.shared.gui`. Though this is not strictly related to REL-2372 I wanted to make sure I could build the PIT with this change