### PR TITLE
REL-2399: Obsolete the NIRI filters Jcont(1.065) and Jcont(1.122) 

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
@@ -27,7 +27,7 @@ public final class Niri {
     /**
      * Cameras
      */
-    public static enum Camera implements StandardSpType {
+    public enum Camera implements StandardSpType {
 
         F6("f/6", "(0.12 arcsec/pix)", "f6", Size.F6),
         F14("f/14", "(0.05 arcsec/pix)", "f14", Size.F14),
@@ -58,14 +58,14 @@ public final class Niri {
          */
         public static final Camera DEFAULT = F6;
 
-        private String _displayValue;
-        private String _description;
-        private String _logValue;
+        private final String _displayValue;
+        private final String _description;
+        private final String _logValue;
 
         // The default science area size for the camera.  Values is "height".
-        private double _height;
+        private final double _height;
 
-        private Camera(String displayVal, String desc, String logValue, double height) {
+        Camera(final String displayVal, final String desc, final String logValue, final double height) {
             _displayValue = displayVal;
             _description = desc;
             _logValue = logValue;
@@ -130,7 +130,7 @@ public final class Niri {
     /**
      * Beam Splitter
      */
-    public static enum BeamSplitter implements DisplayableSpType, SequenceableSpType {
+    public enum BeamSplitter implements DisplayableSpType, SequenceableSpType {
 
         same_as_camera("same as camera", 0.),
         f6("f/6", Camera.Size.F6),
@@ -139,10 +139,10 @@ public final class Niri {
 
         public static final BeamSplitter DEFAULT = same_as_camera;
 
-        private String _displayValue;
-        private double _height;
+        private final String _displayValue;
+        private final double _height;
 
-        private BeamSplitter(String displayVal, double height) {
+        BeamSplitter(final String displayVal, final double height) {
             _displayValue = displayVal;
             _height = height;
         }
@@ -161,14 +161,6 @@ public final class Niri {
         public static BeamSplitter getBeamSplitterByIndex(int index) {
             return SpTypeUtil.valueOf(BeamSplitter.class, index, DEFAULT);
         }
-
-        /**
-         * Return a BeamSplitter by name
-         */
-        public static BeamSplitter getBeamSplitter(String name) {
-            return getBeamSplitter(name, DEFAULT);
-        }
-
 
         /**
          * Return a BeamSplitter by name giving a value to return upon error
@@ -209,7 +201,7 @@ public final class Niri {
     /**
      * Dispersers
      */
-    public static enum Disperser implements DisplayableSpType, SequenceableSpType, LoggableSpType {
+    public enum Disperser implements DisplayableSpType, SequenceableSpType, LoggableSpType {
 
         NONE("none", 0.0, "none"),
         J("J-grism f/6", 1.20, "Jgrism"),
@@ -222,7 +214,7 @@ public final class Niri {
         H_F32("H-grism f/32", H.getCentralWavelength(), "Hgrism"),
         K_F32("K-grism f/32", K.getCentralWavelength(), "Kgrism"),;
 
-        private static final Map<String, Disperser> CONVERTER = new HashMap<String, Disperser>();
+        private static final Map<String, Disperser> CONVERTER = new HashMap<>();
 
         static {
             CONVERTER.put("H-grism", H);
@@ -238,13 +230,13 @@ public final class Niri {
         public static final Disperser DEFAULT = NONE;
 
         // String value for central wavelength, used by TCC
-        private double _wavelength;
+        private final double _wavelength;
 
         // The log value for this disperser
-        private String _displayValue;
-        private String _logValue;
+        private final String _displayValue;
+        private final String _logValue;
 
-        private Disperser(String displayValue, double wavelength, String logValue) {
+        Disperser(final String displayValue, final double wavelength, final String logValue) {
             _displayValue = displayValue;
             _wavelength = wavelength;
             _logValue = logValue;
@@ -316,7 +308,7 @@ public final class Niri {
     /**
      * Read Mode
      */
-    public static enum ReadMode implements StandardSpType {
+    public enum ReadMode implements StandardSpType {
 
 //In NIRI sequence component change readmode choices to be the same as in the NIRI
 // component (with some abbreviation). They should be
@@ -363,12 +355,12 @@ public final class Niri {
         public static final ReadMode DEFAULT = IMAG_1TO25;
         public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "readMode");
 
-        private String _displayValue;
-        private String _description;
-        private String _readNoise;
-        private double[] _minExp;
-        private String _recommendedExp;
-        private String _logValue;
+        private final String _displayValue;
+        private final String _description;
+        private final String _readNoise;
+        private final double[] _minExp;
+        private final String _recommendedExp;
+        private final String _logValue;
 
         // Create a ReadMode with the given name and description.
         // The array of min exposure times (minExp) corresponds to the ROI array
@@ -376,8 +368,8 @@ public final class Niri {
         // each of these at indexes 0,1,2,3.
         // The recommened exposure time is just for display (XXX should it be
         // an array also?)
-        private ReadMode(String displayValue, String description, String readNoise,
-                         double[] minExp, String recommendedExp, String logValue) {
+        ReadMode(final String displayValue, final String description, final String readNoise,
+                         final double[] minExp, final String recommendedExp, final String logValue) {
             _displayValue = displayValue;
             _description = description;
             _readNoise = readNoise;
@@ -403,13 +395,6 @@ public final class Niri {
         }
 
         /**
-         * Return a ReadMode by index *
-         */
-        static public ReadMode getReadModeByIndex(int index) {
-            return SpTypeUtil.valueOf(ReadMode.class, index, DEFAULT);
-        }
-
-        /**
          * Return a ReadMode by name *
          */
         static public ReadMode getReadMode(String name) {
@@ -422,12 +407,13 @@ public final class Niri {
         static public ReadMode getReadMode(String name, ReadMode nvalue) {
 
             // XXX for backward compatibility
-            if (name.equals("narrow-band imaging/spectroscopy")) {
-                return IMAG_SPEC_NB;
-            } else if (name.equals("1-2.5 um imaging")) {
-                return IMAG_1TO25;
-            } else if (name.equals("3-5um imaging/spectroscopy")) {
-                return IMAG_SPEC_3TO5;
+            switch (name) {
+                case "narrow-band imaging/spectroscopy":
+                    return IMAG_SPEC_NB;
+                case "1-2.5 um imaging":
+                    return IMAG_1TO25;
+                case "3-5um imaging/spectroscopy":
+                    return IMAG_SPEC_3TO5;
             }
 
             return SpTypeUtil.oldValueOf(ReadMode.class, name, nvalue);
@@ -464,7 +450,7 @@ public final class Niri {
     /**
      * Masks
      */
-    public static enum Mask implements StandardSpType {
+    public enum Mask implements StandardSpType {
 
         // Note the f/6 value is given for the MASK_NONE, which is sometimes wrong.
         MASK_IMAGING("imaging",
@@ -529,7 +515,7 @@ public final class Niri {
             double MASK_11_HEIGHT = Camera.Size.F32;
         }
 
-        private static final Map<String, Mask> CONVERTER = new HashMap<String, Mask>();
+        private static final Map<String, Mask> CONVERTER = new HashMap<>();
 
         static {
             CONVERTER.put("f/32 6-pix slit center", MASK_9);
@@ -550,12 +536,12 @@ public final class Niri {
         public static final Mask DEFAULT = MASK_IMAGING;
 
         // The internal values of height and width for this instance of Mask
-        private double _width = Size.IMAGING_SIZE;
-        private double _height = Size.IMAGING_SIZE;
-        private String _displayValue;
-        private String _logValue;
+        private final double _width;
+        private final double _height;
+        private final String _displayValue;
+        private final String _logValue;
 
-        private Mask(String displayValue, double width, double height, String logValue) {
+        Mask(final String displayValue, final double width, final double height, final String logValue) {
             _displayValue = displayValue;
             _width = width;
             _height = height;
@@ -620,7 +606,7 @@ public final class Niri {
     /**
      * Class for Filters.
      */
-    public static enum Filter implements StandardSpType, ObsoletableSpType {
+    public enum Filter implements StandardSpType, ObsoletableSpType {
 
         // broadband
         BBF_Y("Y", "Y (1.02 um)", "Y", 1.02, Type.broadband),
@@ -674,20 +660,16 @@ public final class Niri {
             narrowband,;
         }
 
-        private String _displayValue;
-        private String _description;
-        private String _logValue;
-        private boolean _isObsolete;
-        private double _wavelength;
-        private Type _type;
+        private final String _displayValue;
+        private final String _description;
+        private final String _logValue;
+        private final boolean _isObsolete;
+        private final double _wavelength;
+        private final Type _type;
 
-        private Filter(String displayValue, String desc, String logValue,
+        Filter(String displayValue, String desc, String logValue,
                        double wavelength, Type type) {
-            _displayValue = displayValue;
-            _description = desc;
-            _logValue = logValue;
-            _wavelength = wavelength;
-            _type = type;
+            this(displayValue, desc, logValue, wavelength, type, false);
         }
 
         Filter(String displayValue, String desc, String logValue,
@@ -811,20 +793,6 @@ public final class Niri {
         }
 
         /**
-         * Return the x start pixel.
-         */
-        public int getXStart() {
-            return _xStart;
-        }
-
-        /**
-         * Return the y start pixel.
-         */
-        public int getYStart() {
-            return _yStart;
-        }
-
-        /**
          * Return the x size in unbinned pixels.
          */
         public int getXSize() {
@@ -844,7 +812,7 @@ public final class Niri {
      * selected Regions of Interest.  Currently, NIRI supports only
      * the full detector.
      */
-    public static enum BuiltinROI implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum BuiltinROI implements DisplayableSpType, LoggableSpType, SequenceableSpType {
 
         FULL_FRAME("full frame readout", DefaultRoi.DESCRIPTION, "full"),
         CENTRAL_768("central 768x768", new ROIDescription(128, 128, 768, 768), "c768"),
@@ -861,11 +829,11 @@ public final class Niri {
         public static final BuiltinROI DEFAULT = FULL_FRAME;
         public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "builtinROI");
 
-        private ROIDescription _roid;
-        private String _displayValue;
-        private String _logValue;
+        private final ROIDescription _roid;
+        private final String _displayValue;
+        private final String _logValue;
 
-        private BuiltinROI(String displayValue, ROIDescription roid, String logValue) {
+        BuiltinROI(final String displayValue, final ROIDescription roid, final String logValue) {
             _displayValue = displayValue;
             _roid = roid;
             _logValue = logValue;
@@ -908,7 +876,7 @@ public final class Niri {
     /**
      * Well Depth
      */
-    public static enum WellDepth implements DisplayableSpType, DescribableSpType, SequenceableSpType {
+    public enum WellDepth implements DisplayableSpType, DescribableSpType, SequenceableSpType {
 
         SHALLOW("shallow well", "1-2.5 um only"),
         DEEP("deep well", "3-5 um"),;
@@ -918,10 +886,10 @@ public final class Niri {
          */
         public static final WellDepth DEFAULT = SHALLOW;
 
-        private String _displayValue;
-        private String _description;
+        private final String _displayValue;
+        private final String _description;
 
-        private WellDepth(String displayValue, String description) {
+        WellDepth(final String displayValue, final String description) {
             _displayValue = displayValue;
             _description = description;
         }
@@ -936,13 +904,6 @@ public final class Niri {
 
         public String sequenceValue() {
             return _displayValue;
-        }
-
-        /**
-         * Return a WellDepth by index *
-         */
-        static public WellDepth getWellDepthByIndex(int index) {
-            return SpTypeUtil.valueOf(WellDepth.class, index, DEFAULT);
         }
 
         /**
@@ -964,7 +925,7 @@ public final class Niri {
     /**
      * Focus
      */
-    public static enum FocusSuggestion implements DisplayableSpType, SequenceableSpType {
+    public enum FocusSuggestion implements DisplayableSpType, SequenceableSpType {
 
         BEST_FOCUS("best focus"),;
 
@@ -973,9 +934,9 @@ public final class Niri {
          */
         public static final FocusSuggestion DEFAULT = BEST_FOCUS;
 
-        private String _displayValue;
+        private final String _displayValue;
 
-        private FocusSuggestion(String displayValue) {
+        FocusSuggestion(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -991,26 +952,6 @@ public final class Niri {
             return _displayValue;
         }
 
-        /**
-         * Return a Focus by index
-         */
-        static public FocusSuggestion getFocusByIndex(int index) {
-            return SpTypeUtil.valueOf(FocusSuggestion.class, index, DEFAULT);
-        }
-
-        /**
-         * Return a Focus by name
-         */
-        static public FocusSuggestion getFocus(String name) {
-            return getFocusSuggestion(name, DEFAULT);
-        }
-
-        /**
-         * Return a Focus by name giving a value to return upon error
-         */
-        static public FocusSuggestion getFocusSuggestion(String name, FocusSuggestion nvalue) {
-            return SpTypeUtil.oldValueOf(FocusSuggestion.class, name, nvalue);
-        }
     }
 
     public static class Focus extends SuggestibleString {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
@@ -768,18 +768,14 @@ public final class Niri {
      */
     public static final class ROIDescription implements Serializable {
 
-        private int _xStart;
-        private int _yStart;
-        private int _xSize;
-        private int _ySize;
+        private final int _xSize;
+        private final int _ySize;
 
         /**
-         * Constructor for an ROIDescription takes an x and y start along with
+         * Constructor for an ROIDescription takes
          * an x and y size in unbinned pixels.
          */
-        public ROIDescription(int xStart, int yStart, int xSize, int ySize) {
-            _xStart = xStart;
-            _yStart = yStart;
+        public ROIDescription(final int xSize, final int ySize) {
             _xSize = xSize;
             _ySize = ySize;
         }
@@ -788,8 +784,8 @@ public final class Niri {
          * A copy constructor for creating copies of an already
          * existing ROIDescription.
          */
-        public ROIDescription(ROIDescription roid) {
-            this(roid._xStart, roid._yStart, roid._xSize, roid._ySize);
+        public ROIDescription(final ROIDescription roid) {
+            this(roid._xSize, roid._ySize);
         }
 
         /**
@@ -815,15 +811,15 @@ public final class Niri {
     public enum BuiltinROI implements DisplayableSpType, LoggableSpType, SequenceableSpType {
 
         FULL_FRAME("full frame readout", DefaultRoi.DESCRIPTION, "full"),
-        CENTRAL_768("central 768x768", new ROIDescription(128, 128, 768, 768), "c768"),
-        CENTRAL_512("central 512x512", new ROIDescription(256, 256, 512, 512), "c512"),
-        CENTRAL_256("central 256x256", new ROIDescription(384, 384, 256, 256), "c256"),
-        SPEC_1024_512("spectroscopy 1024x512", new ROIDescription(0, 256, 1024, 512), "spec"),;
+        CENTRAL_768("central 768x768", new ROIDescription(768, 768), "c768"),
+        CENTRAL_512("central 512x512", new ROIDescription(512, 512), "c512"),
+        CENTRAL_256("central 256x256", new ROIDescription(256, 256), "c256"),
+        SPEC_1024_512("spectroscopy 1024x512", new ROIDescription(1024, 512), "spec"),;
 
         // The default ROI size (width, height)
         interface DefaultRoi {
             int SIZE = 1024;
-            ROIDescription DESCRIPTION = new ROIDescription(1, 1, SIZE, SIZE);
+            ROIDescription DESCRIPTION = new ROIDescription(SIZE, SIZE);
         }
 
         public static final BuiltinROI DEFAULT = FULL_FRAME;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
@@ -620,7 +620,7 @@ public final class Niri {
     /**
      * Class for Filters.
      */
-    public static enum Filter implements StandardSpType {
+    public static enum Filter implements StandardSpType, ObsoletableSpType {
 
         // broadband
         BBF_Y("Y", "Y (1.02 um)", "Y", 1.02, Type.broadband),
@@ -638,10 +638,10 @@ public final class Niri {
         BBF_M_ORDER_SORT("Order sorting M", "Order sorting M (5.00 um)", "M/OS", 5.00, Type.broadband),
 
         // narrowband
-        J_CONTINUUM_106("J-continuum (1.065 um)", "J-continuum (1.065 um)", "J-cont(1.065)", 1.065, Type.narrowband),
+        J_CONTINUUM_106("J-continuum (1.065 um)", "J-continuum (1.065 um)", "J-cont(1.065)", 1.065, Type.narrowband, true), //REL-2399 - this filter is now obsolete
         NBF_HEI("HeI", "HeI (1.083 um)", "HeI", 1.083, Type.narrowband),
         NBF_PAGAMMA("Pa(gamma)", "Pa(gamma) (1.094 um)", "Pa-gam", 1.094, Type.narrowband),
-        J_CONTINUUM_122("J-continuum (1.122 um)", "J-continuum (1.122 um)", "J-cont(1.122)", 1.122, Type.narrowband),
+        J_CONTINUUM_122("J-continuum (1.122 um)", "J-continuum (1.122 um)", "J-cont(1.122)", 1.122, Type.narrowband, true), //REL-2399 - this filter is now obsolete
         NBF_H("J-continuum(1.207)", "J-continuum (1.207 um)", "J-cont", 1.207, Type.narrowband),
         NBF_PABETA("Pa(beta)", "Pa(beta) (1.282 um)", "Pa-beta", 1.282, Type.narrowband),
         NBF_HCONT("H-continuum(1.57)", "H-continuum (1.570 um)", "H-cont", 1.570, Type.narrowband),
@@ -677,6 +677,7 @@ public final class Niri {
         private String _displayValue;
         private String _description;
         private String _logValue;
+        private boolean _isObsolete;
         private double _wavelength;
         private Type _type;
 
@@ -687,6 +688,16 @@ public final class Niri {
             _logValue = logValue;
             _wavelength = wavelength;
             _type = type;
+        }
+
+        Filter(String displayValue, String desc, String logValue,
+                       double wavelength, Type type, boolean isObsolete) {
+            _displayValue = displayValue;
+            _description = desc;
+            _logValue = logValue;
+            _wavelength = wavelength;
+            _type = type;
+            _isObsolete = isObsolete;
         }
 
         public String displayValue() {
@@ -704,6 +715,9 @@ public final class Niri {
         public String logValue() {
             return _logValue;
         }
+
+        @Override
+        public boolean isObsolete() { return _isObsolete; }
 
         public Type type() {
             return _type;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
@@ -1,9 +1,3 @@
-// Copyright 1997 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: EdCompInstNIRI.java 8275 2007-11-22 20:15:41Z gillies $
-//
 package jsky.app.ot.gemini.niri;
 
 import edu.gemini.pot.sp.ISPNode;
@@ -24,7 +18,6 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.*;
-import java.util.List;
 
 
 /**
@@ -339,32 +332,19 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
 
 
     /**
-     * An auxiliary method that returns a Vector with all the original NIRI Filters wrapped as Option elements,
-     * separated by Type. We use a None element to separate them in the final result. This is used for display
-     * purposes in the ComboBox
+     * An auxiliary method that returns a Vector with all the original NIRI Filters wrapped as <code>Optional</code>
+     * elements, separated by Type. We use an <code>Optional.empty()</code> element to separate them in the final
+     * result.
+     * This is used for display purposes in the ComboBox.
      * @return a Vector of optional filters.
      */
-    private static Vector<Optional<Filter>> buildElements() {
+    private static Vector<Optional<Filter>> getFilterOptions() {
         final java.util.List<Filter> v = new ArrayList<>(SpTypeUtil.getSelectableItems(Niri.Filter.class));
 
-        final List<Optional<Filter>> bbFilters = new ArrayList<>();
-        final List<Optional<Niri.Filter>> nbFilters = new ArrayList<>();
-
-        for (Niri.Filter filter: v) {
-            switch (filter.type()) {
-                case broadband:
-                    bbFilters.add(Optional.of(filter));
-                    break;
-                case narrowband:
-                    nbFilters.add(Optional.of(filter));
-                    break;
-            }
-        }
-
         final Vector<Optional<Niri.Filter>> nv = new Vector<>();
-        nv.addAll(bbFilters);
+        v.stream().filter(f -> f.type() == Filter.Type.broadband).forEach(f -> nv.add(Optional.of(f)));
         nv.add(Optional.empty());
-        nv.addAll(nbFilters);
+        v.stream().filter(f -> f.type() == Filter.Type.narrowband).forEach(f -> nv.add(Optional.of(f)));
         return nv;
     }
 
@@ -377,7 +357,7 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
 
         @SuppressWarnings("unchecked")
         public NiriFilterComboBoxModel() {
-            super(buildElements());
+            super(getFilterOptions());
         }
 
         @Override
@@ -392,7 +372,7 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
     /**
      * A Renderer for the Niri Filter combobox. It uses the description for the display (contrary to
      * what other SpTypes use which is the displayable field, add a mark to obsolete filters, and return
-     * a JComponent.Separator if the filter is a None.
+     * a <code>JComponent.Separator</code> if the filter is an <code>Optional.empty()</code>.
      */
     private final class ΝiriFilterComboBoxRenderer extends BasicComboBoxRenderer {
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
@@ -8,7 +8,6 @@ package jsky.app.ot.gemini.niri;
 
 import edu.gemini.pot.sp.ISPNode;
 import edu.gemini.spModel.gemini.niri.InstNIRI;
-import edu.gemini.spModel.gemini.niri.Niri;
 import edu.gemini.spModel.gemini.niri.Niri.*;
 import edu.gemini.spModel.type.SpTypeUtil;
 import jsky.app.ot.OT;
@@ -23,8 +22,6 @@ import jsky.util.gui.TextBoxWidget;
 import javax.swing.JPanel;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**
@@ -36,15 +33,13 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
     /**
      * The GUI layout panel
      */
-    private final NiriForm _w;
+    private final NiriForm _w = new NiriForm();
 
 
-    /**
     /**
      * The constructor initializes the user interface.
      */
     public EdCompInstNIRI() {
-        _w = new NiriForm();
 
         _w.readModeNarrowBandButton.addActionListener(this);
         _w.readMode1To25Button.addActionListener(this);
@@ -61,14 +56,10 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
 
         _w.camera.setChoices(_getCameras());
 
-//        final String[] filters = _getFilters();
-//        _w.selectedFilter.setChoices(filters);
-//        _w.selectedFilter.setMaximumRowCount(Math.min(filters.length, 20));
-
         final SpTypeComboBoxModel<Filter> filterModel = new SpTypeComboBoxModel<>(Filter.class);
         _w.selectedFilter.setModel(filterModel);
         _w.selectedFilter.setRenderer(new SpTypeComboBoxRenderer());
-        _w.selectedFilter.setMaximumRowCount(Filter.values().length);
+        _w.selectedFilter.setMaximumRowCount(Math.min(Filter.values().length, 20));
         _w.selectedFilter.addActionListener(this);
 
         final String[] dispersers = _getDispersers();
@@ -87,7 +78,6 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         _w.mask.addWatcher(this);
         _w.beamSplitter.addWatcher(this);
         _w.disperser.addWatcher(this);
-//        _w.selectedFilter.addWatcher(this);
         _w.fastModeExposures.addWatcher(this);
 
         // Arrange to be notified when the OT editable state changes.
@@ -130,40 +120,6 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
     }
 
     /**
-     * Return an array of filter names (combined broad band and narrow
-     * band, separated by an empty item).
-     */
-    private String[] _getFilters() {
-        // SW: this is all gross.  We should be storing actual Filter objects
-        // in the combo boxes, not strings.
-        final Niri.Filter[] filters = Niri.Filter.values();
-        final List<String> descriptions = new ArrayList<String>(filters.length + 1);
-
-        Niri.Filter.Type type = Niri.Filter.Type.broadband;
-        for (Filter f : filters) {
-            if (f.type() != type) {
-                type = f.type();
-                descriptions.add("--------------");
-            }
-            descriptions.add(f.description());
-        }
-        return descriptions.toArray(new String[descriptions.size()]);
-    }
-
-
-    /**
-     * Return the Filter object, given the description String
-     */
-    private Filter _getFilterFromDesc(String desc) {
-        final Niri.Filter[] filters = Niri.Filter.values();
-        for (Filter f : filters) {
-            if (desc.equals(f.description())) return f;
-        }
-        return Niri.Filter.DEFAULT;
-    }
-
-
-    /**
      * Return the window containing the editor
      */
     public JPanel getWindow() {
@@ -187,13 +143,6 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         _updateROI();
     }
 
-    /**
-     * Get the index of the filter in the given array, or -1 if the filter
-     * isn't in the array.
-     */
-//    private int _getFilterIndex(Filter filter, SPTypeBaseList blist) {
-//        return blist.getIndexByType(filter);
-//    }
 
     /**
      * Update the filter choice related widgets.
@@ -204,23 +153,6 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         if (filter != null) {
             _w.selectedFilter.getModel().setSelectedItem(filter);
         }
-
-        /*
-        // See which type of filter the selected filter is, if any.
-        if (filter != null) {
-            int index = _getFilterIndex(filter, BroadBandFilter.TYPES);
-            if (index != -1) {
-                _w.selectedFilter.setValue(index);
-            } else {
-                index = _getFilterIndex(filter, NarrowBandFilter.TYPES);
-                if (index != -1) {
-                    // leave room for space between broad and narrow band listings
-                    _w.selectedFilter.setValue(NIRIParams.BROADBANDFILTERS.length + 1 + index);
-                }
-            }
-            // XXX _w.filterWavelength.setText(filter.getDescription());
-        }
-        */
     }
 
 
@@ -293,12 +225,6 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
             _w.deepWellDepthButton.setSelected(true);
         }
     }
-
-    /**
-     * Must watch table widget actions as part of the TableWidgetWatcher
-     * interface, but don't care about them.
-     */
-    //public void	tableAction(TableWidget twe, int colIndex, int rowIndex) {}
 
     /**
      * Return the position angle text box

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
@@ -7,10 +7,6 @@
 package jsky.app.ot.gemini.niri;
 
 import edu.gemini.pot.sp.ISPNode;
-import edu.gemini.shared.util.immutable.ImOption;
-import edu.gemini.shared.util.immutable.None;
-import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.gemini.niri.InstNIRI;
 import edu.gemini.spModel.gemini.niri.Niri;
 import edu.gemini.spModel.gemini.niri.Niri.*;
@@ -159,7 +155,7 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         // First fill in the text box.
         final Filter filter = getDataObject().getFilter();
         if (filter != null) {
-            _w.selectedFilter.getModel().setSelectedItem(ImOption.apply(filter));
+            _w.selectedFilter.getModel().setSelectedItem(Optional.of(filter));
         }
     }
 
@@ -298,8 +294,8 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
             _updateScienceFOV();
         } else if (w == _w.selectedFilter) {
             @SuppressWarnings("unchecked")
-            Option<Filter> filter = (Option<Filter>)_w.selectedFilter.getSelectedItem();
-            getDataObject().setFilter(filter.getOrElse(Filter.DEFAULT));
+            Optional<Filter> filter = (Optional<Filter>)_w.selectedFilter.getSelectedItem();
+            getDataObject().setFilter(filter.orElse(Filter.DEFAULT));
         }
     }
 
@@ -348,26 +344,26 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
      * purposes in the ComboBox
      * @return a Vector of optional filters.
      */
-    private static Vector<Option<Filter>> buildElements() {
+    private static Vector<Optional<Filter>> buildElements() {
         final java.util.List<Filter> v = new ArrayList<>(SpTypeUtil.getSelectableItems(Niri.Filter.class));
 
-        final List<Option<Filter>> bbFilters = new ArrayList<>();
-        final List<Option<Niri.Filter>> nbFilters = new ArrayList<>();
+        final List<Optional<Filter>> bbFilters = new ArrayList<>();
+        final List<Optional<Niri.Filter>> nbFilters = new ArrayList<>();
 
         for (Niri.Filter filter: v) {
             switch (filter.type()) {
                 case broadband:
-                    bbFilters.add(new Some<>(filter));
+                    bbFilters.add(Optional.of(filter));
                     break;
                 case narrowband:
-                    nbFilters.add(new Some<>(filter));
+                    nbFilters.add(Optional.of(filter));
                     break;
             }
         }
 
-        final Vector<Option<Niri.Filter>> nv = new Vector<>();
+        final Vector<Optional<Niri.Filter>> nv = new Vector<>();
         nv.addAll(bbFilters);
-        nv.add(None.instance());
+        nv.add(Optional.empty());
         nv.addAll(nbFilters);
         return nv;
     }
@@ -388,8 +384,8 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         public void setSelectedItem(Object anObject) {
 
             @SuppressWarnings("unchecked")
-            Option<Niri.Filter> filter = (Option<Niri.Filter>) anObject;
-            if (filter.isDefined()) super.setSelectedItem(anObject);
+            Optional<Niri.Filter> filter = (Optional<Niri.Filter>) anObject;
+            if (filter.isPresent()) super.setSelectedItem(anObject);
         }
     }
 
@@ -403,11 +399,11 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         public Component getListCellRendererComponent(JList jList, Object value, int index, boolean isSelected, boolean hasFocus) {
 
             @SuppressWarnings("unchecked")
-            final Option<Niri.Filter> opFilter = (Option<Niri.Filter>) value;
+            final Optional<Niri.Filter> opFilter = (Optional<Niri.Filter>) value;
 
             return opFilter.map(f ->
                             super.getListCellRendererComponent(jList, f.description() + (f.isObsolete() ? "*" : ""), index, isSelected, hasFocus)
-            ).getOrElse(SEPARATOR);
+            ).orElse(SEPARATOR);
 
         }
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/EdCompInstNIRI.java
@@ -13,6 +13,8 @@ import edu.gemini.spModel.gemini.niri.Niri.*;
 import edu.gemini.spModel.type.SpTypeUtil;
 import jsky.app.ot.OT;
 import jsky.app.ot.OTOptions;
+import jsky.app.ot.editor.type.SpTypeComboBoxModel;
+import jsky.app.ot.editor.type.SpTypeComboBoxRenderer;
 import jsky.app.ot.gemini.editor.EdCompInstBase;
 import jsky.util.gui.DropDownListBoxWidget;
 import jsky.util.gui.DropDownListBoxWidgetWatcher;
@@ -59,9 +61,15 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
 
         _w.camera.setChoices(_getCameras());
 
-        final String[] filters = _getFilters();
-        _w.selectedFilter.setChoices(filters);
-        _w.selectedFilter.setMaximumRowCount(Math.min(filters.length, 20));
+//        final String[] filters = _getFilters();
+//        _w.selectedFilter.setChoices(filters);
+//        _w.selectedFilter.setMaximumRowCount(Math.min(filters.length, 20));
+
+        final SpTypeComboBoxModel<Filter> filterModel = new SpTypeComboBoxModel<>(Filter.class);
+        _w.selectedFilter.setModel(filterModel);
+        _w.selectedFilter.setRenderer(new SpTypeComboBoxRenderer());
+        _w.selectedFilter.setMaximumRowCount(Filter.values().length);
+        _w.selectedFilter.addActionListener(this);
 
         final String[] dispersers = _getDispersers();
         _w.disperser.setChoices(dispersers);
@@ -79,7 +87,7 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         _w.mask.addWatcher(this);
         _w.beamSplitter.addWatcher(this);
         _w.disperser.addWatcher(this);
-        _w.selectedFilter.addWatcher(this);
+//        _w.selectedFilter.addWatcher(this);
         _w.fastModeExposures.addWatcher(this);
 
         // Arrange to be notified when the OT editable state changes.
@@ -194,7 +202,7 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
         // First fill in the text box.
         final Filter filter = getDataObject().getFilter();
         if (filter != null) {
-            _w.selectedFilter.setValue(filter.description());
+            _w.selectedFilter.getModel().setSelectedItem(filter);
         }
 
         /*
@@ -354,6 +362,8 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
             getDataObject().setBuiltinROI(BuiltinROI.SPEC_1024_512);
             _updateReadMode();
             _updateScienceFOV();
+        } else if (w == _w.selectedFilter) {
+            getDataObject().setFilter((Filter) _w.selectedFilter.getSelectedItem());
         }
     }
 
@@ -373,9 +383,6 @@ public final class EdCompInstNIRI extends EdCompInstBase<InstNIRI>
             _updateScienceFOV();
         } else if (ddlbw == _w.disperser) {
             getDataObject().setDisperser(Disperser.getDisperserByIndex(index));
-        } else if (ddlbw == _w.selectedFilter) {
-            getDataObject().setFilter(_getFilterFromDesc(val));
-            _updateFilterWidgets();
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/NiriForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/NiriForm.java
@@ -2,6 +2,7 @@ package jsky.app.ot.gemini.niri;
 
 import jsky.util.gui.DropDownListBoxWidget;
 import jsky.util.gui.NumberBoxWidget;
+import jsky.util.gui.SingleSelectComboBox;
 
 import javax.swing.*;
 import java.awt.*;
@@ -42,7 +43,7 @@ public class NiriForm extends JPanel {
         beamSplitterLabel = new JLabel();
         beamSplitter = new DropDownListBoxWidget();
         filterLabel = new JLabel();
-        selectedFilter = new DropDownListBoxWidget();
+        selectedFilter = new SingleSelectComboBox();
         fastModeExposuresLabel = new JLabel();
         fastModeExposures = new NumberBoxWidget();
         fastModeReadsUnits = new JLabel();
@@ -457,7 +458,7 @@ public class NiriForm extends JPanel {
     private JLabel beamSplitterLabel;
     DropDownListBoxWidget beamSplitter;
     private JLabel filterLabel;
-    DropDownListBoxWidget selectedFilter;
+    SingleSelectComboBox selectedFilter;
     private JLabel fastModeExposuresLabel;
     NumberBoxWidget fastModeExposures;
     private JLabel fastModeReadsUnits;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/NiriForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/niri/NiriForm.java
@@ -6,50 +6,47 @@ import jsky.util.gui.SingleSelectComboBox;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 /*
  * Created by JFormDesigner on Wed Nov 02 15:19:48 CET 2005
  */
 
 
-/**
- * @author User #1
- */
 public class NiriForm extends JPanel {
     public NiriForm() {
         initComponents();
     }
 
     private void initComponents() {
-        // JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
-        // Generated using JFormDesigner non-commercial license
-        cameraLabel = new JLabel();
-        expTimeLabel = new JLabel();
+        JLabel cameraLabel = new JLabel();
+        JLabel expTimeLabel = new JLabel();
+        JLabel disperserLabel = new JLabel();
+        JLabel maskLabel = new JLabel();
+        JLabel coaddsLabel = new JLabel();
+        JLabel posAngleLabel = new JLabel();
+        JLabel scienceFOVLabel = new JLabel();
+        JLabel expTimeUnits = new JLabel();
+        JLabel coaddsUnits = new JLabel();
+        JLabel posAngleUnits = new JLabel();
+        JLabel beamSplitterLabel = new JLabel();
+        JLabel filterLabel = new JLabel();
+        JLabel fastModeExposuresLabel = new JLabel();
+        JLabel fastModeReadsUnits = new JLabel();
+        JTabbedPane jTabbedPane1 = new JTabbedPane();
+        JPanel readModePanel = new JPanel();
+        JLabel component1 = new JLabel();
+        JLabel component2 = new JLabel();
+        JPanel roiPanel = new JPanel();
+
         camera = new DropDownListBoxWidget();
         exposureTime = new NumberBoxWidget();
-        disperserLabel = new JLabel();
         disperser = new DropDownListBoxWidget();
-        maskLabel = new JLabel();
         mask = new DropDownListBoxWidget();
-        coaddsLabel = new JLabel();
-        posAngleLabel = new JLabel();
         coadds = new NumberBoxWidget();
         posAngle = new NumberBoxWidget();
-        scienceFOVLabel = new JLabel();
-        expTimeUnits = new JLabel();
-        coaddsUnits = new JLabel();
-        posAngleUnits = new JLabel();
-        beamSplitterLabel = new JLabel();
         beamSplitter = new DropDownListBoxWidget();
-        filterLabel = new JLabel();
         selectedFilter = new SingleSelectComboBox();
-        fastModeExposuresLabel = new JLabel();
         fastModeExposures = new NumberBoxWidget();
-        fastModeReadsUnits = new JLabel();
         scienceFOV = new JLabel();
-        jTabbedPane1 = new JTabbedPane();
-        readModePanel = new JPanel();
         readMode1To25Button = new JRadioButton();
         readModeNarrowBandButton = new JRadioButton();
         readMode3To5Button = new JRadioButton();
@@ -59,19 +56,16 @@ public class NiriForm extends JPanel {
         readModeMinExpTime = new JLabel();
         readModeNoise = new JLabel();
         readModeNoiseLabel = new JLabel();
-        component1 = new JLabel();
         readModeRecMinExpTimeLabel = new JLabel();
         readModeRecMinExpTime = new JLabel();
         minExpTimeLabel = new JLabel();
         shallowWellDepthButton = new JRadioButton();
         deepWellDepthButton = new JRadioButton();
-        roiPanel = new JPanel();
         roiFullFrameButton = new JRadioButton();
         roiCentral768Button = new JRadioButton();
         roiCentral256Button = new JRadioButton();
         roiCentral512Button = new JRadioButton();
         roiSpec1024x512Button = new JRadioButton();
-        component2 = new JLabel();
 
         //======== this ========
         setMinimumSize(new Dimension(350, 378));
@@ -255,11 +249,6 @@ public class NiriForm extends JPanel {
 
                 //---- readModeNarrowBandButton ----
                 readModeNarrowBandButton.setText("1-2.5um: Faint Object Narrow-band Imaging/Spectroscopy");
-                readModeNarrowBandButton.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        readModeNarrowBandButton_actionPerformed(e);
-                    }
-                });
                 readModePanel.add(readModeNarrowBandButton, new GridBagConstraints(0, 0, 4, 1, 0.0, 1.0,
                         GridBagConstraints.WEST, GridBagConstraints.NONE,
                         new Insets(5, 11, 0, 0), 0, 0));
@@ -333,11 +322,6 @@ public class NiriForm extends JPanel {
 
                 //---- shallowWellDepthButton ----
                 shallowWellDepthButton.setText("Shallow well (1-2.5 um)");
-                shallowWellDepthButton.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        shallowWellDepthButton_actionPerformed(e);
-                    }
-                });
                 readModePanel.add(shallowWellDepthButton, new GridBagConstraints(0, 6, 2, 1, 0.0, 1.0,
                         GridBagConstraints.WEST, GridBagConstraints.NONE,
                         new Insets(17, 11, 11, 0), 0, 0));
@@ -379,11 +363,6 @@ public class NiriForm extends JPanel {
                 //---- roiCentral512Button ----
                 roiCentral512Button.setToolTipText("Set the Region of Interest to the central 128x128 pixels");
                 roiCentral512Button.setText("Central 512x512");
-                roiCentral512Button.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e) {
-                        roiCentral512Button_actionPerformed(e);
-                    }
-                });
                 roiPanel.add(roiCentral512Button, new GridBagConstraints(0, 2, 1, 1, 1.0, 1.0,
                         GridBagConstraints.WEST, GridBagConstraints.NONE,
                         new Insets(6, 11, 0, 0), 0, 0));
@@ -425,46 +404,16 @@ public class NiriForm extends JPanel {
         // JFormDesigner - End of component initialization  //GEN-END:initComponents
     }
 
-    private void readModeNarrowBandButton_actionPerformed(ActionEvent e) {
-        // TODO add your code here
-    }
-
-    private void shallowWellDepthButton_actionPerformed(ActionEvent e) {
-        // TODO add your code here
-    }
-
-    private void roiCentral512Button_actionPerformed(ActionEvent e) {
-        // TODO add your code here
-    }
-
-    // JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
-    // Generated using JFormDesigner non-commercial license
-    private JLabel cameraLabel;
-    private JLabel expTimeLabel;
     DropDownListBoxWidget camera;
     NumberBoxWidget exposureTime;
-    private JLabel disperserLabel;
     DropDownListBoxWidget disperser;
-    private JLabel maskLabel;
     DropDownListBoxWidget mask;
-    private JLabel coaddsLabel;
-    private JLabel posAngleLabel;
     NumberBoxWidget coadds;
     NumberBoxWidget posAngle;
-    private JLabel scienceFOVLabel;
-    private JLabel expTimeUnits;
-    private JLabel coaddsUnits;
-    private JLabel posAngleUnits;
-    private JLabel beamSplitterLabel;
     DropDownListBoxWidget beamSplitter;
-    private JLabel filterLabel;
     SingleSelectComboBox selectedFilter;
-    private JLabel fastModeExposuresLabel;
     NumberBoxWidget fastModeExposures;
-    private JLabel fastModeReadsUnits;
     JLabel scienceFOV;
-    private JTabbedPane jTabbedPane1;
-    private JPanel readModePanel;
     JRadioButton readMode1To25Button;
     JRadioButton readModeNarrowBandButton;
     JRadioButton readMode3To5Button;
@@ -474,18 +423,15 @@ public class NiriForm extends JPanel {
     JLabel readModeMinExpTime;
     JLabel readModeNoise;
     JLabel readModeNoiseLabel;
-    private JLabel component1;
     JLabel readModeRecMinExpTimeLabel;
     JLabel readModeRecMinExpTime;
     JLabel minExpTimeLabel;
     JRadioButton shallowWellDepthButton;
     JRadioButton deepWellDepthButton;
-    private JPanel roiPanel;
     JRadioButton roiFullFrameButton;
     JRadioButton roiCentral768Button;
     JRadioButton roiCentral256Button;
     JRadioButton roiCentral512Button;
     JRadioButton roiSpec1024x512Button;
-    JLabel component2;
     // JFormDesigner - End of variables declaration  //GEN-END:variables
 }


### PR DESCRIPTION
I took what I thought it was going to be a small task (<30m) to play around with GitHub and our development process. Unfortunately this took a bit longer than planned, as I was working on this thing I found a few *special* features that distracted me for a while. 

First, the filters were stored as a collection of `String` in the combo, instead of real `Filters` as God mandates. 

Second, they were separated by narrowband/broadband when they were displayed in the Combo (using of course a special String - `-----------`) which looked hideous, and had code to figure out how to map the Strings in the combo to the real Filters. I still believe the UI is confusing as there is no indication as to why the filters are separated, you must know that the ones at the top are broadband, the ones below are narrowband. I actually experimented with adding a small icon before each element to make it clear what they were, but since I didn't have a good icon and this wasn't really being asked, I dropped that idea... oh well. 

Finally, they were not using their display value in the Combo, but the description of the Filters instead. 

So, I ended up creating a custom `ComboBoxModel` and a custom `BasicComboBoxRenderer` to deal with these particularities, and get rid of all those strings and replaced the original `String` separator with a `JSeparator`.

So, the first commit 58b06b4 in this PR deals with making the filters obsolete as requested in the task. The second 4fadf2a was some code clean up to make most of the code warnings go away. The third commit cf777ab was to add the new combobox models and renderer. Finally, the last commit 6cbf9b5
was to update the usage of our `Option` classes to the `Optional` class in Java 8. 

So here you go. Thanks @swalker2m for the help on using some functional features of Java 8 for some of the work done in cf777ab 