### PR TITLE
OCSADV-414: Display observation information on the Catalog Navigator

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -43,10 +43,10 @@ trait PreferredSizeFrame { this: Window =>
 /**
  * Describes the observation used to do a Guide Star Search
  */
-case class ObservationInfo(objectName: Option[String])
+case class ObservationInfo(objectName: Option[String], instrumentName: Option[String])
 
 object ObservationInfo {
-  def apply(ctx: ObsContext):ObservationInfo = ObservationInfo(Option(ctx.getTargets.getBase).map(_.getTarget.getName))
+  def apply(ctx: ObsContext):ObservationInfo = ObservationInfo(Option(ctx.getTargets.getBase).map(_.getTarget.getName), Option(ctx.getInstrument).map(_.getTitle))
 }
 
 /**
@@ -330,6 +330,7 @@ object QueryResultsWindow {
         }
 
         lazy val objectName = new TextField("")
+        lazy val instrumentName = new Label("")
 
         lazy val ra = new RATextField(RightAscension.zero) {
           reactions += queryButtonEnabling
@@ -379,6 +380,10 @@ object QueryResultsWindow {
           }, CC().spanY(2).spanX(2))
           add(new Label("Dec"), CC().spanX(2).newline())
           add(dec, CC().spanX(3).growX())
+          add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
+          add(new Label("Instrument"), CC().spanX(2).newline())
+          add(instrumentName, CC().spanX(3))
+          add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
           add(new Label("Radial Range"), CC().spanX(2).newline())
           add(radiusStart, CC().minWidth(50.px).growX())
           add(new Label("-"), CC())
@@ -416,6 +421,7 @@ object QueryResultsWindow {
         def updateQuery(info: Option[ObservationInfo], query: CatalogQuery): Unit = {
           info.foreach { i =>
             objectName.text = ~i.objectName
+            instrumentName.text = ~i.instrumentName
           }
           // Update the RA
           ra.updateRa(query.base.ra)
@@ -456,7 +462,7 @@ object QueryResultsWindow {
             val coordinates = Coordinates(ra.value, dec.value)
             val radius = RadiusConstraint.between(Angle.fromArcmin(radiusStart.text.toDouble), Angle.fromArcmin(radiusEnd.text.toDouble))
 
-            (ObservationInfo(objectName.text.some).some, CatalogQuery(None, coordinates, radius, currentFilters, ucac4))
+            (ObservationInfo(objectName.text.some, instrumentName.text.some).some, CatalogQuery(None, coordinates, radius, currentFilters, ucac4))
           }
         }
 


### PR DESCRIPTION
On this PR, the Catalog Navigator is enhanced to display information about the observation that triggered the manual guide star search. This includes instrument, guider and conditions. A screenshot is included below:

<img width="1210" alt="screenshot 2015-09-18 00 22 16" src="https://cloud.githubusercontent.com/assets/3615303/9951321/6359a798-5d9b-11e5-81c5-06031dbe2db8.png">

Note that this is a subtask of the overall *Manual Guide Search* task. In this subtask I want to display the observation context info and in later subtasks you could change the conditions to refine the queries.
Observation info is displayed in controls instead of labels, even though those controls don't do anything, as it is duplicated effort to do labels and then change them to combo boxes. In future PRs, these boxes will be used to update the queries