### PR TITLE
OCSADV-399-C

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -79,6 +79,10 @@ public abstract class ITarget implements Cloneable, Serializable {
         return getRa().getAs(CoordinateParam.Units.DEGREES);
     }
 
+    public Option<Double> getRaHours(Option<Long> time) {
+        return new Some(getRaHours());
+    }
+
     public double getRaHours() {
         return getRa().getAs(CoordinateParam.Units.HMS);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -72,7 +72,7 @@ public abstract class ITarget implements Cloneable, Serializable {
     ///
 
     public Option<Double> getRaDegrees(Option<Long> time) {
-        return new Some(getRaDegrees());
+        return new Some(getRa().getAs(CoordinateParam.Units.DEGREES));
     }
 
     public double getRaDegrees() {
@@ -80,7 +80,7 @@ public abstract class ITarget implements Cloneable, Serializable {
     }
 
     public Option<Double> getRaHours(Option<Long> time) {
-        return new Some(getRaHours());
+        return new Some(getRa().getAs(CoordinateParam.Units.HMS));
     }
 
     public double getRaHours() {
@@ -268,7 +268,7 @@ public abstract class ITarget implements Cloneable, Serializable {
 
     /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
     public synchronized Coordinates getSkycalcCoordinates() {
-        return new Coordinates(getRaDegrees(), getDecDegrees());
+        return new Coordinates(getRa().getAs(CoordinateParam.Units.DEGREES), getDec().getAs(CoordinateParam.Units.DEGREES));
     }
 
     public final String toString() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -71,6 +71,10 @@ public abstract class ITarget implements Cloneable, Serializable {
     /// TRANSITIONAL ACCESSORS
     ///
 
+    public Option<Double> getRaDegrees(Option<Long> time) {
+        return new Some(getRaDegrees());
+    }
+
     public double getRaDegrees() {
         return getRa().getAs(CoordinateParam.Units.DEGREES);
     }
@@ -113,6 +117,10 @@ public abstract class ITarget implements Cloneable, Serializable {
 
     /** Get the Dec. */
     protected abstract DMS getDec();
+
+    public Option<Double> getDecDegrees(Option<Long> time) {
+        return new Some(getDecDegrees());
+    }
 
     // TRANSITIONAL
     public double getDecDegrees() {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
@@ -4,6 +4,7 @@
 
 package edu.gemini.spModel.target.env;
 
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.target.SPTarget;
 import static edu.gemini.spModel.target.obsComp.PwfsGuideProbe.pwfs1;
 import static edu.gemini.spModel.target.obsComp.PwfsGuideProbe.pwfs2;
@@ -11,9 +12,9 @@ import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.DefaultImList;
 import edu.gemini.shared.util.immutable.None;
-import edu.gemini.spModel.target.system.CoordinateParam;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Contains common setup for test cases.
@@ -23,6 +24,7 @@ final class Fixture {
     final ImList<SPTarget> tl_pwfs1, tl_pwfs2, tl_gmos;
     final GuideProbeTargets gpt_pwfs1, gpt_pwfs2, gpt_gmos;
     final GuideGroup grp_all, grp_pwfs2_gmos, grp_gmos;
+    final Option<Long> when;
 
     Fixture() {
         t_pwfs1_1 = new SPTarget(1, 1);
@@ -40,12 +42,14 @@ final class Fixture {
         grp_all  = GuideGroup.create("All", gpt_gmos, gpt_pwfs1, gpt_pwfs2);
         grp_pwfs2_gmos = GuideGroup.create("PWFS2/GMOS", gpt_gmos, gpt_pwfs2);
         grp_gmos = GuideGroup.create("GMOS Only", gpt_gmos);
+
+        when = None.instance();
     }
 
-    public static void verifyGuideEnvironmentEquals(GuideEnvironment env1, GuideEnvironment env2) {
+    public static void verifyGuideEnvironmentEquals(GuideEnvironment env1, GuideEnvironment env2, Option<Long> when) {
         assertEquals(env1.getReferencedGuiders(), env2.getReferencedGuiders());
         assertEquals(env1.getPrimaryIndex(), env2.getPrimaryIndex());
-        verifyGroupListEquals(env1.getOptions(), env2.getOptions());
+        verifyGroupListEquals(env1.getOptions(), env2.getOptions(), when);
     }
 
     /**
@@ -53,9 +57,9 @@ final class Fixture {
      * be equals in the sense of grp1.equals(grp2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGroupListEquals(ImList<GuideGroup> lst1, ImList<GuideGroup> lst2) {
+    public static void verifyGroupListEquals(ImList<GuideGroup> lst1, ImList<GuideGroup> lst2, Option<Long> when) {
         assertEquals(lst1.size(), lst2.size());
-        for (int i=0; i<lst1.size(); ++i) verifyGroupEquals(lst1.get(i), lst2.get(i));
+        for (int i=0; i<lst1.size(); ++i) verifyGroupEquals(lst1.get(i), lst2.get(i), when);
     }
 
     /**
@@ -63,9 +67,9 @@ final class Fixture {
      * be equals in the sense of grp1.equals(grp2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGroupEquals(GuideGroup grp1, GuideGroup grp2) {
+    public static void verifyGroupEquals(GuideGroup grp1, GuideGroup grp2, Option<Long> when) {
         assertEquals(grp1.getName(), grp2.getName());
-        verifyGptListEquals(grp1.getAll(), grp2.getAll());
+        verifyGptListEquals(grp1.getAll(), grp2.getAll(), when);
     }
 
     /**
@@ -73,9 +77,9 @@ final class Fixture {
      * be equals in the sense of gtp1.equals(gpt2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGptListEquals(ImList<GuideProbeTargets> lst1, ImList<GuideProbeTargets> lst2) {
+    public static void verifyGptListEquals(ImList<GuideProbeTargets> lst1, ImList<GuideProbeTargets> lst2, Option<Long> when) {
         assertEquals(lst1.size(), lst2.size());
-        for (int i=0; i<lst1.size(); ++i) verifyGptEquals(lst1.get(i), lst2.get(i));
+        for (int i=0; i<lst1.size(); ++i) verifyGptEquals(lst1.get(i), lst2.get(i), when);
     }
 
     /**
@@ -83,10 +87,10 @@ final class Fixture {
      * be equals in the sense of gtp1.equals(gpt2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGptEquals(GuideProbeTargets gpt1, GuideProbeTargets gpt2) {
+    public static void verifyGptEquals(GuideProbeTargets gpt1, GuideProbeTargets gpt2, Option<Long> when) {
         assertEquals(gpt1.getGuider(), gpt2.getGuider());
         assertEquals(gpt1.getPrimaryIndex(), gpt2.getPrimaryIndex());
-        verifySpListEquals(gpt1.getOptions(), gpt2.getOptions());
+        verifySpListEquals(gpt1.getOptions(), gpt2.getOptions(), when);
     }
 
     /**
@@ -98,7 +102,7 @@ final class Fixture {
      * <p>For our purposes of testing TargetEnvironment objects, we just want
      * an idea that they are the same and checking the coordinates is enough.
      */
-    public static void verifySpListEquals(ImList<SPTarget> lst1, ImList<SPTarget> lst2) {
+    public static void verifySpListEquals(ImList<SPTarget> lst1, ImList<SPTarget> lst2, Option<Long> when) {
         assertEquals(lst1.size(), lst2.size());
 
         for (int i=0; i<lst1.size(); ++i) {
@@ -109,8 +113,20 @@ final class Fixture {
             // the coordinates and get enough of an idea that they are the
             // same for the purposes of testing GuideProbeTargets.
 
-            assertEquals(t1.getTarget().getRaDegrees(), t2.getTarget().getRaDegrees(), 0.000001);
-            assertEquals(t1.getTarget().getDecDegrees(), t2.getTarget().getDecDegrees(), 0.000001);
+            assertOptEquals(t1.getTarget().getRaDegrees(when), t2.getTarget().getRaDegrees(when), 0.000001);
+            assertOptEquals(t1.getTarget().getDecDegrees(when), t2.getTarget().getDecDegrees(when), 0.000001);
         }
     }
+
+    /**
+     * Asserts that either (a) both are None, or (b) both are defined and values are within the
+     * given tolerance.
+     */
+    public static void assertOptEquals(Option<Double> a, Option<Double> b, Double tolerance) {
+        if (a.isDefined() || b.isDefined()) {
+            if (a.isEmpty() || b.isEmpty()) fail("unequal: " + a + ", " + b);
+            a.foreach(aa -> b.foreach(bb -> assertEquals(aa, bb, tolerance)));
+        } // otherwise both are None
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideEnvironmentTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideEnvironmentTest.java
@@ -40,6 +40,7 @@ public class GuideEnvironmentTest {
     private final GuideGroup grp3 = GuideGroup.create("3", gpt_gmos);
     private final GuideGroup grp4 = GuideGroup.create("4");
     private final GuideEnvironment env = GuideEnvironment.create(OptionsListImpl.create(grp1, grp2, grp3, grp4));
+    private final Option<Long> when = None.instance();
 
     @Test
     public void testGetReferencedGuiders() {
@@ -75,7 +76,7 @@ public class GuideEnvironmentTest {
     @Test
     public void testCloneTargets() {
         GuideEnvironment env2 = env.cloneTargets();
-        Fixture.verifyGuideEnvironmentEquals(env, env2);
+        Fixture.verifyGuideEnvironmentEquals(env, env2, when);
         assertFalse(env2.containsTarget(t_pwfs1_1)); // SPTarget.equals() not defined
     }
 
@@ -115,7 +116,7 @@ public class GuideEnvironmentTest {
         final PioFactory fact = new PioXmlFactory();
         for (GuideEnvironment expected : lst) {
             final GuideEnvironment actual = GuideEnvironment.fromParamSet(expected.getParamSet(fact));
-            Fixture.verifyGuideEnvironmentEquals(expected, actual);
+            Fixture.verifyGuideEnvironmentEquals(expected, actual, when);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideGroupTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideGroupTest.java
@@ -43,15 +43,15 @@ public final class GuideGroupTest extends TestCase {
     public void testNormalize() {
         // Remove duplicates
         GuideGroup grp = GuideGroup.create("x", fix.gpt_pwfs1, fix.gpt_pwfs1);
-        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs1), grp.getAll());
+        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs1), grp.getAll(), fix.when);
 
         // Sort
         grp = GuideGroup.create("x", fix.gpt_pwfs2, fix.gpt_gmos, fix.gpt_pwfs1);
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
 
         // Sort and remove duplicates.
         grp = GuideGroup.create("x", fix.gpt_pwfs2, fix.gpt_gmos, fix.gpt_pwfs1, fix.gpt_pwfs2, fix.gpt_gmos);
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
     }
 
     public void testSetName() {
@@ -85,8 +85,8 @@ public final class GuideGroupTest extends TestCase {
     }
 
     public void testGet() {
-        Fixture.verifyGptEquals(fix.gpt_pwfs1, fix.grp_all.get(pwfs1).getValue());
-        Fixture.verifyGptEquals(fix.gpt_gmos, fix.grp_gmos.get(GmosOiwfsGuideProbe.instance).getValue());
+        Fixture.verifyGptEquals(fix.gpt_pwfs1, fix.grp_all.get(pwfs1).getValue(), fix.when);
+        Fixture.verifyGptEquals(fix.gpt_gmos, fix.grp_gmos.get(GmosOiwfsGuideProbe.instance).getValue(), fix.when);
         assertTrue(fix.grp_gmos.get(pwfs1).isEmpty());
         assertTrue(GuideGroup.EMPTY.get(pwfs1).isEmpty());
     }
@@ -96,32 +96,32 @@ public final class GuideGroupTest extends TestCase {
         // same as the "all" group.
         GuideGroup grp = fix.grp_gmos.put(fix.gpt_pwfs2).put(fix.gpt_pwfs1);
         assertEquals(grp.getName(), fix.grp_gmos.getName());
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
 
         // Add to an empty group
         grp = GuideGroup.EMPTY.put(fix.gpt_gmos);
         assertEquals(grp.getName(), GuideGroup.EMPTY.getName());
-        Fixture.verifyGptListEquals(fix.grp_gmos.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_gmos.getAll(), grp.getAll(), fix.when);
 
         // Replace an existing GuideProbeTargets.
         GuideProbeTargets gpt = GuideProbeTargets.create(pwfs1, fix.t_pwfs1_2);
         grp = fix.grp_all.put(gpt);  // now the pwfs1 guide probe targets has just one target
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getOptions());
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getOptions(), fix.when);
     }
 
     public void testRemove() {
         GuideGroup grp = fix.grp_all.remove(pwfs1);
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_gmos, fix.gpt_pwfs2), grp.getAll());
+        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_gmos, fix.gpt_pwfs2), grp.getAll(), fix.when);
 
         grp = grp.remove(GmosOiwfsGuideProbe.instance);
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs2), grp.getAll());
+        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs2), grp.getAll(), fix.when);
 
         grp = grp.remove(pwfs2);
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifyGptListEquals(GuideGroup.EMPTY.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(GuideGroup.EMPTY.getAll(), grp.getAll(), fix.when);
 
         // Remove from an empty list
         GuideGroup grp2 = grp.remove(pwfs2);
@@ -131,7 +131,7 @@ public final class GuideGroupTest extends TestCase {
     public void testClear() {
         GuideGroup grp = fix.grp_all.clear();
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifyGptListEquals(GuideGroup.EMPTY.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(GuideGroup.EMPTY.getAll(), grp.getAll(), fix.when);
 
         GuideGroup grp2 = GuideGroup.EMPTY.clear();
         assertSame(GuideGroup.EMPTY, grp2);
@@ -141,54 +141,54 @@ public final class GuideGroupTest extends TestCase {
         // Put all on an empty group.
         GuideGroup grp = GuideGroup.EMPTY.putAll(fix.grp_all.getAll());
         assertEquals(GuideGroup.EMPTY.getName(), grp.getName());
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
 
         // Put all, replacing some members.
         grp = fix.grp_gmos.putAll(fix.grp_all.getAll());
         assertEquals(fix.grp_gmos.getName(), grp.getName());
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
 
         // Test replace via putAll
         GuideProbeTargets gpt = GuideProbeTargets.create(pwfs1, fix.t_pwfs1_2);
         grp = fix.grp_all.putAll(DefaultImList.create(gpt));  // now the pwfs1 guide probe targets has just one target
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getOptions());
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getOptions(), fix.when);
 
         // put all empty
         grp = fix.grp_all.putAll(GuideProbeTargets.EMPTY_LIST);
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
     }
 
     public void testSetAll() {
         // Set all on an empty group.
         GuideGroup grp = GuideGroup.EMPTY.setAll(fix.grp_all.getAll());
         assertEquals(GuideGroup.EMPTY.getName(), grp.getName());
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
 
         // Clear via set all
         grp = fix.grp_all.setAll(GuideProbeTargets.EMPTY_LIST);
         assertEquals(fix.grp_all.getName(), grp.getName());
-        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, grp.getAll());
+        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, grp.getAll(), fix.when);
     }
 
     public void testGetAllContaining() {
-        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs1), fix.grp_all.getAllContaining(fix.t_pwfs1_1));
-        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, fix.grp_gmos.getAllContaining(fix.t_pwfs1_1));
+        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs1), fix.grp_all.getAllContaining(fix.t_pwfs1_1), fix.when);
+        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, fix.grp_gmos.getAllContaining(fix.t_pwfs1_1), fix.when);
 
         // Put the same target in more than one GuideProbeTargets object.
         GuideProbeTargets gpt = fix.gpt_gmos.update(OptionsList.UpdateOps.append(fix.t_pwfs1_1));
 
         // t_pwfs1_1 should be in the first two GuideProbeTarets sets here
         GuideGroup grp = GuideGroup.create("x", fix.gpt_pwfs1, gpt, fix.gpt_pwfs2);
-        Fixture.verifyGptListEquals(DefaultImList.create(gpt, fix.gpt_pwfs1), grp.getAllContaining(fix.t_pwfs1_1));
+        Fixture.verifyGptListEquals(DefaultImList.create(gpt, fix.gpt_pwfs1), grp.getAllContaining(fix.t_pwfs1_1), fix.when);
     }
 
     public void testGetAllMatching() {
-        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs1, fix.gpt_pwfs2), fix.grp_all.getAllMatching(GuideProbe.Type.PWFS));
-        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs2), fix.grp_pwfs2_gmos.getAllMatching(GuideProbe.Type.PWFS));
-        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, fix.grp_gmos.getAllMatching(GuideProbe.Type.PWFS));
-        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, GuideGroup.EMPTY.getAllMatching(GuideProbe.Type.PWFS));
+        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs1, fix.gpt_pwfs2), fix.grp_all.getAllMatching(GuideProbe.Type.PWFS), fix.when);
+        Fixture.verifyGptListEquals(DefaultImList.create(fix.gpt_pwfs2), fix.grp_pwfs2_gmos.getAllMatching(GuideProbe.Type.PWFS), fix.when);
+        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, fix.grp_gmos.getAllMatching(GuideProbe.Type.PWFS), fix.when);
+        Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, GuideGroup.EMPTY.getAllMatching(GuideProbe.Type.PWFS), fix.when);
     }
 
     public void testGetReferencedGuiders() {
@@ -280,7 +280,7 @@ public final class GuideGroupTest extends TestCase {
     public void testCloneTargets() {
         GuideGroup grp = GuideGroup.CLONE_TARGETS.apply(fix.grp_all);
         assertFalse(fix.grp_all.equals(grp));
-        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll());
+        Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
         assertEquals(fix.grp_all.getName(), grp.getName());
 
         grp = GuideGroup.CLONE_TARGETS.apply(fix.grp_gmos);
@@ -313,7 +313,7 @@ public final class GuideGroupTest extends TestCase {
         PioFactory fact = new PioXmlFactory();
         for (GuideGroup expected : DefaultImList.create(fix.grp_all, fix.grp_pwfs2_gmos, fix.grp_gmos)) {
             GuideGroup actual = GuideGroup.fromParamSet(expected.getParamSet(fact));
-            Fixture.verifyGroupEquals(expected, actual);
+            Fixture.verifyGroupEquals(expected, actual, fix.when);
         }
     }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
@@ -90,7 +90,7 @@ public final class GuideProbeTargetsTest extends TestCase {
         PioFactory fact = new PioXmlFactory();
         for (GuideProbeTargets expected : DefaultImList.create(fix.gpt_pwfs1, fix.gpt_pwfs2, fix.gpt_gmos)) {
             GuideProbeTargets actual = GuideProbeTargets.fromParamSet(expected.getParamSet(fact));
-            Fixture.verifyGptEquals(expected, actual);
+            Fixture.verifyGptEquals(expected, actual, fix.when);
         }
     }
 
@@ -119,11 +119,11 @@ public final class GuideProbeTargetsTest extends TestCase {
         GuideProbeTargets cgptpwfs2 = fix.gpt_pwfs2.cloneTargets();
         GuideProbeTargets cgptgmos  = fix.gpt_gmos.cloneTargets();
 
-        Fixture.verifyGptEquals(fix.gpt_pwfs1, cgptpwfs1);
+        Fixture.verifyGptEquals(fix.gpt_pwfs1, cgptpwfs1, fix.when);
         assertFalse(fix.gpt_pwfs1.equals(cgptpwfs1));
-        Fixture.verifyGptEquals(fix.gpt_pwfs2, cgptpwfs2);
+        Fixture.verifyGptEquals(fix.gpt_pwfs2, cgptpwfs2, fix.when);
         assertFalse(fix.gpt_pwfs2.equals(cgptpwfs2));
-        Fixture.verifyGptEquals(fix.gpt_gmos,  cgptgmos);
+        Fixture.verifyGptEquals(fix.gpt_gmos,  cgptgmos, fix.when);
         assertEquals(fix.gpt_gmos, cgptgmos); // no targets, so should be same
     }
 
@@ -131,23 +131,23 @@ public final class GuideProbeTargetsTest extends TestCase {
         GuideProbeTargets gpt;
 
         gpt = fix.gpt_pwfs1.removeTarget(fix.t_pwfs1_1);
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), gpt.getOptions());
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), gpt.getOptions(), fix.when);
 
         gpt = fix.gpt_pwfs1.removeTarget(fix.t_pwfs1_2);
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_1), gpt.getOptions());
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_1), gpt.getOptions(), fix.when);
 
         // Remove a target that doesn't exist in the GuideProbeTargets instance.
         gpt = fix.gpt_pwfs1.removeTarget(fix.t_pwfs2);
-        Fixture.verifySpListEquals(fix.tl_pwfs1, gpt.getOptions());
+        Fixture.verifySpListEquals(fix.tl_pwfs1, gpt.getOptions(), fix.when);
 
         // Remove the only target in the list
         gpt = fix.gpt_pwfs2.removeTarget(fix.t_pwfs2);
         ImList<SPTarget> empty = ImCollections.emptyList();
-        Fixture.verifySpListEquals(empty, gpt.getOptions());
+        Fixture.verifySpListEquals(empty, gpt.getOptions(), fix.when);
 
         // Remove from an empty list.
         gpt = fix.gpt_gmos.removeTarget(fix.t_pwfs1_1);
-        Fixture.verifySpListEquals(fix.tl_gmos, gpt.getOptions());
+        Fixture.verifySpListEquals(fix.tl_gmos, gpt.getOptions(), fix.when);
     }
 
     public void testTargetMatch() {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -38,6 +38,7 @@ import edu.gemini.spModel.gemini.trecs.TReCSParams;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.obs.ObservationStatus;
 import edu.gemini.spModel.obs.SPObservation.Priority;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.plannedtime.PlannedStepSummary;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.target.env.TargetEnvironment;
@@ -219,6 +220,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
     private final boolean ao;
     private final boolean meanParallacticAngle;
     private final ImList<AgsAnalysis> agsAnalysis;
+    private final Option<SchedulingBlock> schedulingBlock;
 
 	// Created/computed lazily
 	private transient WorldCoords coords;
@@ -434,7 +436,8 @@ public final class Obs implements Serializable, Comparable<Obs> {
             boolean lgs,
             boolean ao,
             boolean meanParallacticAngle,
-            ImList<AgsAnalysis> agsAnalysis)
+            ImList<AgsAnalysis> agsAnalysis,
+            Option<SchedulingBlock> schedulingBlock)
     {
 
 		this.prog = prog;
@@ -454,6 +457,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
         this.meanParallacticAngle = meanParallacticAngle;
         this.priority = priority;
         this.tooPriority = tooPriority;
+        this.schedulingBlock = schedulingBlock;
 
         // if some steps have been executed the setup time needs to be added, same if there are still steps left
         this.piPlannedTime = piPlannedTime;
@@ -542,6 +546,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
         this.ao = false;
         this.meanParallacticAngle = false;
         this.agsAnalysis = null;
+        this.schedulingBlock = None.instance();
 	}
 
 	public int compareTo(Obs o) {
@@ -572,11 +577,11 @@ public final class Obs implements Serializable, Comparable<Obs> {
 	}
 
 	public double getRa() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getRaDegrees() : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getRaDegrees(schedulingBlock.map(b -> b.start())).getOrElse(0.0) : 0.0);
 	}
 
 	public double getDec() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getDecDegrees() : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getDecDegrees(schedulingBlock.map(b -> b.start())).getOrElse(0.0) : 0.0);
 	}
 
 	public Conds getConditions() {
@@ -798,6 +803,9 @@ public final class Obs implements Serializable, Comparable<Obs> {
         return prog.getStructuredProgramId().getShortName() + " [" + obsNumber + "]";
     }
 
+    public Option<SchedulingBlock> getSchedulingBlock() {
+        return schedulingBlock;
+    }
 }
 
 

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
@@ -893,7 +893,8 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
             hasLGS(obsShell),
             hasAO(obsShell),
             usesAverageParallacticAngle(obsShell),
-            DefaultImList.create(analysis)
+            DefaultImList.create(analysis),
+            obs.getSchedulingBlock()
         );
 
     }

--- a/bundle/edu.gemini.qpt.shared/src/test/scala/edu/gemini/qpt/shared/util/ObsBuilder.scala
+++ b/bundle/edu.gemini.qpt.shared/src/test/scala/edu/gemini/qpt/shared/util/ObsBuilder.scala
@@ -3,13 +3,13 @@ package edu.gemini.qpt.shared.util
 import edu.gemini.ags.api.AgsAnalysis
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.qpt.shared.sp.{Group, Obs, Prog}
-import edu.gemini.shared.util.immutable.DefaultImList
+import edu.gemini.shared.util.immutable.{None => JNone, DefaultImList}
 import edu.gemini.spModel.core.{Declination, RightAscension, Coordinates, SPProgramID}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.obs.plannedtime.PlannedStepSummary
 import edu.gemini.spModel.obsclass.ObsClass
 import edu.gemini.spModel.obs.SPObservation.Priority
-import edu.gemini.spModel.obs.ObservationStatus
+import edu.gemini.spModel.obs.{SchedulingBlock, ObservationStatus}
 import edu.gemini.spModel.obscomp.SPGroup
 import edu.gemini.spModel.target.env.TargetEnvironment
 import edu.gemini.spModel.target.SPTarget
@@ -24,6 +24,7 @@ import scala.collection.JavaConverters._
  * NOTE: Equality on Obs objects is defined based on the program and the obs number. Therefore it is important
  * to have at least unique obs numbers when creating observations for a test. Either assign one explicitely
  * or the observation will get an obs number assigned on creation based on a static counter.
+ * FURTHER NOTE: Instances always have an empty scheduling block.
  */
 case class ObsBuilder(
 // TODO: define useful defaults, use options on the scala side of things where applicable
@@ -79,7 +80,8 @@ case class ObsBuilder(
       lgs,
       ao,
       meanParallacticAngle,
-      DefaultImList.create(analysis.asJavaCollection)
+      DefaultImList.create(analysis.asJavaCollection),
+      JNone.instance[SchedulingBlock]
     )
   }
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
@@ -114,7 +114,8 @@ object FoldedTargetsProvider {
         headObs.getLGS,
         headObs.getAO,
         headObs.usesMeanParallacticAngle,
-        headObs.getAgsAnalysis
+        headObs.getAgsAnalysis,
+        headObs.getSchedulingBlock
       )
     }
   }
@@ -207,7 +208,8 @@ case class PositionProvider(ctx: QvContext, base: ObservationProvider) extends O
           o.getLGS,
           o.getAO,
           o.usesMeanParallacticAngle,
-          o.getAgsAnalysis
+          o.getAgsAnalysis,
+          o.getSchedulingBlock
         )
       }
       else o

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
@@ -10,6 +10,7 @@ import edu.gemini.pot.sp.*;
 import edu.gemini.pot.spdb.DBAbstractQueryFunctor;
 import edu.gemini.pot.spdb.IDBDatabaseService;
 import edu.gemini.pot.spdb.IDBQueryRunner;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.ao.AOConstants;
 import edu.gemini.spModel.ao.AOTreeUtil;
 import edu.gemini.spModel.core.Affiliate;
@@ -658,8 +659,9 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
             final TargetObsComp targetEnv = (TargetObsComp) targetObsComp.getDataObject();
             final SPTarget tp = targetEnv.getBase();
             final ITarget target = tp.getTarget();
-            ra = target.getRaDegrees();
-            dec = target.getDecDegrees();
+            final Option<Long> when = obs.getSchedulingBlock().map(SchedulingBlock::start);
+            ra = target.getRaDegrees(when).getOrNull();
+            dec = target.getDecDegrees(when).getOrNull();
         }
 
         // Figure out the planned time for all observations.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -1,11 +1,13 @@
 package jsky.app.ot.tpe;
 
 import edu.gemini.pot.sp.*;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.gemini.nici.SeqRepeatNiciOffset;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.gemini.seqcomp.SeqRepeatOffset;
 import edu.gemini.spModel.guide.GuideProbeAvailabilityVolatileDataObject;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
@@ -277,8 +279,9 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         if (tp != null) {
             // Get the RA and Dec from the pos list.
             ITarget target = tp.getTarget();
-            ra = target.getRaDegrees();
-            dec = target.getDecDegrees();
+            final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
+            ra = target.getRaDegrees(when).getOrElse(0.0);
+            dec = target.getDecDegrees(when).getOrElse(0.0);
         }
 
         _iw.loadCachedImage(ra, dec);
@@ -306,7 +309,11 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         ITarget oldBase = oldBasePos.getTarget();
         ITarget newBase = newBasePos.getTarget();
 
-        return (oldBase.getRaDegrees() != newBase.getRaDegrees() || oldBase.getDecDegrees() != newBase.getDecDegrees());
+        Option<Long> oldWhen = oldCtx.schedulingBlockJava().map(SchedulingBlock::start);
+        Option<Long> newWhen = oldCtx.schedulingBlockJava().map(SchedulingBlock::start);
+
+        return (oldBase.getRaDegrees(oldWhen) != newBase.getRaDegrees(newWhen) ||
+                oldBase.getDecDegrees(oldWhen) != newBase.getDecDegrees(newWhen));
     }
 
     private final PropertyChangeListener obsListener = evt -> {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -310,10 +310,10 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         ITarget newBase = newBasePos.getTarget();
 
         Option<Long> oldWhen = oldCtx.schedulingBlockJava().map(SchedulingBlock::start);
-        Option<Long> newWhen = oldCtx.schedulingBlockJava().map(SchedulingBlock::start);
+        Option<Long> newWhen = newCtx.schedulingBlockJava().map(SchedulingBlock::start);
 
-        return (oldBase.getRaDegrees(oldWhen) != newBase.getRaDegrees(newWhen) ||
-                oldBase.getDecDegrees(oldWhen) != newBase.getDecDegrees(newWhen));
+        return (!(oldBase.getRaDegrees(oldWhen).equals(newBase.getRaDegrees(newWhen)) &&
+                  oldBase.getDecDegrees(oldWhen).equals(newBase.getDecDegrees(newWhen)));
     }
 
     private final PropertyChangeListener obsListener = evt -> {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -8,6 +8,7 @@ import edu.gemini.catalog.api.RadiusLimits;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.ags.AgsStrategyKey;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.*;
@@ -488,8 +489,9 @@ public class TpeImageWidget extends NavigatorImageDisplay implements MouseInputL
         // Get the equinox assumed by the coordinate conversion methods (depends on current image)
         //double equinox = getCoordinateConverter().getEquinox();
         ITarget target = ((SPTarget) tp).getTarget();
-        double x = target.getRaDegrees();
-        double y = target.getDecDegrees();
+        final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
+        double x = target.getRaDegrees(when).getOrElse(0.0);
+        double y = target.getDecDegrees(when).getOrElse(0.0);
         WorldCoords pos = new WorldCoords(x, y, 2000.);
         return worldToScreenCoords(pos);
     }
@@ -837,8 +839,9 @@ public class TpeImageWidget extends NavigatorImageDisplay implements MouseInputL
      * The Base position has been updated.
      */
     public void basePosUpdate(ITarget target) {
-        double x = target.getRaDegrees();
-        double y = target.getDecDegrees();
+        final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
+        double x = target.getRaDegrees(when).getOrElse(0.0);
+        double y = target.getDecDegrees(when).getOrElse(0.0);
         WorldCoords pos = new WorldCoords(x, y, 2000.);
         setBasePos(pos);
         repaint();


### PR DESCRIPTION
Ok this is the next set of changes in preparation for time-varying coordinates.

- I added the following methods to `ITarget` which simply delegate to the old methods and always return `Some`. The idea is that you pass a time if you have one … in cases where it doesn't matter (like with extragalactic stuff) you don't need to.
  - `Option<Double> getRaDegrees(Option<Long> when)`
  - `Option<Double> getDecDegrees(Option<Long> when)`
- I began changing calls to use these new methods in cases where a `SchedulingBlock` is available (passing the `start` time) when it's clear what should happen if `None` is returned (which never happens at the moment).

The lack of `for` comprehensions or `|@|` in Java is really irritating.