### PR TITLE
REL-2352: Add SDSS filter to  target bandpass list in PIT

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/CatalogRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/CatalogRobot.scala
@@ -132,8 +132,8 @@ class CatalogRobot(parent: Component) extends Robot {
 
         case Left(target: SiderealTarget) =>
           target.coords(sem.midPoint).map(_.toDegDeg) match {
-            case Some(dd) => s"${target.name} (${dd.ra}, ${dd.dec}) ${target.magnitudes.map(_.band).mkString(" ")}"
-            case None     => s"${target.name} (--, --) ${target.magnitudes.map(_.band).mkString(" ")}"
+            case Some(dd) => s"${target.name} (${dd.ra}, ${dd.dec}) ${target.magnitudes.map(_.band.name).mkString(" ")}"
+            case None     => s"${target.name} (--, --) ${target.magnitudes.map(_.band.name).mkString(" ")}"
           }
 
         case Left(target: NonSiderealTarget) =>

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/target/TargetView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/target/TargetView.scala
@@ -123,7 +123,7 @@ class TargetView(val shellAdvisor:ShellAdvisor) extends BorderPanel with BoundVi
         }
         //        case Epoch      => e.epoch.toString
         case Magnitudes => e match {
-          case t:SiderealTarget    => t.magnitudes.map(_.band.toString).sorted.mkString(" ")
+          case t:SiderealTarget    => t.magnitudes.map(_.band.name).sorted.mkString(" ")
           case t:NonSiderealTarget => t.magnitude(semester.midPoint).map(d => "*").orNull
           case t:TooTarget         => null
         }


### PR DESCRIPTION
Found a small bug on PIT's display of bands. It showed the SDSS bands with the class name rather than the visible name