### PR TITLE
REL-2401-B: specify valid types for a conflict folder

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/validator/ConflictConstraint.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/validator/ConflictConstraint.scala
@@ -1,19 +1,19 @@
 package edu.gemini.pot.sp.validator
 
-import edu.gemini.pot.sp.{SPNodeKey, ISPNode}
+import edu.gemini.pot.sp.{SPComponentType, SPNodeKey, ISPNode}
 
 /** A constraint for the children of a conflict (which is no constraint at all). */
 case object ConflictConstraint extends Constraint {
   val initial = ConflictConstraint
-  def types:Types = sys.error("Unsupported operation.")
+
+  val types: Types =
+    (Types(Set())/:SPComponentType.values()) { (ts,ct) =>
+      if (ct == SPComponentType.CONFLICT_FOLDER) ts
+      else ts.addNarrow(ct)
+    }
+
   def copy(ts: Types) = sys.error("Unsupported operation.")
-  override def apply(n: NodeType[_ <: ISPNode], key:Option[SPNodeKey]) = {
 
-//    println("Validating child %s/%s (unconstrainted)".format(
-//      n.mf.getSimpleName,
-//      n.ct))
-
-    Right(this)
-  }
+  override def apply(n: NodeType[_ <: ISPNode], key:Option[SPNodeKey]) = Right(this)
 }
 


### PR DESCRIPTION
This PR updates the `ConflictConstraint` to specify the set of valid types it may contain.  A conflict folder can contain anything other than another conflict folder.

This will avoid the exception reported in REL-2401, which was a result of the OT attempting to determine which UI features to enable when clicking on the conflict folder.