### PR TITLE
REL-2402: local deletion of unedited remote nodes

### DIFF
--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/PreliminaryMerge.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/PreliminaryMerge.scala
@@ -141,7 +141,11 @@ object PreliminaryMerge {
           mc.remote.parent(child.key).flatMap(mc.remote.get).exists(p => !isUpdatedRemote(p))
         }
 
-        PartitionedChildren(local, pc.both, pc.remote)
+        val remote = pc.remote.filterNot { child =>
+          mc.local.isDeleted(child.key) && !containsUpdatedRemote(child)
+        }
+
+        PartitionedChildren(local, pc.both, remote)
       }
     }
 

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -295,17 +295,6 @@ class MergeTest extends JUnitSuite {
       }
     ),
 
-    ("a locally deleted node inside a remotely edited parent must be present in the merged program",
-      (start, local, remote, pc) => {
-        val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet
-        val inEditedRemoteParent = localDeletedRemotePresent.filter { k =>
-          pc.remote.isParentEdited(pc.remote.nodeMap(k))
-        }
-
-        emptySet(pc, inEditedRemoteParent &~ pc.mergeMap.keySet)
-      }
-    ),
-
     ("a locally resurrected node not inside a remotely edited parent must contain a node that is remotely edited",
       (start, local, remote, pc) => {
         val localDeletedRemotePresent = pc.local.deletedKeys & pc.remote.nodeMap.keySet


### PR DESCRIPTION
This PR contains a small update to the preliminary merge logic.  The goal is to allow a locally deleted node to remain deleted even when the containing node has also been edited remotely.  The example from the issue should help to make this clear:

> Start with a folder with one observation 
> OT1: add second observation and sync 
> OT2: delete observation and sync 
> Surprise! both observations appear in OT2 

> This works as expected using the "Old Sync" button.

All the properties still pass except the one that explicitly stated that these nodes should be resurrected.  Since the point of this PR is to make that property no longer hold, I've removed it from the `MergeTest`.