### PR TITLE
OCSADV-399-B

### DIFF
--- a/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
+++ b/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
@@ -6,6 +6,7 @@ import edu.gemini.skycalc.HHMMSS;
 import edu.gemini.shared.util.immutable.Option;
 
 import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.shared.util.immutable.None;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
@@ -206,7 +207,7 @@ public enum ToContext {
 
         final TargetObsComp toc = new TargetObsComp();
         toc.setTargetEnvironment(env);
-        return ObsContext.create(env, inst, site, conds, Collections.emptySet(), altair);
+        return ObsContext.create(env, inst, site, conds, Collections.emptySet(), altair, None.instance());
     }
 
     private InstAltair getAltair(HttpServletRequest req) throws RequestException {

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsGuideSearchOptionsSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsGuideSearchOptionsSpec.scala
@@ -22,7 +22,7 @@ class GemsGuideSearchOptionsSpec extends Specification {
   val inst = new Gsaoi
   inst.setPosAngle(0.0)
   inst.setIssPort(IssPort.SIDE_LOOKING)
-  val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null)
+  val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
   val posAngles = new java.util.HashSet[Angle]()
 
   "GemsGuideSearchOptions" should {
@@ -57,7 +57,7 @@ class GemsGuideSearchOptionsSpec extends Specification {
       criteria(1).criterion.magRange should beEqualTo(MagnitudeRange(FaintnessConstraint(17.0), Some(SaturationConstraint(8))))
     }
     "provide search options for gsaoi in both tip tilt modes" in {
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null)
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.both
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -349,7 +349,7 @@ class GemsResultsAnalyzerSpec extends MascotProgress with Specification with NoT
     val baseTarget = new SPTarget(coords.getRaDeg, coords.getDecDeg)
     val env = TargetEnvironment.create(baseTarget)
     val offsets = new java.util.HashSet[Offset]
-    val obsContext = ObsContext.create(env, inst, JNone.instance[Site], conditions, offsets, new Gems)
+    val obsContext = ObsContext.create(env, inst, JNone.instance[Site], conditions, offsets, new Gems, JNone.instance())
     val baseRA = Angle.fromDegrees(coords.getRaDeg)
     val baseDec = Angle.fromDegrees(coords.getDecDeg)
     val base = new HmsDegCoordinates.Builder(baseRA.toOldModel, baseDec.toOldModel).build

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
@@ -39,7 +39,7 @@ class GemsVoTableCatalogSpec extends Specification with NoTimeConversions {
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
       val conditions = SPSiteQuality.Conditions.BEST
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], conditions, null, null)
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], conditions, null, null, JNone.instance())
       val base = Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
@@ -63,7 +63,7 @@ class GemsVoTableCatalogSpec extends Specification with NoTimeConversions {
       val inst = new Gsaoi
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null)
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
 
@@ -82,7 +82,7 @@ class GemsVoTableCatalogSpec extends Specification with NoTimeConversions {
       val inst = new Gsaoi
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null)
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
@@ -2,7 +2,7 @@ package edu.gemini.ags.gems
 
 import edu.gemini.ags.gems.mascot.Star
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.shared.util.immutable.{Some => JSome}
+import edu.gemini.shared.util.immutable.{Some => JSome, None => JNone }
 import edu.gemini.spModel.core.AlmostEqual._
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core.{Angle, MagnitudeBand, Site}
@@ -39,7 +39,7 @@ trait UCAC3Regression {
     val env = TargetEnvironment.create(baseTarget)
     val offsets = new java.util.HashSet[edu.gemini.skycalc.Offset]
 
-    val obsContext = ObsContext.create(env, new Gsaoi, new JSome(Site.GS), conditions, offsets, new Gems).withPositionAngle(Angle.zero.toOldModel)
+    val obsContext = ObsContext.create(env, new Gsaoi, new JSome(Site.GS), conditions, offsets, new Gems, JNone.instance()).withPositionAngle(Angle.zero.toOldModel)
     val gemsResults = GemsResultsAnalyzer.analyze(obsContext, posAngles.asJava, results.asJava, None)
     areGuideStarListsEqual(expectedGuideStars, gemsResults.asScala.toList)
   }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
@@ -214,7 +214,7 @@ class MascotGuideStarSpec extends Specification {
       val inst = new Gsaoi()
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null)
+      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
 
       val result = MascotGuideStar.findBestAsterismInQueryResult(loadedTargets, ctx, MascotGuideStar.CWFS, 180.0, 10.0)
 
@@ -231,7 +231,7 @@ class MascotGuideStarSpec extends Specification {
       val inst = new Gsaoi()
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null)
+      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
 
       val result = MascotGuideStar.findBestAsterismInQueryResult(UCAC3Regression.replaceRBands(loadedTargets), ctx, MascotGuideStar.CWFS, 180.0, 10.0)
 
@@ -251,7 +251,7 @@ class MascotGuideStarSpec extends Specification {
         val inst = new Gsaoi()
         inst.setPosAngle(0.0)
         inst.setIssPort(IssPort.SIDE_LOOKING)
-        val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null)
+        val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
 
         val targets = t.result.targets.rows
         val result = MascotGuideStar.findBestAsterismInQueryResult(targets, ctx, MascotGuideStar.CWFS, 180.0, 10.0)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
@@ -4,6 +4,7 @@ import edu.gemini.ags.api.{AgsMagnitude, AgsRegistrar, AgsStrategy}
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.util.immutable.{ None => JNone }
 import edu.gemini.skycalc.{Offset, DDMMSS, HHMMSS}
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.Target.SiderealTarget
@@ -60,8 +61,8 @@ object AgsTest {
     }
     inst.setPosAngleDegrees(0.0)
 
-    val ctx = if (site.isDefined) ObsContext.create(targetEnv, inst, site.asGeminiOpt, BEST, java.util.Collections.emptySet(), null)
-              else ObsContext.create(targetEnv, inst, BEST, java.util.Collections.emptySet(), null)
+    val ctx = if (site.isDefined) ObsContext.create(targetEnv, inst, site.asGeminiOpt, BEST, java.util.Collections.emptySet(), null, JNone.instance())
+              else ObsContext.create(targetEnv, inst, BEST, java.util.Collections.emptySet(), null, JNone.instance())
     AgsTest(
       ctx,
       guideProbe,

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -6,7 +6,7 @@ import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.ags.gems._
 import edu.gemini.catalog.api._
 import edu.gemini.catalog.votable.TestVoTableBackend
-import edu.gemini.shared.util.immutable.{Some => JSome}
+import edu.gemini.shared.util.immutable.{Some => JSome, None => JNone }
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.pot.ModelConverters._
@@ -55,7 +55,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val pwfs1 = List(PwfsGuideProbe.pwfs1)
       val guiders:List[GuideProbe] = gsaoi ::: canopus ::: pwfs1
 
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), SPSiteQuality.Conditions.BEST, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), SPSiteQuality.Conditions.BEST, null, new Gems, JNone.instance())
 
       val estimate = TestGemsStrategy("/gemsstrategyquery.xml").estimate(ctx, ProbeLimitsTable.loadOrThrow())
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
@@ -67,7 +67,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions , null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions , null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.instrument
 
       val posAngles = Set.empty[Angle]
@@ -87,7 +87,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -151,7 +151,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -230,7 +230,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.BEST.cc(SPSiteQuality.CloudCover.PERCENT_50)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -295,7 +295,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).wv(SPSiteQuality.WaterVapor.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -370,7 +370,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).wv(SPSiteQuality.WaterVapor.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -447,7 +447,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -511,7 +511,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.BEST.cc(SPSiteQuality.CloudCover.PERCENT_50)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems)
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -12,7 +12,7 @@ import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core.MagnitudeBand.{_r, R, UC}
 import edu.gemini.spModel.core.MagnitudeSystem.VEGA
 import edu.gemini.spModel.core._
-import edu.gemini.shared.util.immutable.Some
+import edu.gemini.shared.util.immutable.{None => JNone, Some}
 import edu.gemini.spModel.gemini.altair.{AltairAowfsGuider, AltairParams, InstAltair}
 import edu.gemini.spModel.gemini.flamingos2.{Flamingos2, Flamingos2OiwfsGuideProbe}
 import edu.gemini.spModel.gemini.gmos.{GmosNorthType, InstGmosSouth, GmosOiwfsGuideProbe, InstGmosNorth}
@@ -77,7 +77,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       val strategy = SingleProbeStrategy(AltairAowfsKey, SingleProbeStrategyParams.AltairAowfsParams, TestVoTableBackend("/ocsadv245.xml"))
       val aoComp = new InstAltair <| {_.setMode(AltairParams.Mode.NGS)}
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.BEST, null, aoComp)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.BEST, null, aoComp, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -93,7 +93,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       val strategy = SingleProbeStrategy(AltairAowfsKey, SingleProbeStrategyParams.AltairAowfsParams, TestVoTableBackend("/ocsadv-245-lgs.xml"))
       val aoComp = new InstAltair <| {_.setMode(AltairParams.Mode.LGS)}
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), null, aoComp)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), null, aoComp, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -111,7 +111,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Pwfs1NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs1), TestVoTableBackend("/niri_pwfs1.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -129,7 +129,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/niri_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -147,7 +147,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), TestVoTableBackend("/gmosn_oiwfs.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -177,7 +177,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null)
+      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
       val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff", GmosOiwfsGuideProbe.instance, PossibleIqDegradation)
     }
@@ -205,7 +205,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null)
+      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
       val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff Bright", GmosOiwfsGuideProbe.instance)
     }
@@ -237,7 +237,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
 
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null)
+      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
       val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff Flip Bright", GmosOiwfsGuideProbe.instance)
     }
@@ -253,7 +253,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gmosn_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.WORST
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -271,7 +271,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Flamingos2OiwfsKey, SingleProbeStrategyParams.Flamingos2OiwfsParams, TestVoTableBackend("/f2_oiwfs.xml"))
 
       val conditions = SPSiteQuality.Conditions.WORST
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -289,7 +289,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Pwfs2SouthKey, SingleProbeStrategyParams.PwfsParams(Site.GS, PwfsGuideProbe.pwfs2), TestVoTableBackend("/f2_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -307,7 +307,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(GmosSouthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GS), TestVoTableBackend("/gmoss_oiwfs.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -326,7 +326,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Pwfs2SouthKey, SingleProbeStrategyParams.PwfsParams(Site.GS, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gmoss_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -344,7 +344,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gnirs_1.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.cc(SPSiteQuality.CloudCover.PERCENT_70).sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -362,7 +362,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gnirs_2.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.cc(SPSiteQuality.CloudCover.PERCENT_70).sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null)
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -4,6 +4,7 @@ import edu.gemini.ags.api.AgsRegistrar
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.shared.util.immutable.{ None => JNone }
 import edu.gemini.skycalc.{DDMMSS, HHMMSS}
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
@@ -104,7 +105,7 @@ class VignettingTest {
     config.inst.setPosAngleDegrees(posAngle)
     val targetEnv = TargetEnvironment.create(base)
     val offsetSet = offsets.map(_.toOldModel).toSet.asJava
-    val ctx       = ObsContext.create(targetEnv, config.inst, Some(config.site).asGeminiOpt, BEST, offsetSet, null)
+    val ctx       = ObsContext.create(targetEnv, config.inst, Some(config.site).asGeminiOpt, BEST, offsetSet, null, JNone.instance())
     val strategy  = AgsRegistrar.currentStrategy(ctx).get.asInstanceOf[SingleProbeStrategy]
 
     def nextCandidate(candidates: List[SiderealTarget], expected: List[SiderealTarget]): Unit = {

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ObservationElements.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ObservationElements.java
@@ -18,6 +18,7 @@ import edu.gemini.spModel.gemini.gems.Gems;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obs.SPObservation;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.seqcomp.SeqRepeatCbOptions;
@@ -165,6 +166,10 @@ public class ObservationElements implements Serializable {
 
     public Option<ISPObsComponent> getAOComponentNode() {
         return _aoComponentNode;
+    }
+
+    public Option<SchedulingBlock> getSchedulingBlock() {
+        return _observation == null ? None.instance() : _observation.getSchedulingBlock();
     }
 
     private void _setInstrumentNode(ISPObsComponent inst) {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/AgsStrategyTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/AgsStrategyTest.java
@@ -25,7 +25,7 @@ public class AgsStrategyTest {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null);
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
     }
 
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
@@ -47,7 +47,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null);
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
     }
 
     /**
@@ -147,7 +147,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
 
         InstGmosNorth ign = (InstGmosNorth) baseContext.getInstrument();
         ign.setFPUnit(GmosNorthType.FPUnitNorth.IFU_2);
-        ObsContext    ctx = ObsContext.create(env, ign, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null);
+        ObsContext    ctx = ObsContext.create(env, ign, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
 
         assertFalse("Point outside of fov, after IFU selected.",
                 GmosOiwfsGuideProbe.instance.validate(

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArrayTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArrayTest.java
@@ -43,7 +43,7 @@ public class GsaoiDetectorArrayTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.SIDE_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null);
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
     }
 
     private void assertEmpty(Coordinates[] coordsArray) {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
@@ -48,7 +48,7 @@ public class GsaoiOdgwGroupTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.SIDE_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null);
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
     }
 
     // Selection and adding essentially wrap the GsaoiDetectorArray.getId

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/guide/BoundaryValidatorTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/guide/BoundaryValidatorTest.java
@@ -37,7 +37,7 @@ public class BoundaryValidatorTest {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null);
+        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
 
 
         //Assert.notFalse(BoundaryValidator.instance.validate(coords, ctxt, GmosOiwfsGuideProbe.instance), "Expected valid, got 'false' ");
@@ -59,7 +59,7 @@ public class BoundaryValidatorTest {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null);
+        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
 
 
        // Assert.notFalse(BoundaryValidator.instance.validate(coords, ctxt, PwfsGuideProbe.pwfs1), "Expected valid, got 'false' ");

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
@@ -3,6 +3,7 @@ package edu.gemini.spModel.inst
 import java.awt.geom.{Point2D, AffineTransform}
 
 import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.util.immutable.None
 import edu.gemini.skycalc.{Offset => SkyCalcOffset}
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
@@ -71,7 +72,7 @@ trait VignettingArbitraries extends Arbitraries {
         env  <- arbitrary[TargetEnvironment]
         gmos <- arbitrary[InstGmosNorth]
         offs <- arbitrary[java.util.Set[SkyCalcOffset]]
-      } yield ObsContext.create(env, gmos, Conditions.NOMINAL, offs, null)
+      } yield ObsContext.create(env, gmos, Conditions.NOMINAL, offs, null, None.instance())
     }
 
   // Generate guide star candidates at all position angles supported by the

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -3,6 +3,7 @@ package jsky.app.ot.tpe
 import edu.gemini.pot.sp._
 
 import edu.gemini.shared.util.immutable.{None => JNone, Option => JOption, Some => JSome}
+import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.data.{ISPDataObject, IOffsetPosListProvider}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
@@ -20,7 +21,7 @@ import edu.gemini.spModel.telescope.{IssPortProvider, IssPort}
 import edu.gemini.spModel.util.SPTreeUtil
 
 import scala.collection.JavaConverters._
-import edu.gemini.spModel.obs.SPObservation
+import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
 import edu.gemini.skycalc.Offset
 
 object TpeContext {
@@ -198,8 +199,15 @@ case class TpeContext(node: Option[ISPNode]) {
     i <- instrument.dataObject
     ao = (gems.dataObject orElse altair.dataObject).orNull
     obs = s.getDataObject.asInstanceOf[SPObservation]
-  } yield ObsContext.create(obs.getAgsStrategyOverride, t, i, site, c, offsets.scienceOffsetsJava, ao, JNone.instance())
+  } yield ObsContext.create(obs.getAgsStrategyOverride, t, i, site, c, offsets.scienceOffsetsJava, ao, obs.getSchedulingBlock)
 
   def obsContextJavaWithConditions(c: Conditions): JOption[ObsContext] =
     toJOption(obsContextWithConditions(c))
+
+  def schedulingBlock: Option[SchedulingBlock] =
+    obsShell.flatMap(_.getDataObject.asInstanceOf[SPObservation].getSchedulingBlock.asScalaOpt)
+
+  def schedulingBlockJava: JOption[SchedulingBlock] =
+    schedulingBlock.asGeminiOpt
+
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -198,7 +198,7 @@ case class TpeContext(node: Option[ISPNode]) {
     i <- instrument.dataObject
     ao = (gems.dataObject orElse altair.dataObject).orNull
     obs = s.getDataObject.asInstanceOf[SPObservation]
-  } yield ObsContext.create(obs.getAgsStrategyOverride, t, i, site, c, offsets.scienceOffsetsJava, ao)
+  } yield ObsContext.create(obs.getAgsStrategyOverride, t, i, site, c, offsets.scienceOffsetsJava, ao, JNone.instance())
 
   def obsContextJavaWithConditions(c: Conditions): JOption[ObsContext] =
     toJOption(obsContextWithConditions(c))


### PR DESCRIPTION
In preparation for time-based coordinates this PR makes an `Option<SchedulingBlock>` available to some of the common "context" objects that we construct and pass around when working with observations. This value is currently unused.

- `ObsContext` (used in many places)
- `ObservationElements` (used in the P2 checker)
- `TpeContext` (used in the TPE)