### PR TITLE
OCSADV-399-F

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -19,6 +19,8 @@ import edu.gemini.spModel.seqcomp.IObserveSeqComponent;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.system.CoordinateParam;
+import edu.gemini.spModel.target.system.HmsDegTarget;
+import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.time.ChargeClass;
 import edu.gemini.spModel.time.ObsTimeCharges;
 import edu.gemini.spModel.time.ObsTimeCorrection;
@@ -444,8 +446,15 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
             return false;
         } else {
             final TargetObsComp toc = (TargetObsComp) targetComp.getDataObject();
-            final SPTarget target = toc.getBase();
-            return (target.getTarget().getRaDegrees() != 0.0) || (target.getTarget().getDecDegrees() != 0.0);
+            final ITarget target = toc.getBase().getTarget();
+            final boolean too;
+            if (target instanceof HmsDegTarget) {
+                final HmsDegTarget hms = (HmsDegTarget) target;
+                too = hms.getRa().getValue() == 0 && hms.getDec().getValue() == 0;
+            } else {
+                too = false;
+            }
+            return !too;
         }
     }
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -4,6 +4,7 @@
 
 package edu.gemini.spModel.target;
 
+import edu.gemini.shared.util.immutable.None;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.skyobject.SkyObject;
@@ -64,8 +65,8 @@ public final class SPTargetSkyObjectTest {
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
             assertEquals("xyz", target.getTarget().getName());
-            assertEquals(15.0, target.getTarget().getRaDegrees(), 0.000001);
-            assertEquals(20.0, target.getTarget().getDecDegrees(), 0.000001);
+            assertEquals(15.0, target.getTarget().getRaDegrees(None.instance()).getValue(), 0.000001);
+            assertEquals(20.0, target.getTarget().getDecDegrees(None.instance()).getValue(), 0.000001);
             assertEquals(1.0, hmsDeg.getPM1().getValue(), 0.000001);
             assertEquals(2.0, hmsDeg.getPM2().getValue(), 0.000001);
 


### PR DESCRIPTION
More time-based target updates. (3/6)
- Update `SPTarget.hasDefinedTarget` logic to match current logic in effect: `true` unless it's an `HmsDegTarget` with coordinates at `(0.0, 0.0)`.
- Update `SPTargetSkyObjectTest` trivially.
- Update `TelescopePosTableWidget` to support unknown coordinates (still more to do).