### PR TITLE
Added empty settings for OT

### DIFF
--- a/project/OcsCredentials.scala.template
+++ b/project/OcsCredentials.scala.template
@@ -6,6 +6,12 @@ import edu.gemini.osgi.tools.app.Configuration.Distribution.{ Test => TestDistro
 
 object OcsCredentials {
 
+  object Ot {
+    def common_credentials(version: Version) = AppConfig(
+      id = "common_credentials"
+    )
+  }
+
   object Qpt {
 
     // COMMON


### PR DESCRIPTION
Adding empty settings for OT credentials to credentials template file. This allows to compile the code with the template file without access to the actual credentials. (This is only relevant for people outside of the software group that need to work on some parts of the code base, like e.g. Sabrina working on ITC code.)