### PR TITLE
REL-2399: Removing obsolete Niri filters from smartgcal lookup tables

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/BaseCalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/BaseCalibrationMap.java
@@ -3,7 +3,6 @@ package edu.gemini.spModel.gemini.calunit.smartgcal.maps;
 
 import edu.gemini.spModel.gemini.calunit.smartgcal.*;
 import edu.gemini.spModel.type.DisplayableSpType;
-import edu.gemini.spModel.type.ObsoletableSpType;
 
 import java.util.HashSet;
 import java.util.Properties;
@@ -26,18 +25,14 @@ public abstract class BaseCalibrationMap implements CalibrationMap {
 
     static protected <T extends Enum<T>&DisplayableSpType> Set<T> getValues(Class<T> c, Properties properties, ConfigurationKey.Values name) {
         String valueString = getValue(properties, name);
-        Set<T> results = new HashSet<T>();
+        Set<T> results = new HashSet<>();
 
         T[] constants = c.getEnumConstants();
-        boolean isObsoletable = ObsoletableSpType.class.isAssignableFrom(c);
 
         // regular expressions
         if (valueString.startsWith("$")) {
             String s = valueString.substring(1, valueString.length());
             for (T t : constants) {
-                if (isObsoletable && ((ObsoletableSpType) t).isObsolete()) {
-                    continue;
-                }
                 String curDisplayValue = t.displayValue();
                 if (curDisplayValue.matches(s)) {
                     results.add(t);
@@ -48,9 +43,6 @@ public abstract class BaseCalibrationMap implements CalibrationMap {
         } else if (valueString.endsWith("*")) {
             String s = valueString.substring(0, valueString.length()-1).toLowerCase();
             for (T t : constants) {
-                if (isObsoletable && ((ObsoletableSpType) t).isObsolete()) {
-                    continue;
-                }
                 String curDisplayValue = t.displayValue();
                 if (curDisplayValue.toLowerCase().startsWith(s)) {
                     results.add(t);
@@ -60,9 +52,6 @@ public abstract class BaseCalibrationMap implements CalibrationMap {
         // exact search (ignore case)
         } else {
             for (T t : constants) {
-                if (isObsoletable && ((ObsoletableSpType) t).isObsolete()) {
-                    continue;
-                }
                 String curDisplayValue = t.displayValue();
                 if (valueString.equalsIgnoreCase(curDisplayValue)) {
                     results.add(t);

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/java/edu/gemini/spModel/smartgcal/CalibrationMapFactory.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/java/edu/gemini/spModel/smartgcal/CalibrationMapFactory.java
@@ -27,13 +27,13 @@ public class CalibrationMapFactory {
     private static final Logger LOG = Logger.getLogger(CalibrationMapFactory.class.getName());
 
     public static CalibrationMap createFromData(String instrument, CalibrationFile file) {
-        CalibrationMap map = createEmpty(instrument, file.getVersion());
-        CalibrationMapReader reader = new CalibrationMapReader(map);
+        final CalibrationMap map = createEmpty(instrument, file.getVersion());
+        final CalibrationMapReader reader = new CalibrationMapReader(map);
         reader.read(file.getData().getBytes());
         // the data we receive here must not contain errors, it has to be checked previously
         // in case the data can not be successfully parsed we throw an exception
         if (reader.hasErrors()) {
-            LOG.log(Level.INFO, "could not read calibration data");
+            LOG.log(Level.INFO, "could not read calibration data " + reader.getErrors());
             throw new RuntimeException("could not read calibration data");
         }
         return map;

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIRI_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIRI_FLAT.csv
@@ -44,10 +44,10 @@ none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,C
 none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,0.8,1,Day
 none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,1.2,1,Day
 none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,1.2,1,Day
-none,J-continuum (1.065 um) ,imaging,f/6,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,30,1,Day
-none,J-continuum (1.065 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,30,1,Day
-none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,12,1,Day
-none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,12,1,Day
+#none,J-continuum (1.065 um) ,imaging,f/6,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,30,1,Day
+#none,J-continuum (1.065 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,30,1,Day
+#none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,12,1,Day
+#none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,12,1,Day
 none,J-continuum(1.207) ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,3.5,1,Day
 none,J-continuum(1.207) ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,3.5,1,Day
 none,K ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Closed,4.5,1,Day
@@ -156,8 +156,8 @@ none,J ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,3.5,
 none,J ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,3.5,1,Day
 #none,J-continuum (1.065 um) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Closed,unknown,1,Day
 #none,J-continuum (1.065 um) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Open,unknown,1,Day
-none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,9,1,Day
-none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,9,1,Day
+#none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,9,1,Day
+#none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,9,1,Day
 none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4.2,1,Day
 none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,4.2,1,Day
 none,K ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4,1,Day

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIRI_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIRI_FLAT.csv
@@ -44,10 +44,10 @@ none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,C
 none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,0.8,1,Day
 none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,1.2,1,Day
 none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,1.2,1,Day
-#none,J-continuum (1.065 um) ,imaging,f/6,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,30,1,Day
-#none,J-continuum (1.065 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,30,1,Day
-#none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,12,1,Day
-#none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,12,1,Day
+none,J-continuum (1.065 um) ,imaging,f/6,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,30,1,Day
+none,J-continuum (1.065 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,30,1,Day
+none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,12,1,Day
+none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,12,1,Day
 none,J-continuum(1.207) ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,3.5,1,Day
 none,J-continuum(1.207) ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,3.5,1,Day
 none,K ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Closed,4.5,1,Day
@@ -156,8 +156,8 @@ none,J ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,3.5,
 none,J ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,3.5,1,Day
 #none,J-continuum (1.065 um) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Closed,unknown,1,Day
 #none,J-continuum (1.065 um) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Open,unknown,1,Day
-#none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,9,1,Day
-#none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,9,1,Day
+none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,9,1,Day
+none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,9,1,Day
 none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4.2,1,Day
 none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,4.2,1,Day
 none,K ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4,1,Day

--- a/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationMapTest.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationMapTest.java
@@ -46,17 +46,17 @@ public class CalibrationMapTest {
         Assert.assertEquals(6, keys.size());
 
         // wildcard that matches all available values
-        // this also tests that obsoleted values are not taken into account (13 are defined, 2 of them are obsolete)
+        // Note that obsolete values are allowed!
         properties.setProperty(ConfigKeyGnirs.Values.SLIT_WIDTH.toString(), "*");
         keys = map.createConfig(properties);
-        Assert.assertEquals(11, keys.size());
+        Assert.assertEquals(13, keys.size());
 
-        // combination of wildcards: 11 slit widths, 2 pixel scales, 2 well depths = 44 keys...
+        // combination of wildcards: 13 slit widths (2 obsolete), 2 pixel scales, 2 well depths = 52 keys...
         properties.setProperty(ConfigKeyGnirs.Values.SLIT_WIDTH.toString(), "*");
         properties.setProperty(ConfigKeyGnirs.Values.PIXEL_SCALE.toString(), "*");
         properties.setProperty(ConfigKeyGnirs.Values.WELL_DEPTH.toString(), "*");
         keys = map.createConfig(properties);
-        Assert.assertEquals(44, keys.size());
+        Assert.assertEquals(52, keys.size());
     }
 
     @Test


### PR DESCRIPTION
One test case wasn't passing in my previous PR as the look up tables for SmartGCAL we had were referring to these obsolete filters. I'm not sure how we handle this in operations. @fnussber could you review this PR and let me know what the procedure should be when we put this in operations?

I also added more detail info to the error message that is generated when this happens, as suggested by @tpolecat 