### PR TITLE
OCSADV-399-J

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -271,17 +271,19 @@ public enum Canopus {
             SPTarget guideStar = guideStarOpt.getValue();
 
             // Calculate the difference between the coordinate and the observation's base position.
-            CoordinateDiff diff = new CoordinateDiff(ctx.getBaseCoordinates(), guideStar.getTarget().getSkycalcCoordinates());
-            // Get offset and switch it to be defined in the same coordinate
-            // system as the shape.
-            Offset dis = diff.getOffset();
-            double p = -dis.p().toArcsecs().getMagnitude();
-            double q = -dis.q().toArcsecs().getMagnitude();
-            Set<Offset> offsets = new TreeSet<Offset>();
-            offsets.add(offset);
+            return ctx.getBaseCoordinatesOpt().map(base -> {
+                CoordinateDiff diff = new CoordinateDiff(base, guideStar.getTarget().getSkycalcCoordinates());
+                // Get offset and switch it to be defined in the same coordinate
+                // system as the shape.
+                Offset dis = diff.getOffset();
+                double p = -dis.p().toArcsecs().getMagnitude();
+                double q = -dis.q().toArcsecs().getMagnitude();
+                Set<Offset> offsets = new TreeSet<Offset>();
+                offsets.add(offset);
 
-            Area a = Canopus.instance.offsetIntersection(ctx, offsets);
-            return a != null && a.contains(p,q);
+                Area a = Canopus.instance.offsetIntersection(ctx, offsets);
+                return a != null && a.contains(p, q);
+            }).getOrElse(false);
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/CanopusFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/CanopusFeature.java
@@ -294,17 +294,17 @@ public final class CanopusFeature extends TpeImageFeature implements PropertyWat
 
     // draw the probe arm for the given wfs
     private void drawProbeArm(Graphics2D g2d, TpeImageInfo tii, ObsContext ctx, Canopus.Wfs wfs) {
-        Area a = wfs.probeArm(ctx, true);
-        if (a != null) {
-            Shape s = trans.createTransformedShape(flipArea(a));
-            g2d.setColor(AO_FOV_COLOR);
-            g2d.draw(s);
-            Composite c = g2d.getComposite();
-            g2d.setComposite(BLOCKED);
-            g2d.fill(s);
-            g2d.setComposite(c);
-        }
-
+        wfs.probeArm(ctx, true).foreach(a -> {
+            if (a != null) {
+                Shape s = trans.createTransformedShape(flipArea(a));
+                g2d.setColor(AO_FOV_COLOR);
+                g2d.draw(s);
+                Composite c = g2d.getComposite();
+                g2d.setComposite(BLOCKED);
+                g2d.fill(s);
+                g2d.setComposite(c);
+            }
+        });
     }
 
     @Override public boolean isEnabled(TpeContext ctx) {


### PR DESCRIPTION
Updates Canopus to handle guidestars with unknown coordinates. Probe arm geometry computes `Option<Area>` now.

Note that if you add `?w=1` to the URL you'll see a whitespace-neutral diff that is less dramatic.