### PR TITLE
OCSADV-335: Squants example: ITC EmissonLine.

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/SourceDefinition.java
+++ b/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/SourceDefinition.java
@@ -3,6 +3,9 @@ package edu.gemini.itc.shared;
 import edu.gemini.spModel.core.MagnitudeBand;
 import edu.gemini.spModel.core.Wavelength;
 import edu.gemini.spModel.target.*;
+import squants.motion.Velocity;
+import squants.radio.Irradiance;
+import squants.space.Length;
 
 import java.io.Serializable;
 
@@ -117,15 +120,15 @@ public final class SourceDefinition implements Serializable {
         return ((BlackBody) distribution).temperature();
     }
 
-    public Wavelength getELineWavelength() {
+    public Length getELineWavelength() {
         return ((EmissionLine) distribution).wavelength();
     }
 
-    public double getELineWidth() {
+    public Velocity getELineWidth() {
         return ((EmissionLine) distribution).width();
     }
 
-    public EmissionLine.Flux getELineFlux() {
+    public Irradiance getELineFlux() {
         return ((EmissionLine) distribution).flux();
     }
 

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
@@ -32,7 +32,7 @@ public final class HtmlPrinter {
                 sb.append(String.format("n emission line, at a wavelength of %.4f microns, ", sdp.getELineWavelength().toMicrons()));
                 sb.append(String.format(
                         "and with a width of %.2f km/s.\n  It's total flux is %.3e watts_flux on a flat continuum of flux density %.3e watts_fd_wavelength.",
-                        sdp.getELineWidth(), sdp.getELineFlux().toWatts(), sdp.getELineContinuumFlux().toWatts()));
+                        sdp.getELineWidth().toMetersPerSecond()/1000, sdp.getELineFlux().toWattsPerSquareMeter(), sdp.getELineContinuumFlux().toWatts()));
                 break;
             case BBODY:
                 sb.append(" " + sdp.getBBTemp() + "K Blackbody, at " + sdp.getSourceNormalization() +

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -22,9 +22,12 @@ import edu.gemini.spModel.gemini.niri.Niri
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.gemini.trecs.TReCSParams
 import edu.gemini.spModel.guide.GuideProbe
-import edu.gemini.spModel.target.EmissionLine.{Continuum, Flux}
+import edu.gemini.spModel.target.EmissionLine.Continuum
 import edu.gemini.spModel.target._
 import edu.gemini.spModel.telescope.IssPort
+import squants.motion.MetersPerSecond
+import squants.radio.WattsPerSquareMeter
+import squants.space.Microns
 
 /**
  * ITC requests define a generic mechanism to look up values by their parameter names.
@@ -301,9 +304,9 @@ object ITCRequest {
         val flux = r.doubleParameter("lineFlux")
         val cont = r.doubleParameter("lineContinuum")
         EmissionLine(
-          Wavelength.fromMicrons(r.doubleParameter("lineWavelength")),
-          r.doubleParameter("lineWidth"),
-          if (r.parameter("lineFluxUnits") == "watts_flux") Flux.fromWatts(flux) else Flux.fromErgs(flux),
+          Microns(r.doubleParameter("lineWavelength")),
+          MetersPerSecond(r.doubleParameter("lineWidth")*1000),
+          if (r.parameter("lineFluxUnits") == "watts_flux") WattsPerSquareMeter(flux) else WattsPerSquareMeter(flux/1000),
           if (r.parameter("lineContinuumUnits") == "watts_fd_wavelength") Continuum.fromWatts(cont) else Continuum.fromErgs(cont)
         )
     }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcqCamRecipe.java
@@ -42,7 +42,7 @@ public final class AcqCamRecipe implements ImagingRecipe {
 
     private void validateInputParameters() {
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE)) {
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters.getELineWavelength().toNanometers()))) {
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters.getELineWavelength().toNanometers()))) {
                 throw new IllegalArgumentException("Please use a model line width > 1 nm (or " + (3E5 / (_sdParameters.getELineWavelength().toNanometers())) + " km/s) to avoid undersampling of the line profile when convolved with the transmission response");
             }
         }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
@@ -1,7 +1,9 @@
 package edu.gemini.itc.base;
 
-import edu.gemini.spModel.core.Wavelength;
 import edu.gemini.spModel.target.EmissionLine;
+import squants.motion.Velocity;
+import squants.radio.Irradiance;
+import squants.space.Length;
 
 /**
  * This class creates a EmissionLine spectrum over the interval defined by the
@@ -18,7 +20,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
         _spectrum = spectrum;
     }
 
-    public EmissionLineSpectrum(final Wavelength wavelength, final double width, final EmissionLine.Flux flux,
+    public EmissionLineSpectrum(final Length wavelength, final Velocity width, final Irradiance flux,
                                 final EmissionLine.Continuum continuum, final double z, final double interval) {
 
         //shift start and end depending on redshift
@@ -30,11 +32,11 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
 
         // convert values to internal units
         final double _wavelength    = wavelength.toNanometers();
-        final double _flux          = flux.toWatts() * _wavelength / 1.988e-16;
+        final double _flux          = flux.toWattsPerSquareMeter() * _wavelength / 1.988e-16;
         final double _continuumFlux = continuum.toWatts() * _wavelength / 1.988e-13;
 
         // calculate sigma
-        final double sigma = width * _wavelength / 7.05e5;
+        final double sigma = width.toMetersPerSecond()/1000 * _wavelength / 7.05e5;
         int i = 0;
         for (double lam = start; lam <= end; lam += interval) {
             fluxArray[i] = _elineFlux(lam, sigma, _flux, _continuumFlux, _wavelength);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -47,7 +47,7 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
 
     private void validateInputParamters() {
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE)) {
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters.getELineWavelength().toNanometers()))) {
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters.getELineWavelength().toNanometers()))) {
                 throw new RuntimeException(
                         "Please use a model line width > 1 nm (or "
                                 + (3E5 / (_sdParameters.getELineWavelength().toNanometers()))

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -57,7 +57,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
     private void validateInputParameters() {
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE))
             // *25 b/c of increased resolutuion of transmission files
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))) {
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))) {
                 throw new RuntimeException(
                         "Please use a model line width > 0.04 nm (or "
                                 + (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java
@@ -42,7 +42,7 @@ public final class GsaoiRecipe implements ImagingRecipe {
 
     private void validateInputParameters() {
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE))
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters
                     .getELineWavelength().toNanometers() * 25))) { // *25 b/c of increased resolution of transmission files
                 throw new RuntimeException(
                         "Please use a model line width > 0.04 nm (or "

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/MichelleRecipe.java
@@ -43,7 +43,7 @@ public final class MichelleRecipe implements ImagingRecipe, SpectroscopyRecipe {
 
     private void validateInputParameters() {
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE))
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 5))) {  //*5 b/c of increased resolution of transmission files
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 5))) {  //*5 b/c of increased resolution of transmission files
                 throw new RuntimeException("Please use a model line width > 0.2 nm (or " + (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 5)) + " km/s) to avoid undersampling of the line profile when convolved with the transmission response");
             }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -49,7 +49,7 @@ public final class NifsRecipe implements SpectroscopyRecipe {
 
     private void validateInputParameters() {
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE)) {
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))) {  // *25 b/c of increased resolutuion of transmission files
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))) {  // *25 b/c of increased resolutuion of transmission files
                 throw new RuntimeException("Please use a model line width > 0.04 nm (or " + (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25)) + " km/s) to avoid undersampling of the line profile when convolved with the transmission response");
             }
         }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -51,7 +51,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
         }
 
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE))
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))) { // *25 b/c of increased resolution of transmission files
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))) { // *25 b/c of increased resolution of transmission files
                 throw new RuntimeException(
                         "Please use a model line width > 0.04 nm (or "
                                 + (3E5 / (_sdParameters.getELineWavelength().toNanometers() * 25))

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecsRecipe.java
@@ -40,7 +40,7 @@ public final class TRecsRecipe implements ImagingRecipe, SpectroscopyRecipe {
 
     private void validateInputParameters() {
         if (_sdParameters.getDistributionType().equals(SourceDefinition.Distribution.ELINE))
-            if (_sdParameters.getELineWidth() < (3E5 / (_sdParameters.getELineWavelength().toNanometers() / 4))) { // /4 b/c of increased resolution of transmission files
+            if (_sdParameters.getELineWidth().toMetersPerSecond()/1000 < (3E5 / (_sdParameters.getELineWavelength().toNanometers() / 4))) { // /4 b/c of increased resolution of transmission files
                 throw new RuntimeException(
                         "Please use a model line width > 4 nm (or "
                                 + (3E5 / (_sdParameters.getELineWavelength().toNanometers() / 4))

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
@@ -5,9 +5,12 @@ import edu.gemini.itc.shared._
 import edu.gemini.spModel.core.{MagnitudeBand, Wavelength}
 import edu.gemini.spModel.gemini.altair.AltairParams.{FieldLens, GuideStarType}
 import edu.gemini.spModel.guide.GuideProbe
-import edu.gemini.spModel.target.EmissionLine.{Continuum, Flux}
+import edu.gemini.spModel.target.EmissionLine.Continuum
 import edu.gemini.spModel.target._
 import edu.gemini.spModel.telescope.IssPort
+import squants.motion.MetersPerSecond
+import squants.radio.WattsPerSquareMeter
+import squants.space.Microns
 
 /**
  * Definition of test fixtures which hold all input parameters needed to execute different ITC recipes.
@@ -125,7 +128,7 @@ object Fixture {
     ),
     new SourceDefinition(
       UniformSource(),
-      EmissionLine(Wavelength.fromMicrons(2.2), 250.0, Flux.fromWatts(5.0e-19), Continuum.fromWatts(1.0e-16)),
+      EmissionLine(Microns(2.2), MetersPerSecond(250000.0), WattsPerSquareMeter(5.0e-19), Continuum.fromWatts(1.0e-16)),
       22.0, BrightnessUnit.MAG_PSA, MagnitudeBand.K,
       0.75
     )
@@ -141,7 +144,7 @@ object Fixture {
     ),
     new SourceDefinition(
       UniformSource(),
-      EmissionLine(Wavelength.fromMicrons(12.8), 500, Flux.fromWatts(5.0e-19), Continuum.fromWatts(1.0e-16)),
+      EmissionLine(Microns(12.8), MetersPerSecond(500000), WattsPerSquareMeter(5.0e-19), Continuum.fromWatts(1.0e-16)),
       12.0, BrightnessUnit.MAG_PSA, MagnitudeBand.N,
       1.5
     )

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SourcePio.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SourcePio.scala
@@ -4,10 +4,13 @@ import java.util.logging.{Level, Logger}
 
 import edu.gemini.spModel.core.Wavelength
 import edu.gemini.spModel.pio.{ParamSet, Pio, PioFactory}
-import edu.gemini.spModel.target.EmissionLine.{Continuum, Flux}
+import edu.gemini.spModel.target.EmissionLine.Continuum
+import squants.motion.MetersPerSecond
+import squants.radio.WattsPerSquareMeter
+import squants.space.Nanometers
 
+import scalaz.Scalaz._
 import scalaz._
-import Scalaz._
 
 object SourcePio {
   private val LOGGER: Logger = Logger.getLogger(SourcePio.getClass.getName)
@@ -53,9 +56,9 @@ object SourcePio {
 
       case sd: EmissionLine     =>
         factory.createParamSet(EmissionLineName)  <|
-          (Pio.addDoubleParam(factory, _, ElineWavelength, sd.wavelength.toNanometers))<|
-          (Pio.addDoubleParam(factory, _, ElineWidth,      sd.width))                  <|
-          (Pio.addDoubleParam(factory, _, ElineFlux,       sd.flux.toWatts))           <|
+          (Pio.addDoubleParam(factory, _, ElineWavelength, sd.wavelength.toNanometers))   <|
+          (Pio.addDoubleParam(factory, _, ElineWidth,      sd.width.toMetersPerSecond))   <|
+          (Pio.addDoubleParam(factory, _, ElineFlux,       sd.flux.toWattsPerSquareMeter))<|
           (Pio.addDoubleParam(factory, _, ElineContinuum,  sd.continuum.toWatts))
 
       case sd: UserDefined      =>
@@ -86,9 +89,9 @@ object SourcePio {
       }
       val eline = Option(pset.getParamSet(EmissionLineName)).map { p =>
         EmissionLine(
-          Wavelength.fromNanometers(Pio.getDoubleValue(p, ElineWavelength, 0)),
-          Pio.getDoubleValue(p, ElineWidth, 0),
-          Flux.fromWatts(Pio.getDoubleValue(p, ElineFlux, 0)),
+          Nanometers(Pio.getDoubleValue(p, ElineWavelength, 0)),
+          MetersPerSecond(Pio.getDoubleValue(p, ElineWidth, 0)),
+          WattsPerSquareMeter(Pio.getDoubleValue(p, ElineFlux, 0)),
           Continuum.fromWatts(Pio.getDoubleValue(p, ElineContinuum, 0))
         )
       }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SpectralDistribution.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SpectralDistribution.scala
@@ -1,7 +1,9 @@
 package edu.gemini.spModel.target
 
-import edu.gemini.spModel.core.Wavelength
-import edu.gemini.spModel.target.EmissionLine.{Continuum, Flux}
+import edu.gemini.spModel.target.EmissionLine.Continuum
+import squants.motion.Velocity
+import squants.radio.Irradiance
+import squants.space.Length
 
 /** Definitions for the spectral distribution of a source.
   * A source can be anything from a star, galaxy, quasar or planet to a comet or asteroid. */
@@ -14,7 +16,7 @@ final case class BlackBody(temperature: Double) extends SpectralDistribution
 final case class PowerLaw(index: Double) extends SpectralDistribution
 
 /** A single emission line. */
-final case class EmissionLine(wavelength: Wavelength, width: Double, flux: Flux, continuum: Continuum) extends SpectralDistribution
+final case class EmissionLine(wavelength: Length, width: Velocity, flux: Irradiance, continuum: Continuum) extends SpectralDistribution
 
 /** A user defined spectrum. */
 final case class UserDefined(spectrum: String) extends SpectralDistribution
@@ -143,31 +145,6 @@ object LibraryNonStar {
 /** Definition of flux and continuum units and their conversions for emission lines.
   * The units defined here are the ones supported in the ITC web application. */
 object EmissionLine {
-
-  /** Flux of an emission line. Units are per area. */
-  sealed trait Flux extends Serializable {
-    def toWatts: Double                   // units are W/m2
-    def toErgs: Double = toWatts * 1000   // units are ergs/s/cm2
-
-    /** @group Overrides */
-    final override def toString =
-      s"Flux(${toWatts}W/m2)"
-
-    /** @group Overrides */
-    final override def hashCode = toWatts.hashCode
-
-    /** @group Overrides */
-    final override def equals(a: Any) =
-      a match {
-        case a: Flux       => a.toWatts == this.toWatts
-        case _             => false
-      }
-
-  }
-  object Flux {
-    def fromWatts(value: Double) = new Flux { override val toWatts = value }
-    def fromErgs(value: Double)  = new Flux { override val toWatts = value / 1000 }
-  }
 
   /** Flux continuum of an emission line. Units are per length. */
   sealed trait Continuum extends Serializable {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -1,13 +1,16 @@
 package edu.gemini.spModel.target
 
-import edu.gemini.spModel.core.{Wavelength, Arbitraries}
+import edu.gemini.spModel.core.{Arbitraries, Wavelength}
 import edu.gemini.spModel.pio.ParamSet
 import edu.gemini.spModel.pio.xml.PioXmlFactory
-import edu.gemini.spModel.target.EmissionLine.{Continuum, Flux}
-import edu.gemini.spModel.target.system.{ConicTarget, HmsDegTarget, ITarget, CoordinateParam}
+import edu.gemini.spModel.target.EmissionLine.Continuum
+import edu.gemini.spModel.target.system.{ConicTarget, HmsDegTarget, ITarget}
 import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
+import squants.motion.MetersPerSecond
+import squants.radio.WattsPerSquareMeter
+import squants.space.Nanometers
 
 /** Tests Pio input/output operations for SpTargets.
   * Currently this only tests that the source profile and distribution are stored and retrieved.
@@ -22,8 +25,8 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
         BlackBody(10000),
         PowerLaw(0),
         PowerLaw(1),
-        EmissionLine(Wavelength.fromNanometers(450), 150, Flux.fromWatts(13), Continuum.fromWatts(22)),
-        EmissionLine(Wavelength.fromNanometers(550), 400, Flux.fromWatts(23), Continuum.fromWatts(42)),
+        EmissionLine(Nanometers(450), MetersPerSecond(150000), WattsPerSquareMeter(13), Continuum.fromWatts(22)),
+        EmissionLine(Nanometers(550), MetersPerSecond(400000), WattsPerSquareMeter(23), Continuum.fromWatts(42)),
         LibraryStar.A0V,
         LibraryStar.A5III,
         LibraryNonStar.NGC2023,


### PR DESCRIPTION
PR only for discussion.

This is a very cheap example of how using [squants](http://www.squants.com) could look like. Note that I was able to get rid of the `Flux` type, which is currently used to represent W/m^2, with the type `Irradiance` from squants; unfortunately there is no definition for [spectral flux densities](https://en.wikipedia.org/wiki/Spectral_flux_density) (W/m^3), but you get the idea.

SI units are implemented including lots of conversions and I think this could be a very useful library. We might want to add some aliases (e.g. `Wavelength` for `Length`) and we might want to add some stuff to the lib (see above).

Obviously I only want to start investing time into doing substantial work (including potential additions to squants library) once people agree that we want to go forward with squants.

Oppinions?
