### PR TITLE
OCSADV-399-L

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
@@ -15,6 +15,7 @@ import edu.gemini.spModel.gemini.niri.NiriOiwfsGuideProbe
 import edu.gemini.spModel.guide.{GuideStarValidator, PatrolField, ValidatableGuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe
+import edu.gemini.shared.util.immutable.ScalaConverters._
 
 sealed trait SingleProbeStrategyParams {
   def site: Site
@@ -24,10 +25,11 @@ sealed trait SingleProbeStrategyParams {
 
   final def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): Option[CatalogQuery] =
     for {
-      mc <- magnitudeCalc(ctx, mt)
-      rc <- radiusConstraint(ctx)
-      ml <- AgsMagnitude.manualSearchConstraints(mc)
-    } yield CatalogQuery(ctx.getBaseCoordinates.toNewModel, rc, ml, ucac4)
+      base <- ctx.getBaseCoordinatesOpt.asScalaOpt
+      mc   <- magnitudeCalc(ctx, mt)
+      rc   <- radiusConstraint(ctx)
+      ml   <- AgsMagnitude.manualSearchConstraints(mc)
+    } yield CatalogQuery(base.toNewModel, rc, ml, ucac4)
 
   def radiusConstraint(ctx: ObsContext): Option[RadiusConstraint] =
     RadiusLimitCalc.getAgsQueryRadiusLimits(guideProbe, ctx)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -60,7 +60,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
   def genGuidStars(ctx: ObsContext): Gen[List[SiderealTarget]] = {
     def farEnough(c: Coordinates): Boolean = {
       val minDistance = SingleProbeStrategyParams.GmosOiwfsParams.apply(Site.GN).minDistance.map(_.toDegrees) | 0
-      val diff        = Coordinates.difference(ctx.getBaseCoordinates.toNewModel, c).distance.toDegrees
+      val diff        = Coordinates.difference(ctx.getBaseCoordinatesOpt.getValue.toNewModel, c).distance.toDegrees
       diff > minDistance
     }
 
@@ -147,7 +147,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
               val gmosN = ctx.getInstrument.asInstanceOf[InstGmosNorth]
               println(
               s"""--- Test Env ---
-                 |  Base        = ${ctx.getBaseCoordinates.toNewModel.shows}
+                 |  Base        = ${ctx.getBaseCoordinatesOpt.getValue.toNewModel.shows}
                  |  Instrument:
                  |    Pos Angle = ${ctx.getPositionAngle}
                  |    PA Mode   = ${gmosN.getPosAngleConstraint}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -266,13 +266,6 @@ public final class ObsContext {
         return new ObsContext(agsOverride, targets, inst, site, conds, sciencePositions, aoCompOpt, schedulingBlock);
     }
 
-    public Coordinates getBaseCoordinates() {
-        SPTarget target = targets.getBase();
-        double raDeg = target.getTarget().getRaDegrees();
-        double decDeg = target.getTarget().getDecDegrees();
-        return new Coordinates(raDeg, decDeg);
-    }
-
     public Option<Coordinates> getBaseCoordinatesOpt() {
         final Option<Long> when = getSchedulingBlock().map(SchedulingBlock::start);
         SPTarget target = targets.getBase();

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2OiwfsProbeArm.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2OiwfsProbeArm.scala
@@ -90,9 +90,10 @@ object F2OiwfsProbeArm extends ProbeArmGeometry {
     val flip        = flamingos2.getFlipConfig(gemsFlag)
     val posAngle    = ctx.getPositionAngle.toNewModel
     val fovRotation = flamingos2.getRotationConfig(gemsFlag).toNewModel
-    val gsOffset    = guideStarOffset(ctx, guideStar)
-    val angle       = armAngle(posAngle, fovRotation, gsOffset, offset, flip, flamingos2.getLyotWheel.getPlateScale)
-    Some(ArmAdjustment(angle, gsOffset))
+    guideStarOffset(ctx, guideStar).map { gsOffset =>
+      val angle = armAngle(posAngle, fovRotation, gsOffset, offset, flip, flamingos2.getLyotWheel.getPlateScale)
+      ArmAdjustment(angle, gsOffset)
+    }
   }
 
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
@@ -74,14 +74,17 @@ object GmosOiwfsProbeArm extends ProbeArmGeometry {
       case _                    => None
     }
 
-    ifuOpt.map { ifu =>
+    for {
+      gsOffset <- guideStarOffset(ctx, guideStar)
+      ifu      <- ifuOpt
+    } yield {
       val ifuOffset = Offset(ifu.arcsecs[OffsetP], OffsetQ.Zero)
-      val flip      = ctx.getIssPort == IssPort.SIDE_LOOKING
-      val posAngle  = ctx.getPositionAngle.toNewModel
-      val gsOffset  = guideStarOffset(ctx, guideStar)
-      val angle     = armAngle(posAngle, gsOffset,  offset, ifuOffset, flip)
+      val flip = ctx.getIssPort == IssPort.SIDE_LOOKING
+      val posAngle = ctx.getPositionAngle.toNewModel
+      val angle = armAngle(posAngle, gsOffset, offset, ifuOffset, flip)
       ArmAdjustment(angle, gsOffset)
     }
+
   }
 
   /** Calculates the probe arm angle at the position angle for the given guide

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ProbeArmGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ProbeArmGeometry.scala
@@ -6,6 +6,7 @@ import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.inst.FeatureGeometry._
 import edu.gemini.spModel.inst.ProbeArmGeometry.ArmAdjustment
 import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.shared.util.immutable.ScalaConverters._
 
 import java.awt.Shape
 import java.awt.geom.AffineTransform
@@ -63,8 +64,9 @@ object ProbeArmGeometry {
    */
   case class ArmAdjustment(angle: Angle, guideStar: Offset)
 
-  def guideStarOffset(ctx: ObsContext, guideStarCoords: Coordinates): Offset = {
-    val baseCoords = ctx.getBaseCoordinates.toNewModel
-    Coordinates.difference(baseCoords, guideStarCoords).offset
-  }
+  def guideStarOffset(ctx: ObsContext, guideStarCoords: Coordinates): Option[Offset] =
+    ctx.getBaseCoordinatesOpt.asScalaOpt.map { baseCoords =>
+      Coordinates.difference(baseCoords.toNewModel, guideStarCoords).offset
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
@@ -117,7 +117,7 @@ trait VignettingArbitraries extends Arbitraries {
         //    p = delta RA * cos(dec)
         // so
         //    deltaRA = p / cos(dec)
-        val base     = ctx.getBaseCoordinates.toNewModel
+        val base     = ctx.getBaseCoordinatesOpt.getValue.toNewModel
         val cos      = math.cos(math.toRadians(base.dec.toDegrees))
         val deltaRa  = if (cos == 0) 0.0 else pd/cos
         val deltaDec = qd

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingCalcSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingCalcSpec.scala
@@ -18,6 +18,8 @@ import scala.collection.JavaConverters._
 import scalaz._
 import Scalaz._
 
+import edu.gemini.shared.util.immutable.ScalaConverters._
+
 object VignettingCalcSpec extends Specification with ScalaCheck with VignettingArbitraries with Helpers {
 
   case class TestEnv(ctx: ObsContext, candidates: List[Coordinates]) {
@@ -27,7 +29,7 @@ object VignettingCalcSpec extends Specification with ScalaCheck with VignettingA
       val gmosN = ctx.getInstrument.asInstanceOf[InstGmosNorth]
 
       s"""---- Test Env ----
-         |  Base        = ${ctx.getBaseCoordinates.toNewModel.shows}
+         |  Base        = ${ctx.getBaseCoordinatesOpt.asScalaOpt.map(_.toNewModel.shows)}
          |  Instrument:
          |    Pos Angle = ${ctx.getPositionAngle}
          |    ISS Port  = ${ctx.getIssPort}
@@ -70,7 +72,7 @@ object VignettingCalcSpec extends Specification with ScalaCheck with VignettingA
         // Figure out the offset from the base of each candidate that does not
         // vignette the science area.
         val zeroVigCandidates = env.candidates.filter(env.vc.calc(_) == 0)
-        val base              = env.ctx.getBaseCoordinates.toNewModel
+        val base              = env.ctx.getBaseCoordinatesOpt.getValue.toNewModel
         val candidateOffsets  = zeroVigCandidates.map(Coordinates.difference(base, _).offset)
 
         // Check that at each offset, the candidate isn't on the science area.


### PR DESCRIPTION
This updates the Scala uses of `ObsContext.getBaseCoordinates` to use the variant returning an `Option`, which will be renamed and become the only such method in a later PR.