### PR TITLE
OCSADV-399-M

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -59,7 +59,7 @@ object GemsResultsAnalyzer {
    * @return a sorted List of GemsGuideStars
    */
   def analyze(obsContext: ObsContext, posAngles: java.util.Set[Angle], catalogSearch: java.util.List[GemsCatalogSearchResults], mascotProgress: Option[MascotProgress]): java.util.List[GemsGuideStars] = {
-    obsContext.getBaseCoordinatesOpt.asScalaOpt.map(_.toNewModel).map { base =>
+    obsContext.getBaseCoordinates.asScalaOpt.map(_.toNewModel).map { base =>
       // gemsGuideStars needs to be mutable to support updates from inside mascot
       val gemsGuideStars = TiptiltFlexurePair.pairs(catalogSearch.asScala.toList).foldLeft(List.empty[GemsGuideStars]) { (gemsGuideStars, pair) =>
         val tiptiltGroup = pair.tiptiltResults.criterion.key.group
@@ -99,7 +99,7 @@ object GemsResultsAnalyzer {
    * @return a sorted List of GemsGuideStars
    */
   def analyzeGoodEnough(obsContext: ObsContext, posAngles: Set[Angle], catalogSearch: List[GemsCatalogSearchResults], progressGoodEnough: (Strehl, Boolean) => Boolean): List[GemsGuideStars] = {
-    obsContext.getBaseCoordinatesOpt.asScalaOpt.map(_.toNewModel).foldMap { base =>
+    obsContext.getBaseCoordinates.asScalaOpt.map(_.toNewModel).foldMap { base =>
 
       @tailrec
       def go(stars: List[GemsGuideStars], pairs: List[TiptiltFlexurePair]): List[GemsGuideStars] = {

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
@@ -56,7 +56,7 @@ object MascotGuideStar {
                                     magLimits: MagLimits = defaultMagLimits,
                                     progress: ProgressFunction = Mascot.defaultProgress)
   : List[(List[Strehl], Double, Double, Double)] =
-    ctx.getBaseCoordinatesOpt.asScalaOpt.foldMap { base =>
+    ctx.getBaseCoordinates.asScalaOpt.foldMap { base =>
     val center = base.toNewModel
     val simple = posAngleTolerance == 0.0 && basePosTolerance == 0.0
     val guideStarFilter = guideStarType.filter(ctx, magLimits, _: Star)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
@@ -26,7 +26,7 @@ protected case class CandidateValidator(params: SingleProbeStrategyParams, mt: M
    * established context. Returns constant `false` if base coordinates are unknown.
    */
   private def isValid(ctx: ObsContext): (SiderealTarget) => Boolean =
-    ctx.getBaseCoordinatesOpt.asScalaOpt.fold((_: SiderealTarget) => false) { base =>
+    ctx.getBaseCoordinates.asScalaOpt.fold((_: SiderealTarget) => false) { base =>
     val magLimits:Option[MagnitudeConstraints] = params.magnitudeCalc(ctx, mt).flatMap(AgsMagnitude.autoSearchConstraints(_, ctx.getConditions))
 
     (st: SiderealTarget) => {

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -163,7 +163,7 @@ trait GemsStrategy extends AgsStrategy {
   }
 
   protected [impl] def search(tipTiltMode: GemsTipTiltMode, ctx: ObsContext, posAngles: Set[Angle], nirBand: Option[MagnitudeBand]): Future[List[GemsCatalogSearchResults]] =
-    ctx.getBaseCoordinatesOpt.asScalaOpt.fold(Future.successful(List.empty[GemsCatalogSearchResults])) { base =>
+    ctx.getBaseCoordinates.asScalaOpt.fold(Future.successful(List.empty[GemsCatalogSearchResults])) { base =>
     // Get the instrument: F2 or GSAOI?
     val gemsInstrument =
       (ctx.getInstrument.getType == SPComponentType.INSTRUMENT_GSAOI) ? GemsInstrument.gsaoi | GemsInstrument.flamingos2
@@ -206,7 +206,7 @@ trait GemsStrategy extends AgsStrategy {
   }
 
   override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] =
-    ctx.getBaseCoordinatesOpt.asScalaOpt.fold(List.empty[CatalogQuery]) { base =>
+    ctx.getBaseCoordinates.asScalaOpt.fold(List.empty[CatalogQuery]) { base =>
       import AgsMagnitude._
       val cond = ctx.getConditions
       val mags = magnitudes(ctx, mt).toMap

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -190,7 +190,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
 
   private def filterUnbounded(ctx: ObsContext, mt: MagnitudeTable, candidates: List[SiderealTarget]): List[(ObsContext, List[SiderealTarget])] = {
     for {
-      base <- ctx.getBaseCoordinatesOpt.asScalaOpt.toList
+      base <- ctx.getBaseCoordinates.asScalaOpt.toList
       so <- candidates
       pa = SingleProbeStrategy.calculatePositionAngle(base.toNewModel, so)
       ctxSo = ctx.withPositionAngle(pa.toOldModel)
@@ -211,7 +211,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
 
     val pairs: List[(Angle, SiderealTarget)] =
       for {
-        base <- ctx.getBaseCoordinatesOpt.asScalaOpt.toList
+        base <- ctx.getBaseCoordinates.asScalaOpt.toList
         so   <- candidates
       } yield (SingleProbeStrategy.calculatePositionAngle(base.toNewModel, so), so)
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
@@ -25,7 +25,7 @@ sealed trait SingleProbeStrategyParams {
 
   final def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): Option[CatalogQuery] =
     for {
-      base <- ctx.getBaseCoordinatesOpt.asScalaOpt
+      base <- ctx.getBaseCoordinates.asScalaOpt
       mc   <- magnitudeCalc(ctx, mt)
       rc   <- radiusConstraint(ctx)
       ml   <- AgsMagnitude.manualSearchConstraints(mc)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -60,7 +60,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
   def genGuidStars(ctx: ObsContext): Gen[List[SiderealTarget]] = {
     def farEnough(c: Coordinates): Boolean = {
       val minDistance = SingleProbeStrategyParams.GmosOiwfsParams.apply(Site.GN).minDistance.map(_.toDegrees) | 0
-      val diff        = Coordinates.difference(ctx.getBaseCoordinatesOpt.getValue.toNewModel, c).distance.toDegrees
+      val diff        = Coordinates.difference(ctx.getBaseCoordinates.getValue.toNewModel, c).distance.toDegrees
       diff > minDistance
     }
 
@@ -147,7 +147,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
               val gmosN = ctx.getInstrument.asInstanceOf[InstGmosNorth]
               println(
               s"""--- Test Env ---
-                 |  Base        = ${ctx.getBaseCoordinatesOpt.getValue.toNewModel.shows}
+                 |  Base        = ${ctx.getBaseCoordinates.getValue.toNewModel.shows}
                  |  Instrument:
                  |    Pos Angle = ${ctx.getPositionAngle}
                  |    PA Mode   = ${gmosN.getPosAngleConstraint}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -105,7 +105,7 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
     }
 
     public Option<BoundaryPosition> checkBoundaries(final Coordinates coords, final ObsContext ctx) {
-        return ctx.getBaseCoordinatesOpt().map(baseCoordinates -> {
+        return ctx.getBaseCoordinates().map(baseCoordinates -> {
             final Angle positionAngle = ctx.getPositionAngle();
             final Set<Offset> sciencePositions = ctx.getSciencePositions();
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -242,7 +242,7 @@ public enum Canopus {
         // coordinates of the given guide star
         // (i.e.: The guide star is vignetted by the wfs probe arm)
         private static Option<Boolean> isVignetted(Wfs wfs, SPTarget guideStar, ObsContext ctx) {
-            return ctx.getBaseCoordinatesOpt().flatMap(coords ->
+            return ctx.getBaseCoordinates().flatMap(coords ->
                 wfs.probeArm(ctx, false).map(a -> {
                 if (a == null) return false;
 
@@ -271,7 +271,7 @@ public enum Canopus {
             SPTarget guideStar = guideStarOpt.getValue();
 
             // Calculate the difference between the coordinate and the observation's base position.
-            return ctx.getBaseCoordinatesOpt().map(base -> {
+            return ctx.getBaseCoordinates().map(base -> {
                 CoordinateDiff diff = new CoordinateDiff(base, guideStar.getTarget().getSkycalcCoordinates());
                 // Get offset and switch it to be defined in the same coordinate
                 // system as the shape.
@@ -496,7 +496,7 @@ public enum Canopus {
      * in range or is vignetted
      */
     public Option<Area> probeArm(ObsContext ctx, Wfs cwfs, boolean validate) {
-        return ctx.getBaseCoordinatesOpt().map(coords -> {
+        return ctx.getBaseCoordinates().map(coords -> {
             GuideProbeTargets targets = ctx.getTargets().getOrCreatePrimaryGuideGroup().get(cwfs).getOrElse(null);
             if (targets != null) {
                 SPTarget target = targets.getPrimary().getOrElse(null);
@@ -538,7 +538,7 @@ public enum Canopus {
     public Set<Wfs> getProbesInRange(Coordinates coords, ObsContext ctx) {
         Set<Wfs> res = new HashSet<Wfs>();
 
-        ctx.getBaseCoordinatesOpt().foreach(bcs -> {
+        ctx.getBaseCoordinates().foreach(bcs -> {
             // Calculate the difference between the coordinate and the observation's
             // base position.
             CoordinateDiff diff;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -75,7 +75,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     public Option<BoundaryPosition> checkBoundaries(final Coordinates coords, final ObsContext ctx) {
-        return ctx.getBaseCoordinatesOpt().map(baseCoordinates -> {
+        return ctx.getBaseCoordinates().map(baseCoordinates -> {
             final Angle positionAngle = ctx.getPositionAngle();
             final Set<Offset> sciencePositions = ctx.getSciencePositions();
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArray.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArray.java
@@ -283,7 +283,7 @@ public enum GsaoiDetectorArray {
      * off the array or base coordinates are unknown
      */
     public Option<Id> getId(Coordinates coords, ObsContext ctx) {
-        return ctx.getBaseCoordinatesOpt().flatMap(base -> {
+        return ctx.getBaseCoordinates().flatMap(base -> {
             // Calculate the difference between the coordinate and the observation's
             // base position.
             CoordinateDiff diff;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
@@ -122,7 +122,7 @@ public enum GuideProbeUtil {
     public GuideStarValidation validate(final Coordinates coords, final GuideProbe guideProbe, final ObsContext ctx) {
         final Angle positionAngle = ctx.getPositionAngle();
         final Set<Offset> sciencePositions = ctx.getSciencePositions();
-        return ctx.getBaseCoordinatesOpt().map(bcs ->
+        return ctx.getBaseCoordinates().map(bcs ->
             guideProbe.getCorrectedPatrolField(ctx).exists(patrolField -> {
                final BoundaryPosition bp = patrolField.checkBoundaries(coords, bcs, positionAngle, sciencePositions);
                return !(bp == BoundaryPosition.outside || bp == BoundaryPosition.outerBoundary);
@@ -154,7 +154,7 @@ public enum GuideProbeUtil {
                 // and we must rotate the patrol field according to position angle
                 final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians().getMagnitude()));
                 // find distance of base position to the guide star
-                return ctx.getBaseCoordinatesOpt().map(baseCoordinates -> {
+                return ctx.getBaseCoordinates().map(baseCoordinates -> {
                     final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, guideStar.getTarget().getSkycalcCoordinates());
                     final Offset dis = diff.getOffset();
                     final double p = -dis.p().toArcsecs().getMagnitude();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
@@ -267,7 +267,7 @@ public class PatrolField {
 
         @Override
         public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-            return ctx.getBaseCoordinatesOpt().map(baseCoordinates -> {
+            return ctx.getBaseCoordinates().map(baseCoordinates -> {
                 final Coordinates guideCoordinates = guideStar.getTarget().getSkycalcCoordinates();
                 // Calculate the difference between the coordinate and the observation's
                 // base position.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -266,7 +266,7 @@ public final class ObsContext {
         return new ObsContext(agsOverride, targets, inst, site, conds, sciencePositions, aoCompOpt, schedulingBlock);
     }
 
-    public Option<Coordinates> getBaseCoordinatesOpt() {
+    public Option<Coordinates> getBaseCoordinates() {
         final Option<Long> when = getSchedulingBlock().map(SchedulingBlock::start);
         SPTarget target = targets.getBase();
         return

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -309,7 +309,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
      * @return
      */
     public Option<BoundaryPosition> checkBoundaries(final Coordinates coords, final ObsContext ctx) {
-        return ctx.getBaseCoordinatesOpt().map(baseCoordinates -> {
+        return ctx.getBaseCoordinates().map(baseCoordinates -> {
             final Angle positionAngle = ctx.getPositionAngle();
             final Set<Offset> sciencePositions = ctx.getSciencePositions();
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ProbeArmGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ProbeArmGeometry.scala
@@ -65,7 +65,7 @@ object ProbeArmGeometry {
   case class ArmAdjustment(angle: Angle, guideStar: Offset)
 
   def guideStarOffset(ctx: ObsContext, guideStarCoords: Coordinates): Option[Offset] =
-    ctx.getBaseCoordinatesOpt.asScalaOpt.map { baseCoords =>
+    ctx.getBaseCoordinates.asScalaOpt.map { baseCoords =>
       Coordinates.difference(baseCoords.toNewModel, guideStarCoords).offset
     }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
@@ -117,7 +117,7 @@ trait VignettingArbitraries extends Arbitraries {
         //    p = delta RA * cos(dec)
         // so
         //    deltaRA = p / cos(dec)
-        val base     = ctx.getBaseCoordinatesOpt.getValue.toNewModel
+        val base     = ctx.getBaseCoordinates.getValue.toNewModel
         val cos      = math.cos(math.toRadians(base.dec.toDegrees))
         val deltaRa  = if (cos == 0) 0.0 else pd/cos
         val deltaDec = qd

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingCalcSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingCalcSpec.scala
@@ -29,7 +29,7 @@ object VignettingCalcSpec extends Specification with ScalaCheck with VignettingA
       val gmosN = ctx.getInstrument.asInstanceOf[InstGmosNorth]
 
       s"""---- Test Env ----
-         |  Base        = ${ctx.getBaseCoordinatesOpt.asScalaOpt.map(_.toNewModel.shows)}
+         |  Base        = ${ctx.getBaseCoordinates.asScalaOpt.map(_.toNewModel.shows)}
          |  Instrument:
          |    Pos Angle = ${ctx.getPositionAngle}
          |    ISS Port  = ${ctx.getIssPort}
@@ -72,7 +72,7 @@ object VignettingCalcSpec extends Specification with ScalaCheck with VignettingA
         // Figure out the offset from the base of each candidate that does not
         // vignette the science area.
         val zeroVigCandidates = env.candidates.filter(env.vc.calc(_) == 0)
-        val base              = env.ctx.getBaseCoordinatesOpt.getValue.toNewModel
+        val base              = env.ctx.getBaseCoordinates.getValue.toNewModel
         val candidateOffsets  = zeroVigCandidates.map(Coordinates.difference(base, _).offset)
 
         // Check that at each offset, the candidate isn't on the science area.


### PR DESCRIPTION
This does two unrelated things, sorry:

- renames `getBaseCoordinatesOpt` to `getBaseCoordinates`.
- fixes `GeneralRule` target equality to cope with missing coordinates.
