### PR TITLE
OCSADV-410: Request for feedback on Background AGS and Guide Star Status type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ project/OcsCredentials.scala
 # Reinclude packages named "target" and bundles that end in ".log"
 !/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/target
 !/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target
+!/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target
 !/bundle/edu.gemini.pot/src/main/resources/edu/gemini/spModel/target
 !/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target
 !/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 2, 1)
 
 pitVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 2, 1)
+ocsVersion in ThisBuild := OcsVersion("2015B", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 0)
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -99,7 +99,7 @@ object AgsStrategy {
         val target = new SPTarget(HmsDegTarget.fromSkyObject(ass.guideStar.toOldModel))
         val oldGpt = curEnv.getPrimaryGuideProbeTargets(ass.guideProbe).asScalaOpt
 
-        val newGpt = oldGpt.getOrElse(GuideProbeTargets.create(ass.guideProbe)).setBAGSTarget(target)
+        val newGpt = oldGpt.getOrElse(GuideProbeTargets.create(ass.guideProbe)).setBagsTarget(target)
         curEnv.putPrimaryGuideProbeTargets(newGpt)
       }
     }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -87,9 +87,10 @@ object AgsStrategy {
      * the Selection.
      */
     def applyTo(env: TargetEnvironment): TargetEnvironment = {
+      // Only interested in the manual targets here as we either have no AGS target or will be replacing it.
       def findMatching(gpt: GuideProbeTargets, target: SPTarget): Option[SPTarget] =
         Option(target.getTarget.getName).flatMap { n =>
-          gpt.getOptions.toList.asScala.find { t =>
+          gpt.getManualTargets.toList.asScala.find { t =>
             Option(t.getTarget.getName).map(_.trim).exists(_ == n.trim)
           }
         }
@@ -98,16 +99,7 @@ object AgsStrategy {
         val target = new SPTarget(HmsDegTarget.fromSkyObject(ass.guideStar.toOldModel))
         val oldGpt = curEnv.getPrimaryGuideProbeTargets(ass.guideProbe).asScalaOpt
 
-        val newGpt = oldGpt.fold(GuideProbeTargets.create(ass.guideProbe, target)) { gpt =>
-          // We already have guide probe targets for guide probe.
-          // Does one with the same target name already exist? If so, mark it as
-          // primary and replace it with the target we just made.  If not, add the
-          // target and mark it as primary.
-          findMatching(gpt, target).fold(gpt.update(OptionsList.UpdateOps.appendAsPrimary(target))) { existing =>
-            gpt.selectPrimary(existing).setPrimary(target)
-          }
-        }
-
+        val newGpt = oldGpt.getOrElse(GuideProbeTargets.create(ass.guideProbe)).setBAGSTarget(target)
         curEnv.putPrimaryGuideProbeTargets(newGpt)
       }
     }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -239,7 +239,8 @@ object GemsResultsAnalyzer {
       case                                     _ =>
         probe
     }
-    gp.map(GuideProbeTargets.create(_, toSPTarget(target)))
+    val spTarget = toSPTarget(target)
+    gp.map(GuideProbeTargets.create(_, spTarget).selectPrimary(spTarget))
   }
 
   // Returns the given targets list with any objects removed that are not valid in at least one of the

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
@@ -46,7 +46,8 @@ trait UCAC3Regression {
 
   // Build a GuideProbeTargets class out of a list of targets
   def guideProbeTargetsGenerator(targets: Map[String, SPTarget]):GuideProbeTargetsFinder = (guider: GuideProbe, name: String) => {
-    GuideProbeTargets.create(guider, targets.getOrElse(name, defaultTarget))
+    val target = targets.getOrElse(name, defaultTarget)
+    GuideProbeTargets.create(guider, target).selectPrimary(target)
   }
 
   // Converts targets with R magnitude to r', R or UC discarding duplicates

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -234,7 +234,7 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
         // Get the target component and update the base position.
         ISPObsComponent targetComp = _findComponent(obs, TargetObsComp.SP_TYPE);
         TargetObsComp targetObsComp = (TargetObsComp) targetComp.getDataObject();
-        TargetEnvironment targetEnv = targetObsComp.getTargetEnvironment();
+        final TargetEnvironment targetEnv = targetObsComp.getTargetEnvironment();
         SPTarget base = targetEnv.getBase();
 
         base.setName(tooTarget.getName());
@@ -272,14 +272,14 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
                     }
 
                     if (probe != null) {
-                        Option<GuideProbeTargets> gtOpt = targetEnv.getPrimaryGuideProbeTargets(probe);
-                        GuideProbeTargets gt = gtOpt.isEmpty() ? GuideProbeTargets.create(probe) : gtOpt.getValue();
+                        final Option<GuideProbeTargets> gtOpt = targetEnv.getPrimaryGuideProbeTargets(probe);
+                        final GuideProbeTargets gt = gtOpt.isEmpty() ? GuideProbeTargets.create(probe) : gtOpt.getValue();
 
-                        Option<SPTarget> targetOpt = gt.getPrimary();
-                        SPTarget target = targetOpt.isEmpty() ? new SPTarget() : targetOpt.getValue();
+                        final Option<SPTarget> targetOpt = gt.getPrimary();
+                        final SPTarget target = targetOpt.isEmpty() ? new SPTarget() : targetOpt.getValue();
 
                         target.setRaDecDegrees(gs.getRa(), gs.getDec());
-                        String name = gs.getName();
+                        final String name = gs.getName();
                         if (name != null) {
                             target.setName(name);
                         }
@@ -287,10 +287,9 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
                         target.setMagnitudes(gs.getMagnitudes());
 
                         if (targetOpt.isEmpty()) {
-                            ImList<SPTarget> lst = gt.getOptions().cons(target);
-                            gt = GuideProbeTargets.create(probe, lst);
-                            targetEnv = targetEnv.putPrimaryGuideProbeTargets(gt);
-                            targetObsComp.setTargetEnvironment(targetEnv);
+                            final GuideProbeTargets gtNew = gt.setManualTargets(gt.getManualTargets().cons(target)).selectPrimary(target);
+                            final TargetEnvironment targetEnvNew = targetEnv.putPrimaryGuideProbeTargets(gtNew);
+                            targetObsComp.setTargetEnvironment(targetEnvNew);
                         }
                     }
                 }

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -220,77 +220,77 @@ public final class TooUpdateServiceImpl implements TooUpdateService {
         return null;
     }
 
-    private void _setTarget(ISPObservation obs, TooUpdate update)  {
-        TooTarget tooTarget = update.getBasePosition();
+    private void _setTarget(final ISPObservation obs, final TooUpdate update)  {
+        final TooTarget tooTarget = update.getBasePosition();
         if (tooTarget == null) {
             LOG.warning("Too update missing target information.");
             return;
         }
 
         // Set the title of the observation.
-        SPObservation obsDobj = (SPObservation) obs.getDataObject();
+        final SPObservation obsDobj = (SPObservation) obs.getDataObject();
         obsDobj.setTitle(tooTarget.getName());
 
         // Get the target component and update the base position.
-        ISPObsComponent targetComp = _findComponent(obs, TargetObsComp.SP_TYPE);
-        TargetObsComp targetObsComp = (TargetObsComp) targetComp.getDataObject();
-        final TargetEnvironment targetEnv = targetObsComp.getTargetEnvironment();
-        SPTarget base = targetEnv.getBase();
+        final ISPObsComponent targetComp = _findComponent(obs, TargetObsComp.SP_TYPE);
+        if (targetComp == null) {
+            LOG.warning("Too update has no target component.");
+            return;
+        }
 
+        final TargetObsComp targetObsComp = (TargetObsComp) targetComp.getDataObject();
+        final TargetEnvironment targetEnv = targetObsComp.getTargetEnvironment();
+
+        final SPTarget base = targetEnv.getBase();
         base.setName(tooTarget.getName());
         base.setRaDecDegrees(tooTarget.getRa(), tooTarget.getDec());
         base.setMagnitudes(tooTarget.getMagnitudes());
 
         // Set the guide star, if present.
-        TooGuideTarget gs = update.getGuideStar();
+        final TooGuideTarget gs = update.getGuideStar();
         if (gs != null) {
-            TooGuideTarget.GuideProbe tooProbe = gs.getGuideProbe();
+            final TooGuideTarget.GuideProbe tooProbe = gs.getGuideProbe();
             if (tooProbe == null) {
                 LOG.warning("Guide star probe not specified.");
             } else {
-                Double ra  = gs.getRa();
-                Double dec = gs.getDec();
+                // damn
+                final GuideProbe probe;
+                switch (tooProbe) {
+                    case AOWFS:
+                        probe = AltairAowfsGuider.instance;
+                        break;
+                    case OIWFS:
+                        probe = getOiwfs(obs);
+                        break;
+                    case PWFS1:
+                        probe = PwfsGuideProbe.pwfs1;
+                        break;
+                    case PWFS2:
+                        probe = PwfsGuideProbe.pwfs2;
+                        break;
+                    default:
+                        probe = null;
+                }
 
-                if ((ra == null) || (dec == null)) {
-                    LOG.warning("Guide star ra or dec missing.");
-                } else {
-                    // damn
-                    GuideProbe probe = null;
-                    switch (tooProbe) {
-                        case AOWFS:
-                            probe = AltairAowfsGuider.instance;
-                            break;
-                        case OIWFS:
-                            probe = getOiwfs(obs);
-                            break;
-                        case PWFS1:
-                            probe = PwfsGuideProbe.pwfs1;
-                            break;
-                        case PWFS2:
-                            probe = PwfsGuideProbe.pwfs2;
-                            break;
+                if (probe != null) {
+                    final Option<GuideProbeTargets> gtOpt = targetEnv.getPrimaryGuideProbeTargets(probe);
+                    final GuideProbeTargets gt = gtOpt.isEmpty() ? GuideProbeTargets.create(probe) : gtOpt.getValue();
+
+                    final Option<SPTarget> targetOpt = gt.getPrimary();
+                    final SPTarget target = targetOpt.isEmpty() ? new SPTarget() : targetOpt.getValue();
+
+                    target.setRaDecDegrees(gs.getRa(), gs.getDec());
+                    final String name = gs.getName();
+                    if (name != null) {
+                        target.setName(name);
                     }
-
-                    if (probe != null) {
-                        final Option<GuideProbeTargets> gtOpt = targetEnv.getPrimaryGuideProbeTargets(probe);
-                        final GuideProbeTargets gt = gtOpt.isEmpty() ? GuideProbeTargets.create(probe) : gtOpt.getValue();
-
-                        final Option<SPTarget> targetOpt = gt.getPrimary();
-                        final SPTarget target = targetOpt.isEmpty() ? new SPTarget() : targetOpt.getValue();
-
-                        target.setRaDecDegrees(gs.getRa(), gs.getDec());
-                        final String name = gs.getName();
-                        if (name != null) {
-                            target.setName(name);
-                        }
 
                         target.setMagnitudes(gs.getMagnitudes());
 
-                        if (targetOpt.isEmpty()) {
-                            final GuideProbeTargets gtNew = gt.setManualTargets(gt.getManualTargets().cons(target)).selectPrimary(target);
-                            final TargetEnvironment targetEnvNew = targetEnv.putPrimaryGuideProbeTargets(gtNew);
-                            targetObsComp.setTargetEnvironment(targetEnvNew);
-                        }
+                    if (targetOpt.isEmpty()) {
+                        final GuideProbeTargets gtNew = gt.setManualTargets(gt.getManualTargets().cons(target)).selectPrimary(target);
+                        final TargetEnvironment targetEnvNew = targetEnv.putPrimaryGuideProbeTargets(gtNew);
+                        targetObsComp.setTargetEnvironment(targetEnvNew);
                     }
                 }
             }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -154,16 +154,16 @@ public class GeneralRule implements IRule {
         public IP2Problems check(ObservationElements elements)  {
             if (elements.getTargetObsComp().isEmpty()) return null; //can't check
 
-            TargetEnvironment env = elements.getTargetObsComp().getValue().getTargetEnvironment();
+            final TargetEnvironment env = elements.getTargetObsComp().getValue().getTargetEnvironment();
 
-            P2Problems problems = new P2Problems();
-            SPTarget baseTarget = env.getBase();
+            final P2Problems problems = new P2Problems();
+            final SPTarget baseTarget = env.getBase();
 
             final boolean hasAltairComp = elements.hasAltair();
             boolean isLgs = false;
 
             // Don't do Altair checks if Altair is not supported
-            boolean altairSupported = isAltairSupported(elements);
+            final boolean altairSupported = isAltairSupported(elements);
 
             if (hasAltairComp && altairSupported) {
                 final ISPObsComponent targetComp = elements.getTargetObsComponentNode().getValue();
@@ -193,12 +193,12 @@ public class GeneralRule implements IRule {
                 }
             }
 
-            for (GuideProbeTargets guideTargets : env.getOrCreatePrimaryGuideGroup()) {
-                GuideProbe guider = guideTargets.getGuider();
+            for (final GuideProbeTargets guideTargets : env.getOrCreatePrimaryGuideGroup()) {
+                final GuideProbe guider = guideTargets.getGuider();
                 // TODO: GuideProbeTargets.isEnabled
 
                 final boolean dis = elements.getObsContext().exists(c -> !GuideProbeUtil.instance.isAvailable(c, guider) &&
-                                                                         (guideTargets.getOptions().size() > 0));
+                                                                         (guideTargets.getTargets().size() > 0));
                 if (dis) {
                     problems.addError(PREFIX+"DISABLED_GUIDER", String.format(DISABLED_GUIDER, guider.getKey()),
                             elements.getTargetObsComponentNode().getValue());
@@ -206,8 +206,8 @@ public class GeneralRule implements IRule {
                 }
 
                 if (guider == PwfsGuideProbe.pwfs1) {
-                    if (guideTargets.getOptions().size() > 0) {
-                        SPInstObsComp instrument = elements.getInstrument();
+                    if (guideTargets.getTargets().size() > 0) {
+                        final SPInstObsComp instrument = elements.getInstrument();
                         if(instrument!=null && instrument.getSite().contains(Site.GN) && !isLgs){
                             problems.addWarning(PREFIX+"P2_PREFERRED", P2_PREFERRED,elements.getTargetObsComponentNode().getValue());
                         }
@@ -215,8 +215,8 @@ public class GeneralRule implements IRule {
                     continue;
                 }
 
-                Set<String> errorSet = new TreeSet<String>();
-                for (SPTarget target : guideTargets) {
+                final Set<String> errorSet = new TreeSet<>();
+                for (final SPTarget target : guideTargets) {
                     //Check for empty name
                     if ("".equals(target.getTarget().getName().trim())) {
                         errorSet.add(String.format(WFS_EMPTY_NAME_TEMPLATE, guider.getKey()));
@@ -247,9 +247,9 @@ public class GeneralRule implements IRule {
                     }
 
                 }
-                for (String error : errorSet) {
-                    String id = error.equals(WFS_EMPTY_NAME_TEMPLATE) ? "WFS_EMPTY_NAME_TEMPLATE" :
-                            (error.equals(NAME_CLASH_MESSAGE) ? "NAME_CLASH_MESSAGE" : "COORD_CLASH_MESSAGE");
+                for (final String error : errorSet) {
+                    final String id = error.equals(WFS_EMPTY_NAME_TEMPLATE) ? "WFS_EMPTY_NAME_TEMPLATE" :
+                              (error.equals(NAME_CLASH_MESSAGE) ? "NAME_CLASH_MESSAGE" : "COORD_CLASH_MESSAGE");
                     problems.addError(PREFIX+id, error, elements.getTargetObsComponentNode().getValue());
                 }
             }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/michelle/MichelleRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/michelle/MichelleRule.java
@@ -46,16 +46,16 @@ public class MichelleRule implements IRule {
         private static final String OI_PRESENT_MESSAGE = "MICHELLE has no OIWFS";
 
         public IP2Problems check(ObservationElements elements)  {
-            P2Problems prob = new P2Problems();
-            for (TargetObsComp obsCommp : elements.getTargetObsComp()) {
+            final P2Problems prob = new P2Problems();
+            for (final TargetObsComp obsCommp : elements.getTargetObsComp()) {
 
-                TargetEnvironment env = obsCommp.getTargetEnvironment();
+                final TargetEnvironment env = obsCommp.getTargetEnvironment();
 
-                Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(PwfsGuideProbe.pwfs2);
+                final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(PwfsGuideProbe.pwfs2);
 
                 // TODO: GuideProbeTargets.isEnabled
-                boolean activeP2 = elements.getObsContext().exists(c -> GuideProbeUtil.instance.isAvailable(c, PwfsGuideProbe.pwfs2));
-                boolean hasP2 = !gtOpt.isEmpty() && activeP2 && (gtOpt.getValue().getOptions().size() > 0);
+                final boolean activeP2 = elements.getObsContext().exists(c -> GuideProbeUtil.instance.isAvailable(c, PwfsGuideProbe.pwfs2));
+                final boolean hasP2 = activeP2 && gtOpt.exists(GuideProbeTargets::containsTargets);
 
                 if (!hasP2) {
                     prob.addWarning(PREFIX + "NO_P2_MESSAGE", NO_P2_MESSAGE, elements.getTargetObsComponentNode().getValue());
@@ -67,16 +67,12 @@ public class MichelleRule implements IRule {
             return prob;
         }
 
-        private boolean hasOI(TargetEnvironment env) {
-            GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
+        private boolean hasOI(final TargetEnvironment env) {
+            final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
 
-            ImList<GuideProbeTargets> col = grp.getAllMatching(GuideProbe.Type.OIWFS);
+            final ImList<GuideProbeTargets> col = grp.getAllMatching(GuideProbe.Type.OIWFS);
             if ((col == null) || (col.size() == 0)) return false;
-
-            for (GuideProbeTargets gt : col) {
-                if (gt.getOptions().size() > 0) return true;
-            }
-            return false;
+            return col.exists(gpt -> gpt.getTargets().nonEmpty());
         }
     };
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -840,8 +840,9 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         final TargetEnvironment tenv  = dataObj.getTargetEnvironment();
 
         final GuideGroup gg = tenv.getOrCreatePrimaryGuideGroup();
-        final Option<GuideProbeTargets> gpt = gg.get(Flamingos2OiwfsGuideProbe.instance);
-        return gpt.exists(spTargets -> !spTargets.getPrimary().isEmpty());
+
+        final Option<GuideProbeTargets> gptOpt = gg.get(Flamingos2OiwfsGuideProbe.instance);
+        return gptOpt.exists(gpt -> gpt.getPrimary().isDefined());
     }
 
     public static double getSpectroscopySetupSec() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -13,6 +13,7 @@ import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.OptionsList.UpdateOps;
 import edu.gemini.spModel.target.env.OptionsListImpl;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import scalaz.Alpha;
 
 import java.awt.geom.Area;
 import java.util.*;
@@ -79,37 +80,31 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
             return new Some<GuideProbe>(lookup(idOpt.getValue()));
         }
 
-        public TargetEnvironment add(SPTarget guideStar, ObsContext ctx) {
+        public TargetEnvironment add(final SPTarget guideStar, final boolean isBAGS, final ObsContext ctx) {
             // Select the appropriate guider, if any.
-            TargetEnvironment env = ctx.getTargets();
-            Option<GuideProbe> probeOpt = select(guideStar.getTarget().getSkycalcCoordinates(), ctx);
-            GuideProbe probe;
-            if (probeOpt.isEmpty()) {
-                // Just use ODGW1 since we're adding a target that is off the
-                // valid range.
-                probe = GsaoiOdgw.odgw1;
-            } else {
-                probe = probeOpt.getValue();
-            }
+            final TargetEnvironment env = ctx.getTargets();
+            final Option<GuideProbe> probeOpt = select(guideStar.getTarget().getSkycalcCoordinates(), ctx);
+
+            // If no probe is defined, just use ODGW1 since we're adding a target that is off the valid range.
+            final GuideProbe probe = probeOpt.getOrElse(GsaoiOdgw.odgw1);
 
             // Return an updated target environment that incorporates this
             // guide star.
-            GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
+            final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
 
-            GuideProbeTargets gpt;
-            Option<GuideProbeTargets> gptOpt = grp.get(probe);
-            if (gptOpt.isEmpty()) {
-                gpt = GuideProbeTargets.create(probe, guideStar);
-            } else {
-                gpt = gptOpt.getValue();
-                if (gpt.containsTarget(guideStar)) return env;
-                // Requested to always make new guide stars primary, whether
-                // they fall on the detector or not.  Adding as primary.
-                gpt = gpt.update(UpdateOps.appendAsPrimary(guideStar));
-            }
-            grp = grp.put(gpt);
+            final Option<GuideProbeTargets> gptOpt = grp.get(probe);
 
-            return env.setPrimaryGuideGroup(grp);
+            // If the target is already defined, ignore it, even if it is a BAGS target. We do not want any
+            // overlap between manual and BAGS, and manual overrides BAGS.
+            if (gptOpt.exists(gpt -> gpt.containsTarget(guideStar)))
+                return env;
+
+            final GuideProbeTargets gptNew = isBAGS
+                    ? gptOpt.map(gpt -> gpt.setBAGSTarget(guideStar).setPrimaryToBAGSTarget()).
+                        getOrElse(GuideProbeTargets.create(probe, guideStar).selectPrimary(guideStar))
+                    : gptOpt.getOrElse(GuideProbeTargets.create(probe, guideStar)).selectPrimary(guideStar);
+            final GuideGroup grpNew = grp.put(gptNew);
+            return env.setPrimaryGuideGroup(grpNew);
         }
 
         // Sort the targets in the current context into a map keyed by
@@ -117,24 +112,24 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
         // appear in the list associated with appropriate guide window.
         // Targets that don't land on the array are kept with whatever
         // guide window they were previously associated with.
-        private Map<GsaoiOdgw, List<SPTarget>> sortTargets(ObsContext ctx) {
+        private Map<GsaoiOdgw, List<SPTarget>> sortTargets(final ObsContext ctx) {
 
             // Initialize the map with empty lists.
-            Map<GsaoiOdgw, List<SPTarget>> map = new HashMap<GsaoiOdgw, List<SPTarget>>();
-            for (GsaoiOdgw odgw : GsaoiOdgw.values()) {
-                map.put(odgw, new ArrayList<SPTarget>());
+            final Map<GsaoiOdgw, List<SPTarget>> map = new HashMap<>();
+            for (final GsaoiOdgw odgw : GsaoiOdgw.values()) {
+                map.put(odgw, new ArrayList<>());
             }
 
             // Sort each ODGW target into a map of lists where each list is
             // keyed by the ODGW type.  Sort according to which dector array
             // that they fall into.
-            TargetEnvironment env = ctx.getTargets();
-            for (GsaoiOdgw odgw : GsaoiOdgw.values()) {
-                Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(odgw);
+            final TargetEnvironment env = ctx.getTargets();
+            for (final GsaoiOdgw odgw : GsaoiOdgw.values()) {
+                final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(odgw);
                 if (gtOpt.isEmpty()) continue;
 
-                for (SPTarget target : gtOpt.getValue().getOptions()) {
-                    Option<GuideProbe> opt = select(target.getTarget().getSkycalcCoordinates(), ctx);
+                for (final SPTarget target : gtOpt.getValue().getTargets()) {
+                    final Option<GuideProbe> opt = select(target.getTarget().getSkycalcCoordinates(), ctx);
                     if (opt.isEmpty()) {
                         // Doesn't fall on the detector, so keep it with
                         // whichever ODGW it was associated with.
@@ -142,7 +137,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
                     } else {
                         // Does fall on the detector, so put it with that
                         // detector be-it the same as before or a new one.
-                        GsaoiOdgw newOdgw = (GsaoiOdgw) opt.getValue();
+                        final GsaoiOdgw newOdgw = (GsaoiOdgw) opt.getValue();
                         map.get(newOdgw).add(target);
                     }
                 }
@@ -154,23 +149,18 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
         // Gets the mapping of GsaoiOdgw to the guide star that is marked
         // as primary for that guider, if any.
         private Map<GsaoiOdgw, SPTarget> getOldPrimaryMap(ObsContext ctx) {
-            TargetEnvironment env = ctx.getTargets();
+            final TargetEnvironment env = ctx.getTargets();
 
-            Map<GsaoiOdgw, SPTarget> res = new HashMap<GsaoiOdgw, SPTarget>();
-            for (GsaoiOdgw odgw : GsaoiOdgw.values()) {
-                Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(odgw);
-                if (gtOpt.isEmpty()) continue; // no targets for this guider
-
-                Option<SPTarget> primary = gtOpt.getValue().getPrimary();
-                if (primary.isEmpty()) continue; // no primary for this guider
-
-                res.put(odgw, primary.getValue());
+            final Map<GsaoiOdgw, SPTarget> res = new HashMap<GsaoiOdgw, SPTarget>();
+            for (final GsaoiOdgw odgw : GsaoiOdgw.values()) {
+                final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(odgw);
+                gtOpt.foreach(gt -> gt.getPrimary().foreach(p -> res.put(odgw, p)));
             }
 
             return res;
         }
 
-        private SPTarget findNewPrimary(GsaoiOdgw odgw, SPTarget oldPrimary, Set<SPTarget> oldPrimarySet, List<SPTarget> newTargetList) {
+        private SPTarget findNewPrimary(final SPTarget oldPrimary, final Set<SPTarget> oldPrimarySet, final List<SPTarget> newTargetList) {
             // If the old primary guide star for this guide window is still
             // in the same detector array, then select it.
             if ((oldPrimary != null) && newTargetList.contains(oldPrimary)) {
@@ -183,24 +173,21 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
             // If one of the new guide stars for this guide window was
             // primary in its old home, then make it primary here.
-            for (SPTarget target : newTargetList) {
-                if (oldPrimarySet.contains(target)) return target;
-            }
-
-            // Just choose the first option since there is no logical choice.
-            return (newTargetList.size() > 0) ? newTargetList.get(0) : null;
+            return newTargetList.stream().
+                    filter(oldPrimarySet::contains).findFirst().
+                    orElse(newTargetList.stream().findFirst().orElse(null));
         }
 
         // Figures out, for each GsaoiOdgw, which guide star should be marked
         // as primary in the new assignment of guider stars to guiders.
-        private Map<GsaoiOdgw, SPTarget> getNewPrimaryMap(ObsContext ctx, Map<GsaoiOdgw, List<SPTarget>> newMap) {
-            Map<GsaoiOdgw, SPTarget> newPrimaryMap = new HashMap<GsaoiOdgw, SPTarget>();
-            Map<GsaoiOdgw, SPTarget> oldPrimaryMap = getOldPrimaryMap(ctx);
-            Set<SPTarget> oldPrimarySet = new HashSet<SPTarget>(oldPrimaryMap.values());
+        private Map<GsaoiOdgw, SPTarget> getNewPrimaryMap(final ObsContext ctx, final Map<GsaoiOdgw, List<SPTarget>> newMap) {
+            final Map<GsaoiOdgw, SPTarget> newPrimaryMap = new HashMap<>();
+            final Map<GsaoiOdgw, SPTarget> oldPrimaryMap = getOldPrimaryMap(ctx);
+            final Set<SPTarget> oldPrimarySet = new HashSet<>(oldPrimaryMap.values());
 
-            for (GsaoiOdgw odgw : GsaoiOdgw.values()) {
-                SPTarget oldPrimary = oldPrimaryMap.get(odgw);
-                SPTarget newPrimary = findNewPrimary(odgw, oldPrimary, oldPrimarySet, newMap.get(odgw));
+            for (final GsaoiOdgw odgw : GsaoiOdgw.values()) {
+                final SPTarget oldPrimary = oldPrimaryMap.get(odgw);
+                final SPTarget newPrimary = findNewPrimary(oldPrimary, oldPrimarySet, newMap.get(odgw));
                 if (newPrimary != null) newPrimaryMap.put(odgw, newPrimary);
             }
             return newPrimaryMap;
@@ -208,21 +195,21 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
         public Option<TargetEnvironment> optimize(ObsContext ctx) {
             // Sort the targets in the current context.
-            Map<GsaoiOdgw, List<SPTarget>> sortedMap = sortTargets(ctx);
+            final Map<GsaoiOdgw, List<SPTarget>> sortedMap = sortTargets(ctx);
 
             // Now figure out what the primary guide star should be in the
             // new context.
-            Map<GsaoiOdgw, SPTarget> primaryMap = getNewPrimaryMap(ctx, sortedMap);
+            final Map<GsaoiOdgw, SPTarget> primaryMap = getNewPrimaryMap(ctx, sortedMap);
 
             // Map all the old GuideTargets in the old target environment, keyed
             // by their guider.  This will include all guiders in use, not just
             // GsaoiOdgw.
 //            boolean enabled = true;
-            TargetEnvironment env = ctx.getTargets();
-            Map<GuideProbe, GuideProbeTargets> gtMap = new HashMap<GuideProbe, GuideProbeTargets>();
+            final TargetEnvironment env = ctx.getTargets();
+            final Map<GuideProbe, GuideProbeTargets> gtMap = new HashMap<>();
 
-            GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
-            for (GuideProbeTargets gt : grp) {
+            final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
+            for (final GuideProbeTargets gt : grp) {
                 gtMap.put(gt.getGuider(), gt);
 
                 // All ODGW should be disabled if any are disabled.
@@ -234,36 +221,46 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
             // Create the optimized target environment.
             boolean updated = false;
-            for (GsaoiOdgw odgw : GsaoiOdgw.values()) {
-                List<SPTarget> lst = sortedMap.get(odgw);
+            for (final GsaoiOdgw odgw : GsaoiOdgw.values()) {
+                final List<SPTarget> lst = sortedMap.get(odgw);
                 if (lst.size() == 0) {
                     // No guide stars for this guide window, so remove it from
                     // the map if it is there.
-                    GuideProbeTargets old = gtMap.remove(odgw);
-                    if ((old != null) && !old.getOptions().isEmpty()) {
+                    final GuideProbeTargets old = gtMap.remove(odgw);
+                    if ((old != null) && old.containsTargets()) {
                         updated = true;
                     }
                 } else {
                     // Create a new GuideTargets instance for this ODGW.  The
                     // primary was decided above, so just look it up in the
                     // primaryMap.
-                    ImList<SPTarget> imLst = DefaultImList.create(lst);
-                    SPTarget primary = primaryMap.get(odgw);
-                    int primaryIndex = imLst.indexOf(primary);
-                    Option<Integer> primaryOpt = (primaryIndex == -1) ? None.INTEGER : new Some<Integer>(primaryIndex);
-                    GuideProbeTargets old;
-                    old = gtMap.put(odgw, GuideProbeTargets.create(odgw, OptionsListImpl.create(primaryOpt, imLst)));
+                    final ImList<SPTarget> imLst = DefaultImList.create(lst);
+                    final SPTarget primary = primaryMap.get(odgw);
+                    final int primaryIndex = imLst.indexOf(primary);
 
-                    if (!updated && ((old == null) || targetsUpdated(imLst, old.getOptions()))) {
-                        updated = true;
+                    final Option<Integer> primaryOpt = (primaryIndex == -1) ? None.INTEGER : new Some<>(primaryIndex);
+
+                    // TODO: PROBLEM HERE: is primary BAGS or not?
+                    final GuideProbeTargets gptOld = gtMap.get(odgw);
+                    if (gptOld != null) {
+                        final boolean primaryIsBags = gptOld.getBAGSTarget().exists(primary::equals);
+                        final Option<SPTarget> bagsTarget = primaryIsBags ? new Some<>(primary) : GuideProbeTargets.NO_TARGET;
+                        final GuideProbeTargets gptNew = GuideProbeTargets.create(odgw, bagsTarget, new Some<>(primary), imLst);
+                        gtMap.put(odgw, gptNew);
+
+                        if (!updated && (targetsUpdated(imLst, gptOld.getManualTargets()) || !gptOld.getBAGSTarget().equals(bagsTarget))) {
+                            updated = true;
+                        }
                     }
                 }
             }
 
-            Option<TargetEnvironment> res = None.instance();
+            final Option<TargetEnvironment> res;
             if (updated) {
-                ImList<GuideProbeTargets> gtList = DefaultImList.create(gtMap.values());
-                res = new Some<TargetEnvironment>(env.setPrimaryGuideGroup(grp.setAll(gtList)));
+                final ImList<GuideProbeTargets> gtList = DefaultImList.create(gtMap.values());
+                res = new Some<>(env.setPrimaryGuideGroup(grp.setAll(gtList)));
+            } else {
+                res = None.instance();
             }
             return res;
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsSetupTimeService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsSetupTimeService.java
@@ -90,9 +90,9 @@ public class NifsSetupTimeService {
 
         // Add 5 minutes if using the OIWFS
         if (ctx.target != null) {
-            TargetEnvironment env = ctx.target.getTargetEnvironment();
-            Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(NifsOiwfsGuideProbe.instance);
-            if (!gtOpt.isEmpty() && (gtOpt.getValue().getOptions().size() > 0)) {
+            final TargetEnvironment env = ctx.target.getTargetEnvironment();
+            final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(NifsOiwfsGuideProbe.instance);
+            if (gtOpt.isDefined() && gtOpt.getValue().containsTargets()) {
                 setupSeconds += OIWFS_SETUP_SEC;
             }
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/OptimizableGuideProbeGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/OptimizableGuideProbeGroup.java
@@ -20,13 +20,16 @@ public interface OptimizableGuideProbeGroup extends GuideProbeGroup {
      * @param guideStar the new guide star to incorporate in the target
      * environment
      *
+     * @param isBAGS determines if the guide star was chosen by background
+     * AGS (true) or manually selected (false)*
+     *
      * @param ctx the context of the observation, which contains information
      * needed to assign a guider to the new guide star
      *
      * @return a newly optimized TargetEnvironment which incorporates the given
      * <code>guideStar</code>
      */
-    TargetEnvironment add(SPTarget guideStar, ObsContext ctx);
+    TargetEnvironment add(SPTarget guideStar, boolean isBAGS, ObsContext ctx);
 
     /**
      * Optimizes the assignment of guide stars to guiders according to the given

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ElectronicOffsetSync.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ElectronicOffsetSync.java
@@ -134,19 +134,16 @@ public enum ElectronicOffsetSync implements ISPEventMonitor {
             if (None.instance().equals(target)) return false;
 
             // Figure out the guider to use.
-            ElectronicOffsetProvider prov;
-            prov = (ElectronicOffsetProvider) inst.getDataObject();
-            GuideProbe guider = prov.getElectronicOffsetGuider();
+            final ElectronicOffsetProvider prov = (ElectronicOffsetProvider) inst.getDataObject();
+            final GuideProbe guider = prov.getElectronicOffsetGuider();
 
             // Get the target environment.
-            TargetObsComp targetComp;
-            targetComp = (TargetObsComp) target.getValue().getDataObject();
-            TargetEnvironment env = targetComp.getTargetEnvironment();
+            final TargetObsComp targetComp = (TargetObsComp) target.getValue().getDataObject();
+            final TargetEnvironment env = targetComp.getTargetEnvironment();
 
             // Figure out whether it supports the indicated guide star.
-            Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(guider);
-            if (gtOpt.isEmpty()) return false;
-            return (gtOpt.getValue().getOptions().size() > 0);
+            final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(guider);
+            return gtOpt.exists(GuideProbeTargets::containsTargets);
         }
 
         /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideEnvironment.java
@@ -72,22 +72,17 @@ public final class GuideEnvironment implements Serializable, TargetContainer, Op
      * Gets the subset of referenced guiders that are actually selected, if any.
      */
     public SortedSet<GuideProbe> getPrimaryReferencedGuiders() {
-        return guideGroups.getPrimary().map(new MapOp<GuideGroup, SortedSet<GuideProbe>>() {
-            @Override
-            public SortedSet<GuideProbe> apply(GuideGroup group) {
-                return group.getPrimaryReferencedGuiders();
-            }
-        }).getOrElse(new TreeSet<>());
+        return guideGroups.getPrimary().map(GuideGroup::getPrimaryReferencedGuiders).getOrElse(new TreeSet<>());
     }
 
     @Override
     public ImList<SPTarget> getTargets() {
-        return guideGroups.getOptions().flatMap(TargetContainer.EXTRACT_TARGET);
+        return guideGroups.getOptions().flatMap(TargetContainer::getTargets);
     }
 
     @Override
     public boolean containsTarget(SPTarget target) {
-        return guideGroups.getOptions().exists(new TargetMatch(target));
+        return guideGroups.getOptions().exists(gg -> gg.containsTarget(target));
     }
 
     private GuideEnvironment updateGuideGroups(UpdateOp<GuideGroup> f) {
@@ -98,12 +93,12 @@ public final class GuideEnvironment implements Serializable, TargetContainer, Op
 
     @Override
     public GuideEnvironment cloneTargets() {
-        return updateGuideGroups(GuideGroup.CLONE_TARGETS);
+        return updateGuideGroups(GuideGroup::cloneTargets);
     }
 
     @Override
     public GuideEnvironment removeTarget(SPTarget target) {
-        return updateGuideGroups(GuideGroup.removeTargetUpdate(target));
+        return updateGuideGroups(g -> g.removeTarget(target));
     }
 
     public GuideEnvironment removeGroup(GuideGroup group) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideGroup.java
@@ -155,7 +155,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * instance; <code>false</code> otherwise
      */
     public boolean contains(GuideProbe guider) {
-        return guideTargets.exists(GuideProbeTargets.match(guider));
+        return guideTargets.exists(gpt -> gpt.getGuider() == guider);
     }
 
     /**
@@ -169,7 +169,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * {@link edu.gemini.shared.util.immutable.None} if none
      */
     public Option<GuideProbeTargets> get(GuideProbe guider) {
-        return guideTargets.find(GuideProbeTargets.match(guider));
+        return guideTargets.find(gpt -> gpt.getGuider() == guider);
     }
 
     /**
@@ -186,7 +186,8 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * given guide probe target options
      */
     public GuideGroup put(GuideProbeTargets targets) {
-        return new GuideGroup(name, sortByGuider(guideTargets.remove(GuideProbeTargets.match(targets.getGuider())).cons(targets)));
+        final GuideProbe guideProbe = targets.getGuider();
+        return new GuideGroup(name, sortByGuider(guideTargets.remove(gpt -> gpt.getGuider() == guideProbe).cons(targets)));
     }
 
     /**
@@ -201,7 +202,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * {@link GuideProbeTargets} entry associated with {@link GuideProbe}
      */
     public GuideGroup remove(GuideProbe guider) {
-        final ImList<GuideProbeTargets> lst = guideTargets.remove(GuideProbeTargets.match(guider));
+        final ImList<GuideProbeTargets> lst = guideTargets.remove(gpt -> gpt.getGuider() == guider);
         if (lst.size() == guideTargets.size()) return this;
         return new GuideGroup(name, lst);
     }
@@ -287,7 +288,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * with the given <code>type</code>, or an empty collection if none
      */
     public ImList<GuideProbeTargets> getAllMatching(GuideProbe.Type type) {
-        return guideTargets.filter(GuideProbeTargets.match(type));
+        return guideTargets.filter(gpt -> gpt.getGuider().getType() == type);
     }
 
 
@@ -300,7 +301,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * list if there are none
      */
     private ImList<GuideProbe> getReferencedGuiderList() {
-        return guideTargets.filter(GuideProbeTargets.MATCH_NON_EMPTY).map(GuideProbeTargets.EXTRACT_PROBE);
+        return guideTargets.filter(GuideProbeTargets::containsTargets).map(GuideProbeTargets::getGuider);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideGroup.java
@@ -339,11 +339,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * selected target.
      */
     public SortedSet<GuideProbe> getPrimaryReferencedGuiders() {
-        return toSet(guideTargets.filter(new PredicateOp<GuideProbeTargets>() {
-            @Override public Boolean apply(GuideProbeTargets gpt) {
-                return gpt.getPrimary().isDefined();
-            }
-        }).map(GuideProbeTargets.EXTRACT_PROBE));
+        return toSet(guideTargets.filter(gpt -> gpt.getPrimary().isDefined()).map(GuideProbeTargets::getGuider));
     }
 
     /**
@@ -380,11 +376,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
 
     @Override
     public GuideGroup removeTarget(final SPTarget target) {
-        ImList<GuideProbeTargets> updated = guideTargets.map(new Function1<GuideProbeTargets, GuideProbeTargets>() {
-            @Override public GuideProbeTargets apply(GuideProbeTargets t) {
-                return t.update(UpdateOps.remove(target));
-            }
-        });
+        final ImList<GuideProbeTargets> updated = guideTargets.map(gpt -> gpt.removeTargetSelectPrimary(target));
         return new GuideGroup(name, updated);
     }
 
@@ -396,11 +388,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
 
     @Override
     public GuideGroup cloneTargets() {
-        ImList<GuideProbeTargets> cloned = guideTargets.map(new Function1<GuideProbeTargets, GuideProbeTargets>() {
-            @Override public GuideProbeTargets apply(GuideProbeTargets t) {
-                return t.cloneTargets();
-            }
-        });
+        final ImList<GuideProbeTargets> cloned = guideTargets.map(GuideProbeTargets::cloneTargets);
         return new GuideGroup(name, cloned);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideGroup.java
@@ -275,7 +275,7 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
      * <code>{@link edu.gemini.shared.util.immutable.None}</code> otherwise
      */
     public ImList<GuideProbeTargets> getAllContaining(SPTarget target) {
-        return guideTargets.filter(new TargetMatch(target));
+        return guideTargets.filter(gt -> gt.containsTarget(target));
     }
 
     /**
@@ -359,20 +359,12 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
 
     @Override
     public ImList<SPTarget> getTargets() {
-        return guideTargets.flatMap(TargetContainer.EXTRACT_TARGET);
+        return guideTargets.flatMap(TargetContainer::getTargets);
     }
 
     @Override
     public boolean containsTarget(SPTarget target) {
-        return guideTargets.exists(new TargetMatch(target));
-    }
-
-    public static UpdateOp<GuideGroup> removeTargetUpdate(final SPTarget target) {
-        return new UpdateOp<GuideGroup>() {
-            @Override public GuideGroup apply(GuideGroup group) {
-                return group.removeTarget(target);
-            }
-        };
+        return guideTargets.exists(gt -> gt.containsTarget(target));
     }
 
     @Override
@@ -380,12 +372,6 @@ public final class GuideGroup implements Serializable, Iterable<GuideProbeTarget
         final ImList<GuideProbeTargets> updated = guideTargets.map(gpt -> gpt.removeTargetSelectPrimary(target));
         return new GuideGroup(name, updated);
     }
-
-    public static final UpdateOp<GuideGroup> CLONE_TARGETS = new UpdateOp<GuideGroup>() {
-        @Override public GuideGroup apply(GuideGroup guideGroup) {
-            return guideGroup.cloneTargets();
-        }
-    };
 
     @Override
     public GuideGroup cloneTargets() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -20,14 +20,14 @@ import java.util.*;
 //* context of the observation, and disabled otherwise.
 
 /**
- * An immutable pairing of a {@link GuideProbe} with an {@link OptionsList}
- * &lt;{@link SPTarget}&gt;, which is a list of targets and an optional
- * target designated as the primary target.
+ * An immutable pairing of a {@link GuideProbe} with a collection of {@SPTarget}.
+ * One target may be marked as having been picked by background AGS (BAGS).
+ * One target may be marked as the primary target for the guider.
  *
- * <p>Note, the guide targets list itself is immutable but unfortunately the
- * {@link SPTarget} objects it contains are mutable.
+ * <p>Note that while this object and the list of targets itself is immutable, the actual SPTargets themselves are
+ * mutable.
  */
-public final class GuideProbeTargets implements Serializable, TargetContainer, OptionsList<SPTarget> {
+public final class GuideProbeTargets implements Serializable, TargetContainer, Iterable<SPTarget> {
 
     /**
      * An empty list of GuideProbeTargets.  This is the same object as
@@ -35,6 +35,13 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
      * typed for convenience.
      */
     public static final ImList<GuideProbeTargets> EMPTY_LIST = ImCollections.emptyList();
+
+    /**
+     * An empty SPTarget. Ths is the same object as
+     * {@link edu.gemini.shared.util.immutable.None#INSTANCE}, but typed
+     * for convenience.
+     */
+    public static final Option<SPTarget> NO_TARGET = None.instance();
 
     /**
      * Creates a {@link PredicateOp} that can be used with an {@link ImList} of
@@ -52,11 +59,7 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
      * {@link GuideProbe}
      */
     public static PredicateOp<GuideProbeTargets> match(final GuideProbe guider) {
-        return new PredicateOp<GuideProbeTargets>() {
-            @Override public Boolean apply(GuideProbeTargets targets) {
-                return targets.getGuider() == guider;
-            }
-        };
+        return (final GuideProbeTargets targets) -> targets.getGuider() == guider;
     }
 
     /**
@@ -75,11 +78,7 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
      * {@link GuideProbe.Type}
      */
     public static PredicateOp<GuideProbeTargets> match(final GuideProbe.Type type) {
-        return new PredicateOp<GuideProbeTargets>() {
-            @Override public Boolean apply(GuideProbeTargets guideTargets) {
-                return guideTargets.getGuider().getType() == type;
-            }
-        };
+        return (final GuideProbeTargets guideTargets) -> guideTargets.getGuider().getType() == type;
     }
 
     /**
@@ -89,9 +88,9 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
     public static enum GuiderComparator implements Serializable, Comparator<GuideProbeTargets> {
         instance;
 
-        @Override public int compare(GuideProbeTargets gt1, GuideProbeTargets gt2) {
-            GuideProbe g1 = gt1.getGuider();
-            GuideProbe g2 = gt2.getGuider();
+        @Override public int compare(final GuideProbeTargets gt1, final GuideProbeTargets gt2) {
+            final GuideProbe g1 = gt1.getGuider();
+            final GuideProbe g2 = gt2.getGuider();
             return GuideProbe.KeyComparator.instance.compare(g1, g2);
         }
     }
@@ -104,7 +103,7 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
      *
      * @return sorted list of GuideProbeTargets
      */
-    public static ImList<GuideProbeTargets> sortByGuider(ImList<GuideProbeTargets> lst) {
+    public static ImList<GuideProbeTargets> sortByGuider(final ImList<GuideProbeTargets> lst) {
         return lst.sort(GuiderComparator.instance);
     }
 
@@ -113,34 +112,56 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
      * A "function" that extracts the guider from a GuideProbeTarget.  Intended
      * for use with the {@link ImList#map} method.
      */
-    public static final Function1<GuideProbeTargets, GuideProbe> EXTRACT_PROBE = new Function1<GuideProbeTargets, GuideProbe>() {
-        @Override public GuideProbe apply(GuideProbeTargets gpt) {
-            return gpt.getGuider();
-        }
-    };
+    public static final Function1<GuideProbeTargets, GuideProbe> EXTRACT_PROBE = GuideProbeTargets::getGuider;
+
 
     /**
      * A {@link PredicateOp} that matches on GuideProbeTargets instances that
      * have at least one contained {@link SPTarget}.
+     * This can be either a target selected by BAGS, or a manually selected target.
      */
-    public static final PredicateOp<GuideProbeTargets> MATCH_NON_EMPTY = new PredicateOp<GuideProbeTargets>() {
-        @Override public Boolean apply(GuideProbeTargets gpt) {
-            return gpt.targetOptions.getOptions().size() > 0;
-        }
-    };
+    public static final PredicateOp<GuideProbeTargets> MATCH_NON_EMPTY =
+            (final GuideProbeTargets gpt) -> gpt.bagsTarget.isDefined() || gpt.manualTargets.nonEmpty();
+
+
+    /**
+     * Given an Option<SPTarget> and an SPTarget, if the optional SPTarget is the target, return None, otherwise
+     * return the optional SPTarget. This is used in SPTarget removals to set the bagsTarget and primaryTarget
+     * appropriately.
+     */
+    static private final Function2<Option<SPTarget>, SPTarget, Option<SPTarget>> possiblyRemoveTarget = ((o,t) ->
+            o.exists(t::equals) ? NO_TARGET : o
+    );
+
 
     /**
      * Creates a GuideTargets instance associated with the given
-     * {@link GuideProbe}.  It has no primary star if no targets are provided,
-     * otherwise it selects the first target in the list.
+     * {@link GuideProbe}.
+     * It marks no BAGS guide star, and no primary guide star.
      *
      * @param guider guide probe to associate with the GuideTargets
-     * @param targets zero or more targets to associate with the guide probe
+     * @param manualTargets zero or more manual targets
      *
      * @return a new GuideTargets object with the given targets
      */
-    public static GuideProbeTargets create(GuideProbe guider, SPTarget... targets) {
-        return new GuideProbeTargets(guider, OptionsListImpl.create(targets));
+    public static GuideProbeTargets create(final GuideProbe guider, final SPTarget... manualTargets) {
+        return new GuideProbeTargets(guider, NO_TARGET, NO_TARGET, DefaultImList.create(manualTargets));
+    }
+
+    /**
+     * Creates a GuideTargets instance associated with the given
+     * {@link GuideProbe}.
+     *
+     * @param guider guide probe to associate with the GuideTargets
+     * @param bagsTarget the automatic guide star as chosen by BAGS
+     * @param primaryTarget the primary target, which must be either the BAGS target or in the targets list
+     * @param manualTargets zero or more manual targets
+     *
+     * @return a new GuideTargets object with the given targets
+     */
+    public static GuideProbeTargets create(final GuideProbe guider, final Option<SPTarget> bagsTarget,
+                                           final Option<SPTarget> primaryTarget, final SPTarget... manualTargets) {
+        return new GuideProbeTargets(guider, bagsTarget, primaryTarget, DefaultImList.create(manualTargets));
     }
 
     /**
@@ -150,41 +171,44 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
      * target in the list.
      *
      * @param guider guider to associate with these targets
-     * @param targetList zero or more targets to associate with the guide probe
+     * @param bagsTarget the automatic guide star as chosen by BAGS
+     * @param primaryTarget the primary target, which must be either the BAGS target or in the targets list
+     * @param manualTargets a list of the manual targets
      *
      * @return a new GuideTargets object with the given targets
      */
-    public static GuideProbeTargets create(GuideProbe guider, ImList<SPTarget> targetList) {
-        return new GuideProbeTargets(guider, OptionsListImpl.create(targetList));
-    }
-
-    /**
-     * Creates a GuideTargets instance associated with the given
-     * {@link GuideProbe} and target options.
-     *
-     * @param guider guider to associate with these targets
-     * @param targets target options to associate with the guide probe
-     *
-     * @return a new GuideTargets object with the given targets
-     */
-    public static GuideProbeTargets create(GuideProbe guider, OptionsList<SPTarget> targets) {
-        return new GuideProbeTargets(guider, targets);
+    public static GuideProbeTargets create(final GuideProbe guider, final Option<SPTarget> bagsTarget,
+                                           final Option<SPTarget> primaryTarget, final ImList<SPTarget> manualTargets) {
+        return new GuideProbeTargets(guider, bagsTarget, primaryTarget, manualTargets);
     }
 
 
     private final GuideProbe guider;
-    private final OptionsList<SPTarget> targetOptions;
+    private final ImList<SPTarget> manualTargets;
 
-    private GuideProbeTargets(GuideProbe guider, OptionsList<SPTarget> targetOptions) {
-        if (guider == null) {
+    // The targets selected as the primary target and the target chosen by bags.
+    // Note that these can be the same.
+    private final Option<SPTarget> primaryTarget;
+    private final Option<SPTarget> bagsTarget;
+
+
+    private GuideProbeTargets(final GuideProbe guider, final Option<SPTarget> bagsTarget,
+                              final Option<SPTarget> primaryTarget, final ImList<SPTarget> manualTargets) {
+        if (guider == null)
             throw new IllegalArgumentException("missing guider");
-        }
-        if (targetOptions == null) {
+        if (bagsTarget == null)
+            throw new IllegalArgumentException("missing BAGS target");
+        if (primaryTarget == null)
+            throw new IllegalArgumentException("missing primary target");
+        if (manualTargets == null)
             throw new IllegalArgumentException("missing target options");
-        }
+        if (!bagsTarget.equals(primaryTarget) && !primaryTarget.forall(manualTargets::contains))
+            throw new IllegalArgumentException("primary target must be either BAGS target or in manual targets");
 
         this.guider = guider;
-        this.targetOptions = targetOptions;
+        this.bagsTarget = bagsTarget;
+        this.primaryTarget = primaryTarget;
+        this.manualTargets = manualTargets;
     }
 
     /**
@@ -194,147 +218,392 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, O
         return guider;
     }
 
-    @Override
-    public boolean containsTarget(SPTarget target) {
-        return targetOptions.getOptions().contains(target);
+    /**
+     * Quick boolean method to determine if this object contains any targets, as calling getTargets().nonEmpty
+     * is inefficient since it creates a new list.
+     * @return true if there are any targets in this object, and false otherwise
+     */
+    public boolean containsTargets() {
+        return bagsTarget.isDefined() || manualTargets.nonEmpty();
     }
 
+    /**
+     * Determine if the targets contain the specified target.
+     * This is the case if the given target has been selected by BAGS or manually.
+     * @param target the target in question
+     * @return true if either the BAGS target or a manual target, and false otherwise
+     */
+    @Override
+    public boolean containsTarget(final SPTarget target) {
+        return bagsTarget.exists(target::equals) || manualTargets.contains(target);
+    }
+
+    /**
+     * Get a list of the targets. If a BAGS target has been specified, it will be prepended to the list of
+     * manual targets
+     * @return a list of all targets
+     */
     @Override
     public ImList<SPTarget> getTargets() {
-        return targetOptions.getOptions();
+        if (bagsTarget.isDefined())
+            return DefaultImList.create(bagsTarget.getValue()).append(manualTargets);
+        else
+            return manualTargets;
     }
 
+    /**
+     * Get a list of the manual targets only.
+     * @return a list of the manual targets
+     */
+    public ImList<SPTarget> getManualTargets() {
+        return manualTargets;
+    }
+
+    /**
+     * Create a deep clone of this instance.
+     * @return the deep clone
+     */
     @Override
     public GuideProbeTargets cloneTargets() {
-        Option<Integer>   primaryIndex = targetOptions.getPrimaryIndex();
-        ImList<SPTarget> clonedTargets = targetOptions.getOptions().map(new Function1<SPTarget, SPTarget>() {
-            public SPTarget apply(final SPTarget target) {
-                return target.clone();
-            }
-        });
-        OptionsListImpl<SPTarget> clone = OptionsListImpl.create(primaryIndex, clonedTargets);
-        return new GuideProbeTargets(guider, clone);
+        final Option<SPTarget> bagsTargetClone = bagsTarget.map(SPTarget::clone);
+        final ImList<SPTarget> manualTargetsClone = manualTargets.map(SPTarget::clone);
+
+        // Cases:
+        // 1. Primary is None
+        // 2. Primary is BAGS
+        // 3. Primary is in manual list
+        final Option<SPTarget> primaryTargetClone = primaryTarget.map(t ->
+                bagsTarget.exists(t::equals) ? bagsTarget.getValue() :
+                manualTargetsClone.get(manualTargets.indexOf(t))
+        );
+
+        return new GuideProbeTargets(guider, bagsTargetClone, primaryTargetClone, manualTargetsClone);
     }
 
+
+    /**
+     * Remove a target.
+     * If it is the BAGS target, then create a new copy with BAGS target set to None.
+     * If it is the primary target, then create a new copy with no primary target.
+     * @param target the target to remove
+     * @return a copy of this GuideProbeTargets with the target removed
+     */
     @Override
-    public GuideProbeTargets removeTarget(SPTarget target) {
-        return update(UpdateOps.remove(target));
+    public GuideProbeTargets removeTarget(final SPTarget target) {
+        if (!bagsTarget.exists(target::equals) && !manualTargets.contains(target))
+            return this;
+
+        final Option<SPTarget> bagsTargetNew = possiblyRemoveTarget.apply(bagsTarget, target);
+        final Option<SPTarget> primaryTargetNew = possiblyRemoveTarget.apply(primaryTarget, target);
+        final ImList<SPTarget> manualTargetsNew = manualTargets.remove(target);
+        return new GuideProbeTargets(guider, bagsTargetNew, primaryTargetNew, manualTargetsNew);
     }
 
+    /**
+     * Remove a target. If is the primary target, we want to maintain a primary target, either as
+     * the next candidate in the list if one is defined, or the previous candidate if one isn't (otherwise
+     * None).
+     * @param target the target to remove
+     * @return a copy of this GuideProbeTargets with the target removed and a primary selected as per the description
+     */
+    public GuideProbeTargets removeTargetSelectPrimary(final SPTarget target) {
+        // If no primary, or target is not primary, then regular removal is sufficient.
+        if (!primaryTarget.exists(target::equals))
+            return removeTarget(target);
+
+        final Option<SPTarget> bagsTargetNew = possiblyRemoveTarget.apply(bagsTarget, target);
+        final ImList<SPTarget> manualTargetsNew = manualTargets.remove(target);
+
+        // We are removing the primary target, so determine the new primary if one can be chosen.
+        final ImList<SPTarget> oldTargets = getTargets();
+        final int oldIndex = oldTargets.indexOf(target);
+        final int newIndex = oldIndex+1 < oldTargets.size() ? oldIndex+1
+                : (oldIndex-1 >= 0 ? oldIndex-1 : -1);
+        final Option<SPTarget> primaryTargetNew = newIndex == -1 ? NO_TARGET : new Some<>(oldTargets.get(newIndex));
+        return new GuideProbeTargets(guider, bagsTargetNew, primaryTargetNew, manualTargetsNew);
+    }
+
+    /**
+     * Iterator to all of the SPTargets in this object, including the BAGS target (which leads).
+     */
     @Override
     public Iterator<SPTarget> iterator() {
-        return targetOptions.iterator();
+        return getTargets().iterator();
+    }
+
+    public Option<SPTarget> getBAGSTarget() {
+        return bagsTarget;
     }
 
     public Option<SPTarget> getPrimary() {
-        return targetOptions.getPrimary();
+        return primaryTarget;
     }
 
-    @Override
-    public GuideProbeTargets selectPrimary(Option<SPTarget> primary) {
-        return new GuideProbeTargets(guider, targetOptions.selectPrimary(primary));
+    /**
+     * Determine if the primary guide star is the guide star as selected by BAGS.
+     * If the primary guide star is not selected, this returns false.
+     * @return returns true if the primary guide star is the BAGS star, else false
+     */
+    public boolean primaryIsBAGSTarget() {
+        return primaryTarget.exists(t -> bagsTarget.exists(t::equals));
     }
 
-    @Override
-    public GuideProbeTargets selectPrimary(SPTarget primary) {
-        return new GuideProbeTargets(guider, targetOptions.selectPrimary(primary));
+    /**
+     * Determine if the primary guide star is a manual target.
+     * If the primary guide star is not selected, this returns false.
+     * @return returns true if the primary guide star is a manual target, else false
+     */
+    public boolean primaryIsManualTarget() {
+        return primaryTarget.exists(manualTargets::contains);
     }
 
-    @Override
-    public GuideProbeTargets setPrimary(SPTarget primary) {
-        return new GuideProbeTargets(guider, targetOptions.setPrimary(primary));
+    /**
+     * Set the BAGS target. If the primary is the old BAGS target or unset, then the primary is set to the
+     * new BAGS target automatically; otherwise, it is maintained.
+     * @param targetOption the new BAGS target
+     * @return a new GuideProbeTargets with the primary target and BAGS target as described
+     */
+    public GuideProbeTargets setBAGSTarget(final Option<SPTarget> targetOption) {
+        if (targetOption.equals(bagsTarget))
+            return this;
+
+        final Option<SPTarget> primaryTargetNew = primaryIsBAGSTarget() ? targetOption : primaryTarget;
+        return new GuideProbeTargets(guider, targetOption, primaryTargetNew, manualTargets);
     }
 
-    @Override
+    /**
+     * Set the BAGS target. If the primary is the old BAGS target, then the primary is set to the
+     * new BAGS target automatically; otherwise, it is maintained.
+     * @param target the new BAGS target
+     * @return a new GuideProbeTargets with the primary target and BAGS target as described
+     */
+    public GuideProbeTargets setBAGSTarget(final SPTarget target) {
+        final Option<SPTarget> targetOption = target == null ? NO_TARGET : new Some<>(target);
+        return setBAGSTarget(targetOption);
+    }
+
+    /**
+     * Simply set the primary guide star indiscriminately to the BAGS guide star.
+     * If there is no BAGS guide star, then primary is unset.
+     * @return a new GuideProbeTargets with the primary target set as described
+     */
+    public GuideProbeTargets setPrimaryToBAGSTarget() {
+        if (primaryIsBAGSTarget())
+            return this;
+        return new GuideProbeTargets(guider, bagsTarget, bagsTarget, manualTargets);
+    }
+
+    /**
+     * Select the primary guide star. This must already be either the BAGS guide star or in the
+     * list of manual targets if it is defined.
+     * @param targetOption the primary target to select, or None
+     * @return a new GuideProbeTargets with the primary target as indicated
+     */
+    public GuideProbeTargets selectPrimary(final Option<SPTarget> targetOption) {
+        if (targetOption.equals(primaryTarget))
+            return this;
+        return new GuideProbeTargets(guider, bagsTarget, targetOption, manualTargets);
+    }
+
+    /**
+     * Select the primary guide star. This must already be either the BAGS guide star or in the
+     * list of manual targets.
+     * @param target the primary target to select
+     * @return a new GuideProbeTargets with the primary target as indicated
+     */
+    public GuideProbeTargets selectPrimary(final SPTarget target) {
+        final Option<SPTarget> targetOption = target == null ? NO_TARGET : new Some<>(target);
+        return selectPrimary(targetOption);
+    }
+
+    /**
+     * Set the primary guide star. If it is not in the list, add it to the end of the list and mark it as the primary.
+     * @param target the primary guide star.
+     * @return the new GuideProbeTargets with the primary target as indicated.
+     */
+    public GuideProbeTargets setPrimary(final SPTarget target) {
+        if (target == null)
+            return new GuideProbeTargets(guider, bagsTarget, NO_TARGET, manualTargets);
+
+        final boolean alreadyInList = manualTargets.contains(target);
+        if (alreadyInList && primaryTarget.exists(target::equals))
+            return this;
+
+        final ImList<SPTarget> manualTargetsNew = alreadyInList ? manualTargets : manualTargets.append(target);
+        return new GuideProbeTargets(guider, bagsTarget, new Some<>(target), manualTargetsNew);
+    }
+
+    /**
+     * Return the index of the primary target, if one exists, or None if there is no primary target.
+     * Note that if a BAGS target exists, we count the BAGS target as index 0 and then begin counting the manual targets at index 1.
+     * Otherwise, we begin counting the manual targets at index 0.
+     * @return the index as described above, or None if no primary
+     */
     public Option<Integer> getPrimaryIndex() {
-        return targetOptions.getPrimaryIndex();
+        if (primaryIsBAGSTarget())
+            return new Some<>(0);
+
+        final int bagsIncrementor = bagsTarget.isEmpty() ? 0 : 1;
+        return primaryTarget.map(t -> manualTargets.indexOf(t) + bagsIncrementor);
+    }
+
+    /**
+     * Set the primary target by index.
+     * If no index is specified, return a new GuideProbeTargets with no primary.
+     * If there is a BAGS star, we begin counting it as 0, and then the manual targets at index 1.
+     * Otherwise, we begin counting the manual targets at index 0.
+     * @param indexOption the optional index to use as the primary
+     * @return the new GuideProbeTargets with the new primary as described above
+     */
+    public GuideProbeTargets setPrimaryIndex(final Option<Integer> indexOption) {
+        // If the current primary is already as set, nothing to do.
+        final Option<Integer> oldPrimaryIndex = getPrimaryIndex();
+        if (indexOption.exists(i -> oldPrimaryIndex.exists(i::equals))
+                || (indexOption.isEmpty() && oldPrimaryIndex.isEmpty()))
+            return this;
+
+        if (indexOption.isEmpty())
+            return new GuideProbeTargets(guider, bagsTarget, NO_TARGET, manualTargets);
+
+        return setPrimaryIndex(indexOption.getValue());
+    }
+
+    /**
+     * Set the primary target by index.
+     * If there is a BAGS star, we begin counting it as 0, and then the manual targets at index 1.
+     * Otherwise, we begin counting the manual targets at index 0.
+     * @param index the index to use as the primary
+     * @throws java.lang.IndexOutOfBoundsException if the index does not indicate a valid guide star
+     * @return the new GuideProbeTargets with the new primary as described above
+     */
+    public GuideProbeTargets setPrimaryIndex(final int index) {
+        if (index == 0 && bagsTarget.isDefined())
+            return new GuideProbeTargets(guider, bagsTarget, bagsTarget, manualTargets);
+
+        final int bagsAdjustment = bagsTarget.isEmpty() ? 0 : 1;
+        final SPTarget primaryNew = manualTargets.get(index - bagsAdjustment);
+        return new GuideProbeTargets(guider, bagsTarget, new Some<>(primaryNew), manualTargets);
+    }
+
+    /**
+     * Toggles the primary element:
+     * 1. If target is not the primary, it is set as the primary.
+     * 2. If target is set as the primary, the primary is set to NONE.
+     * @param target the primary target to toggle
+     * @return the new GuideProbeTargets with the primary as described above
+     * @throws java.lang.IllegalArgumentException if <code>primary</code> is not in the list of targets.
+     */
+    public GuideProbeTargets togglePrimary(final SPTarget target) {
+        if (!getTargets().contains(target))
+            throw new IllegalArgumentException("not a member of the list");
+        return new GuideProbeTargets(guider, bagsTarget, new Some<>(target), manualTargets);
+    }
+
+    /**
+     * Add a target to the list of manual targets. Does not change the primary target.
+     * @param target the manual target to add.
+     * @return a new GuideProbeTargets with the manual target added.
+     */
+    public GuideProbeTargets addManualTarget(final SPTarget target) {
+        return new GuideProbeTargets(guider, bagsTarget, primaryTarget, manualTargets.append(target));
+    }
+
+    /**
+     * Set the manual targets.
+     * If a primary guide star was specified before that is no longer in the manual targets, then set it to None.
+     * @param manualTargetsNew the new list of manual targets to use
+     * @return a new GuideProbeTargets as described above.
+     */
+    // TODO: Was setOptions.
+    public GuideProbeTargets setManualTargets(final ImList<SPTarget> manualTargetsNew) {
+        // If the primary target is None, or the primary is the BAGS, then just return with the new list.
+        if (primaryTarget.forall(t -> bagsTarget.forall(t::equals)))
+            return new GuideProbeTargets(guider, bagsTarget, primaryTarget, manualTargetsNew);
+
+        final Option<SPTarget> primaryTargetNew = primaryTarget.forall(manualTargetsNew::contains) ? primaryTarget : NO_TARGET;
+        return new GuideProbeTargets(guider, bagsTarget, primaryTargetNew, manualTargetsNew);
     }
 
     @Override
-    public GuideProbeTargets setPrimaryIndex(Option<Integer> primary) {
-        return new GuideProbeTargets(guider, targetOptions.setPrimaryIndex(primary));
-    }
-
-    @Override
-    public GuideProbeTargets setPrimaryIndex(int primary) {
-        return new GuideProbeTargets(guider, targetOptions.setPrimaryIndex(primary));
-    }
-
-    @Override
-    public ImList<SPTarget> getOptions() {
-        return targetOptions.getOptions();
-    }
-
-    @Override
-    public GuideProbeTargets setOptions(ImList<SPTarget> newList) {
-        return new GuideProbeTargets(guider, targetOptions.setOptions(newList));
-    }
-
-    @Override
-    public GuideProbeTargets update(Option<Integer> primaryIndex, ImList<SPTarget> list) {
-        return new GuideProbeTargets(guider, targetOptions.update(primaryIndex, list));
-    }
-
-    @Override
-    public GuideProbeTargets update(Op<SPTarget> op) {
-        return new GuideProbeTargets(guider, targetOptions.update(op));
-    }
-
-    @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        GuideProbeTargets that = (GuideProbeTargets) o;
-
+        final GuideProbeTargets that = (GuideProbeTargets) o;
         if (!guider.equals(that.guider)) return false;
-        return targetOptions.equals(that.targetOptions);
+        if (!bagsTarget.equals(that.bagsTarget)) return false;
+        if (!primaryTarget.equals(that.primaryTarget)) return false;
+        return manualTargets.equals(that.manualTargets);
     }
 
     @Override
     public int hashCode() {
         int result = guider.hashCode();
-        result = 31 * result + targetOptions.hashCode();
+        result = 31 * result + bagsTarget.hashCode();
+        result = 31 * result + primaryTarget.hashCode();
+        result = 31 * result + manualTargets.hashCode();
         return result;
     }
 
 
-    public static final String PARAM_SET_NAME = "guider";
 
-    public ParamSet getParamSet(PioFactory factory) {
-        ParamSet paramSet = factory.createParamSet(PARAM_SET_NAME);
+    public static final String GUIDER_PARAM_SET_NAME = "guider";
+    public static final String BAGSTARGET_PARAM_SET_NAME = "bagsTarget";
+
+    // TODO: modified, must be tested.
+    public ParamSet getParamSet(final PioFactory factory) {
+        final ParamSet paramSet = factory.createParamSet(GUIDER_PARAM_SET_NAME);
 
         Pio.addParam(factory, paramSet, "key", getGuider().getKey());
-        if (!targetOptions.getPrimaryIndex().isEmpty()) {
-            Pio.addIntParam(factory, paramSet, "primary", targetOptions.getPrimaryIndex().getValue());
-        }
-        for (SPTarget target : this) {
-            paramSet.addParamSet(target.getParamSet(factory));
-        }
+
+        // If a bags target is set, store it.
+        bagsTarget.foreach(t -> {
+            final ParamSet bagsParamSet = factory.createParamSet(BAGSTARGET_PARAM_SET_NAME);
+            bagsParamSet.addParamSet(t.getParamSet(factory));
+        });
+
+        // If a primary target is set, store the index.
+        getPrimaryIndex().foreach(i ->
+            Pio.addIntParam(factory, paramSet, "primary", i)
+        );
+
+        getManualTargets().foreach(t -> paramSet.addParamSet(t.getParamSet(factory)));
 
         return paramSet;
     }
 
-    public static GuideProbeTargets fromParamSet(ParamSet parent) {
-        String key = Pio.getValue(parent, "key");
-        GuideProbe probe = GuideProbeMap.instance.get(key);
+    public static GuideProbeTargets fromParamSet(final ParamSet parent) {
+        final String key = Pio.getValue(parent, "key");
+        final GuideProbe probe = GuideProbeMap.instance.get(key);
         if (probe == null) return null;
 
-        int primaryIndex = Pio.getIntValue(parent, "primary", -1);
-        Option<Integer> primary = (primaryIndex>=0) ? new Some<>(primaryIndex) : None.INTEGER;
+
+        // Read in the bagsTarget if there is one.
+        final ParamSet bagsParamSet = parent.getParamSet(BAGSTARGET_PARAM_SET_NAME);
+        final Option<SPTarget> bagsTarget = bagsParamSet == null || bagsParamSet.getParamSetCount() != 1
+                ? NO_TARGET
+                : new Some<>(SPTarget.fromParamSet(bagsParamSet.getParamSets().get(0)));
+
+        // Primary index.
+        final int primaryIndex = Pio.getIntValue(parent, "primary", -1);
+        final Option<Integer> primary = (primaryIndex>=0) ? new Some<>(primaryIndex) : None.INTEGER;
+
 
         final List<SPTarget> lst = new ArrayList<>();
-        for (ParamSet ps : parent.getParamSets()) {
-            SPTarget target = SPTarget.fromParamSet(ps);
-            lst.add(target);
-        }
-        ImList<SPTarget> targets = DefaultImList.create(lst);
+        parent.getParamSets().forEach(ps -> lst.add(SPTarget.fromParamSet(ps)));
+        final ImList<SPTarget> manualTargets = DefaultImList.create(lst);
 
-        return new GuideProbeTargets(probe, OptionsListImpl.create(primary, targets));
+        final GuideProbeTargets gpt = new GuideProbeTargets(probe, bagsTarget, NO_TARGET, manualTargets);
+        return gpt.setPrimaryIndex(primary);
     }
 
-    public String mkString(String prefix, String sep, String suffix) {
-        return prefix + "guider=" + guider + sep + "targets=" + targetOptions.mkString(prefix, sep, suffix) + suffix;
+    public String mkString(final String prefix, final String sep, final String suffix) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(prefix).append("guider=").append(guider).append(sep);
+        bagsTarget.foreach(t -> sb.append("bagsTarget").append(t.toString()).append(sep));
+        primaryTarget.foreach(t -> sb.append("primaryTarget").append(t.toString()).append(sep));
+        sb.append(manualTargets.mkString(prefix, sep, suffix)).append(suffix);
+        return sb.toString();
     }
 
     public String toString() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -314,7 +314,7 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
         if (targetOption.equals(bagsTarget))
             return this;
 
-        final Option<SPTarget> primaryTargetNew = primaryIsBagsTarget() ? targetOption : primaryTarget;
+        final Option<SPTarget> primaryTargetNew = primaryIsBagsTarget() || primaryTarget.isEmpty() ? targetOption : primaryTarget;
         return new GuideProbeTargets(guider, targetOption, primaryTargetNew, manualTargets);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetContainer.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetContainer.java
@@ -4,9 +4,7 @@
 
 package edu.gemini.spModel.target.env;
 
-import edu.gemini.shared.util.immutable.Function1;
 import edu.gemini.shared.util.immutable.ImList;
-import edu.gemini.shared.util.immutable.PredicateOp;
 import edu.gemini.spModel.target.SPTarget;
 
 /**
@@ -14,40 +12,6 @@ import edu.gemini.spModel.target.SPTarget;
  * providing a few conveniences for its clients.
  */
 public interface TargetContainer {
-
-    /**
-     * A {@link PredicateOp} that can be used with an {@link ImList} of
-     * <code>? extends TargetContainer</code> to match on those containing the
-     * given {@link SPTarget}. For example, it can be used to find an instance
-     * that contains a particular {@link SPTarget}:
-     * <pre>
-     *     ImList<GuideProbeTargets> lst = ...
-     *     Option<GuideProbeTargets> result = lst.find(new TargetMatch(target));
-     * </pre>
-     */
-    final class TargetMatch implements PredicateOp<TargetContainer> {
-        private final SPTarget target;
-        public TargetMatch(SPTarget target) { this.target = target; }
-        @Override public Boolean apply(TargetContainer tc) {
-            return tc.containsTarget(target);
-        }
-    }
-
-    /**
-     * A function that can be used to extract the targets contained in a
-     * TargetContainer.  For example, to get all the targets in a collection
-     * of {@link GuideGroup}:
-     * <pre>
-     *     ImList<GuideGroup> lst = ...
-     *     ImList<SPTarget> alltargets = lst.flatMap(EXTRACT_TARGET);
-     * </pre>
-     */
-    Function1<TargetContainer, ImList<SPTarget>> EXTRACT_TARGET = new Function1<TargetContainer, ImList<SPTarget>>() {
-        @Override public ImList<SPTarget> apply(TargetContainer tc) {
-            return tc.getTargets();
-        }
-    };
-
     /**
      * @return <code>true</code> if the target container contains the given
      * target

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -266,13 +266,9 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      */
     @Override
     public TargetEnvironment cloneTargets() {
-        SPTarget clonedBase = base.clone();
-        GuideEnvironment clonedGuide = guide.cloneTargets();
-        ImList<SPTarget> clonedUser  = user.map(new Function1<SPTarget, SPTarget>() {
-            public SPTarget apply(final SPTarget target) {
-                return target.clone();
-            }
-        });
+        final SPTarget clonedBase = base.clone();
+        final GuideEnvironment clonedGuide = guide.cloneTargets();
+        final ImList<SPTarget> clonedUser = user.map(SPTarget::clone);
         return new TargetEnvironment(clonedBase, clonedGuide, clonedUser);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironmentDiff.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironmentDiff.java
@@ -50,18 +50,8 @@ public final class TargetEnvironmentDiff implements Serializable {
      * of each environment.
      */
     public static TargetEnvironmentDiff guideProbe(TargetEnvironment oldEnv, TargetEnvironment newEnv, final GuideProbe guider) {
-        final Function1<OptionsList<SPTarget>, ImList<SPTarget>> f1 = new Function1<OptionsList<SPTarget>, ImList<SPTarget>>() {
-            @Override public ImList<SPTarget> apply(OptionsList<SPTarget> optList) {
-                return optList.getOptions();
-            }
-        };
-        Function1<GuideGroup, ImList<SPTarget>> f2 = new Function1<GuideGroup, ImList<SPTarget>>() {
-            @Override public ImList<SPTarget> apply(GuideGroup guideGroup) {
-                ImList<SPTarget> empty = ImCollections.emptyList();
-                return guideGroup.get(guider).map(f1).getOrElse(empty);
-            }
-        };
-
+        final ImList<SPTarget> empty = ImCollections.emptyList();
+        final Function1<GuideGroup, ImList<SPTarget>> f2 = (g -> g.get(guider).map(GuideProbeTargets::getTargets).getOrElse(empty));
         return primaryGuideGroupExtraction(oldEnv, newEnv, f2);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironmentDiff.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironmentDiff.java
@@ -36,12 +36,7 @@ public final class TargetEnvironmentDiff implements Serializable {
      * guide stars in the primary guide group of each environment.
      */
     public static TargetEnvironmentDiff primaryGuideGroup(TargetEnvironment oldEnv, TargetEnvironment newEnv) {
-        Function1<GuideGroup, ImList<SPTarget>> f = new Function1<GuideGroup, ImList<SPTarget>>() {
-            @Override public ImList<SPTarget> apply(GuideGroup guideGroup) {
-                return guideGroup.getTargets();
-            }
-        };
-        return primaryGuideGroupExtraction(oldEnv, newEnv, f);
+        return primaryGuideGroupExtraction(oldEnv, newEnv, GuideGroup::getTargets);
     }
 
     /**
@@ -57,9 +52,8 @@ public final class TargetEnvironmentDiff implements Serializable {
 
     private static TargetEnvironmentDiff primaryGuideGroupExtraction(TargetEnvironment oldEnv, TargetEnvironment newEnv, Function1<GuideGroup, ImList<SPTarget>> f) {
         final ImList<SPTarget> empty = ImCollections.emptyList();
-        ImList<SPTarget> oldList, newList;
-        oldList = oldEnv.getGuideEnvironment().getPrimary().map(f).getOrElse(empty);
-        newList = newEnv.getGuideEnvironment().getPrimary().map(f).getOrElse(empty);
+        final ImList<SPTarget> oldList = oldEnv.getGuideEnvironment().getPrimary().map(f).getOrElse(empty);
+        final ImList<SPTarget> newList = newEnv.getGuideEnvironment().getPrimary().map(f).getOrElse(empty);
         return new TargetEnvironmentDiff(oldEnv, newEnv, oldList, newList);
     }
 
@@ -74,10 +68,10 @@ public final class TargetEnvironmentDiff implements Serializable {
         this.oldEnv = oldEnv;
         this.newEnv = newEnv;
 
-        Set<SPTarget> oldSet = Collections.newSetFromMap(new IdentityHashMap<SPTarget, Boolean>());
+        Set<SPTarget> oldSet = Collections.newSetFromMap(new IdentityHashMap<>());
         if (oldEnv != null) oldSet.addAll(oldTargets.toList());
 
-        Set<SPTarget> newSet = Collections.newSetFromMap(new IdentityHashMap<SPTarget, Boolean>());
+        Set<SPTarget> newSet = Collections.newSetFromMap(new IdentityHashMap<>());
         if (newEnv != null) newSet.addAll(newTargets.toList());
 
         if (oldEnv != null) newSet.removeAll(oldTargets.toList());

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/GuideSequence.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/GuideSequence.java
@@ -112,23 +112,9 @@ public final class GuideSequence implements ConfigPostProcessor {
      * "primary" assigned to it in the primary guide group.
      */
     public static ImList<GuideProbe> getRequiredGuiders(Option<TargetEnvironment> envOpt) {
-        return envOpt.map(new MapOp<TargetEnvironment, ImList<GuideProbe>>() {
-            @Override public ImList<GuideProbe> apply(TargetEnvironment env) {
-                return env.getOrCreatePrimaryGuideGroup().getAll().
-                        filter(new PredicateOp<GuideProbeTargets>() {
-                            @Override
-                            public Boolean apply(GuideProbeTargets gpt) {
-                                return !gpt.getPrimary().isEmpty();
-                            }
-                        }).
-                        map(new MapOp<GuideProbeTargets, GuideProbe>() {
-                            @Override
-                            public GuideProbe apply(GuideProbeTargets gpt) {
-                                return gpt.getGuider();
-                            }
-                        });
-            }
-        }).getOrElse(ImCollections.emptyList());
+        return envOpt.map(env -> env.getOrCreatePrimaryGuideGroup().getAll().
+                        filter(gpt -> gpt.getPrimary().isDefined()).
+                        map(GuideProbeTargets::getGuider)).getOrElse(ImCollections.emptyList());
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
@@ -65,32 +65,26 @@ public final class TargetSelection {
 
         final List<Selection> res = new ArrayList<>();
         res.add(new Selection(null, env.getBase()));
-        for (GuideGroup g : env.getGroups()) {
+        for (final GuideGroup g : env.getGroups()) {
             res.add(new Selection(g, null));
-            for (SPTarget t : g.getTargets()) res.add(new Selection(g, t));
+            g.getTargets().foreach(t -> res.add(new Selection(g, t)));
         }
-        for (SPTarget t : env.getUserTargets()) res.add(new Selection(null, t));
+        env.getUserTargets().foreach(t -> res.add(new Selection(null, t)));
         return DefaultImList.create(res);
     }
 
-    private static final MapOp<Tuple2<Selection, Integer>, Integer> INDEX_OF = new MapOp<Tuple2<Selection, Integer>, Integer>() {
-        @Override public Integer apply(Tuple2<Selection, Integer> tup) { return tup._2(); }
-    };
+    private static final MapOp<Tuple2<Selection, Integer>, Integer> INDEX_OF = Tuple2::_2;
 
     public static int indexOf(TargetEnvironment env, final SPTarget target) {
-        return toSelections(env).zipWithIndex().find(new PredicateOp<Tuple2<Selection, Integer>>() {
-            @Override public Boolean apply(Tuple2<Selection, Integer> tup) {
-                return tup._1().target == target;
-            }
-        }).map(INDEX_OF).getOrElse(NO_SELECTION.value);
+        return toSelections(env).zipWithIndex().
+                find(tup -> target.equals(tup._1().target)).
+                map(INDEX_OF).getOrElse(NO_SELECTION.value);
     }
 
     public static int indexOf(TargetEnvironment env, final GuideGroup grp) {
-        return toSelections(env).zipWithIndex().find(new PredicateOp<Tuple2<Selection, Integer>>() {
-            @Override public Boolean apply(Tuple2<Selection, Integer> tup) {
-                return tup._1().guideGroup == grp;
-            }
-        }).map(INDEX_OF).getOrElse(NO_SELECTION.value);
+        return toSelections(env).zipWithIndex().
+                find(tup -> grp.equals(tup._1().guideGroup)).
+                map(INDEX_OF).getOrElse(NO_SELECTION.value);
     }
 
     private static Selection selectionAt(TargetEnvironment env, int index) {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/GuideStarStatus.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/GuideStarStatus.scala
@@ -1,5 +1,0 @@
-package edu.gemini.spModel.target
-
-sealed trait GuideStarStatus
-case object  ManualGuideStar    extends GuideStarStatus
-case object  AutomaticGuideStar extends GuideStarStatus

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/GuideStarStatus.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/GuideStarStatus.scala
@@ -1,0 +1,5 @@
+package edu.gemini.spModel.target
+
+sealed trait GuideStarStatus
+case object  ManualGuideStar    extends GuideStarStatus
+case object  AutomaticGuideStar extends GuideStarStatus

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/flamingos2/PlannedTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/flamingos2/PlannedTimeTest.java
@@ -116,7 +116,8 @@ public final class PlannedTimeTest {
         final TargetEnvironment tenv = targetDo.getTargetEnvironment();
         obs.addObsComponent(targetComp);
 
-        final GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, new SPTarget());
+        final SPTarget pwfs2Target = new SPTarget();
+        final GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, new SPTarget()).selectPrimary(pwfs2Target);
         targetDo.setTargetEnvironment(tenv.putPrimaryGuideProbeTargets(pwfs2));
         targetComp.setDataObject(targetDo);
 
@@ -124,7 +125,8 @@ public final class PlannedTimeTest {
         verify(Flamingos2.getImagingSetupSec(obs) + readout);
 
         // With OIWFS
-        final GuideProbeTargets oiwfs = GuideProbeTargets.create(Flamingos2OiwfsGuideProbe.instance, new SPTarget());
+        final SPTarget oiwfsTarget = new SPTarget();
+        final GuideProbeTargets oiwfs = GuideProbeTargets.create(Flamingos2OiwfsGuideProbe.instance, oiwfsTarget).selectPrimary(oiwfsTarget);
         targetDo.setTargetEnvironment(tenv.putPrimaryGuideProbeTargets(oiwfs));
         targetComp.setDataObject(targetDo);
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/flamingos2/PlannedTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/flamingos2/PlannedTimeTest.java
@@ -117,7 +117,7 @@ public final class PlannedTimeTest {
         obs.addObsComponent(targetComp);
 
         final SPTarget pwfs2Target = new SPTarget();
-        final GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, new SPTarget()).selectPrimary(pwfs2Target);
+        final GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, pwfs2Target).selectPrimary(pwfs2Target);
         targetDo.setTargetEnvironment(tenv.putPrimaryGuideProbeTargets(pwfs2));
         targetComp.setDataObject(targetDo);
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
@@ -41,10 +41,10 @@ public class GsaoiOdgwGroupTest extends TestCase {
         // (OT-8) Account for ODGW hotspot (and convert arcsec value to deg)
         final double d = GsaoiDetectorArray.ODGW_HOTSPOT_OFFSET/3600.;
 
-        SPTarget base         = new SPTarget(d, d);
-        TargetEnvironment env = TargetEnvironment.create(base);
+        final SPTarget base         = new SPTarget(d, d);
+        final TargetEnvironment env = TargetEnvironment.create(base);
 
-        Gsaoi inst = new Gsaoi();
+        final Gsaoi inst = new Gsaoi();
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.SIDE_LOOKING);
 
@@ -59,7 +59,7 @@ public class GsaoiOdgwGroupTest extends TestCase {
     @Test
     public void testEmptySelect() {
         // In the gap between detectors for the baseContext.
-        Coordinates coords = new Coordinates(
+        final Coordinates coords = new Coordinates(
             new Angle(0, ARCSECS), new Angle(midDetector, ARCSECS)
         );
         assertTrue(group.select(coords, baseContext).isEmpty());
@@ -67,15 +67,15 @@ public class GsaoiOdgwGroupTest extends TestCase {
 
     @Test
     public void testSelect() {
-        Coordinates[] coordsArray = new Coordinates[] {
+        final Coordinates[] coordsArray = new Coordinates[] {
                 new Coordinates(new Angle( midDetector, ARCSECS), new Angle(-midDetector, ARCSECS)), // 1
                 new Coordinates(new Angle(-midDetector, ARCSECS), new Angle(-midDetector, ARCSECS)), // 2
                 new Coordinates(new Angle(-midDetector, ARCSECS), new Angle( midDetector, ARCSECS)), // 3
                 new Coordinates(new Angle( midDetector, ARCSECS), new Angle( midDetector, ARCSECS)), // 4
         };
         for (int i=0; i<4; ++i) {
-            Coordinates coords = coordsArray[i];
-            GsaoiOdgw expected = GsaoiOdgw.values()[i];
+            final Coordinates coords = coordsArray[i];
+            final GsaoiOdgw expected = GsaoiOdgw.values()[i];
             assertEquals(expected, group.select(coords, baseContext).getValue());
         }
     }
@@ -83,56 +83,55 @@ public class GsaoiOdgwGroupTest extends TestCase {
     @Test
     public void testEmptyAdd() {
         // In the gap between detectors for the baseContext.
-        Coordinates coords = new Coordinates(
+        final Coordinates coords = new Coordinates(
             new Angle(0, ARCSECS), new Angle(midDetector, ARCSECS)
         );
 
-        SPTarget guideTarget = new SPTarget(coords.getRaDeg(), coords.getDecDeg());
-        TargetEnvironment env = group.add(guideTarget, baseContext);
+        final SPTarget guideTarget = new SPTarget(coords.getRaDeg(), coords.getDecDeg());
+        final TargetEnvironment env = group.add(guideTarget, false, baseContext);
 
         // Adds an ODGW1 target by default.
-        ImList<GuideProbeTargets> col = env.getOrCreatePrimaryGuideGroup().getAll();
+        final ImList<GuideProbeTargets> col = env.getOrCreatePrimaryGuideGroup().getAll();
         assertEquals(1, col.size());
 
-        Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw1);
+        final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw1);
         assertFalse(gtOpt.isEmpty());
 
-        GuideProbeTargets gt = gtOpt.getValue();
-        assertEquals(1, gt.getOptions().size());
-        assertEquals(guideTarget, gt.getOptions().head());
+        final GuideProbeTargets gt = gtOpt.getValue();
+        assertEquals(1, gt.getTargets().size());
+        assertEquals(guideTarget, gt.getTargets().head());
     }
 
     @Test
     public void testAdd() {
-        Coordinates[] coordsArray = new Coordinates[] {
+        final Coordinates[] coordsArray = new Coordinates[] {
                 new Coordinates(new Angle( midDetector, ARCSECS), new Angle(-midDetector, ARCSECS)), // 1
                 new Coordinates(new Angle(-midDetector, ARCSECS), new Angle(-midDetector, ARCSECS)), // 2
                 new Coordinates(new Angle(-midDetector, ARCSECS), new Angle( midDetector, ARCSECS)), // 3
                 new Coordinates(new Angle( midDetector, ARCSECS), new Angle( midDetector, ARCSECS)), // 4
         };
         for (int i=0; i<4; ++i) {
-            Coordinates coords   = coordsArray[i];
-            SPTarget guideTarget;
-            guideTarget = new SPTarget(coords.getRaDeg(), coords.getDecDeg());
-            GsaoiOdgw odgw = GsaoiOdgw.values()[i];
+            final Coordinates coords   = coordsArray[i];
+            final SPTarget guideTarget = new SPTarget(coords.getRaDeg(), coords.getDecDeg());
+            final GsaoiOdgw odgw = GsaoiOdgw.values()[i];
 
-            TargetEnvironment env = group.add(guideTarget, baseContext);
+            final TargetEnvironment env = group.add(guideTarget, false, baseContext);
 
             // Should have just one set of GuideTargets for the new guide star.
             assertEquals(1, env.getOrCreatePrimaryGuideGroup().getAll().size());
 
             // Should be guide targets for the expected guide window.
-            Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(odgw);
-            assertEquals(1, gtOpt.getValue().getOptions().size());
+            final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(odgw);
+            assertEquals(1, gtOpt.getValue().getTargets().size());
 
             // Should be the new target that was added.
-            assertEquals(guideTarget, gtOpt.getValue().getOptions().head());
+            assertEquals(guideTarget, gtOpt.getValue().getTargets().head());
         }
     }
 
     private GuideProbeTargets create(GsaoiOdgw odgw, Coordinates coords) {
-        SPTarget target = new SPTarget(coords.getRaDeg(), coords.getDecDeg());
-        return GuideProbeTargets.create(odgw, target);
+        final SPTarget target = new SPTarget(coords.getRaDeg(), coords.getDecDeg());
+        return GuideProbeTargets.create(odgw, target).selectPrimary(target);
     }
 
     // Simple test case where an ODGW star ends up in another detector due to
@@ -140,27 +139,26 @@ public class GsaoiOdgwGroupTest extends TestCase {
     @Test
     public void testOptimizeOne() {
         // Setup a target in the detector with id 1.
-        Coordinates coords = new Coordinates(new Angle(midDetector, ARCSECS), new Angle(-midDetector, ARCSECS)); // 1
-        GuideProbeTargets gt = create(GsaoiOdgw.odgw1, coords);
-        SPTarget target = gt.getOptions().head();
+        final Coordinates coords = new Coordinates(new Angle(midDetector, ARCSECS), new Angle(-midDetector, ARCSECS)); // 1
+        final GuideProbeTargets gt = create(GsaoiOdgw.odgw1, coords);
+        SPTarget target = gt.getTargets().head();
 
-        TargetEnvironment env = baseContext.getTargets().putPrimaryGuideProbeTargets(gt);
-        ObsContext ctx = baseContext.withTargets(env);
+        final TargetEnvironment env = baseContext.getTargets().putPrimaryGuideProbeTargets(gt);
 
-        // Now, optimize this context when rotated 90 degrees
-        ctx = ctx.withPositionAngle(new Angle(90, DEGREES));
-        Option<TargetEnvironment> optEnv = group.optimize(ctx);
+        // Optimize this context when rotated 90 degrees
+        final ObsContext ctx = baseContext.withTargets(env).withPositionAngle(new Angle(90, DEGREES));
+        final Option<TargetEnvironment> optEnv = group.optimize(ctx);
 
         // Should have moved to Id 4.
-        TargetEnvironment newEnv = optEnv.getValue();
-        Set<GuideProbe> guiders = newEnv.getOrCreatePrimaryGuideGroup().getReferencedGuiders();
+        final TargetEnvironment newEnv = optEnv.getValue();
+        final Set<GuideProbe> guiders = newEnv.getOrCreatePrimaryGuideGroup().getReferencedGuiders();
         assertEquals(1, guiders.size());
         assertEquals(GsaoiOdgw.odgw4, guiders.iterator().next());
 
-        Option<GuideProbeTargets> gtOpt = newEnv.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw4);
-        gt = gtOpt.getValue();
-        assertEquals(1, gt.getOptions().size());
-        assertSame(target, gt.getOptions().get(0));
+        final Option<GuideProbeTargets> gtOpt = newEnv.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw4);
+        final GuideProbeTargets gtNew = gtOpt.getValue();
+        assertEquals(1, gtNew.getTargets().size());
+        assertSame(target, gtNew.getTargets().get(0));
     }
 
     // Tests that an existing primary guide star is kept when new targets are
@@ -168,31 +166,29 @@ public class GsaoiOdgwGroupTest extends TestCase {
     @Test
     public void testKeepPrimary() {
         // Create a target in detector 2, just on the border with 3.
-        Coordinates coords2 = new Coordinates(new Angle(-midDetector, ARCSECS), new Angle(-DETECTOR_GAP_ARCSEC, ARCSECS));
-        GuideProbeTargets gt2 = create(GsaoiOdgw.odgw2, coords2);
+        final Coordinates coords2 = new Coordinates(new Angle(-midDetector, ARCSECS), new Angle(-DETECTOR_GAP_ARCSEC, ARCSECS));
+        final GuideProbeTargets gt2 = create(GsaoiOdgw.odgw2, coords2);
 
         // Create a target in detector 3, just on the border with 2.
-        Coordinates coords3 = new Coordinates(new Angle(-midDetector, ARCSECS), new Angle( DETECTOR_GAP_ARCSEC, ARCSECS));
-        GuideProbeTargets gt3 = create(GsaoiOdgw.odgw3, coords3);
+        final Coordinates coords3 = new Coordinates(new Angle(-midDetector, ARCSECS), new Angle( DETECTOR_GAP_ARCSEC, ARCSECS));
+        final GuideProbeTargets gt3 = create(GsaoiOdgw.odgw3, coords3);
 
-        // Set up an obs context with tese targets.
-        TargetEnvironment env = baseContext.getTargets().putPrimaryGuideProbeTargets(gt2).putPrimaryGuideProbeTargets(gt3);
-        ObsContext ctx = baseContext.withTargets(env);
+        // Set up an obs context with these targets, and optimize when rotated 45 degrees.
+        final TargetEnvironment env = baseContext.getTargets().putPrimaryGuideProbeTargets(gt2).putPrimaryGuideProbeTargets(gt3);
+        final ObsContext ctx = baseContext.withTargets(env).withPositionAngle(new Angle(45, DEGREES));
 
-        // Optimize this context when rotated 45 degrees.  This will bring the
-        // target in detector 4 into detector 1.
-        ctx = ctx.withPositionAngle(new Angle(45, DEGREES));
-        Option<TargetEnvironment> optEnv = group.optimize(ctx);
+        // This will bring the target in detector 4 into detector 1.
+        final Option<TargetEnvironment> optEnv = group.optimize(ctx);
 
         // Should have two targets in detector 2.
-        TargetEnvironment newEnv = optEnv.getValue();
-        Set<GuideProbe> guiders = newEnv.getOrCreatePrimaryGuideGroup().getReferencedGuiders();
+        final TargetEnvironment newEnv = optEnv.getValue();
+        final Set<GuideProbe> guiders = newEnv.getOrCreatePrimaryGuideGroup().getReferencedGuiders();
         assertEquals(1, guiders.size());
         assertEquals(GsaoiOdgw.odgw2, guiders.iterator().next());
 
-        Option<GuideProbeTargets> gtOpt = newEnv.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw2);
-        GuideProbeTargets gt = gtOpt.getValue();
-        assertEquals(2, gt.getOptions().size());
+        final Option<GuideProbeTargets> gtOpt = newEnv.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw2);
+        final GuideProbeTargets gt = gtOpt.getValue();
+        assertEquals(2, gt.getTargets().size());
 
         // Make sure that the primary star is the primary star from gt2.
         // In other words, it shouldn't change just because a new star was
@@ -205,38 +201,33 @@ public class GsaoiOdgwGroupTest extends TestCase {
     @Test
     public void testKeepTransferPrimary() {
         // Put two guide stars in the same detector (detector 2).
-        Coordinates coords2a = new Coordinates(new Angle(midDetector, ARCSECS), new Angle(-DETECTOR_GAP_ARCSEC, ARCSECS));
-        Coordinates coords2b = new Coordinates(new Angle(DETECTOR_GAP_ARCSEC, ARCSECS), new Angle(-midDetector, ARCSECS));
-        SPTarget target2a = new SPTarget(coords2a.getRaDeg(), coords2a.getDecDeg());
-        SPTarget target2b = new SPTarget(coords2b.getRaDeg(), coords2b.getDecDeg());
+        final Coordinates coords2a = new Coordinates(new Angle(midDetector, ARCSECS), new Angle(-DETECTOR_GAP_ARCSEC, ARCSECS));
+        final Coordinates coords2b = new Coordinates(new Angle(DETECTOR_GAP_ARCSEC, ARCSECS), new Angle(-midDetector, ARCSECS));
+        final SPTarget target2a = new SPTarget(coords2a.getRaDeg(), coords2a.getDecDeg());
+        final SPTarget target2b = new SPTarget(coords2b.getRaDeg(), coords2b.getDecDeg());
 
-        GuideProbeTargets gt = GuideProbeTargets.create(GsaoiOdgw.odgw2, target2a, target2b);
+        final GuideProbeTargets gt = GuideProbeTargets.create(GsaoiOdgw.odgw2, target2a, target2b).selectPrimary(target2b);
 
-        // Make the second one primary.
-        gt = gt.selectPrimary(target2b);
+        // Setup the obs context, rotated 90 degrees.
+        final TargetEnvironment env = baseContext.getTargets().putPrimaryGuideProbeTargets(gt);
+        final ObsContext ctx = baseContext.withTargets(env).withPositionAngle(new Angle(90, DEGREES));
 
-        // Setup the obs context.
-        TargetEnvironment env = baseContext.getTargets().putPrimaryGuideProbeTargets(gt);
-        ObsContext ctx = baseContext.withTargets(env);
-
-        // Optimize this context when rotated 90 degrees.  This will put both
-        // targets in detector 1.
-        ctx = ctx.withPositionAngle(new Angle(90, DEGREES));
-        Option<TargetEnvironment> optEnv = group.optimize(ctx);
+        // This will put both targets in detector 1.
+        final Option<TargetEnvironment> optEnv = group.optimize(ctx);
 
         // Should have two targets in detector 4.
-        TargetEnvironment newEnv = optEnv.getValue();
-        Set<GuideProbe> guiders = newEnv.getOrCreatePrimaryGuideGroup().getReferencedGuiders();
+        final TargetEnvironment newEnv = optEnv.getValue();
+        final Set<GuideProbe> guiders = newEnv.getOrCreatePrimaryGuideGroup().getReferencedGuiders();
         assertEquals(1, guiders.size());
         assertEquals(GsaoiOdgw.odgw4, guiders.iterator().next());
 
-        Option<GuideProbeTargets> gtOpt1 = newEnv.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw4);
-        GuideProbeTargets gt1 = gtOpt1.getValue();
-        assertEquals(2, gt1.getOptions().size());
+        final Option<GuideProbeTargets> gtOpt1 = newEnv.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw4);
+        final GuideProbeTargets gt1 = gtOpt1.getValue();
+        assertEquals(2, gt1.getTargets().size());
 
         // Make sure that the second star is still primary in the new
         // environment.
-        Option<SPTarget> actual = gt1.getPrimary();
+        final Option<SPTarget> actual = gt1.getPrimary();
         assertFalse(actual.isEmpty());
         assertEquals(target2b, actual.getValue());
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/SetupTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/SetupTimeTest.java
@@ -139,7 +139,7 @@ public final class SetupTimeTest {
 
                 // Remove the OIWFS if it exists.
                 GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
-                ImList<GuideProbeTargets> gtList = grp.getAll().remove(GuideProbeTargets.match(NifsOiwfsGuideProbe.instance));
+                final ImList<GuideProbeTargets> gtList = grp.getAll().remove(gpt -> gpt.getGuider() == NifsOiwfsGuideProbe.instance);
                 env = env.setPrimaryGuideGroup(grp.setAll(gtList));
 
                 dataObj.setTargetEnvironment(env);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/SetupTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/SetupTimeTest.java
@@ -161,7 +161,8 @@ public final class SetupTimeTest {
                 TargetEnvironment env = dataObj.getTargetEnvironment();
 
                 // Add the OIWFS if it doesn't exist.
-                GuideProbeTargets gt = GuideProbeTargets.create(NifsOiwfsGuideProbe.instance, new SPTarget());
+                final SPTarget target = new SPTarget();
+                GuideProbeTargets gt = GuideProbeTargets.create(NifsOiwfsGuideProbe.instance, target).selectPrimary(target);
                 env = env.putPrimaryGuideProbeTargets(gt);
                 dataObj.setTargetEnvironment(env);
                 ctx.targetComponent.setDataObject(dataObj);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
@@ -4,14 +4,11 @@
 
 package edu.gemini.spModel.target.env;
 
-import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.target.SPTarget;
 import static edu.gemini.spModel.target.obsComp.PwfsGuideProbe.pwfs1;
 import static edu.gemini.spModel.target.obsComp.PwfsGuideProbe.pwfs2;
 import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
-import edu.gemini.shared.util.immutable.ImList;
-import edu.gemini.shared.util.immutable.DefaultImList;
-import edu.gemini.shared.util.immutable.None;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -35,9 +32,9 @@ final class Fixture {
         tl_pwfs2 = DefaultImList.create(t_pwfs2);
         tl_gmos  = DefaultImList.create();
 
-        gpt_pwfs1 = GuideProbeTargets.create(pwfs1, tl_pwfs1).selectPrimary(t_pwfs1_2);
-        gpt_pwfs2 = GuideProbeTargets.create(pwfs2, tl_pwfs2).setPrimaryIndex(None.INTEGER);
-        gpt_gmos  = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance, tl_gmos);
+        gpt_pwfs1 = GuideProbeTargets.create(pwfs1, GuideProbeTargets.NO_TARGET, new Some<>(t_pwfs1_2), tl_pwfs1);
+        gpt_pwfs2 = GuideProbeTargets.create(pwfs2, GuideProbeTargets.NO_TARGET, GuideProbeTargets.NO_TARGET, tl_pwfs2);
+        gpt_gmos  = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance);
 
         grp_all  = GuideGroup.create("All", gpt_gmos, gpt_pwfs1, gpt_pwfs2);
         grp_pwfs2_gmos = GuideGroup.create("PWFS2/GMOS", gpt_gmos, gpt_pwfs2);
@@ -46,7 +43,7 @@ final class Fixture {
         when = None.instance();
     }
 
-    public static void verifyGuideEnvironmentEquals(GuideEnvironment env1, GuideEnvironment env2, Option<Long> when) {
+    public static void verifyGuideEnvironmentEquals(final GuideEnvironment env1, final GuideEnvironment env2, final Option<Long> when) {
         assertEquals(env1.getReferencedGuiders(), env2.getReferencedGuiders());
         assertEquals(env1.getPrimaryIndex(), env2.getPrimaryIndex());
         verifyGroupListEquals(env1.getOptions(), env2.getOptions(), when);
@@ -57,9 +54,9 @@ final class Fixture {
      * be equals in the sense of grp1.equals(grp2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGroupListEquals(ImList<GuideGroup> lst1, ImList<GuideGroup> lst2, Option<Long> when) {
+    public static void verifyGroupListEquals(final ImList<GuideGroup> lst1, final ImList<GuideGroup> lst2, final Option<Long> when) {
         assertEquals(lst1.size(), lst2.size());
-        for (int i=0; i<lst1.size(); ++i) verifyGroupEquals(lst1.get(i), lst2.get(i), when);
+        lst1.zip(lst2).foreach(p -> verifyGroupEquals(p._1(), p._2(), when));
     }
 
     /**
@@ -67,7 +64,7 @@ final class Fixture {
      * be equals in the sense of grp1.equals(grp2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGroupEquals(GuideGroup grp1, GuideGroup grp2, Option<Long> when) {
+    public static void verifyGroupEquals(final GuideGroup grp1, final GuideGroup grp2, final Option<Long> when) {
         assertEquals(grp1.getName(), grp2.getName());
         verifyGptListEquals(grp1.getAll(), grp2.getAll(), when);
     }
@@ -77,9 +74,9 @@ final class Fixture {
      * be equals in the sense of gtp1.equals(gpt2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGptListEquals(ImList<GuideProbeTargets> lst1, ImList<GuideProbeTargets> lst2, Option<Long> when) {
+    public static void verifyGptListEquals(final ImList<GuideProbeTargets> lst1, final ImList<GuideProbeTargets> lst2, final Option<Long> when) {
         assertEquals(lst1.size(), lst2.size());
-        for (int i=0; i<lst1.size(); ++i) verifyGptEquals(lst1.get(i), lst2.get(i), when);
+        lst1.zip(lst2).foreach(p -> verifyGptEquals(p._1(), p._2(), when));
     }
 
     /**
@@ -87,10 +84,10 @@ final class Fixture {
      * be equals in the sense of gtp1.equals(gpt2) because SPTargets don't
      * define an equals method.
      */
-    public static void verifyGptEquals(GuideProbeTargets gpt1, GuideProbeTargets gpt2, Option<Long> when) {
+    public static void verifyGptEquals(final GuideProbeTargets gpt1, final GuideProbeTargets gpt2, final Option<Long> when) {
         assertEquals(gpt1.getGuider(), gpt2.getGuider());
         assertEquals(gpt1.getPrimaryIndex(), gpt2.getPrimaryIndex());
-        verifySpListEquals(gpt1.getOptions(), gpt2.getOptions(), when);
+        verifySpListEquals(gpt1.getTargets(), gpt2.getTargets(), when);
     }
 
     /**
@@ -102,12 +99,12 @@ final class Fixture {
      * <p>For our purposes of testing TargetEnvironment objects, we just want
      * an idea that they are the same and checking the coordinates is enough.
      */
-    public static void verifySpListEquals(ImList<SPTarget> lst1, ImList<SPTarget> lst2, Option<Long> when) {
+    public static void verifySpListEquals(final ImList<SPTarget> lst1, final ImList<SPTarget> lst2, final Option<Long> when) {
         assertEquals(lst1.size(), lst2.size());
 
-        for (int i=0; i<lst1.size(); ++i) {
-            SPTarget t1 = lst1.get(i);
-            SPTarget t2 = lst2.get(i);
+        lst1.zip(lst2).foreach(p -> {
+            final SPTarget t1 = p._1();
+            final SPTarget t2 = p._2();
 
             // The two targets won't compare .equals(), but we can just check
             // the coordinates and get enough of an idea that they are the
@@ -115,14 +112,14 @@ final class Fixture {
 
             assertOptEquals(t1.getTarget().getRaDegrees(when), t2.getTarget().getRaDegrees(when), 0.000001);
             assertOptEquals(t1.getTarget().getDecDegrees(when), t2.getTarget().getDecDegrees(when), 0.000001);
-        }
+        });
     }
 
     /**
      * Asserts that either (a) both are None, or (b) both are defined and values are within the
      * given tolerance.
      */
-    public static void assertOptEquals(Option<Double> a, Option<Double> b, Double tolerance) {
+    public static void assertOptEquals(final Option<Double> a, final Option<Double> b, final Double tolerance) {
         if (a.isDefined() || b.isDefined()) {
             if (a.isEmpty() || b.isEmpty()) fail("unequal: " + a + ", " + b);
             a.foreach(aa -> b.foreach(bb -> assertEquals(aa, bb, tolerance)));

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideEnvironmentTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideEnvironmentTest.java
@@ -126,19 +126,19 @@ public class GuideEnvironmentTest {
         assertEquals(0, env.getOptions().get(3).getAll().size());
 
         // Add guide probe targets to the 4th group.
-        GuideEnvironment env2 = env.putGuideProbeTargets(grp4, gpt_pwfs1);
+        final GuideEnvironment env2 = env.putGuideProbeTargets(grp4, gpt_pwfs1);
 
         // Make sure that they are there now.
-        GuideGroup newGrp4 = env2.getOptions().get(3);
-        GuideProbeTargets gpt = newGrp4.get(pwfs1).getValue();
+        final GuideGroup newGrp4 = env2.getOptions().get(3);
+        final GuideProbeTargets gpt = newGrp4.get(pwfs1).getValue();
         assertNotNull(gpt);
 
         // Update them with a new target (the 3rd in the list of options)
-        GuideProbeTargets gpt2 = gpt.setOptions(gpt.getOptions().append(new SPTarget()));
-        GuideEnvironment  env3 = env2.putGuideProbeTargets(newGrp4, gpt2);
+        final GuideProbeTargets gpt2 = gpt.setManualTargets(gpt.getManualTargets().append(new SPTarget()));
+        final GuideEnvironment  env3 = env2.putGuideProbeTargets(newGrp4, gpt2);
 
         // Check that they now contain the new target.
-        GuideProbeTargets gpt3 = env3.getOptions().get(3).get(pwfs1).getValue();
-        assertEquals(3, gpt3.getOptions().size());
+        final GuideProbeTargets gpt3 = env3.getOptions().get(3).get(pwfs1).getValue();
+        assertEquals(3, gpt3.getManualTargets().size());
     }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideGroupTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideGroupTest.java
@@ -104,10 +104,10 @@ public final class GuideGroupTest extends TestCase {
         Fixture.verifyGptListEquals(fix.grp_gmos.getAll(), grp.getAll(), fix.when);
 
         // Replace an existing GuideProbeTargets.
-        GuideProbeTargets gpt = GuideProbeTargets.create(pwfs1, fix.t_pwfs1_2);
+        GuideProbeTargets gpt = GuideProbeTargets.create(pwfs1, fix.t_pwfs1_2).selectPrimary(fix.t_pwfs1_2);
         grp = fix.grp_all.put(gpt);  // now the pwfs1 guide probe targets has just one target
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getOptions(), fix.when);
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getTargets(), fix.when);
     }
 
     public void testRemove() {
@@ -149,10 +149,10 @@ public final class GuideGroupTest extends TestCase {
         Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
 
         // Test replace via putAll
-        GuideProbeTargets gpt = GuideProbeTargets.create(pwfs1, fix.t_pwfs1_2);
+        GuideProbeTargets gpt = GuideProbeTargets.create(pwfs1, fix.t_pwfs1_2).selectPrimary(fix.t_pwfs1_2);
         grp = fix.grp_all.putAll(DefaultImList.create(gpt));  // now the pwfs1 guide probe targets has just one target
         assertEquals(grp.getName(), fix.grp_all.getName());
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getOptions(), fix.when);
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), grp.get(pwfs1).getValue().getTargets(), fix.when);
 
         // put all empty
         grp = fix.grp_all.putAll(GuideProbeTargets.EMPTY_LIST);
@@ -177,7 +177,7 @@ public final class GuideGroupTest extends TestCase {
         Fixture.verifyGptListEquals(GuideProbeTargets.EMPTY_LIST, fix.grp_gmos.getAllContaining(fix.t_pwfs1_1), fix.when);
 
         // Put the same target in more than one GuideProbeTargets object.
-        GuideProbeTargets gpt = fix.gpt_gmos.update(OptionsList.UpdateOps.append(fix.t_pwfs1_1));
+        GuideProbeTargets gpt = fix.gpt_gmos.addManualTarget(fix.t_pwfs1_1);
 
         // t_pwfs1_1 should be in the first two GuideProbeTarets sets here
         GuideGroup grp = GuideGroup.create("x", fix.gpt_pwfs1, gpt, fix.gpt_pwfs2);
@@ -211,16 +211,17 @@ public final class GuideGroupTest extends TestCase {
     public void testGetReferencedGuidersByType() {
         // Make a GMOS GuideProbeTargets instance with a guide star so that
         // it is not eliminated from the results because it is empty.
-        GuideProbeTargets gpt = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance, new SPTarget());
-        GuideGroup all = fix.grp_all.put(gpt);
+        final SPTarget target = new SPTarget();
+        final GuideProbeTargets gpt = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance, target).selectPrimary(target);
+        final GuideGroup all = fix.grp_all.put(gpt);
 
-        Set<GuideProbe> pwfs = new HashSet<GuideProbe>();
+        final Set<GuideProbe> pwfs = new HashSet<>();
         pwfs.add(pwfs1); pwfs.add(pwfs2);
 
-        Set<GuideProbe> oiwfs = new HashSet<GuideProbe>();
+        final Set<GuideProbe> oiwfs = new HashSet<>();
         oiwfs.add(GmosOiwfsGuideProbe.instance);
 
-        Set<GuideProbe> empty = Collections.emptySet();
+        final Set<GuideProbe> empty = Collections.emptySet();
 
         assertEquals(pwfs,  all.getReferencedGuiders(GuideProbe.Type.PWFS));
         assertEquals(oiwfs, all.getReferencedGuiders(GuideProbe.Type.OIWFS));

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideGroupTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideGroupTest.java
@@ -247,7 +247,7 @@ public final class GuideGroupTest extends TestCase {
     }
 
     public void testRemoveTargetUpdate() {
-        UpdateOp<GuideGroup> f = GuideGroup.removeTargetUpdate(fix.t_pwfs1_2);
+        UpdateOp<GuideGroup> f = g -> g.removeTarget(fix.t_pwfs1_2);
 
         GuideGroup grp = f.apply(fix.grp_all);
         ImList<SPTarget> expected = DefaultImList.create(
@@ -279,13 +279,12 @@ public final class GuideGroupTest extends TestCase {
     }
 
     public void testCloneTargets() {
-        GuideGroup grp = GuideGroup.CLONE_TARGETS.apply(fix.grp_all);
+        final GuideGroup grp = fix.grp_all.cloneTargets();
         assertFalse(fix.grp_all.equals(grp));
         Fixture.verifyGptListEquals(fix.grp_all.getAll(), grp.getAll(), fix.when);
         assertEquals(fix.grp_all.getName(), grp.getName());
 
-        grp = GuideGroup.CLONE_TARGETS.apply(fix.grp_gmos);
-
+        //grp = GuideGroup.CLONE_TARGETS.apply(fix.grp_gmos);
         // XXX allan: removed GuideGroup.equals def to avoid having new, empty groups being equal
 //        assertTrue(fix.grp_gmos.equals(grp)); // no SPTargets so these are .equals too
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
@@ -150,14 +150,14 @@ public final class GuideProbeTargetsTest extends TestCase {
     }
 
     public void testTargetMatch() {
-        PredicateOp<TargetContainer> f = new TargetContainer.TargetMatch(fix.t_pwfs2);
+        PredicateOp<TargetContainer> f = t -> t.containsTarget(fix.t_pwfs2);
         assertFalse(f.apply(fix.gpt_pwfs1));
         assertTrue(f.apply(fix.gpt_pwfs2));
         assertFalse(f.apply(fix.gpt_gmos));
     }
 
     public void testExtractTarget() {
-        Function1<TargetContainer, ImList<SPTarget>> f = TargetContainer.EXTRACT_TARGET;
+        final Function1<TargetContainer, ImList<SPTarget>> f = TargetContainer::getTargets;
         assertEquals(fix.tl_pwfs1, f.apply(fix.gpt_pwfs1));
         assertEquals(fix.tl_pwfs2, f.apply(fix.gpt_pwfs2));
         assertEquals(fix.tl_gmos,  f.apply(fix.gpt_gmos));

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
@@ -18,8 +18,7 @@ import org.junit.Test;
 import java.util.Comparator;
 
 /**
- * Test cases for {@link GuideProbeTargets}.  The bulk of it is delegated
- * to an OptionsListImpl which is tested in OptionsListTest.
+ * Test cases for {@link GuideProbeTargets}.
  */
 public final class GuideProbeTargetsTest extends TestCase {
 
@@ -27,15 +26,15 @@ public final class GuideProbeTargetsTest extends TestCase {
 
     @Test
     public void testMatchGuider() {
-        PredicateOp<GuideProbeTargets> op = GuideProbeTargets.match(pwfs1);
+        final PredicateOp<GuideProbeTargets> op = GuideProbeTargets.match(pwfs1);
         assertTrue(op.apply(fix.gpt_pwfs1));
         assertFalse(op.apply(fix.gpt_pwfs2));
         assertFalse(op.apply(fix.gpt_gmos));
     }
 
     @Test
-    public void tesetMatchType() {
-        PredicateOp<GuideProbeTargets> op = GuideProbeTargets.match(GuideProbe.Type.OIWFS);
+    public void testMatchType() {
+        final PredicateOp<GuideProbeTargets> op = GuideProbeTargets.match(GuideProbe.Type.OIWFS);
         assertFalse(op.apply(fix.gpt_pwfs1));
         assertFalse(op.apply(fix.gpt_pwfs2));
         assertTrue(op.apply(fix.gpt_gmos));
@@ -131,23 +130,23 @@ public final class GuideProbeTargetsTest extends TestCase {
         GuideProbeTargets gpt;
 
         gpt = fix.gpt_pwfs1.removeTarget(fix.t_pwfs1_1);
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), gpt.getOptions(), fix.when);
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_2), gpt.getTargets(), fix.when);
 
         gpt = fix.gpt_pwfs1.removeTarget(fix.t_pwfs1_2);
-        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_1), gpt.getOptions(), fix.when);
+        Fixture.verifySpListEquals(DefaultImList.create(fix.t_pwfs1_1), gpt.getTargets(), fix.when);
 
         // Remove a target that doesn't exist in the GuideProbeTargets instance.
         gpt = fix.gpt_pwfs1.removeTarget(fix.t_pwfs2);
-        Fixture.verifySpListEquals(fix.tl_pwfs1, gpt.getOptions(), fix.when);
+        Fixture.verifySpListEquals(fix.tl_pwfs1, gpt.getTargets(), fix.when);
 
         // Remove the only target in the list
         gpt = fix.gpt_pwfs2.removeTarget(fix.t_pwfs2);
         ImList<SPTarget> empty = ImCollections.emptyList();
-        Fixture.verifySpListEquals(empty, gpt.getOptions(), fix.when);
+        Fixture.verifySpListEquals(empty, gpt.getTargets(), fix.when);
 
         // Remove from an empty list.
         gpt = fix.gpt_gmos.removeTarget(fix.t_pwfs1_1);
-        Fixture.verifySpListEquals(fix.tl_gmos, gpt.getOptions(), fix.when);
+        Fixture.verifySpListEquals(fix.tl_gmos, gpt.getTargets(), fix.when);
     }
 
     public void testTargetMatch() {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/GuideProbeTargetsTest.java
@@ -26,7 +26,7 @@ public final class GuideProbeTargetsTest extends TestCase {
 
     @Test
     public void testMatchGuider() {
-        final PredicateOp<GuideProbeTargets> op = GuideProbeTargets.match(pwfs1);
+        final PredicateOp<GuideProbeTargets> op = gpt -> gpt.getGuider() == pwfs1;
         assertTrue(op.apply(fix.gpt_pwfs1));
         assertFalse(op.apply(fix.gpt_pwfs2));
         assertFalse(op.apply(fix.gpt_gmos));
@@ -34,7 +34,7 @@ public final class GuideProbeTargetsTest extends TestCase {
 
     @Test
     public void testMatchType() {
-        final PredicateOp<GuideProbeTargets> op = GuideProbeTargets.match(GuideProbe.Type.OIWFS);
+        final PredicateOp<GuideProbeTargets> op = gpt -> gpt.getGuider().getType() == GuideProbe.Type.OIWFS;
         assertFalse(op.apply(fix.gpt_pwfs1));
         assertFalse(op.apply(fix.gpt_pwfs2));
         assertTrue(op.apply(fix.gpt_gmos));
@@ -70,7 +70,7 @@ public final class GuideProbeTargetsTest extends TestCase {
 
     @Test
     public void testExtractProbe() {
-        Function1<GuideProbeTargets, GuideProbe> f = GuideProbeTargets.EXTRACT_PROBE;
+        Function1<GuideProbeTargets, GuideProbe> f = GuideProbeTargets::getGuider;
         assertEquals(pwfs1, f.apply(fix.gpt_pwfs1));
         assertEquals(pwfs2, f.apply(fix.gpt_pwfs2));
         assertEquals(GmosOiwfsGuideProbe.instance, f.apply(fix.gpt_gmos));
@@ -78,7 +78,7 @@ public final class GuideProbeTargetsTest extends TestCase {
 
     @Test
     public void testMatchNonEmpty() {
-        PredicateOp<GuideProbeTargets> f = GuideProbeTargets.MATCH_NON_EMPTY;
+        PredicateOp<GuideProbeTargets> f = GuideProbeTargets::containsTargets;
         assertTrue(f.apply(fix.gpt_pwfs1));
         assertTrue(f.apply(fix.gpt_pwfs2));
         assertFalse(f.apply(fix.gpt_gmos));

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
@@ -71,7 +71,7 @@ public class Pre2010BTargetEnvironmentIoTest {
                 GuideProbeTargets gpt = gptOpt.getValue();
 
                 // Which contains a single target
-                assertEquals(1, gpt.getOptions().size());
+                assertEquals(1, gpt.getTargets().size());
 
                 SPTarget primary = gpt.getPrimary().getValue();
                 verifyTarget("GSC001", primary);

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gsaoi/PlannedTimeTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gsaoi/PlannedTimeTest.scala
@@ -36,7 +36,8 @@ class PlannedTimeTest extends InstrumentSequenceTestBase[Gsaoi, GsaoiSeqConfig] 
     // Add a canopus guide star so that guiding will be turned on
     val env  = getTargetEnvironment
     val grp  = env.getOrCreatePrimaryGuideGroup
-    val env2 = env.setPrimaryGuideGroup(grp.put(GuideProbeTargets.create(Canopus.Wfs.cwfs3, new SPTarget(0.0, 0.0))))
+    val target = new SPTarget(0.0, 0.0)
+    val env2 = env.setPrimaryGuideGroup(grp.put(GuideProbeTargets.create(Canopus.Wfs.cwfs3, target).selectPrimary(target)))
 
     val dobj = getTarget.getDataObject.asInstanceOf[TargetObsComp]
     dobj.setTargetEnvironment(env2)

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
@@ -27,7 +27,7 @@ enum SPTargetPosListParser {
     private static final Logger LOG = Logger.getLogger(SPTargetPosListParser.class.getName());
 
     // A small helper that is basically a mutable target enviornment.  It is
-    // built up target by target parsed fromt the XML, then converted into a
+    // built up target by target parsed from the XML, then converted into a
     // real TargetEnvironment.
     private final static class Targets {
         SPTarget base;
@@ -76,9 +76,10 @@ enum SPTargetPosListParser {
         public void addTarget(SPTarget target, Targets targets) {
             GuideProbeTargets gt = targets.guideMap.get(guider);
             if (gt == null) {
-                gt = GuideProbeTargets.create(guider, ImCollections.singletonList(target));
+                gt = GuideProbeTargets.create(guider, GuideProbeTargets.NO_TARGET,
+                        GuideProbeTargets.NO_TARGET, ImCollections.singletonList(target));
             } else {
-                gt = gt.setOptions(gt.getOptions().append(target));
+                gt = gt.addManualTarget(target);
             }
             targets.guideMap.put(guider, gt);
         }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -158,18 +158,14 @@ public final class ObservationEnvironment {
     }
 
     public boolean containsTargets(GuideProbe probe) {
-        Option<GuideProbeTargets> gtOpt = _targetEnv.getPrimaryGuideProbeTargets(probe);
-        return (!gtOpt.isEmpty() && (gtOpt.getValue().getOptions().size() > 0));
+        final Option<GuideProbeTargets> gtOpt = _targetEnv.getPrimaryGuideProbeTargets(probe);
+        return gtOpt.exists(GuideProbeTargets::containsTargets);
     }
 
     public boolean containsTargets(GuideProbe.Type type) {
-        GuideGroup grp = _targetEnv.getOrCreatePrimaryGuideGroup();
-        ImList<GuideProbeTargets> gtList = grp.getAllMatching(type);
-        return gtList.exists(new PredicateOp<GuideProbeTargets>() {
-            @Override public Boolean apply(GuideProbeTargets gt) {
-                return gt.getOptions().size() > 0;
-            }
-        });
+        final GuideGroup grp = _targetEnv.getOrCreatePrimaryGuideGroup();
+        final ImList<GuideProbeTargets> gtList = grp.getAllMatching(type);
+        return gtList.exists(GuideProbeTargets::containsTargets);
     }
 
     public enum AoAspect {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
@@ -30,7 +30,7 @@ public final class TargetGroupConfig extends ParamSet {
         final GuideProbe guider = gt.getGuider();
         final ImList<SPTarget> manualTargets = gt.getManualTargets();
         final Option<SPTarget> primaryOpt = gt.getPrimary();
-        final Option<SPTarget> bagsTargetOpt = gt.getBAGSTarget();
+        final Option<SPTarget> bagsTargetOpt = gt.getBagsTarget();
 
         // SW: no longer always setting a primary target.
 //        if ((primary == null) && (targets.size() > 0)) primary = targets.head();

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -128,11 +128,11 @@ public class TccFieldConfig extends ParamSet {
         if (!_oe.getAvailableGuiders().contains(gt.getGuider())) return;
 
         // Ignore empty guide targets.
-        ImList<SPTarget> targets = gt.getOptions();
+        final ImList<SPTarget> targets = gt.getTargets();
         if (targets.size() == 0) return;
 
         // Add each target, setting any missing names along the way.
-        String tag = TargetConfig.getTag(gt.getGuider());
+        final String tag = TargetConfig.getTag(gt.getGuider());
 
         int pos = 1;
         for (SPTarget target : targets) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccNames.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccNames.java
@@ -23,6 +23,7 @@ public final class TccNames {
     public static final String AZEL = "AzEl";
     public static final String BASE = "Base";
 //    public static final String BASE = "sciencetarget";
+    public static final String BAGSTARGET = "bagsTarget";
     public static final String BASICCHOP = "BasicChop";
     public static final String BRIGHTNESS = "brightness";
     //public static final String FIELD = "targetEnv";

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
@@ -44,8 +44,8 @@ public final class GsaoiSupportTest extends InstrumentSupportTestBase<Gsaoi> {
     }
 
     private static GuideProbeTargets createGuideTargets(GuideProbe probe) {
-        ImList<SPTarget> targetList = ImCollections.singletonList(new SPTarget());
-        return GuideProbeTargets.create(probe, targetList);
+        final SPTarget target = new SPTarget();
+        return GuideProbeTargets.create(probe, target).selectPrimary(target);
     }
 
     private static ImList<GuideProbeTargets> createGuideTargetsList(GuideProbe... probes) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
@@ -46,8 +46,8 @@ public class GuideConfigTest extends TestBase {
     }
 
     private static GuideProbeTargets createGuideTargets(GuideProbe probe) {
-        ImList<SPTarget> targetList = ImCollections.singletonList(new SPTarget());
-        return GuideProbeTargets.create(probe, targetList);
+        final SPTarget target = new SPTarget();
+        return GuideProbeTargets.create(probe, target).selectPrimary(target);
     }
 
     private static ImList<GuideProbeTargets> createGuideTargetsList(GuideProbe... probes) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
@@ -40,8 +40,8 @@ public final class GuideGroupTest extends TestBase {
     }
 
     private static GuideProbeTargets createGuideTargets(GuideProbe probe) {
-        ImList<SPTarget> targetList = ImCollections.singletonList(new SPTarget());
-        return GuideProbeTargets.create(probe, targetList);
+        final SPTarget target = new SPTarget();
+        return GuideProbeTargets.create(probe, target).selectPrimary(target);
     }
 
     private static ImList<GuideProbeTargets> createGuideTargetsList(GuideProbe... probes) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -33,16 +33,15 @@ public final class TargetMagnitudeTest extends TestBase {
     protected void setUp() throws Exception {
         super.setUp();
 
-        SPTarget base = new SPTarget();
+        final SPTarget base = new SPTarget();
         base.setName("Base Pos");
 
         pwfs1_1 = new SPTarget();
         pwfs1_1.setName("PWFS1-1");
 
-        env = TargetEnvironment.create(base);
-        GuideProbeTargets gpt = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, pwfs1_1);
-        GuideGroup grp = GuideGroup.create("Default Guide Group", gpt);
-        env = env.setPrimaryGuideGroup(grp);
+        final GuideProbeTargets gpt = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, pwfs1_1).selectPrimary(pwfs1_1);
+        final GuideGroup grp = GuideGroup.create("Default Guide Group", gpt);
+        env = TargetEnvironment.create(base).setPrimaryGuideGroup(grp);
     }
 
     public void testNoMagnitudeInfo() throws Exception {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/PrimaryTargetToggle.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/PrimaryTargetToggle.java
@@ -9,7 +9,6 @@ import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideGroup;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
-import static edu.gemini.spModel.target.env.OptionsList.UpdateOps.togglePrimary;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 
 /**
@@ -32,16 +31,13 @@ public enum PrimaryTargetToggle {
     public void toggle(TargetObsComp obsComp, SPTarget target) {
         if ((obsComp == null) || (target == null)) return;
 
-        TargetEnvironment env = obsComp.getTargetEnvironment();
+        final TargetEnvironment env = obsComp.getTargetEnvironment();
         final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
         final ImList<GuideProbeTargets> lst = grp.getAllContaining(target);
         if (lst.isEmpty()) return; // target not associated with any guider
 
-        for (GuideProbeTargets gt : lst) {
-            gt  = gt.update(togglePrimary(target));
-            env = env.putPrimaryGuideProbeTargets(gt);
-        }
-
-        obsComp.setTargetEnvironment(env);
+        final TargetEnvironment finalEnv = lst.foldLeft(env,
+                (e, gt) -> e.putPrimaryGuideProbeTargets(gt.togglePrimary(target)));
+        obsComp.setTargetEnvironment(finalEnv);
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -9,6 +9,7 @@ package jsky.app.ot.gemini.editor.targetComponent;
 import edu.gemini.ags.api.*;
 import edu.gemini.pot.ModelConverters;
 import edu.gemini.pot.sp.ISPObsComponent;
+import edu.gemini.shared.gui.DoubleIcon;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.guide.*;
@@ -33,8 +34,6 @@ import org.jdesktop.swingx.decorator.HighlighterFactory;
 import org.jdesktop.swingx.treetable.AbstractTreeTableModel;
 
 import javax.swing.*;
-import javax.swing.event.TreeSelectionEvent;
-import javax.swing.event.TreeSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -42,6 +41,7 @@ import javax.swing.tree.TreePath;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.NumberFormat;
@@ -75,37 +75,25 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             },
 
             RA("RA") {
-                public Object getValue(Row row) {
-                    return row.target().map(new MapOp<SPTarget, String>() {
-                        @Override public String apply(SPTarget t) {
-                            return t.getTarget().getRaString();
-                        }
-                    }).getOrElse("");
+                public Object getValue(final Row row) {
+                    return row.target().map(t -> t.getTarget().getRaString()).getOrElse("");
                 }
             },
 
             DEC("Dec") {
-                public Object getValue(Row row) {
-                    return row.target().map(new MapOp<SPTarget, String>() {
-                        @Override public String apply(SPTarget t) {
-                            return t.getTarget().getDecString();
-                        }
-                    }).getOrElse("");
+                public Object getValue(final Row row) {
+                    return row.target().map(t -> t.getTarget().getDecString()).getOrElse("");
                 }
             },
 
             DIST("Dist") {
-                public Object getValue(Row row) {
-                    return row.distance().map(new MapOp<Double, String>() {
-                        @Override public String apply(Double dist) {
-                            return nf.format(dist);
-                        }
-                    }).getOrElse("");
+                public Object getValue(final Row row) {
+                    return row.distance().map(nf::format).getOrElse("");
                 }
             };
 
             private final String displayName;
-            Col(String displayName) { this.displayName = displayName; }
+            Col(final String displayName) { this.displayName = displayName; }
             public String displayName() { return displayName; }
             public abstract Object getValue(Row row);
         }
@@ -144,28 +132,21 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             public Option<GuideGroup> group() { return None.instance(); }
             public Option<Double> distance()  { return None.instance(); }
             public List<Row> children()       { return Collections.emptyList(); }
+            public boolean editable()         { return true; }
 
             public Option<Magnitude> getMagnitude(final Magnitude.Band band) {
-                return target.flatMap(new MapOp<SPTarget, Option<Magnitude>>() {
-                    @Override public Option<Magnitude> apply(SPTarget spTarget) {
-                        return spTarget.getTarget().getMagnitude(band);
-                    }
-                });
+                return target.flatMap(t -> t.getTarget().getMagnitude(band));
             }
 
             public String formatMagnitude(Magnitude.Band band) {
-                return getMagnitude(band).map(new MapOp<Magnitude, String>() {
-                    @Override public String apply(Magnitude mag) {
-                        return MagnitudeEditor.formatBrightness(mag);
-                    }
-                }).getOrElse("");
+                return getMagnitude(band).map(MagnitudeEditor::formatBrightness).getOrElse("");
             }
 
             public Icon getIcon() { return blankIcon; }
         }
 
         static final class BaseTargetRow extends AbstractRow {
-            BaseTargetRow(SPTarget target) {
+            BaseTargetRow(final SPTarget target) {
                 super(true, TargetEnvironment.BASE_NAME, target.getTarget().getName(), new Some<>(target));
             }
         }
@@ -173,7 +154,8 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
         static abstract class NonBaseTargetRow extends AbstractRow {
             final Option<Double> distance;
 
-            NonBaseTargetRow(boolean enabled, String tag, SPTarget target, Option<WorldCoords> baseCoords, Option<Long> when) {
+            NonBaseTargetRow(final boolean enabled, final String tag, final SPTarget target,
+                             final Option<WorldCoords> baseCoords, final Option<Long> when) {
                 super(enabled, tag, target.getTarget().getName(), new Some<>(target));
                 final Option<WorldCoords> coords = getWorldCoords(target, when);
                 distance =
@@ -196,8 +178,48 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             }
 
             @Override public Icon getIcon() {
-                if (!isActiveGuideProbe) return errorIcon;
-                else return GuidingIcon.apply(quality.getOrElse(AgsGuideQuality.Unusable$.MODULE$), enabled);
+                return isActiveGuideProbe ?
+                        GuidingIcon.apply(quality.getOrElse(AgsGuideQuality.Unusable$.MODULE$), enabled) :
+                        errorIcon;
+            }
+        }
+
+        static final class BagsTargetRow extends NonBaseTargetRow {
+            final boolean isActiveGuideProbe;
+            final Option<AgsGuideQuality> quality;
+            BagsTargetRow(final boolean isActiveGuideProbe, final Option<AgsGuideQuality> quality, final boolean enabled,
+                          final GuideProbe probe, final SPTarget target, final Option<WorldCoords> baseCoords,
+                          final Option<Long> when) {
+                super(enabled, String.format("%s (BAGS)", probe.getKey()), target, baseCoords, when);
+                this.isActiveGuideProbe = isActiveGuideProbe;
+                this.quality = quality;
+            }
+
+            private static final Icon bagsEnabled  = bagsIcon(true);
+            private static final Icon bagsDisabled = bagsIcon(false);
+            private static final int  bagsGap      = 5;
+
+            private static Icon bagsIcon(boolean enabled) {
+                final BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+                final Graphics      g2  = img.createGraphics();
+                g2.setColor(enabled ? Color.blue : Color.lightGray);
+                g2.fillRect(0, 0, 16, 16);
+                g2.setColor(Color.white);
+                g2.setFont(g2.getFont().deriveFont(16.0f).deriveFont(Font.BOLD));
+                g2.drawString("A", 2, 14);
+                return new ImageIcon(img);
+            }
+
+            @Override public boolean editable() {
+                return false;
+            }
+
+            @Override public Icon getIcon() {
+                final Icon qualityIcon = isActiveGuideProbe ?
+                        GuidingIcon.apply(quality.getOrElse(AgsGuideQuality.Unusable$.MODULE$), enabled) :
+                        errorIcon;
+                final Icon bagsIcon = enabled ? bagsEnabled : bagsDisabled;
+                return new DoubleIcon(bagsIcon, qualityIcon, bagsGap);
             }
         }
 
@@ -242,7 +264,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                     return AgsRegistrar.instance().currentStrategyForJava(tup._1()).map(strategy -> {
                         final Option<AgsAnalysis> agsAnalysis = strategy.analyzeForJava(tup._1(), tup._2(), vgp, ModelConverters.toSideralTarget(guideStar));
                         return agsAnalysis.map(AgsAnalysis::quality);
-                    }).getOrElse(None.<AgsGuideQuality>instance());
+                    }).getOrElse(None.instance());
                 } else {
                     return None.instance();
                 }
@@ -265,12 +287,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             tmp.add(new BaseTargetRow(base));
 
             // Add all the guide groups and targets.
-            final Option<Tuple2<ObsContext, AgsMagnitude.MagnitudeTable>> ags = ctx.map(new MapOp<ObsContext, Tuple2<ObsContext, AgsMagnitude.MagnitudeTable>>() {
-                @Override public Tuple2<ObsContext, AgsMagnitude.MagnitudeTable> apply(ObsContext oc) {
-                    return new Pair<>(oc, OT.getMagnitudeTable());
-                }
-            });
-
+            final Option<Tuple2<ObsContext, AgsMagnitude.MagnitudeTable>> ags = ctx.map(oc -> new Pair<>(oc, OT.getMagnitudeTable()));
             final GuideEnvironment ge = env.getGuideEnvironment();
             final ImList<GuideGroup> groups = ge.getOptions();
             final GuideGroup primaryGroup = env.getOrCreatePrimaryGuideGroup();
@@ -279,11 +296,21 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                     final GuideProbe guideProbe = gt.getGuider();
                     final boolean isActive = ctx.exists(c -> GuideProbeUtil.instance.isAvailable(c, guideProbe));
                     final Option<SPTarget> primary = gt.getPrimary();
+                    final Option<SPTarget> bagsTarget = gt.getBagsTarget();
+
+                    // If the first target is a bags target, we do not add to the index.
+                    final int bagsIndexModifier = bagsTarget.isDefined() ? 0 : 1;
+
                     gt.getTargets().zipWithIndex().foreach(tup -> {
                         final SPTarget target = tup._1();
                         final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
-                        final boolean isPrimary = !primary.isEmpty() && (primary.getValue() == target);
-                        tmp.add(new GuideTargetRow(isActive, quality, isPrimary, guideProbe, tup._2() + 1, target, baseCoords, when));
+                        final boolean isPrimary = primary.exists(target::equals);
+                        final boolean isBagsTarget = bagsTarget.exists(target::equals);
+
+                        final Row row = isBagsTarget ?
+                                new BagsTargetRow(isActive, quality, isPrimary, guideProbe, target, baseCoords, when) :
+                                new GuideTargetRow(isActive, quality, isPrimary, guideProbe, tup._2() + bagsIndexModifier, target, baseCoords, when);
+                        tmp.add(row);
                     });
                 }
             } else {
@@ -295,11 +322,21 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                         final GuideProbe guideProbe = gt.getGuider();
                         final boolean isActive = ctx.exists(c -> GuideProbeUtil.instance.isAvailable(c, guideProbe));
                         final Option<SPTarget> primary = gt.getPrimary();
+                        final Option<SPTarget> bagsTarget = gt.getBagsTarget();
+
+                        // If the first target is a bags target, we do not add to the index.
+                        final int bagsIndexModifier = bagsTarget.isDefined() ? 0 : 1;
+
                         gt.getTargets().zipWithIndex().foreach(tup -> {
                             final SPTarget target = tup._1();
                             final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
-                            final boolean enabled = isPrimaryGroup && !primary.isEmpty() && (primary.getValue() == tup._1());
-                            rowList.add(new GuideTargetRow(isActive, quality, enabled, guideProbe, tup._2() + 1, tup._1(), baseCoords, when));
+                            final boolean enabled = isPrimaryGroup && primary.exists(target::equals);
+                            final boolean isBagsTarget = bagsTarget.exists(target::equals);
+
+                            final Row row = isBagsTarget ?
+                                    new BagsTargetRow(isActive, quality, enabled, guideProbe, target, baseCoords, when) :
+                                    new GuideTargetRow(isActive, quality, enabled, guideProbe, tup._2() + bagsIndexModifier, target, baseCoords, when);
+                            rowList.add(row);
                         });
                     }
 
@@ -362,26 +399,18 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
         }
 
         public Option<SPTarget> targetAt(int index) {
-            return rowAt(index).flatMap(new MapOp<Row, Option<SPTarget>>() {
-                @Override
-                public Option<SPTarget> apply(Row row) {
-                    return row.target();
-                }
-            });
+            return rowAt(index).flatMap(Row::target);
         }
 
         public Option<GuideGroup> groupAt(int index) {
-            return rowAt(index).flatMap(new MapOp<Row, Option<GuideGroup>>() {
-                @Override public Option<GuideGroup> apply(Row row) {
-                    return row.group();
-                }
-            });
+            return rowAt(index).flatMap(Row::group);
         }
 
         public Option<Row> rowAt(int index) {
             int i = 0;
             for (Row row : rows) {
-                if (i == index) return new Some<>(row);
+                if (i == index)
+                    return new Some<>(row);
 
                 final TreePath path = treeTable.getPathForRow(i);
                 ++i;
@@ -405,12 +434,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             for (Col c : Col.values()) hdr.add(c.displayName());
 
             // Add each magnitude band name
-            hdr.addAll(bands.map(new MapOp<Magnitude.Band, String>() {
-                @Override public String apply(Magnitude.Band band) {
-                    return band.name();
-                }
-            }).toList());
-
+            hdr.addAll(bands.map(Magnitude.Band::name).toList());
             return DefaultImList.create(hdr);
         }
 
@@ -543,7 +567,9 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                     final GuideGroup primary = env.getOrCreatePrimaryGuideGroup();
                     if (primary != group && confirmGroupChange(primary, group)) {
                         final GuideEnvironment ge = env.getGuideEnvironment();
-                        _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.selectPrimary(group)));
+                        if (ge != null) {
+                            _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.selectPrimary(group)));
+                        }
                     }
                 }
             }
@@ -602,16 +628,14 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
         setColumnSelectionAllowed(false);
         getTableHeader().setReorderingAllowed(false);
 
-        addTreeSelectionListener(new TreeSelectionListener() {
-            @Override
-            public void valueChanged(TreeSelectionEvent e) {
-                if (_ignoreSelection) return;
-                final Object o = e.getPath().getLastPathComponent();
-                if (o instanceof TableData.Row) {
-                    _notifySelect((TableData.Row) o);
-                }
+        addTreeSelectionListener(e -> {
+            if (_ignoreSelection) return;
+            final Object o = e.getPath().getLastPathComponent();
+            if (o instanceof TableData.Row) {
+                _notifySelect((TableData.Row) o);
             }
         });
+
         setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         setShowHorizontalLines(false);
         setShowVerticalLines(true);
@@ -667,11 +691,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
 
         // Remove all target listeners for the old target environment.
         if (_env != null) {
-            _env.getTargets().foreach(new ApplyOp<SPTarget>() {
-                public void apply(SPTarget spTarget) {
-                    spTarget.deleteWatcher(TelescopePosTableWidget.this);
-                }
-            });
+            _env.getTargets().foreach(t -> t.deleteWatcher(TelescopePosTableWidget.this));
         }
 
         // Stop watching for changes on the obsComp
@@ -686,18 +706,12 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
         startWatchingSelection();
 
         final TargetEnvironment env = _dataObject.getTargetEnvironment();
-        env.getTargets().foreach(new ApplyOp<SPTarget>() {
-            public void apply(SPTarget spTarget) {
-                spTarget.addWatcher(TelescopePosTableWidget.this);
-            }
-        });
+        env.getTargets().foreach(t -> t.addWatcher(TelescopePosTableWidget.this));
 
         final SPTarget tp = TargetSelection.get(_dataObject.getTargetEnvironment(), _obsComp);
         _resetTable(_dataObject.getTargetEnvironment());
 
-        int index = -1;
-        if (tp != null) index = _tableData.indexOf(tp);
-
+        final int index = _tableData.indexOf(tp);
         if (index >= 0) {
             _setSelectedRow(index);
         } else {
@@ -765,21 +779,16 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
 
             // First update the target listeners according to what was added
             // and removed.
-            for (SPTarget pos : rmTargets) {
-                pos.deleteWatcher(TelescopePosTableWidget.this);
-            }
-            for (SPTarget pos : addTargets) {
-                pos.addWatcher(TelescopePosTableWidget.this);
-            }
+            rmTargets.forEach(t -> t.deleteWatcher(TelescopePosTableWidget.this));
+            addTargets.forEach(t -> t.addWatcher(TelescopePosTableWidget.this));
 
             // Remember what was selected before the reset below.
             int oldSelIndex = getSelectedRow();
             final TreePath tp = getTreeSelectionModel().getSelectionPath();
-            final Object o = tp != null? tp.getLastPathComponent() : null;
-            SPTarget oldSelTarget = null;
-            if (o instanceof TableData.Row) {
-                oldSelTarget = ((TableData.Row)o).target().getOrNull();
-            }
+            final Object o = tp != null ? tp.getLastPathComponent() : null;
+            final SPTarget oldSelTarget = o instanceof TableData.Row ?
+                    ((TableData.Row)o).target().getOrNull() :
+                    null;
 
             // Update the table -- setting _tableData ....
             _resetTable(newEnv);
@@ -833,11 +842,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             _saveTreeState();
         }
         _env = env;
-        final Option<ObsContext> ctx = ObsContext.create(owner.getContextObservation()).map(new MapOp<ObsContext, ObsContext>() {
-            @Override public ObsContext apply(ObsContext ctx) {
-                return ctx.withTargets(env);
-            }
-        });
+        final Option<ObsContext> ctx = ObsContext.create(owner.getContextObservation()).map(c -> c.withTargets(env));
         _tableData = new TableData(ctx, env, this);
 
         _ignoreSelection = true;
@@ -890,14 +895,12 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             }
         }
         // do this last, since it changes the row indexes
-        for(TreePath path : expandList) {
-            expandPath(path);
-        }
+        expandList.forEach(this::expandPath);
     }
 
     public void expandGroup(GuideGroup group) {
         final int numRows = getRowCount();
-        for(int i = 0; i < numRows; i++) {
+        for (int i = 0; i < numRows; i++) {
             final TreePath path = getPathForRow(i);
             if (!isExpanded(path)) {
                 final Object o = path.getLastPathComponent();
@@ -988,7 +991,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
      * Returns true if it is ok to move the given row item to the given parent row
      */
     public boolean isOkayToMove(TableData.Row item, TableData.Row parent) {
-        return isOkayToAdd(item, parent);
+        return !(item instanceof TableData.BagsTargetRow) && isOkayToAdd(item, parent);
     }
 
     /**
@@ -1006,6 +1009,11 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
         final ImList<GuideProbeTargets> targetList = srcGrp.getAllContaining(target);
         if (targetList.size() == 0) return;
         final GuideProbeTargets src = targetList.get(0);
+
+        // A bags target cannot be moved.
+        final boolean isBagsTarget = src.getBagsTarget().getOrElse(null) == target;
+        if (isBagsTarget)
+            return;
 
         final GuideProbe guideprobe = src.getGuider();
         GuideProbeTargets snk = snkGrp.get(guideprobe).getOrElse(null);
@@ -1029,7 +1037,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
     private GuideGroup getTargetGroup(SPTarget target) {
         final GuideEnvironment ge = _env.getGuideEnvironment();
         final ImList<GuideGroup> groups = ge.getOptions();
-        for(GuideGroup group : groups) {
+        for (GuideGroup group : groups) {
             if (group.containsTarget(target)) {
                 return group;
             }
@@ -1044,7 +1052,6 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
 
     public void selectRowAt(int index) {
         if (_tableData == null) return;
-
         final SPTarget target = _tableData.targetAt(index).getOrNull();
         if (target != null) {
             selectPos(target);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -23,7 +23,6 @@ import edu.gemini.spModel.target.obsComp.TargetSelection;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
 import edu.gemini.spModel.target.offset.OffsetPosList;
 import edu.gemini.spModel.target.offset.OffsetUtil;
-import edu.gemini.spModel.target.system.CoordinateParam.Units;
 import edu.gemini.spModel.target.system.ITarget;
 import jsky.app.ot.OT;
 import jsky.app.ot.OTOptions;
@@ -276,11 +275,11 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             final ImList<GuideGroup> groups = ge.getOptions();
             final GuideGroup primaryGroup = env.getOrCreatePrimaryGuideGroup();
             if (groups.size() < 2) {
-                for (GuideProbeTargets gt : primaryGroup.getAll()) {
+                for (final GuideProbeTargets gt : primaryGroup.getAll()) {
                     final GuideProbe guideProbe = gt.getGuider();
                     final boolean isActive = ctx.exists(c -> GuideProbeUtil.instance.isAvailable(c, guideProbe));
                     final Option<SPTarget> primary = gt.getPrimary();
-                    gt.getOptions().zipWithIndex().foreach(tup -> {
+                    gt.getTargets().zipWithIndex().foreach(tup -> {
                         final SPTarget target = tup._1();
                         final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
                         final boolean isPrimary = !primary.isEmpty() && (primary.getValue() == target);
@@ -296,7 +295,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                         final GuideProbe guideProbe = gt.getGuider();
                         final boolean isActive = ctx.exists(c -> GuideProbeUtil.instance.isAvailable(c, guideProbe));
                         final Option<SPTarget> primary = gt.getPrimary();
-                        gt.getOptions().zipWithIndex().foreach(tup -> {
+                        gt.getTargets().zipWithIndex().foreach(tup -> {
                             final SPTarget target = tup._1();
                             final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
                             final boolean enabled = isPrimaryGroup && !primary.isEmpty() && (primary.getValue() == tup._1());
@@ -1017,10 +1016,8 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
         final boolean isPrimary = src.getPrimary().getOrElse(null) == target;
         final GuideProbeTargets newSrc = src.removeTarget(target);
         final SPTarget newTarget = target.clone();
-        GuideProbeTargets newSnk = snk.setOptions(snk.getOptions().append(newTarget));
-        if (isPrimary) {
-            newSnk = newSnk.selectPrimary(newTarget);
-        }
+
+        final GuideProbeTargets newSnk = isPrimary ? snk.addManualTarget(newTarget).selectPrimary(newTarget) : snk.addManualTarget(newTarget);
 
         final GuideEnvironment guideEnv = _env.getGuideEnvironment();
         final GuideEnvironment newGuideEnv = guideEnv.putGuideProbeTargets(srcGrp, newSrc).putGuideProbeTargets(snkGrp, newSnk);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/CanopusFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/CanopusFeature.java
@@ -342,8 +342,8 @@ public final class CanopusFeature extends TpeImageFeature implements PropertyWat
     }
 
     private static boolean containsTarget(TargetEnvironment env, GuideProbe guider, SPTarget target) {
-        Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(guider);
-        return (!gtOpt.isEmpty()) && gtOpt.getValue().getOptions().contains(target);
+        final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(guider);
+        return gtOpt.exists(gt -> gt.containsTarget(target));
     }
 
     public void handleDragStarted(Object dragObject, ObsContext context) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
@@ -882,11 +882,7 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
     private boolean primaryOiwfsStarExists() {
         final TargetEnvironment env = getContextTargetEnv();
         if (env == null) return false;
-
-        for (GuideProbeTargets targets : env.getPrimaryGuideProbeTargets(GmosOiwfsGuideProbe.instance)) {
-            return !targets.getPrimary().isEmpty();
-        }
-        return false;
+        return env.getPrimaryGuideProbeTargets(GmosOiwfsGuideProbe.instance).exists(gt -> gt.getPrimary().isDefined());
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -171,15 +171,14 @@ public class TpeGuidePosFeature extends TpePositionFeature
 
         /** This is called, e.g., to create a new guide star in reaction to a mouse down **/
         public void create(TpeMouseEvent tme, TpeImageInfo tii) {
-            TargetObsComp obsComp = getTargetObsComp();
+            final TargetObsComp obsComp = getTargetObsComp();
             if (obsComp == null) return;
 
-            SPTarget pos = createNewTarget(tme);
+            final SPTarget pos = createNewTarget(tme);
 
-            TargetEnvironment env = obsComp.getTargetEnvironment();
-            Option<GuideProbeTargets> gptOpt = env.getPrimaryGuideProbeTargets(guider);
-            GuideProbeTargets gpt = gptOpt.getOrElse(GuideProbeTargets.create(guider));
-            gpt = gpt.update(UpdateOps.appendAsPrimary(pos));
+            final TargetEnvironment env = obsComp.getTargetEnvironment();
+            final Option<GuideProbeTargets> gptOpt = env.getPrimaryGuideProbeTargets(guider);
+            final GuideProbeTargets gpt = gptOpt.getOrElse(GuideProbeTargets.create(guider)).setPrimary(pos);
 
             obsComp.setTargetEnvironment(env.putPrimaryGuideProbeTargets(gpt));
             _iw.getContext().targets().commit();
@@ -228,7 +227,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
             Option<ObsContext> ctx = tme.source.getObsContext();
             if (ctx.isEmpty()) return;
 
-            obsComp.setTargetEnvironment(group.add(pos,ctx.getValue()));
+            obsComp.setTargetEnvironment(group.add(pos, false, ctx.getValue()));
             _iw.getContext().targets().commit();
         }
     }
@@ -297,7 +296,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
 
             TargetEnvironment env = obsComp.getTargetEnvironment();
             for (GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
-                if (!gt.getOptions().contains(tp)) continue;
+                if (!gt.getTargets().contains(tp)) continue;
 
                 if (positionIsClose(pme, tme.xWidget, tme.yWidget)) {
                     Tuple2<GuideProbe, SPTarget> tup = new Pair<>(gt.getGuider(), tp);
@@ -328,16 +327,15 @@ public class TpeGuidePosFeature extends TpePositionFeature
     /**
      */
     public boolean erase(TpeMouseEvent tme) {
-        Option<Tuple2<GuideProbe, SPTarget>> res = locatePosition(tme);
+        final Option<Tuple2<GuideProbe, SPTarget>> res = locatePosition(tme);
         if (res.isEmpty()) return false;
 
-        TargetObsComp     toc = getTargetObsComp();
-        TargetEnvironment env = getTargetEnvironment();
-        Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(res.getValue()._1());
+        final TargetObsComp     toc = getTargetObsComp();
+        final TargetEnvironment env = getTargetEnvironment();
+        final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(res.getValue()._1());
         if (gtOpt.isEmpty()) return false;
 
-        GuideProbeTargets gt = gtOpt.getValue();
-        gt = gt.update(UpdateOps.remove(res.getValue()._2()));
+        final GuideProbeTargets gt = gtOpt.getValue().removeTargetSelectPrimary(res.getValue()._2());
         toc.setTargetEnvironment(env.putPrimaryGuideProbeTargets(gt));
         _iw.getContext().targets().commit();
         return true;
@@ -346,17 +344,17 @@ public class TpeGuidePosFeature extends TpePositionFeature
     /**
      * @see jsky.app.ot.tpe.TpeSelectableFeature
      */
-    public Object select(TpeMouseEvent tme) {
-        TargetObsComp obsComp = getTargetObsComp();
+    public Object select(final TpeMouseEvent tme) {
+        final TargetObsComp obsComp = getTargetObsComp();
         if (obsComp == null) return false;
 
-        TpePositionMap pm = TpePositionMap.getMap(_iw);
-        SPTarget tp = (SPTarget) pm.locatePos(tme.xWidget, tme.yWidget);
+        final TpePositionMap pm = TpePositionMap.getMap(_iw);
+        final SPTarget tp = (SPTarget) pm.locatePos(tme.xWidget, tme.yWidget);
         if (tp == null) return null;
 
-        TargetEnvironment env = obsComp.getTargetEnvironment();
-        for (GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
-            if (gt.getOptions().contains(tp)) {
+        final TargetEnvironment env = obsComp.getTargetEnvironment();
+        for (final GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
+            if (gt.getTargets().contains(tp)) {
                 TargetSelection.set(env, getContext().targets().shell().get(), tp);
                 return tp;
             }
@@ -411,7 +409,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
 
             // Draw each star of this type.
             int index = 1;
-            ImList<SPTarget> targetList = gt.getOptions();
+            final ImList<SPTarget> targetList = gt.getTargets();
             for (SPTarget target : targetList) {
                 // If there is exactly one of this type, then no need to show
                 // the index.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -154,15 +154,12 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         }
 
         String getGuideProbe() {
-            if (_guideProbeTargets != null) {
-                return _guideProbeTargets.getGuider().getKey();
-            }
-            return null;
+            return _guideProbeTargets == null ? null : _guideProbeTargets.getGuider().getKey();
         }
 
         String getId() {
             if (_guideProbeTargets != null) {
-                if (!_guideProbeTargets.getPrimary().isEmpty()) {
+                if (_guideProbeTargets.getPrimary().isDefined()) {
                     return _guideProbeTargets.getPrimary().getValue().getTarget().getName();
                 }
             } else if (_gemsGuideStars != null) { // top level displays Strehl values


### PR DESCRIPTION
This is a quick initial PR to begin the project and gather feedback regarding the initial planned changed for Background AGS. @tpolecat - looking at you in particular :-).

In order to properly implement the background AGS (BAGS) lookups, we need to be able to mark guide stars as either manually added / selected or automatically (by AGS) added / selected: this is to preserve manual guide star selections and not override them by a background AGS lookup when an observation changes.

Right now, the `GuideProbeTargets` class holds `SPTargets`, which need to be marked as either manually added / selected or automatically added / selected. The mechanism we propose to do this is to add a new immutable class, `GuideStar`, which will simply contain an `SPTarget` and a `GuideStarStatus` (as per this PR), and then modify the `GuideProbeTargets` class and the affected code accordingly.

Does anyone see any issues that may arise because of this, or have any questions / comments?