### PR TITLE
OCSADV-399-I

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -6,7 +6,7 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core.{BandsList, Magnitude}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.ImageQuality
-import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe, GuideProbeGroup, GuideSpeed}
+import edu.gemini.spModel.guide.{GuideStarValidation, ValidatableGuideProbe, GuideProbe, GuideProbeGroup, GuideSpeed}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.SPTarget
@@ -152,7 +152,7 @@ object AgsAnalysis {
    */
   protected [ags] def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget, bands: BandsList): Option[AgsAnalysis] = {
     val spTarget = new SPTarget(guideStar.coordinates.ra.toAngle.toDegrees, guideStar.coordinates.dec.toDegrees)
-    if (!guideProbe.validate(spTarget, ctx)) Some(NotReachable(guideProbe, guideStar, bands))
+    if (guideProbe.validate(spTarget, ctx) != GuideStarValidation.VALID) Some(NotReachable(guideProbe, guideStar, bands))
     else magnitudeAnalysis(ctx, mt, guideProbe, guideStar, bands)
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -7,7 +7,7 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.core.{BandsList, Angle}
 import edu.gemini.spModel.core.Target.SiderealTarget
-import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
+import edu.gemini.spModel.guide.{GuideStarValidation, ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.shared.util.immutable.{Option => JOption, Some => JSome}
@@ -29,7 +29,7 @@ trait AgsStrategy {
 
   def analyzeForJava(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): JOption[AgsAnalysis] = {
     val spTarget = new SPTarget(guideStar.coordinates.ra.toAngle.toDegrees, guideStar.coordinates.dec.toDegrees)
-    if (!guideProbe.validate(spTarget, ctx)) new JSome(NotReachable(guideProbe, guideStar, probeBands))
+    if (guideProbe.validate(spTarget, ctx) != GuideStarValidation.VALID) new JSome(NotReachable(guideProbe, guideStar, probeBands))
     else analyze(ctx, mt, guideProbe, guideStar).asGeminiOpt
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
@@ -3,6 +3,7 @@ package edu.gemini.ags.impl
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
 import edu.gemini.spModel.core.Coordinates
 import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.guide.GuideStarValidation
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.ags.api.AgsMagnitude
@@ -40,7 +41,7 @@ protected case class CandidateValidator(params: SingleProbeStrategyParams, mt: M
       def brightnessOk = (magLimits |@| params.referenceMagnitude(st))(_ contains _) | false
 
       // Only keep those that are in range of the guide probe.
-      def inProbeRange = params.validator(ctx).validate(new SPTarget(HmsDegTarget.fromSkyObject(st.toOldModel)), ctx)
+      def inProbeRange = params.validator(ctx).validate(new SPTarget(HmsDegTarget.fromSkyObject(st.toOldModel)), ctx) == GuideStarValidation.VALID
 
       farEnough && brightnessOk && inProbeRange
     }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
@@ -18,6 +18,7 @@ import edu.gemini.spModel.gemini.gems.Canopus;
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi;
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
+import edu.gemini.spModel.guide.GuideStarValidation;
 import edu.gemini.spModel.guide.ValidatableGuideProbe;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
@@ -173,7 +174,7 @@ public final class GemsGuideStarRule implements IRule {
         if (primaryOpt.isEmpty()) return true; // okay, no target to check
 
         SPTarget primary = primaryOpt.getValue();
-        return guider.validate(primary, ctx);
+        return guider.validate(primary, ctx) == GuideStarValidation.VALID;
     }
 
     private void addError(P2Problems problems, String id, String tmpl, ObsContext ctx, int index, ISPProgramNode node) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -123,7 +123,7 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
         return GuideProbeUtil.instance.inRange(this, ctx, offset);
     }
 
-    @Override public boolean validate(SPTarget guideStar, ObsContext ctx) {
+    @Override public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
@@ -98,7 +98,7 @@ public enum Flamingos2OiwfsGuideProbe implements GuideProbe, ValidatableGuidePro
     }
 
     @Override
-    public boolean validate(SPTarget guideStar, ObsContext ctx) {
+    public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -101,15 +101,15 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     @Override
-    public boolean validate(final SPTarget guideStar, final ObsContext ctx) {
+    public GuideStarValidation validate(final SPTarget guideStar, final ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 
-    public boolean validate(final SkyObject guideStar, final ObsContext ctx) {
+    public GuideStarValidation validate(final SkyObject guideStar, final ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 
-    public boolean validate(final Coordinates guideStar, final ObsContext ctx) {
+    public GuideStarValidation validate(final Coordinates guideStar, final ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
@@ -95,7 +95,7 @@ public enum GnirsOiwfsGuideProbe implements ValidatableGuideProbe {
     }
 
     @Override
-    public boolean validate(SPTarget guideStar, ObsContext ctx) {
+    public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
@@ -61,7 +61,7 @@ public enum NiciOiwfsGuideProbe implements ValidatableGuideProbe {
         return (ctx.getInstrument() instanceof InstNICI) ? new Some<>(getPatrolField()) : None.<PatrolField>instance();
     }
     @Override
-    public boolean validate(SPTarget guideStar, ObsContext ctx) {
+    public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
@@ -80,7 +80,7 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     @Override
-    public boolean validate(SPTarget guideStar, ObsContext ctx) {
+    public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
@@ -60,7 +60,7 @@ public enum NiriOiwfsGuideProbe implements ValidatableGuideProbe {
     }
 
     @Override
-    public boolean validate(SPTarget guideStar, ObsContext ctx) {
+    public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideStarValidation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideStarValidation.java
@@ -1,0 +1,21 @@
+package edu.gemini.spModel.guide;
+
+public enum GuideStarValidation {
+
+    /** Guide star is valid in the given context. */
+    VALID,
+
+    /** Guide star is <em>not</em> valid in the given context. */
+    INVALID,
+
+    /** Validity cannot be checked because guide star or base coordinates are undefined. */
+    UNDEFINED
+
+    ;
+
+    /** Return the most pessimistic value. */
+    public GuideStarValidation and(GuideStarValidation other) {
+        return ordinal() < other.ordinal() ? other : this;
+    }
+
+}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideStarValidator.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideStarValidator.java
@@ -16,8 +16,7 @@ public interface GuideStarValidator {
      *
      * @param ctx context in which the guide star is validated
      *
-     * @return <code>true</code> if the guide star is considered valid in the
-     * given {@link edu.gemini.spModel.obs.context.ObsContext}; <code>false</code> otherwise
+     * @return a {@link edu.gemini.spModel.guide.GuideStarValidation}
      */
-    boolean validate(SPTarget guideStar, ObsContext ctx);
+    GuideStarValidation validate(SPTarget guideStar, ObsContext ctx);
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
@@ -265,19 +265,21 @@ public class PatrolField {
             this.validArea = validArea;
         }
 
-        @Override public boolean validate(SPTarget guideStar, ObsContext ctx) {
-            final Coordinates baseCoordinates  = ctx.getBaseCoordinates();
-            final Coordinates guideCoordinates = guideStar.getTarget().getSkycalcCoordinates();
-            // Calculate the difference between the coordinate and the observation's
-            // base position.
-            CoordinateDiff diff;
-            diff = new CoordinateDiff(baseCoordinates, guideCoordinates);
-            // Get offset and switch it to be defined in the same coordinate
-            // system as the shape.
-            Offset dis = diff.getOffset();
-            double p = -dis.p().toArcsecs().getMagnitude();
-            double q = -dis.q().toArcsecs().getMagnitude();
-            return validArea.contains(p, q);
+        @Override
+        public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
+            return ctx.getBaseCoordinatesOpt().map(baseCoordinates -> {
+                final Coordinates guideCoordinates = guideStar.getTarget().getSkycalcCoordinates();
+                // Calculate the difference between the coordinate and the observation's
+                // base position.
+                CoordinateDiff diff;
+                diff = new CoordinateDiff(baseCoordinates, guideCoordinates);
+                // Get offset and switch it to be defined in the same coordinate
+                // system as the shape.
+                Offset dis = diff.getOffset();
+                double p = -dis.p().toArcsecs().getMagnitude();
+                double q = -dis.q().toArcsecs().getMagnitude();
+                return validArea.contains(p, q) ? GuideStarValidation.VALID : GuideStarValidation.INVALID;
+            }).getOrElse(GuideStarValidation.UNDEFINED);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -15,6 +15,7 @@ import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.gemini.gmos.GmosCommonType;
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon;
 import edu.gemini.spModel.guide.*;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.SPTarget;
@@ -279,15 +280,18 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
 
     /* ValidatableGuideProbe */
 
-    public boolean validate(SPTarget guideStar, ObsContext ctx) {
-        return validate(guideStar.getTarget().getSkycalcCoordinates(), ctx);
+    public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
+        final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
+        return guideStar.getTarget().getSkycalcCoordinates(when).map(coords ->
+            validate(coords, ctx)
+        ).getOrElse(GuideStarValidation.UNDEFINED);
     }
 
-    public boolean validate(SkyObject guideStar, ObsContext ctx) {
+    public GuideStarValidation validate(SkyObject guideStar, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 
-    public boolean validate(Coordinates coords, ObsContext ctx) {
+    public GuideStarValidation validate(Coordinates coords, ObsContext ctx) {
         return GuideProbeUtil.instance.validate(coords, this, ctx);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -271,6 +271,15 @@ public abstract class ITarget implements Cloneable, Serializable {
         return new Coordinates(getRa().getAs(CoordinateParam.Units.DEGREES), getDec().getAs(CoordinateParam.Units.DEGREES));
     }
 
+    /** Gets a Skycalc {@link edu.gemini.skycalc.Coordinates} representation. */
+    public synchronized Option<Coordinates> getSkycalcCoordinates(Option<Long> when) {
+        return
+            getRaDegrees(when).flatMap(ra ->
+            getDecDegrees(when).map(dec ->
+                new Coordinates(ra, dec)
+            ));
+    }
+
     public final String toString() {
         return String.format("ITarget(%s, %s)", getTag(), getName());
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
@@ -4,6 +4,7 @@ import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.guide.BoundaryPosition;
+import edu.gemini.spModel.guide.GuideStarValidation;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.TargetEnvironment;
@@ -75,7 +76,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         assertFalse("Mid point of fov, after (-width,-height) movement of base.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(middle.getRaDeg(), middle.getDecDeg()),
-                        ctx));
+                        ctx) == GuideStarValidation.VALID);
 
         //mid point of fov moved
         Coordinates middleMoved = new Coordinates(
@@ -85,7 +86,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         assertTrue("Mid point of fov moved by (-width,-height), after (-width,-height) movement of base.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(middleMoved.getRaDeg(), middleMoved.getDecDeg()),
-                        ctx));
+                        ctx) == GuideStarValidation.VALID);
 
     }
 
@@ -108,19 +109,19 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         assertTrue("Mid point of fov.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
-                        baseContext));
+                        baseContext) == GuideStarValidation.VALID);
 
         ObsContext ctx = baseContext.withPositionAngle(new Angle(90, DEGREES));
         assertFalse("Mid point of fov, after 90 degree rotation of fov.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
-                        ctx));
+                        ctx) == GuideStarValidation.VALID);
 
         ctx = baseContext.withPositionAngle(new Angle(45, DEGREES));
         assertTrue("Mid point of fov, after 45 degree rotation of fov.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
-                        ctx));
+                        ctx) == GuideStarValidation.VALID);
 
     }
 
@@ -143,7 +144,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         assertTrue("Point in fov.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
-                        baseContext));
+                        baseContext) == GuideStarValidation.VALID);
 
         InstGmosNorth ign = (InstGmosNorth) baseContext.getInstrument();
         ign.setFPUnit(GmosNorthType.FPUnitNorth.IFU_2);
@@ -152,7 +153,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         assertFalse("Point outside of fov, after IFU selected.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
-                        ctx));
+                        ctx) == GuideStarValidation.VALID);
 
 
     }
@@ -187,7 +188,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         Coordinates[] corners=getCorners(GmosOiwfsGuideProbe.instance.getPatrolField().getArea().getBounds2D(), 0.0001);
         for(Integer i=0;i<4;i++){
             SPTarget guideTarget = new SPTarget(corners[i].getRaDeg(), corners[i].getDecDeg());
-            assertTrue("Corner "+i+" failed.",GmosOiwfsGuideProbe.instance.validate(guideTarget,baseContext));
+            assertTrue("Corner "+i+" failed.",GmosOiwfsGuideProbe.instance.validate(guideTarget,baseContext) == GuideStarValidation.VALID);
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -429,7 +429,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
                 boolean valid = true;
                 AttributedString txt = new AttributedString(tag, attrMap);
                 if (!obsContextOpt.isEmpty() && (validator != null) &&
-                        !validator.validate(target, obsContextOpt.getValue())) {
+                        validator.validate(target, obsContextOpt.getValue()) != GuideStarValidation.VALID) {
                     txt.addAttribute(TextAttribute.STRIKETHROUGH, true);
                     txt.addAttribute(TextAttribute.FOREGROUND, invalidColor);
                     g2d.setColor(invalidColor);


### PR DESCRIPTION
This PR changes guidestar validation from a `Boolean` to a ternary `Valid/Invalid/Undefined` to reflect the case where base or guidestar coordinates are unknown for the context scheduling block.