### PR TITLE
REL-2382-A: Update Simbad name resolvers

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -78,8 +78,8 @@ trait GemsStrategy extends AgsStrategy {
         for {
           result                                                    <- agsCatalogResults
           angle                                                     <- anglesToTry
-          q @ ConeSearchCatalogQuery(_, _, radiusConstraint, mc, _) = result.query
         } yield {
+          val ConeSearchCatalogQuery(_, _, radiusConstraint, mc, _) = result.query
           val catalogSearchCriterion     = CatalogSearchCriterion("ags", radiusConstraint, mc.head, None, angle.some)
           val gemsCatalogSearchCriterion = new GemsCatalogSearchCriterion(result.searchKey, catalogSearchCriterion)
           new GemsCatalogSearchResults(gemsCatalogSearchCriterion, result.catalogResult.targets.rows)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -75,17 +75,15 @@ trait GemsStrategy extends AgsStrategy {
     val anglesToTry = (0 until 360 by 45).map(Angle.fromDegrees(_))
 
     futureAgsCatalogResults.map { agsCatalogResults =>
-      for {
-        result  <- agsCatalogResults
-        angle   <- anglesToTry
-      } yield {
-        val query                      = result.query
-        val radiusConstraint           = query.radiusConstraint
-        val mc                         = query.magnitudeConstraints
-        val catalogSearchCriterion     = CatalogSearchCriterion("ags", radiusConstraint, mc.head, None, angle.some)
-        val gemsCatalogSearchCriterion = new GemsCatalogSearchCriterion(result.searchKey, catalogSearchCriterion)
-        new GemsCatalogSearchResults(gemsCatalogSearchCriterion, result.catalogResult.targets.rows)
-      }
+        for {
+          result                                                    <- agsCatalogResults
+          angle                                                     <- anglesToTry
+          q @ ConeSearchCatalogQuery(_, _, radiusConstraint, mc, _) = result.query
+        } yield {
+          val catalogSearchCriterion     = CatalogSearchCriterion("ags", radiusConstraint, mc.head, None, angle.some)
+          val gemsCatalogSearchCriterion = new GemsCatalogSearchCriterion(result.searchKey, catalogSearchCriterion)
+          new GemsCatalogSearchResults(gemsCatalogSearchCriterion, result.catalogResult.targets.rows)
+        }
     }
   }
 
@@ -220,8 +218,8 @@ trait GemsStrategy extends AgsStrategy {
         (ml |@| lim(can))(_ union _).flatten
       }
 
-      val canopusConstraint = canMagLimits.map(c => CatalogQuery(CanopusTipTiltId.some, base.toNewModel, RadiusConstraint.between(Angle.zero, Canopus.Wfs.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), ucac4))
-      val odgwConstraint    = odgwMagLimits.map(c => CatalogQuery(OdgwFlexureId.some,   base.toNewModel, RadiusConstraint.between(Angle.zero, GsaoiOdgw.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), ucac4))
+      val canopusConstraint = canMagLimits.map(c => CatalogQuery(CanopusTipTiltId, base.toNewModel, RadiusConstraint.between(Angle.zero, Canopus.Wfs.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), ucac4))
+      val odgwConstraint    = odgwMagLimits.map(c => CatalogQuery(OdgwFlexureId,   base.toNewModel, RadiusConstraint.between(Angle.zero, GsaoiOdgw.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), ucac4))
       List(canopusConstraint, odgwConstraint).flatten
     }
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -19,7 +19,7 @@ case class MagnitudeQueryFilter(mc: MagnitudeConstraints) extends QueryResultsFi
 }
 
 /**
- * Represents a query on a catalog, indicating the location, radius and an optional set of magnitude constraints
+ * Represents a query on a catalog
  */
 sealed trait CatalogQuery {
   val id: Option[Int]
@@ -29,6 +29,9 @@ sealed trait CatalogQuery {
   def isSuperSetOf(c: CatalogQuery):Boolean
 }
 
+/**
+ * CatalogQuery using the ConeSearch method with additional constraints on radius and magnitude
+ */
 case class ConeSearchCatalogQuery(id: Option[Int], base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: List[MagnitudeConstraints], catalog: CatalogName) extends CatalogQuery {
 
   val filters: NonEmptyList[QueryResultsFilter] = NonEmptyList(RadiusFilter(base, radiusConstraint), magnitudeConstraints.map(MagnitudeQueryFilter.apply): _*)
@@ -54,6 +57,15 @@ object ConeSearchCatalogQuery {
   implicit val equals = Equal.equalA[ConeSearchCatalogQuery]
 }
 
+/**
+ * Name based query, typically without filtering
+ */
+case class NameCatalogQuery(search: String, catalog: CatalogName) extends CatalogQuery {
+  override val id: Option[Int] = None
+  def filter(t: SiderealTarget) = true
+  def isSuperSetOf(c: CatalogQuery) = false
+}
+
 object CatalogQuery {
   // Useful constructors
   def apply(id: Int, base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: List[MagnitudeConstraints], catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(id.some, base, radiusConstraint, magnitudeConstraints, catalog)
@@ -63,6 +75,8 @@ object CatalogQuery {
   def apply(base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: MagnitudeConstraints, catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(None, base, radiusConstraint, List(magnitudeConstraints), catalog)
 
   def apply(base: Coordinates, radiusConstraint: RadiusConstraint, catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(None, base, radiusConstraint, Nil, catalog)
+
+  def apply(search: String):CatalogQuery = NameCatalogQuery(search, simbad)
 
   implicit val equals = Equal.equalA[CatalogQuery]
 }
@@ -75,3 +89,4 @@ case object ppmxl extends CatalogName("ppmxl")
 case object ucac4 extends CatalogName("ucac4")
 case object twomass_psc extends CatalogName("twomass_psc")
 case object twomass_xsc extends CatalogName("twomass_xsc")
+case object simbad extends CatalogName("simbad")

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -19,34 +19,50 @@ case class MagnitudeQueryFilter(mc: MagnitudeConstraints) extends QueryResultsFi
 }
 
 /**
- * Represents a query on a acatalog, indicating the location, radius and an optional set of magnitude constraints
+ * Represents a query on a catalog, indicating the location, radius and an optional set of magnitude constraints
  */
-case class CatalogQuery(id: Option[Int], base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: List[MagnitudeConstraints], catalog: CatalogName) {
+sealed trait CatalogQuery {
+  val id: Option[Int]
+  val catalog: CatalogName
+
+  def filter(t: SiderealTarget):Boolean
+  def isSuperSetOf(c: CatalogQuery):Boolean
+}
+
+case class ConeSearchCatalogQuery(id: Option[Int], base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: List[MagnitudeConstraints], catalog: CatalogName) extends CatalogQuery {
 
   val filters: NonEmptyList[QueryResultsFilter] = NonEmptyList(RadiusFilter(base, radiusConstraint), magnitudeConstraints.map(MagnitudeQueryFilter.apply): _*)
-  def filter(t: SiderealTarget):Boolean = filters.list.forall(_.filter(t))
+  override def filter(t: SiderealTarget):Boolean = filters.list.forall(_.filter(t))
 
-  def isSuperSetOf(c: CatalogQuery) = {
-    // Angular separation, or distance between the two.
-    val distance = Coordinates.difference(base, c.base).distance
+  override def isSuperSetOf(q: CatalogQuery) = q match {
+    case c: ConeSearchCatalogQuery =>
+      // Angular separation, or distance between the two.
+      val distance = Coordinates.difference(base, c.base).distance
 
-    // Add the given query's outer radius limit to the distance to get the
-    // maximum distance from this base position of any potential guide star.
-    val max = distance + c.radiusConstraint.maxLimit
+      // Add the given query's outer radius limit to the distance to get the
+      // maximum distance from this base position of any potential guide star.
+      val max = distance + c.radiusConstraint.maxLimit
 
-    // See whether the other base position falls out of range of our
-    // radius limits.
-    radiusConstraint.maxLimit >= max
+      // See whether the other base position falls out of range of our
+      // radius limits.
+      radiusConstraint.maxLimit >= max
+    case _ => false
   }
+}
+
+object ConeSearchCatalogQuery {
+  implicit val equals = Equal.equalA[ConeSearchCatalogQuery]
 }
 
 object CatalogQuery {
   // Useful constructors
-  def apply(base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: List[MagnitudeConstraints], catalog: CatalogName):CatalogQuery = CatalogQuery(None, base, radiusConstraint, magnitudeConstraints, catalog)
+  def apply(id: Int, base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: List[MagnitudeConstraints], catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(id.some, base, radiusConstraint, magnitudeConstraints, catalog)
 
-  def apply(base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: MagnitudeConstraints, catalog: CatalogName):CatalogQuery = CatalogQuery(None, base, radiusConstraint, List(magnitudeConstraints), catalog)
+  def apply(base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: List[MagnitudeConstraints], catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(None, base, radiusConstraint, magnitudeConstraints, catalog)
 
-  def apply(base: Coordinates, radiusConstraint: RadiusConstraint, catalog: CatalogName):CatalogQuery = CatalogQuery(None, base, radiusConstraint, Nil, catalog)
+  def apply(base: Coordinates, radiusConstraint: RadiusConstraint, magnitudeConstraints: MagnitudeConstraints, catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(None, base, radiusConstraint, List(magnitudeConstraints), catalog)
+
+  def apply(base: Coordinates, radiusConstraint: RadiusConstraint, catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(None, base, radiusConstraint, Nil, catalog)
 
   implicit val equals = Equal.equalA[CatalogQuery]
 }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
@@ -80,7 +80,7 @@ sealed trait CatalogProblem
 
 case class ValidationError(url: URL) extends CatalogProblem
 case class GenericError(msg: String) extends CatalogProblem
-case class MissingValues(fields: List[Ucd]) extends CatalogProblem
+case class MissingValue(field: FieldId) extends CatalogProblem
 case class FieldValueProblem(ucd: Ucd, value: String) extends CatalogProblem
 case class UnmatchedField(ucd: Ucd) extends CatalogProblem
 case object UnknownCatalog extends CatalogProblem

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
@@ -1,5 +1,7 @@
 package edu.gemini.catalog.votable
 
+import java.net.URL
+
 import edu.gemini.catalog.api.CatalogQuery
 import edu.gemini.spModel.core.MagnitudeBand
 import edu.gemini.spModel.core.Target.SiderealTarget
@@ -76,7 +78,7 @@ case class QueryResult(query: CatalogQuery, result: CatalogQueryResult)
 /** Indicates an issue parsing the targets, e.g. missing values, bad format, etc. */
 sealed trait CatalogProblem
 
-case class ValidationError(url: String) extends CatalogProblem
+case class ValidationError(url: URL) extends CatalogProblem
 case class GenericError(msg: String) extends CatalogProblem
 case class MissingValues(fields: List[Ucd]) extends CatalogProblem
 case class FieldValueProblem(ucd: Ucd, value: String) extends CatalogProblem

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -104,7 +104,7 @@ trait CachedBackend extends VoTableBackend {
         a.lift(pos) match {
           case None                                                            => None
           case Some(CacheEntry(SearchKey(query:ConeSearchCatalogQuery, r), v)) => if (query.isSuperSetOf(k.query)) Some((pos, v)) else go(pos + 1)
-          case Some(_)                                                         => None // Not caching named queries so far
+          case _                                                               => None // Not caching named queries so far
         }
       go(0)
     }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -125,7 +125,6 @@ trait CachedBackend extends VoTableBackend {
     p.future
   }
 
-
   // Cache the query not the future so that failed queries are executed again
   protected val cachedQuery = cache(query)
 
@@ -186,8 +185,6 @@ case object SimbadNameBackend extends CachedBackend {
   val Log = Logger.getLogger(getClass.getName)
 
   private val timeout = 30 * 1000 // Max time to wait
-
-  private def format(a: Angle)= f"${a.toDegrees}%4.03f"
 
   protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair] = q match {
     case qs: NameCatalogQuery => Array(

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -4,7 +4,7 @@ import java.net.{URL, UnknownHostException}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Logger
 
-import edu.gemini.catalog.api.{ConeSearchCatalogQuery, CatalogQuery}
+import edu.gemini.catalog.api.{NameCatalogQuery, ConeSearchCatalogQuery, CatalogQuery}
 import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.core.Target.SiderealTarget
 import org.apache.commons.httpclient.{NameValuePair, HttpClient}

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -204,7 +204,10 @@ case object SimbadNameBackend extends CachedBackend {
 
     try {
       client.executeMethod(method)
-      VoTableParser.parse(e.url, method.getResponseBodyAsStream).fold(p => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(e.query, CatalogQueryResult(y)))
+      VoTableParser.parse(e.url, method.getResponseBodyAsStream) match {
+        case -\/(p) => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p)))
+        case \/-(y) => QueryResult(e.query, CatalogQueryResult(y))
+      }
     } finally {
       method.releaseConnection()
     }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -99,7 +99,7 @@ object CatalogAdapter {
 
 }
 
-// Common methods for UCAC4 and Simbad
+// Common methods for UCAC4 and PPMXL
 trait StandardAdapter {
   // Find what band the field descriptor should represent, in general prefer "upper case" bands over "lower case" Sloan bands.
   // This will prefer U, R and I over u', r' and i' but will map "g" and "z" to the Sloan bands g' and z'.

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -62,44 +62,90 @@ sealed trait CatalogAdapter {
   val pmRaField = FieldId("pmra", VoTableParser.UCD_PMRA)
   val pmDecField = FieldId("pmde", VoTableParser.UCD_PMDEC)
 
-  // Indicates if a field should be ignored
-  def ignoredMagnitudeField(v: FieldId): Boolean = false
-  // Indicates if a magnitude is valid
-  def validMagnitude(m: Magnitude): Boolean = !(m.value.isNaN || m.error.exists(_.isNaN))
+  // Indicates if the field is a magnitude
+  def isMagnitudeField(v: (FieldId, String)): Boolean = containsMagnitude(v._1) && !v._1.ucd.includes(VoTableParser.STAT_ERR) && v._2.nonEmpty
+  // Indicates if the field is a magnitude error
+  def isMagnitudeErrorField(v: (FieldId, String)): Boolean = containsMagnitude(v._1) && v._1.ucd.includes(VoTableParser.STAT_ERR) && v._2.nonEmpty
+  // filter magnitudes as a whole, removing invalid values and duplicates
+  def filterAndDeduplicateMagnitudes(magnitudeFields: List[(FieldId, Magnitude)]): List[Magnitude] = magnitudeFields.collect { case (_, mag) if validMagnitude(mag) => mag }
+  // Attempts to extract a band and value for a magnitude from a pair of field and value
+  def parseMagnitude(p: (FieldId, String)): CatalogProblem \/ (FieldId, MagnitudeBand, Double) = {
+    val (fieldId: FieldId, value: String) = p
 
+    val band = fieldToBand(fieldId)
+
+    for {
+      b <- band \/> UnmatchedField(fieldId.ucd)
+      v <- CatalogAdapter.parseDoubleValue(fieldId.ucd, value)
+    } yield (fieldId, b, v)
+  }
+
+  // From a Field extract the band from either the field id or the UCD
+  protected def fieldToBand(field: FieldId): Option[MagnitudeBand]
+
+  // Indicates if a field contianing a magnitude should be ignored, by default all fields are considered
+  protected def ignoreMagnitudeField(v: FieldId): Boolean = false
+  // Indicates if a parsed magnitude is valid
+  protected def validMagnitude(m: Magnitude): Boolean = !(m.value.isNaN || m.error.exists(_.isNaN))
+  // Indicates if the field has a magnitude field
+  protected def containsMagnitude(v: FieldId): Boolean = v.ucd.includes(VoTableParser.UCD_MAG) && v.ucd.matches(CatalogAdapter.magRegex) && !ignoreMagnitudeField(v)
+}
+
+object CatalogAdapter {
+  val magRegex = """(?i)em.(opt|IR)(\.\w)?""".r
+
+  def parseDoubleValue(ucd: Ucd, s: String): CatalogProblem \/ Double =
+    \/.fromTryCatch(s.toDouble).leftMap(_ => FieldValueProblem(ucd, s))
+
+}
+
+// Common methods for UCAC4 and Simbad
+trait StandardAdapter {
   // Find what band the field descriptor should represent, in general prefer "upper case" bands over "lower case" Sloan bands.
   // This will prefer U, R and I over u', r' and i' but will map "g" and "z" to the Sloan bands g' and z'.
-  def findBand(id: FieldId, band: String): Option[MagnitudeBand] =
+  def parseBand(fieldId: FieldId, band: String): Option[MagnitudeBand] =
     MagnitudeBand.all.
       find(_.name == band.toUpperCase).
       orElse(MagnitudeBand.all.find(_.name == band))
 
-  // filter magnitudes as a whole
-  def filterMagnitudeFields(magnitudeFields: List[(FieldId, Magnitude)]): List[Magnitude] = magnitudeFields.collect { case (_, mag) if validMagnitude(mag) => mag }
+  // From a Field extract the band from either the field id or the UCD
+  protected def fieldToBand(field: FieldId): Option[MagnitudeBand] = {
+    // Parses a UCD token to extract the band for catalogs that include the band in the UCD (UCAC4/PPMXL)
+    def parseBandToken(token: String):Option[String] = token match {
+      case CatalogAdapter.magRegex(_, null) => "UC".some
+      case CatalogAdapter.magRegex(_, b)    => b.replace(".", "").some
+      case _                                => none
+    }
+
+    (for {
+      t <- field.ucd.tokens
+      b <- parseBandToken(t.token)
+    } yield parseBand(field, b)).headOption.flatten
+  }
 }
 
-case object UCAC4Adapter extends CatalogAdapter {
+case object UCAC4Adapter extends CatalogAdapter with StandardAdapter {
   val idField = FieldId("ucac4", VoTableParser.UCD_OBJID)
   val raField = FieldId("raj2000", VoTableParser.UCD_RA)
   val decField = FieldId("dej2000", VoTableParser.UCD_DEC)
 
-  val ucac4BadMagnitude = 20.0
-  val ucac4BadMagnitudeError = 0.9.some
+  private val ucac4BadMagnitude = 20.0
+  private val ucac4BadMagnitudeError = 0.9.some
 
   // UCAC4 ignores A-mags
-  override def ignoredMagnitudeField(v: FieldId) = v.id === "amag" || v.id === "e_amag"
-  // Magnitudes with value 20 or error over or equal to 0.9 are invalid
+  override def ignoreMagnitudeField(v: FieldId) = v.id === "amag" || v.id === "e_amag"
+  // Magnitudes with value 20 or error over or equal to 0.9 are invalid in UCAC4
   override def validMagnitude(m: Magnitude) = super.validMagnitude(m) && m.value =/= ucac4BadMagnitude && m.error.map(math.abs) <= ucac4BadMagnitudeError
   // UCAC4 has a few special cases to map magnitudes, g, r and i refer to the Sloan bands g', r' and i'
-  override def findBand(id: FieldId, band: String): Option[MagnitudeBand] = (id.id, id.ucd) match {
+  override def parseBand(id: FieldId, band: String): Option[MagnitudeBand] = (id.id, id.ucd) match {
     case ("gmag" | "e_gmag", ucd) if ucd.includes(UcdWord("em.opt.r")) => Some(MagnitudeBand._g)
     case ("rmag" | "e_rmag", ucd) if ucd.includes(UcdWord("em.opt.r")) => Some(MagnitudeBand._r)
     case ("imag" | "e_imag", ucd) if ucd.includes(UcdWord("em.opt.i")) => Some(MagnitudeBand._i)
-    case _                                                             => super.findBand(id, band)
+    case _                                                             => super.parseBand(id, band)
   }
 }
 
-case object PPMXLAdapter extends CatalogAdapter {
+case object PPMXLAdapter extends CatalogAdapter with StandardAdapter {
   val idField = FieldId("ppmxl", VoTableParser.UCD_OBJID)
   val raField = FieldId("raj2000", VoTableParser.UCD_RA)
   val decField = FieldId("decj2000", VoTableParser.UCD_DEC)
@@ -110,7 +156,7 @@ case object PPMXLAdapter extends CatalogAdapter {
   val alternateMagnitudesIds = List("r2mag", "b2mag")
   val idsMapping = primaryMagnitudesIds.zip(alternateMagnitudesIds)
 
-  override def filterMagnitudeFields(magnitudeFields: List[(FieldId, Magnitude)]): List[Magnitude] = {
+  override def filterAndDeduplicateMagnitudes(magnitudeFields: List[(FieldId, Magnitude)]): List[Magnitude] = {
     // Read all magnitudes, including duplicates
     val magMap1 = (Map.empty[String, Magnitude]/:magnitudeFields) {
       case (m, (FieldId(i, _), mag)) if validMagnitude(mag) => m + (i -> mag)
@@ -125,20 +171,43 @@ case object PPMXLAdapter extends CatalogAdapter {
 }
 
 case object SimbadAdapter extends CatalogAdapter {
+  private val errorFluxID = "FLUX_ERROR_(.)".r
+  private val fluxID = "FLUX_(.)".r
   val idField = FieldId("MAIN_ID", VoTableParser.UCD_OBJID)
   val raField = FieldId("RA_d", VoTableParser.UCD_RA)
   val decField = FieldId("DEC_d", VoTableParser.UCD_DEC)
   override val pmRaField = FieldId("PMRA", VoTableParser.UCD_PMRA)
   override val pmDecField = FieldId("PMDEC", VoTableParser.UCD_PMDEC)
 
-  override def ignoredMagnitudeField(v: FieldId) = !v.id.toLowerCase.startsWith("flux")
+  override def ignoreMagnitudeField(v: FieldId) = !v.id.toLowerCase.startsWith("flux")
+
+  // Simbad has a few special cases to map sloan magnitudes
+  def findBand(id: FieldId): Option[MagnitudeBand] = (id.id, id.ucd) match {
+    case ("FLUX_z" | "e_gmag", ucd) if ucd.includes(UcdWord("em.opt.i")) => Some(MagnitudeBand._z) // Special case
+    case ("FLUX_g" | "e_rmag", ucd) if ucd.includes(UcdWord("em.opt.b")) => Some(MagnitudeBand._g) // Special case
+    case (errorFluxID(b), _)                                             => findBand(b)
+    case (fluxID(b), _)                                                  => findBand(b)
+    case _                                                               => None
+  }
+
+  // Simbad doesn't put the band in the ucd for magnitude errors
+  override def isMagnitudeErrorField(v: (FieldId, String)): Boolean =
+    v._1.ucd.includes(VoTableParser.UCD_MAG) && v._1.ucd.includes(VoTableParser.STAT_ERR) && errorFluxID.findFirstIn(v._1.id).isDefined && !ignoreMagnitudeField(v._1) && v._2.nonEmpty
+
+  protected def findBand(band: String): Option[MagnitudeBand] =
+    MagnitudeBand.all.
+      find(_.name == band)
+
+  override def fieldToBand(field: FieldId): Option[MagnitudeBand] = {
+    ((field.ucd.includes(VoTableParser.UCD_MAG) && !ignoreMagnitudeField(field)) option {
+      findBand(field)
+    }).flatten
+  }
 }
 
 trait VoTableParser {
 
   import scala.xml.Node
-
-  private val magRegex = """(?i)em.(opt|IR)(\.\w)?""".r
 
   protected def parseFieldDescriptor(xml: Node): Option[FieldDescriptor] = xml match {
     case f @ <FIELD>{_*}</FIELD> =>
@@ -171,29 +240,6 @@ trait VoTableParser {
       tr    <-  table \\ "TR"
     } yield parseTableRow(fields, tr)
 
-  def parseDoubleValue(ucd: Ucd, s: String): CatalogProblem \/ Double =
-    \/.fromTryCatch(s.toDouble).leftMap(_ => FieldValueProblem(ucd, s))
-
-  protected def parseBands[T <: CatalogAdapter](filter: T)(p: (FieldId, String)): CatalogProblem \/ (FieldId, MagnitudeBand, Double) = {
-    val (fieldId: FieldId, value: String) = p
-
-    def parseBandToken(token: String):Option[String] = token match {
-      case magRegex(_, null) => "UC".some
-      case magRegex(_, b)    => b.replace(".", "").some
-      case _                 => none
-    }
-
-    val band = for {
-      t <- fieldId.ucd.tokens
-      b <- parseBandToken(t.token)
-    } yield filter.findBand(fieldId, b)
-
-    for {
-      b <- band.headOption.flatten \/> UnmatchedField(fieldId.ucd)
-      v <- parseDoubleValue(fieldId.ucd, value)
-    } yield (fieldId, b, v)
-  }
-
   /**
    * Takes an XML Node and attempts to extract the resources and targets from a VOBTable
    */
@@ -214,31 +260,25 @@ trait VoTableParser {
     val entries = row.itemsMap
 
     val catalogAdapter: CatalogProblem \/ CatalogAdapter = {
-      val isUCAC4 = fields.exists(_.name === "ucac4")
-      val isPPMXL = fields.exists(_.name === "ppmxl")
+      val isUCAC4  = fields.exists(_.name === "ucac4")
+      val isPPMXL  = fields.exists(_.name === "ppmxl")
       val isSimbad = tableId.exists(_.equalsIgnoreCase("simbad"))
       if (isUCAC4) UCAC4Adapter.right else if (isPPMXL) PPMXLAdapter.right else if (isSimbad) SimbadAdapter.right else UnknownCatalog.left
     }
 
-    def containsMagnitude(v: FieldId, magFilter: CatalogAdapter) = v.ucd.includes(VoTableParser.UCD_MAG) && v.ucd.matches(magRegex) && !magFilter.ignoredMagnitudeField(v)
-    def magnitudeField(v: (FieldId, String), magFilter: CatalogAdapter) = {
-      containsMagnitude(v._1, magFilter) && !v._1.ucd.includes(VoTableParser.STAT_ERR) && v._2.nonEmpty
-    }
-    def magnitudeErrorField(v: (FieldId, String), magFilter: CatalogAdapter) = containsMagnitude(v._1, magFilter) && v._1.ucd.includes(VoTableParser.STAT_ERR)
-
     def parseProperMotion(pm: (Option[String], Option[String])): CatalogProblem \/ Option[ProperMotion] = {
       val k = for {
-        pmra <- pm._1
-        pmdec <- pm._2
+        pmra  <- pm._1.filter(_.nonEmpty)
+        pmdec <- pm._2.filter(_.nonEmpty)
       } yield for {
-          pmrav <- parseDoubleValue(VoTableParser.UCD_PMRA, pmra)
-          pmdecv <- parseDoubleValue(VoTableParser.UCD_PMDEC, pmdec)
+          pmrav  <- CatalogAdapter.parseDoubleValue(VoTableParser.UCD_PMRA, pmra)
+          pmdecv <- CatalogAdapter.parseDoubleValue(VoTableParser.UCD_PMDEC, pmdec)
         } yield ProperMotion(RightAscensionAngularVelocity(AngularVelocity(pmrav)), DeclinationAngularVelocity(AngularVelocity(pmdecv)))
 
       k.sequenceU
     }
 
-    def combineWithErrorsAndFilter(m: List[(FieldId, MagnitudeBand, Double)], e: List[(FieldId, MagnitudeBand, Double)], magFilter: CatalogAdapter): List[Magnitude] = {
+    def combineWithErrorsAndFilter(m: List[(FieldId, MagnitudeBand, Double)], e: List[(FieldId, MagnitudeBand, Double)], adapter: CatalogAdapter): List[Magnitude] = {
       val mags = m.map {
           case (f, b, d) => f -> new Magnitude(d, b, b.defaultSystem)
         }
@@ -246,25 +286,25 @@ trait VoTableParser {
           case (_, b, d) => b -> d
         }.toMap
       // Filter magnitudes as a whole
-      val magnitudes = magFilter.filterMagnitudeFields(mags)
+      val magnitudes = adapter.filterAndDeduplicateMagnitudes(mags)
       // Link magnitudes with their errors
-      magnitudes.map(i => i.copy(error = magErrors.get(i.band))).filter(magFilter.validMagnitude)
+      magnitudes.map(i => i.copy(error = magErrors.get(i.band)))
     }
 
     def toSiderealTarget(id: String, ra: String, dec: String, pm: (Option[String], Option[String])): \/[CatalogProblem, SiderealTarget] = {
       for {
-        magFilter      <- catalogAdapter
+        adapter        <- catalogAdapter
         r              <- Angle.parseDegrees(ra).leftMap(_ => FieldValueProblem(VoTableParser.UCD_RA, ra))
         d              <- Angle.parseDegrees(dec).leftMap(_ => FieldValueProblem(VoTableParser.UCD_DEC, dec))
         declination    <- Declination.fromAngle(d) \/> FieldValueProblem(VoTableParser.UCD_DEC, dec)
         properMotion   <- parseProperMotion(pm)
-        mags            = entries.filter(magnitudeField(_, magFilter))
-        magErrs         = entries.filter(magnitudeErrorField(_, magFilter))
-        magnitudes     <- mags.map(parseBands(magFilter)).toList.sequenceU
-        magnitudeErrs  <- magErrs.map(parseBands(magFilter)).toList.sequenceU
+        mags            = entries.filter(adapter.isMagnitudeField)
+        magErrs         = entries.filter(adapter.isMagnitudeErrorField)
+        magnitudes     <- mags.map(adapter.parseMagnitude).toList.sequenceU
+        magnitudeErrs  <- magErrs.map(adapter.parseMagnitude).toList.sequenceU
       } yield {
         val coordinates = Coordinates(RightAscension.fromAngle(r), declination)
-        val combMags    = combineWithErrorsAndFilter(magnitudes, magnitudeErrs, magFilter).sorted(VoTableParser.MagnitudeOrdering)
+        val combMags    = combineWithErrorsAndFilter(magnitudes, magnitudeErrs, adapter).sorted(VoTableParser.MagnitudeOrdering)
         SiderealTarget(id, coordinates, properMotion, combMags, None)
       }
     }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -317,6 +317,6 @@ trait VoTableParser {
       (pmRa, pmDec)   = (entries.get(adapter.pmRaField), entries.get(adapter.pmDecField))
     } yield toSiderealTarget(id, ra, dec, (pmRa, pmDec))
 
-    result.flatMap(identity)
+    result.join
   }
 }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -1,6 +1,7 @@
 package edu.gemini.catalog.votable
 
 import java.io.{ByteArrayInputStream, InputStream}
+import java.net.URL
 
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.Target.SiderealTarget
@@ -48,7 +49,7 @@ object VoTableParser extends VoTableParser {
   /**
    * parse takes an input stream and attempts to read the xml content and convert it to a VoTable resource
    */
-  def parse(url: String, is: InputStream): CatalogResult =
+  def parse(url: URL, is: InputStream): CatalogResult =
     validate(is).fold(k => \/.left(ValidationError(url)), r => \/.right(parse(XML.loadString(r))))
 }
 

--- a/bundle/edu.gemini.catalog/src/test/resources/simbad-2MFGC6625.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/simbad-2MFGC6625.xml
@@ -1,0 +1,1336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<DEFINITIONS>
+<COOSYS ID="COOSYS" equinox="2000" epoch="J2000" system="ICRS"/>
+</DEFINITIONS>
+<RESOURCE name="Simbad query" type="results">
+<TABLE ID="simbad" name="simbad query"><DESCRIPTION>... query string ...</DESCRIPTION>
+<FIELD ID="TYPED_ID" name="TYPED_ID" datatype="char" width="25" ucd="meta.id" arraysize="*">
+<DESCRIPTION>Raw identifier as typed in the query</DESCRIPTION>
+</FIELD>
+<FIELD ID="ANG_DIST" name="ANG_DIST" datatype="float" precision="4" width="8" ucd="pos.posAng" unit="arcsec">
+<DESCRIPTION>Angular distance from the center</DESCRIPTION>
+</FIELD>
+<FIELD ID="MAIN_ID" name="MAIN_ID" datatype="char" width="22" ucd="meta.id;meta.main" arraysize="*">
+<DESCRIPTION>Main identifier for an object</DESCRIPTION>
+<LINK value="${MAIN_ID}" href="http://simbad.u-strasbg.fr/simbad/sim-id?Ident=${MAIN_ID}&amp;NbIdent=1"/>
+</FIELD>
+<FIELD ID="OTYPE_S" name="OTYPE_S" datatype="char" width="6" ucd="src.class" arraysize="*">
+<DESCRIPTION>Object type</DESCRIPTION>
+<LINK href="http://simbad.u-strasbg.fr/simbad/sim-display?data=otypes"/>
+</FIELD>
+<FIELD ID="RA_d" name="RA_d" datatype="double" precision="8" width="11" ucd="pos.eq.ra;meta.main" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="DEC_d" name="DEC_d" datatype="double" precision="8" width="12" ucd="pos.eq.dec;meta.main" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MAJA_d" name="COO_ERR_MAJA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MINA_d" name="COO_ERR_MINA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_ANGLE_d" name="COO_ERR_ANGLE_d" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.eq" unit="deg">
+<DESCRIPTION>Coordinate error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMRA" name="PMRA" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.ra" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in RA</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMDEC" name="PMDEC" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.dec" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in DEC</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MAJA" name="PM_ERR_MAJA" datatype="float" precision="3" width="5" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MINA" name="PM_ERR_MINA" datatype="float" precision="3" width="5" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_ANGLE" name="PM_ERR_ANGLE" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.pm" unit="deg">
+<DESCRIPTION>Proper motion error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_VALUE" name="PLX_VALUE" datatype="double" precision="3" width="9" ucd="pos.parallax.trig" unit="mas">
+<DESCRIPTION>Parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="RV_VALUE" name="RV_VALUE" datatype="double" precision="3" ucd="spect.dopplerVeloc.opt" unit="km.s-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_VALUE" name="Z_VALUE" datatype="double" precision="7" ucd="src.redshift">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MAJAXIS" name="GALDIM_MAJAXIS" datatype="float" width="4" ucd="phys.angSize.smajAxis" unit="arcmin">
+<DESCRIPTION>Angular size major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MINAXIS" name="GALDIM_MINAXIS" datatype="float" width="4" ucd="phys.angSize.sminAxis" unit="arcmin">
+<DESCRIPTION>Angular size minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_ANGLE" name="GALDIM_ANGLE" datatype="short" width="3" ucd="pos.posAng" unit="deg">
+<DESCRIPTION>Galaxy ellipse angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_INCL" name="GALDIM_INCL" datatype="short" width="1" ucd="src.orbital.inclination">
+<DESCRIPTION>Galaxy inclinaison code (0-7)</DESCRIPTION>
+</FIELD>
+<FIELD ID="SP_TYPE" name="SP_TYPE" datatype="char" width="6" ucd="src.spType" arraysize="*">
+<DESCRIPTION>MK spectral type</DESCRIPTION>
+</FIELD>
+<FIELD ID="MORPH_TYPE" name="MORPH_TYPE" datatype="char" width="20" ucd="src.morph.type" arraysize="*">
+<DESCRIPTION>Morphological type</DESCRIPTION>
+</FIELD>
+<FIELD ID="NB_REF" name="NB_REF" datatype="int" width="4" ucd="meta.bib;meta.number">
+<DESCRIPTION>number of references</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_U" name="FILTER_NAME_U" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_U" name="FLUX_U" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude U</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_U" name="FLUX_ERROR_U" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_U" name="FLUX_BIBCODE_U" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_U" name="FLUX_VAR_U" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_U" name="FLUX_MULT_U" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_U" name="FLUX_QUAL_U" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_U" name="FLUX_UNIT_U" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_B" name="FILTER_NAME_B" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_B" name="FLUX_B" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude B</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_B" name="FLUX_ERROR_B" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_B" name="FLUX_BIBCODE_B" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_B" name="FLUX_VAR_B" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_B" name="FLUX_MULT_B" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_B" name="FLUX_QUAL_B" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_B" name="FLUX_UNIT_B" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_V" name="FILTER_NAME_V" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_V" name="FLUX_V" datatype="float" ucd="phot.mag;em.opt.V" unit="mag">
+<DESCRIPTION>Magnitude V</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_V" name="FLUX_ERROR_V" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_V" name="FLUX_BIBCODE_V" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_V" name="FLUX_VAR_V" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_V" name="FLUX_MULT_V" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_V" name="FLUX_QUAL_V" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_V" name="FLUX_UNIT_V" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_R" name="FILTER_NAME_R" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_R" name="FLUX_R" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude R</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_R" name="FLUX_ERROR_R" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_R" name="FLUX_BIBCODE_R" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_R" name="FLUX_VAR_R" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_R" name="FLUX_MULT_R" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_R" name="FLUX_QUAL_R" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_R" name="FLUX_UNIT_R" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_I" name="FILTER_NAME_I" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_I" name="FLUX_I" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude I</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_I" name="FLUX_ERROR_I" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_I" name="FLUX_BIBCODE_I" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_I" name="FLUX_VAR_I" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_I" name="FLUX_MULT_I" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_I" name="FLUX_QUAL_I" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_I" name="FLUX_UNIT_I" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_J" name="FILTER_NAME_J" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_J" name="FLUX_J" datatype="float" ucd="phot.mag;em.IR.J" unit="mag">
+<DESCRIPTION>Magnitude J</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_J" name="FLUX_ERROR_J" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_J" name="FLUX_BIBCODE_J" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_J" name="FLUX_VAR_J" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_J" name="FLUX_MULT_J" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_J" name="FLUX_QUAL_J" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_J" name="FLUX_UNIT_J" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_H" name="FILTER_NAME_H" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_H" name="FLUX_H" datatype="float" ucd="phot.mag;em.IR.H" unit="mag">
+<DESCRIPTION>Magnitude H</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_H" name="FLUX_ERROR_H" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_H" name="FLUX_BIBCODE_H" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_H" name="FLUX_VAR_H" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_H" name="FLUX_MULT_H" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_H" name="FLUX_QUAL_H" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_H" name="FLUX_UNIT_H" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_K" name="FILTER_NAME_K" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_K" name="FLUX_K" datatype="float" ucd="phot.mag;em.IR.K" unit="mag">
+<DESCRIPTION>Magnitude K</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_K" name="FLUX_ERROR_K" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_K" name="FLUX_BIBCODE_K" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_K" name="FLUX_VAR_K" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_K" name="FLUX_MULT_K" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_K" name="FLUX_QUAL_K" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_K" name="FLUX_UNIT_K" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_u" name="FILTER_NAME_u" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_u" name="FLUX_u" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude SDSS u</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_u" name="FLUX_ERROR_u" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_u" name="FLUX_BIBCODE_u" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_u" name="FLUX_VAR_u" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_u" name="FLUX_MULT_u" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_u" name="FLUX_QUAL_u" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_u" name="FLUX_UNIT_u" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_g" name="FILTER_NAME_g" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_g" name="FLUX_g" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude SDSS g</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_g" name="FLUX_ERROR_g" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_g" name="FLUX_BIBCODE_g" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_g" name="FLUX_VAR_g" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_g" name="FLUX_MULT_g" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_g" name="FLUX_QUAL_g" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_g" name="FLUX_UNIT_g" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_r" name="FILTER_NAME_r" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_r" name="FLUX_r" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude SDSS r</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_r" name="FLUX_ERROR_r" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_r" name="FLUX_BIBCODE_r" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_r" name="FLUX_VAR_r" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_r" name="FLUX_MULT_r" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_r" name="FLUX_QUAL_r" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_r" name="FLUX_UNIT_r" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_i" name="FILTER_NAME_i" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_i" name="FLUX_i" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS i</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_i" name="FLUX_ERROR_i" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_i" name="FLUX_BIBCODE_i" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_i" name="FLUX_VAR_i" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_i" name="FLUX_MULT_i" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_i" name="FLUX_QUAL_i" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_i" name="FLUX_UNIT_i" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_z" name="FILTER_NAME_z" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_z" name="FLUX_z" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS z</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_z" name="FLUX_ERROR_z" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_z" name="FLUX_BIBCODE_z" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_z" name="FLUX_VAR_z" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_z" name="FLUX_MULT_z" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_z" name="FLUX_QUAL_z" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_z" name="FLUX_UNIT_z" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U1" name="CEL:U1" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>Magn U1 (210-320nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU1" name="CEL:meU1" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U2" name="CEL:U2" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV" unit="mag">
+<DESCRIPTION>Magn U2 (155-320nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU2" name="CEL:meU2" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U2)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U3" name="CEL:U3" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV" unit="mag">
+<DESCRIPTION>Magn U3 (135-315nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU3" name="CEL:meU3" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U3)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U4" name="CEL:U4" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>Magn U4 (105-215nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU4" name="CEL:meU4" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U4)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_pec" name="CEL:pec" datatype="char" width="13" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>peculiarities</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_bibcode" name="CEL:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_D" name="Cl.G:D" datatype="int" width="1" ucd="SRC.CLASS.DISTANCE">
+<DESCRIPTION>Distance class</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_R" name="Cl.G:R" datatype="int" width="1" ucd="SRC.CLASS.RICHNESS">
+<DESCRIPTION>Richness class</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_Nga" name="Cl.G:Nga" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>number of cluster members between m3 and m3+2</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pNga" name="Cl.G:pNga" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_Acl" name="Cl.G:Acl" datatype="char" width="3" ucd="SRC.CLASS.STRUCT" arraysize="3">
+<DESCRIPTION>Cluster classification in Abell s system</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_BMclass" name="Cl.G:BMclass" datatype="char" width="6" ucd="SRC.CLASS.STRUCT" arraysize="6">
+<DESCRIPTION>Cluster classification in the Bautz-Morgan system</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pBMclass" name="Cl.G:pBMclass" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>BMclass flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m1" name="Cl.G:m1" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the fist-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm1" name="Cl.G:pm1" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m1 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m3" name="Cl.G:m3" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the third-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm3" name="Cl.G:pm3" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m3 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m10" name="Cl.G:m10" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the tenth-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm10" name="Cl.G:pm10" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m10 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m10a" name="Cl.G:m10a" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the tenth-ranked cluster member (xxx)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm10a" name="Cl.G:pm10a" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m10a flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_bibcode" name="Cl.G:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_diameter" name="diameter:diameter" datatype="double" precision="2" width="8" ucd="PHYS.ANGSIZE">
+<DESCRIPTION>Diameter value</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_Q" name="diameter:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_unit" name="diameter:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (mas/km)</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_error" name="diameter:error" datatype="double" precision="2" width="8" ucd="STAT.ERROR">
+<DESCRIPTION>Error</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_filter" name="diameter:filter" datatype="char" width="8" ucd="INSTR.FILTER" arraysize="8">
+<DESCRIPTION>filter or wavelength</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_method" name="diameter:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_bibcode" name="diameter:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_distance" name="distance:distance" datatype="double" precision="3" width="9" ucd="POS.DISTANCE">
+<DESCRIPTION>Distance value</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_Q" name="distance:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_unit" name="distance:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (pc,kpc or Mpc)</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_merr" name="distance:merr" datatype="double" precision="3" width="7" ucd="STAT.ERROR">
+<DESCRIPTION>minus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_perr" name="distance:perr" datatype="double" precision="3" width="7" ucd="STAT.ERROR">
+<DESCRIPTION>plus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_method" name="distance:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>distance calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_bibcode" name="distance:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_RA" name="Einstein:RA" datatype="char" width="10" ucd="POS.EQ.RA;META.MAIN" arraysize="10" unit="h:m:s">
+<DESCRIPTION>Right Ascension B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_DEC" name="Einstein:DEC" datatype="char" width="9" ucd="POS.EQ.DEC;META.MAIN" arraysize="9" unit="d:m:s">
+<DESCRIPTION>Declination B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Err_coo" name="Einstein:Err_coo" datatype="int" width="4" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Error on position</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Count" name="Einstein:Count" datatype="double" precision="5" width="9" ucd="PHOT.COUNT;EM.X-RAY" unit="ct/s">
+<DESCRIPTION>Count rate in the total Einstein energy band (0.16 to 3.5 keV)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Err_count" name="Einstein:Err_count" datatype="double" precision="5" width="7" ucd="STAT.ERROR" unit="ct/s">
+<DESCRIPTION>error on count rate</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Hard" name="Einstein:Hard" datatype="float" precision="3" width="6" ucd="PHOT.FLUX;ARITH.RATIO">
+<DESCRIPTION>Hardness ratio</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_HardErrPlus" name="Einstein:HardErrPlus" datatype="float" precision="3" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>+Hardness ratio error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_HardErrMinus" name="Einstein:HardErrMinus" datatype="float" precision="3" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>-Hardness ratio error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_bibcode" name="Einstein:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Teff" name="Fe_H:Teff" datatype="int" width="5" ucd="PHYS.TEMPERATURE.EFFECTIVE" unit="unit-degK">
+<DESCRIPTION>Effective Temperature</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_log_g" name="Fe_H:log_g" datatype="float" precision="1" width="5" ucd="PHYS.GRAVITY" unit="cm/s**2">
+<DESCRIPTION>Decimal logarithm of the surface gravity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Fe_H" name="Fe_H:Fe_H" datatype="float" precision="2" width="5" ucd="PHYS.ABUND.FE">
+<DESCRIPTION>Metallicity index relative to the Sun</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_flag" name="Fe_H:flag" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Flag on the [Fe/H] value</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CompStar" name="Fe_H:CompStar" datatype="char" width="9" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Designates the comparison star from which the [Fe/H] value was obtained</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CatNo" name="Fe_H:CatNo" datatype="char" width="5" ucd="META.ID;META.MAIN" arraysize="5">
+<DESCRIPTION>Star in the Cayrel et al. (1997A&amp;AS..124..299C) compilation</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_bibcode" name="Fe_H:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_radvel" name="GCRV:radvel" datatype="float" precision="2" width="8" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km.s-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_Q" name="GCRV:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_nmes" name="GCRV:nmes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_rem" name="GCRV:rem" datatype="char" width="5" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_Rf" name="GCRV:Rf" datatype="char" width="2" ucd="META.ID;INSTR.OBSTY" arraysize="2">
+<DESCRIPTION>Observatory code</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_dis" name="GCRV:dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="A.mm-1">
+<DESCRIPTION>Dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_bibcode" name="GCRV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_U_B" name="GEN:U_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.U;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index U-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_V_B" name="GEN:V_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index V-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_B1_B" name="GEN:B1_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index B1-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_B2_B" name="GEN:B2_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index B2-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_V1_B" name="GEN:V1_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index V1-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_G_B" name="GEN:G_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index G-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Wt_colind" name="GEN:Wt_colind" datatype="int" width="3" ucd="STAT.WEIGHT">
+<DESCRIPTION>weight on color indices</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_me_colind" name="GEN:me_colind" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>m.e. sigma on color indices</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Vmag" name="GEN:Vmag" datatype="float" precision="3" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Wt_Vmag" name="GEN:Wt_Vmag" datatype="int" width="3" ucd="STAT.WEIGHT">
+<DESCRIPTION>weight on V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_me_Vmag" name="GEN:me_Vmag" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>m.e. sigma on V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Rem" name="GEN:Rem" datatype="char" width="5" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_bibcode" name="GEN:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_plx" name="GJ:plx" datatype="float" precision="3" width="6" ucd="POS.PARALLAX.TRIG" unit="unit-plx">
+<DESCRIPTION>resulting parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_pe_plx" name="GJ:pe_plx" datatype="int" width="3" ucd="STAT.ERROR" unit="unit-plx">
+<DESCRIPTION>probable error on parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_Mabs" name="GJ:Mabs" datatype="float" precision="2" width="5" ucd="PHYS.MAGABS" unit="mag">
+<DESCRIPTION>Absolute magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_P_Mabs" name="GJ:P_Mabs" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Flag indication that Mabs=Mpg</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_Q_Mabs" name="GJ:Q_Mabs" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality on Abs. magn (A:very good-&gt;F:very poor)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_U" name="GJ:U" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.X" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=0d l=0d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_V" name="GJ:V" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.Y" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=0d l=+90d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_W" name="GJ:W" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.Z" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=+90d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_bibcode" name="GJ:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_Hbet" name="Hbet:Hbet" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.LINE.HBETA" unit="mag">
+<DESCRIPTION>Hbeta index</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_R" name="Hbet:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Qualifier for measurement number</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_nmes" name="Hbet:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_bibcode" name="Hbet:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_Hbet" name="Hbet1:Hbet" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.LINE.HBETA" unit="mag">
+<DESCRIPTION>Hbeta index</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_errHbet" name="Hbet1:errHbet" datatype="float" precision="2" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>Erreur sur Hbet</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_nmes" name="Hbet1:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r1" name="Hbet1:r1" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r2" name="Hbet1:r2" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r3" name="Hbet1:r3" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r4" name="Hbet1:r4" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_bibcode" name="Hbet1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="*">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_ObsId" name="Herschel:ObsId" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_alpha" name="Herschel:alpha" datatype="char" width="11" ucd="POS.EQ.RA;META.MAIN" arraysize="11" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_delta" name="Herschel:delta" datatype="char" width="11" ucd="POS.EQ.DEC;META.MAIN" arraysize="11" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_width" name="HGAM:width" datatype="float" precision="1" width="7" ucd="SPECT.LINE.EQWIDTH">
+<DESCRIPTION>equivalent width of H{gamma} line</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_mes" name="HGAM:mes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_Flag" name="HGAM:Flag" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Flag (E: emission  R: ???)</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_bibcode" name="HGAM:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_RA" name="IRAS:RA" datatype="char" width="10" ucd="POS.EQ.RA;META.MAIN" arraysize="10" unit="h:m:s">
+<DESCRIPTION>Right Ascension B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_DEC" name="IRAS:DEC" datatype="char" width="9" ucd="POS.EQ.DEC;META.MAIN" arraysize="9" unit="d:m:s">
+<DESCRIPTION>Declination B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errmaj" name="IRAS:errmaj" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>major axis of error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errmin" name="IRAS:errmin" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>minor axis of error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errangle" name="IRAS:errangle" datatype="int" width="3" ucd="POS.POSANG" unit="deg">
+<DESCRIPTION>position angle (east of north)</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f12" name="IRAS:f12" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.8-15UM" unit="Jy">
+<DESCRIPTION>flux density in 12mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q12" name="IRAS:Q12" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 12mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f25" name="IRAS:f25" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.15-30UM" unit="Jy">
+<DESCRIPTION>flux density in 25mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q25" name="IRAS:Q25" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 25mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f60" name="IRAS:f60" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.30-60UM" unit="Jy">
+<DESCRIPTION>flux density in 60mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q60" name="IRAS:Q60" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 60mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f100" name="IRAS:f100" datatype="float" precision="8" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.60-100UM" unit="Jy">
+<DESCRIPTION>flux density in 100mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q100" name="IRAS:Q100" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 100mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e12" name="IRAS:e12" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f12</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e25" name="IRAS:e25" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f25</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e60" name="IRAS:e60" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f60</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e100" name="IRAS:e100" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f100</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_conf" name="IRAS:conf" datatype="char" width="4" ucd="META.CODE" arraysize="4">
+<DESCRIPTION>confusion flags (c) for the four bands</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_v" name="IRAS:v" datatype="int" width="2" ucd="STAT.FIT.GOODNESS;SRC.VAR">
+<DESCRIPTION>percent likelihood of variability of the source in the far infra-red</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_ns" name="IRAS:ns" datatype="int" width="2" ucd="META.NUMBER">
+<DESCRIPTION>Number of significant low-resolution spectra</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_na" name="IRAS:na" datatype="int" width="2" ucd="META.NUMBER">
+<DESCRIPTION>Number of associated (optical) sources in the original catalog</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_bibcode" name="IRAS:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Krem" name="IRC:Krem" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>K magnitude remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Kmag" name="IRC:Kmag" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.IR.K" unit="mag">
+<DESCRIPTION>K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_mes_K" name="IRC:mes_K" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of observations</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_me_K" name="IRC:me_K" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_chi2_K" name="IRC:chi2_K" datatype="float" precision="2" width="5" ucd="STAT.FIT.CHI2">
+<DESCRIPTION>{chi}2 on K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Irem" name="IRC:Irem" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>I magnitude remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Imag" name="IRC:Imag" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.OPT.I" unit="mag">
+<DESCRIPTION>I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_mes_I" name="IRC:mes_I" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of observations</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_me_I" name="IRC:me_I" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_chi2_I" name="IRC:chi2_I" datatype="float" precision="2" width="5" ucd="STAT.FIT.CHI2">
+<DESCRIPTION>{chi}2 on I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_bibcode" name="IRC:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_R" name="IRC:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_TDT" name="ISO:TDT" datatype="char" width="8" ucd="META.ID;META.MAIN" arraysize="8">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_alpha" name="ISO:alpha" datatype="double" precision="4" width="8" ucd="POS.EQ.RA;META.MAIN" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_delta" name="ISO:delta" datatype="double" precision="4" width="8" ucd="POS.EQ.DEC;META.MAIN" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Homogenized_Name" name="IUE:Homogenized_Name" datatype="char" width="16" ucd="META.ID;META.MAIN" arraysize="*">
+<DESCRIPTION>Homogenized Name</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ComplID" name="IUE:ComplID" datatype="char" width="12" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Complementary Identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_PROG" name="IUE:PROG" datatype="char" width="5" ucd="META.ID;OBS" arraysize="5">
+<DESCRIPTION>Observing Program Identification</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CL" name="IUE:CL" datatype="int" width="2" ucd="SRC.CLASS">
+<DESCRIPTION>IUE class code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_D" name="IUE:D" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Dispersion code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CAM" name="IUE:CAM" datatype="char" width="3" ucd="META.ID;INSTR" arraysize="3">
+<DESCRIPTION>Camera id</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_IMAGE" name="IUE:IMAGE" datatype="int" width="5" ucd="OBS.IMAGE">
+<DESCRIPTION>Image number</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_A" name="IUE:A" datatype="char" width="1" ucd="INSTR.FOV" arraysize="1">
+<DESCRIPTION>Aperture designation code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_FES" name="IUE:FES" datatype="int" width="5" ucd="PHOT.COUNT;EM.OPT">
+<DESCRIPTION>FES count</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_MD" name="IUE:MD" datatype="char" width="2" ucd="META.CODE" arraysize="2">
+<DESCRIPTION>FES mode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ObsDate" name="IUE:ObsDate" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation date</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Time" name="IUE:Time" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ExpTim" name="IUE:ExpTim" datatype="int" width="6" ucd="TIME.EXPO" unit="sec">
+<DESCRIPTION>Effective exposure time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_m" name="IUE:m" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Abnormality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CEB" name="IUE:CEB" datatype="char" width="3" ucd="META.CODE.CLASS" arraysize="3">
+<DESCRIPTION>Exposure quality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_S" name="IUE:S" datatype="char" width="1" ucd="META.FLAG;INSTR.TEL" arraysize="1">
+<DESCRIPTION>Station (V=Vilspa/G=Goddard)</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Comments" name="IUE:Comments" datatype="char" width="20" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Comments</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_F" name="IUE:F" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_bibcode" name="IUE:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_U_360" name="JP11:U_360" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.U" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 360 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_U" name="JP11:sp_U" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value U magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_U" name="JP11:nmes_U" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_B_450" name="JP11:B_450" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.B" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 450 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_B" name="JP11:sp_B" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value B magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_B" name="JP11:nmes_B" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_V_555" name="JP11:V_555" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 555 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_V" name="JP11:sp_V" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_V" name="JP11:nmes_V" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_R_670" name="JP11:R_670" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.R" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 670 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_R" name="JP11:sp_R" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value R magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_R" name="JP11:nmes_R" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_I_870" name="JP11:I_870" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.I" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 870 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_I" name="JP11:sp_I" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_I" name="JP11:nmes_I" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_J_1200" name="JP11:J_1200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.J" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 1200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_J" name="JP11:sp_J" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value J magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_J" name="JP11:nmes_J" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_K_2200" name="JP11:K_2200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.K" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 2200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_K" name="JP11:sp_K" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_K" name="JP11:nmes_K" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_L_3500" name="JP11:L_3500" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.3-4UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 3500 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_L" name="JP11:sp_L" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value L magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_L" name="JP11:nmes_L" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_M_5000" name="JP11:M_5000" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.4-8UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 5000 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_M" name="JP11:sp_M" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value M magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_M" name="JP11:nmes_M" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_N_9000" name="JP11:N_9000" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.8-15UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 9000 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_N" name="JP11:sp_N" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value N magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_N" name="JP11:nmes_N" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_H_16200" name="JP11:H_16200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.H" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 16200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_H" name="JP11:sp_H" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value H magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_H" name="JP11:nmes_H" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_bibcode" name="JP11:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_ds" name="MK:ds" datatype="char" width="2" ucd="META.ID;INSTR" arraysize="2">
+<DESCRIPTION>dispersive system</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_mss" name="MK:mss" datatype="char" width="3" ucd="META.NOTE" arraysize="3">
+<DESCRIPTION>mss notes</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_Spectral_type" name="MK:Spectral_type" datatype="char" width="36" ucd="SRC.SPTYPE" arraysize="*">
+<DESCRIPTION>MK/MSS spectral type</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_bibcode" name="MK:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_RVel" name="oRV:RVel" datatype="float" precision="7" width="1" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km/s">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Q" name="oRV:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Nmes" name="oRV:Nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Rem" name="oRV:Rem" datatype="char" width="7" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Orig" name="oRV:Orig" datatype="char" width="2" ucd="META.NOTE" arraysize="2">
+<DESCRIPTION>Origin of the radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Dis" name="oRV:Dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="a.mm-1">
+<DESCRIPTION>dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_bibcode" name="oRV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_plx" name="PLX:plx" datatype="float" precision="3" width="6" ucd="POS.PARALLAX.TRIG" unit="arcsec">
+<DESCRIPTION>Parallaxe</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_me" name="PLX:me" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>sigma{plx}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_R" name="PLX:R" datatype="char" width="2" ucd="META.ID;INSTR.OBSTY" arraysize="2">
+<DESCRIPTION>Observatory code</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_bibcode" name="PLX:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmra" name="PM:pmra" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.RA" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion R.A.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmra" name="PM:me_pmra" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="arcsec.yr-1">
+<DESCRIPTION>sigma{pm-ra}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmde" name="PM:pmde" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.DEC" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion DEC.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmde" name="PM:me_pmde" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="arcsec.yr-1">
+<DESCRIPTION>sigma{pm-de}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_system" name="PM:system" datatype="char" width="4" ucd="POS.FRAME" arraysize="4">
+<DESCRIPTION>coordinates system designation</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_bibcode" name="PM:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_RA" name="pos:RA" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_DEC" name="pos:DEC" datatype="char" width="13" ucd="POS.EQ.DEC;META.MAIN" arraysize="13" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_me_al" name="pos:me_al" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="sec">
+<DESCRIPTION>sigma{RA}</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_me_de" name="pos:me_de" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="sec">
+<DESCRIPTION>sigma{DEC}</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_equi" name="pos:equi" datatype="int" width="4" ucd="TIME.EQUINOX" unit="yr">
+<DESCRIPTION>Equinox</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_epoch" name="pos:epoch" datatype="float" precision="7" width="2" ucd="TIME.EPOCH" unit="yr">
+<DESCRIPTION>Epoch</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_bibcode" name="pos:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_RA" name="posa:RA" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_DEC" name="posa:DEC" datatype="char" width="13" ucd="POS.EQ.DEC;META.MAIN" arraysize="13" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_upMajAxis" name="posa:upMajAxis" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_MajAxis" name="posa:MajAxis" datatype="float" precision="3" width="8" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Major axis of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_upMinAxis" name="posa:upMinAxis" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_MinAxis" name="posa:MinAxis" datatype="float" precision="3" width="8" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Minor axis of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_PA" name="posa:PA" datatype="float" precision="1" width="5" ucd="POS.POSANG" unit="deg">
+<DESCRIPTION>Position angle of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_equi" name="posa:equi" datatype="int" width="4" ucd="TIME.EQUINOX" unit="yr">
+<DESCRIPTION>Equinox</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_epoch" name="posa:epoch" datatype="float" precision="7" width="2" ucd="TIME.EPOCH" unit="yr">
+<DESCRIPTION>Epoch</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_bibcode" name="posa:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_upVsini" name="ROT:upVsini" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Vsini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_Vsini" name="ROT:Vsini" datatype="float" precision="2" width="6" ucd="PHYS.VELOC.ROTAT" unit="km.s-1">
+<DESCRIPTION>V sini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_err" name="ROT:err" datatype="float" precision="2" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>error</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_mes" name="ROT:mes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_qual" name="ROT:qual" datatype="char" width="1" ucd="CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_bibcode" name="ROT:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_Rvel" name="RVel:Rvel" datatype="int" width="7" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km.sec-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_nmes" name="RVel:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_rem" name="RVel:rem" datatype="char" width="5" ucd="META.NOTE" arraysize="5">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_dis" name="RVel:dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="a.mm-1">
+<DESCRIPTION>Dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_bibcode" name="RVel:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_alpha" name="SAO:alpha" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_delta" name="SAO:delta" datatype="char" width="14" ucd="POS.EQ.DEC;META.MAIN" arraysize="14" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_coo" name="SAO:me_coo" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Mean error on position</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_pm_ra" name="SAO:pm_ra" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.RA" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion {mu}alpha*cos(delta)</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_pmra" name="SAO:me_pmra" datatype="int" width="3" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma on pm-ra</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_pm_de" name="SAO:pm_de" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.DEC" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion {mu}delta</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_pmde" name="SAO:me_pmde" datatype="int" width="3" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma on pm-de</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_bibcode" name="SAO:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m2740" name="TD1:m2740" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>magnitude at 274.0 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m2740" name="TD1:se_m2740" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m2740)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m2365" name="TD1:m2365" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>magnitude at 236.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m2365" name="TD1:se_m2365" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m2365)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m1965" name="TD1:m1965" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>magnitude at 196.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m1965" name="TD1:se_m1965" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1965)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m1565" name="TD1:m1565" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>magnitude at 156.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m1565" name="TD1:se_m1565" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1565)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_bibcode" name="TD1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_Ph_syst" name="UBV:Ph_syst" datatype="char" width="3" ucd="META.ID;PHOT" arraysize="3">
+<DESCRIPTION>Photometric system</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_V" name="UBV:V" datatype="float" precision="3" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_B_V" name="UBV:B_V" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>B-V color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_U_B" name="UBV:U_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.U;EM.OPT.B" unit="mag">
+<DESCRIPTION>U-B color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_qual" name="UBV:qual" datatype="char" width="5" ucd="META.CODE.QUAL" arraysize="5">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_remarks" name="UBV:remarks" datatype="char" width="11" ucd="META.NOTE" arraysize="*" unit="char">
+<DESCRIPTION>REMARKS</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_bibcode" name="UBV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_b_y" name="uvby:b_y" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>b-y color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_m1" name="uvby:m1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>m1 index (Balmer discontinuity)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_c1" name="uvby:c1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>c1 index (line blocking)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_flag" name="uvby:flag" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_nbmes" name="uvby:nbmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_bibcode" name="uvby:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_b_y" name="uvby1:b_y" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>b-y color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_b_y" name="uvby1:me_b_y" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(b-y)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_m1" name="uvby1:m1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>m1 index (Balmer discontinuity)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_m1" name="uvby1:me_m1" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_c1" name="uvby1:c1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>c1 index (line blocking)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_c1" name="uvby1:me_c1" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(c1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_flag" name="uvby1:flag" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_nbmes" name="uvby1:nbmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f1" name="uvby1:f1" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 1</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f2" name="uvby1:f2" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 2</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f3" name="uvby1:f3" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 3</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f4" name="uvby1:f4" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 4</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_bibcode" name="uvby1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__vartyp" name="V*:vartyp" datatype="char" width="6" ucd="META.CODE;SRC.VAR" arraysize="6">
+<DESCRIPTION>Type of variability</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__LoVmax" name="V*:LoVmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Upper limit flag for Vmax</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmax" name="V*:Vmax" datatype="float" precision="2" width="5" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Maximum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmax" name="V*:R_Vmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__magtyp" name="V*:magtyp" datatype="char" width="1" ucd="META.ID;PHOT" arraysize="1">
+<DESCRIPTION>Magnitude type</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpVmin" name="V*:UpVmin" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmin" name="V*:Vmin" datatype="float" precision="2" width="5" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Minimum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmin" name="V*:R_Vmin" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpPeriod" name="V*:UpPeriod" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for the period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__period" name="V*:period" datatype="double" precision="4" width="10" ucd="TIME.PERIOD" unit="day">
+<DESCRIPTION>Period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_period" name="V*:R_period" datatype="char" width="2" ucd="META.CODE.ERROR" arraysize="2">
+<DESCRIPTION>Uncertainty flag on period (:)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__epoch" name="V*:epoch" datatype="double" precision="4" width="13" ucd="TIME.EPOCH" unit="day">
+<DESCRIPTION>Epoch of maximum or minimum</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_epoch" name="V*:R_epoch" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty on epoch (:)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__D_rt" name="V*:D_rt" datatype="float" precision="1" width="4" ucd="TIME.INTERVAL">
+<DESCRIPTION>Raising time for all other variable types</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_D_rt" name="V*:R_D_rt" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag on raising time</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__bibcode" name="V*:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="XMM_Obsno" name="XMM:Obsno" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_redshift" name="Z:redshift" datatype="double" precision="5" width="8" ucd="SRC.REDSHIFT">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_R" name="Z:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>colon is uncertain question mark is questionable</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_bibcode" name="Z:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_redshift" name="ze:redshift" datatype="double" precision="6" width="9" ucd="SRC.REDSHIFT">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_R" name="ze:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>colon is uncertain question mark is questionable</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_me" name="ze:me" datatype="double" precision="6" width="8" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_bibcode" name="ze:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="OID4" name="OID4" datatype="char" width="10" ucd="meta.record;meta.id" arraysize="*">
+<DESCRIPTION>Object internal identifier</DESCRIPTION>
+</FIELD>
+<DATA>
+<TABLEDATA>
+<TR><TD>SDSS J082354.96+280621.6</TD><TD></TD><TD>2MFGC 6625</TD><TD>HII_G</TD><TD>125.979025</TD><TD>+28.106022</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>13828</TD><TD>0.04724</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>u</TD><TD>17.353</TD><TD>0.009</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>u</TD><TD>g</TD><TD>16.826</TD><TD>0.004</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>g</TD><TD>r</TD><TD>17.286</TD><TD>0.005</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>r</TD><TD>i</TD><TD>16.902</TD><TD>0.005</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>i</TD><TD>z</TD><TD>17.015</TD><TD>0.011</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>z</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>08 20 52.6</TD><TD>+28 16 03</TD><TD>57</TD><TD>10</TD><TD>103</TD><TD>0.25</TD><TD>L</TD><TD>0.26</TD><TD>L</TD><TD>1.25</TD><TD></TD><TD>1.65</TD><TD></TD><TD>9</TD><TD>8</TD><TD></TD><TD></TD><TD>----</TD><TD></TD><TD>0</TD><TD>0</TD><TD>1988NASAR1190....1B</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>@4699400</TD></TR>
+
+</TABLEDATA>
+
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>

--- a/bundle/edu.gemini.catalog/src/test/resources/simbad-J000008.13.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/simbad-J000008.13.xml
@@ -1,0 +1,1336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<DEFINITIONS>
+<COOSYS ID="COOSYS" equinox="2000" epoch="J2000" system="ICRS"/>
+</DEFINITIONS>
+<RESOURCE name="Simbad query" type="results">
+<TABLE ID="simbad" name="simbad query"><DESCRIPTION>... query string ...</DESCRIPTION>
+<FIELD ID="TYPED_ID" name="TYPED_ID" datatype="char" width="25" ucd="meta.id" arraysize="*">
+<DESCRIPTION>Raw identifier as typed in the query</DESCRIPTION>
+</FIELD>
+<FIELD ID="ANG_DIST" name="ANG_DIST" datatype="float" precision="4" width="8" ucd="pos.posAng" unit="arcsec">
+<DESCRIPTION>Angular distance from the center</DESCRIPTION>
+</FIELD>
+<FIELD ID="MAIN_ID" name="MAIN_ID" datatype="char" width="22" ucd="meta.id;meta.main" arraysize="*">
+<DESCRIPTION>Main identifier for an object</DESCRIPTION>
+<LINK value="${MAIN_ID}" href="http://simbad.u-strasbg.fr/simbad/sim-id?Ident=${MAIN_ID}&amp;NbIdent=1"/>
+</FIELD>
+<FIELD ID="OTYPE_S" name="OTYPE_S" datatype="char" width="6" ucd="src.class" arraysize="*">
+<DESCRIPTION>Object type</DESCRIPTION>
+<LINK href="http://simbad.u-strasbg.fr/simbad/sim-display?data=otypes"/>
+</FIELD>
+<FIELD ID="RA_d" name="RA_d" datatype="double" precision="8" width="11" ucd="pos.eq.ra;meta.main" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="DEC_d" name="DEC_d" datatype="double" precision="8" width="12" ucd="pos.eq.dec;meta.main" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MAJA_d" name="COO_ERR_MAJA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MINA_d" name="COO_ERR_MINA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_ANGLE_d" name="COO_ERR_ANGLE_d" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.eq" unit="deg">
+<DESCRIPTION>Coordinate error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMRA" name="PMRA" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.ra" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in RA</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMDEC" name="PMDEC" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.dec" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in DEC</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MAJA" name="PM_ERR_MAJA" datatype="float" precision="3" width="5" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MINA" name="PM_ERR_MINA" datatype="float" precision="3" width="5" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_ANGLE" name="PM_ERR_ANGLE" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.pm" unit="deg">
+<DESCRIPTION>Proper motion error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_VALUE" name="PLX_VALUE" datatype="double" precision="3" width="9" ucd="pos.parallax.trig" unit="mas">
+<DESCRIPTION>Parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="RV_VALUE" name="RV_VALUE" datatype="double" precision="3" ucd="spect.dopplerVeloc.opt" unit="km.s-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_VALUE" name="Z_VALUE" datatype="double" precision="7" ucd="src.redshift">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MAJAXIS" name="GALDIM_MAJAXIS" datatype="float" width="4" ucd="phys.angSize.smajAxis" unit="arcmin">
+<DESCRIPTION>Angular size major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MINAXIS" name="GALDIM_MINAXIS" datatype="float" width="4" ucd="phys.angSize.sminAxis" unit="arcmin">
+<DESCRIPTION>Angular size minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_ANGLE" name="GALDIM_ANGLE" datatype="short" width="3" ucd="pos.posAng" unit="deg">
+<DESCRIPTION>Galaxy ellipse angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_INCL" name="GALDIM_INCL" datatype="short" width="1" ucd="src.orbital.inclination">
+<DESCRIPTION>Galaxy inclinaison code (0-7)</DESCRIPTION>
+</FIELD>
+<FIELD ID="SP_TYPE" name="SP_TYPE" datatype="char" width="6" ucd="src.spType" arraysize="*">
+<DESCRIPTION>MK spectral type</DESCRIPTION>
+</FIELD>
+<FIELD ID="MORPH_TYPE" name="MORPH_TYPE" datatype="char" width="20" ucd="src.morph.type" arraysize="*">
+<DESCRIPTION>Morphological type</DESCRIPTION>
+</FIELD>
+<FIELD ID="NB_REF" name="NB_REF" datatype="int" width="4" ucd="meta.bib;meta.number">
+<DESCRIPTION>number of references</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_U" name="FILTER_NAME_U" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_U" name="FLUX_U" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude U</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_U" name="FLUX_ERROR_U" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_U" name="FLUX_BIBCODE_U" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_U" name="FLUX_VAR_U" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_U" name="FLUX_MULT_U" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_U" name="FLUX_QUAL_U" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_U" name="FLUX_UNIT_U" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_B" name="FILTER_NAME_B" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_B" name="FLUX_B" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude B</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_B" name="FLUX_ERROR_B" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_B" name="FLUX_BIBCODE_B" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_B" name="FLUX_VAR_B" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_B" name="FLUX_MULT_B" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_B" name="FLUX_QUAL_B" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_B" name="FLUX_UNIT_B" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_V" name="FILTER_NAME_V" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_V" name="FLUX_V" datatype="float" ucd="phot.mag;em.opt.V" unit="mag">
+<DESCRIPTION>Magnitude V</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_V" name="FLUX_ERROR_V" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_V" name="FLUX_BIBCODE_V" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_V" name="FLUX_VAR_V" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_V" name="FLUX_MULT_V" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_V" name="FLUX_QUAL_V" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_V" name="FLUX_UNIT_V" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_R" name="FILTER_NAME_R" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_R" name="FLUX_R" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude R</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_R" name="FLUX_ERROR_R" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_R" name="FLUX_BIBCODE_R" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_R" name="FLUX_VAR_R" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_R" name="FLUX_MULT_R" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_R" name="FLUX_QUAL_R" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_R" name="FLUX_UNIT_R" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_I" name="FILTER_NAME_I" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_I" name="FLUX_I" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude I</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_I" name="FLUX_ERROR_I" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_I" name="FLUX_BIBCODE_I" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_I" name="FLUX_VAR_I" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_I" name="FLUX_MULT_I" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_I" name="FLUX_QUAL_I" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_I" name="FLUX_UNIT_I" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_J" name="FILTER_NAME_J" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_J" name="FLUX_J" datatype="float" ucd="phot.mag;em.IR.J" unit="mag">
+<DESCRIPTION>Magnitude J</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_J" name="FLUX_ERROR_J" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_J" name="FLUX_BIBCODE_J" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_J" name="FLUX_VAR_J" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_J" name="FLUX_MULT_J" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_J" name="FLUX_QUAL_J" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_J" name="FLUX_UNIT_J" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_H" name="FILTER_NAME_H" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_H" name="FLUX_H" datatype="float" ucd="phot.mag;em.IR.H" unit="mag">
+<DESCRIPTION>Magnitude H</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_H" name="FLUX_ERROR_H" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_H" name="FLUX_BIBCODE_H" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_H" name="FLUX_VAR_H" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_H" name="FLUX_MULT_H" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_H" name="FLUX_QUAL_H" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_H" name="FLUX_UNIT_H" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_K" name="FILTER_NAME_K" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_K" name="FLUX_K" datatype="float" ucd="phot.mag;em.IR.K" unit="mag">
+<DESCRIPTION>Magnitude K</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_K" name="FLUX_ERROR_K" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_K" name="FLUX_BIBCODE_K" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_K" name="FLUX_VAR_K" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_K" name="FLUX_MULT_K" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_K" name="FLUX_QUAL_K" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_K" name="FLUX_UNIT_K" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_u" name="FILTER_NAME_u" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_u" name="FLUX_u" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude SDSS u</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_u" name="FLUX_ERROR_u" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_u" name="FLUX_BIBCODE_u" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_u" name="FLUX_VAR_u" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_u" name="FLUX_MULT_u" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_u" name="FLUX_QUAL_u" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_u" name="FLUX_UNIT_u" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_g" name="FILTER_NAME_g" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_g" name="FLUX_g" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude SDSS g</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_g" name="FLUX_ERROR_g" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_g" name="FLUX_BIBCODE_g" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_g" name="FLUX_VAR_g" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_g" name="FLUX_MULT_g" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_g" name="FLUX_QUAL_g" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_g" name="FLUX_UNIT_g" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_r" name="FILTER_NAME_r" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_r" name="FLUX_r" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude SDSS r</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_r" name="FLUX_ERROR_r" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_r" name="FLUX_BIBCODE_r" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_r" name="FLUX_VAR_r" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_r" name="FLUX_MULT_r" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_r" name="FLUX_QUAL_r" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_r" name="FLUX_UNIT_r" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_i" name="FILTER_NAME_i" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_i" name="FLUX_i" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS i</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_i" name="FLUX_ERROR_i" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_i" name="FLUX_BIBCODE_i" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_i" name="FLUX_VAR_i" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_i" name="FLUX_MULT_i" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_i" name="FLUX_QUAL_i" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_i" name="FLUX_UNIT_i" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_z" name="FILTER_NAME_z" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_z" name="FLUX_z" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS z</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_z" name="FLUX_ERROR_z" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_z" name="FLUX_BIBCODE_z" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_z" name="FLUX_VAR_z" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_z" name="FLUX_MULT_z" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_z" name="FLUX_QUAL_z" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_z" name="FLUX_UNIT_z" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U1" name="CEL:U1" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>Magn U1 (210-320nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU1" name="CEL:meU1" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U2" name="CEL:U2" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV" unit="mag">
+<DESCRIPTION>Magn U2 (155-320nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU2" name="CEL:meU2" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U2)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U3" name="CEL:U3" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV" unit="mag">
+<DESCRIPTION>Magn U3 (135-315nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU3" name="CEL:meU3" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U3)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U4" name="CEL:U4" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>Magn U4 (105-215nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU4" name="CEL:meU4" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U4)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_pec" name="CEL:pec" datatype="char" width="13" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>peculiarities</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_bibcode" name="CEL:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_D" name="Cl.G:D" datatype="int" width="1" ucd="SRC.CLASS.DISTANCE">
+<DESCRIPTION>Distance class</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_R" name="Cl.G:R" datatype="int" width="1" ucd="SRC.CLASS.RICHNESS">
+<DESCRIPTION>Richness class</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_Nga" name="Cl.G:Nga" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>number of cluster members between m3 and m3+2</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pNga" name="Cl.G:pNga" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_Acl" name="Cl.G:Acl" datatype="char" width="3" ucd="SRC.CLASS.STRUCT" arraysize="3">
+<DESCRIPTION>Cluster classification in Abell s system</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_BMclass" name="Cl.G:BMclass" datatype="char" width="6" ucd="SRC.CLASS.STRUCT" arraysize="6">
+<DESCRIPTION>Cluster classification in the Bautz-Morgan system</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pBMclass" name="Cl.G:pBMclass" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>BMclass flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m1" name="Cl.G:m1" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the fist-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm1" name="Cl.G:pm1" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m1 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m3" name="Cl.G:m3" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the third-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm3" name="Cl.G:pm3" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m3 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m10" name="Cl.G:m10" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the tenth-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm10" name="Cl.G:pm10" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m10 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m10a" name="Cl.G:m10a" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the tenth-ranked cluster member (xxx)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm10a" name="Cl.G:pm10a" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m10a flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_bibcode" name="Cl.G:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_diameter" name="diameter:diameter" datatype="double" precision="2" width="8" ucd="PHYS.ANGSIZE">
+<DESCRIPTION>Diameter value</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_Q" name="diameter:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_unit" name="diameter:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (mas/km)</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_error" name="diameter:error" datatype="double" precision="2" width="8" ucd="STAT.ERROR">
+<DESCRIPTION>Error</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_filter" name="diameter:filter" datatype="char" width="8" ucd="INSTR.FILTER" arraysize="8">
+<DESCRIPTION>filter or wavelength</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_method" name="diameter:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_bibcode" name="diameter:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_distance" name="distance:distance" datatype="double" precision="3" width="9" ucd="POS.DISTANCE">
+<DESCRIPTION>Distance value</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_Q" name="distance:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_unit" name="distance:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (pc,kpc or Mpc)</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_merr" name="distance:merr" datatype="double" precision="3" width="7" ucd="STAT.ERROR">
+<DESCRIPTION>minus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_perr" name="distance:perr" datatype="double" precision="3" width="7" ucd="STAT.ERROR">
+<DESCRIPTION>plus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_method" name="distance:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>distance calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_bibcode" name="distance:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_RA" name="Einstein:RA" datatype="char" width="10" ucd="POS.EQ.RA;META.MAIN" arraysize="10" unit="h:m:s">
+<DESCRIPTION>Right Ascension B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_DEC" name="Einstein:DEC" datatype="char" width="9" ucd="POS.EQ.DEC;META.MAIN" arraysize="9" unit="d:m:s">
+<DESCRIPTION>Declination B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Err_coo" name="Einstein:Err_coo" datatype="int" width="4" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Error on position</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Count" name="Einstein:Count" datatype="double" precision="5" width="9" ucd="PHOT.COUNT;EM.X-RAY" unit="ct/s">
+<DESCRIPTION>Count rate in the total Einstein energy band (0.16 to 3.5 keV)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Err_count" name="Einstein:Err_count" datatype="double" precision="5" width="7" ucd="STAT.ERROR" unit="ct/s">
+<DESCRIPTION>error on count rate</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Hard" name="Einstein:Hard" datatype="float" precision="3" width="6" ucd="PHOT.FLUX;ARITH.RATIO">
+<DESCRIPTION>Hardness ratio</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_HardErrPlus" name="Einstein:HardErrPlus" datatype="float" precision="3" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>+Hardness ratio error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_HardErrMinus" name="Einstein:HardErrMinus" datatype="float" precision="3" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>-Hardness ratio error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_bibcode" name="Einstein:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Teff" name="Fe_H:Teff" datatype="int" width="5" ucd="PHYS.TEMPERATURE.EFFECTIVE" unit="unit-degK">
+<DESCRIPTION>Effective Temperature</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_log_g" name="Fe_H:log_g" datatype="float" precision="1" width="5" ucd="PHYS.GRAVITY" unit="cm/s**2">
+<DESCRIPTION>Decimal logarithm of the surface gravity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Fe_H" name="Fe_H:Fe_H" datatype="float" precision="2" width="5" ucd="PHYS.ABUND.FE">
+<DESCRIPTION>Metallicity index relative to the Sun</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_flag" name="Fe_H:flag" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Flag on the [Fe/H] value</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CompStar" name="Fe_H:CompStar" datatype="char" width="9" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Designates the comparison star from which the [Fe/H] value was obtained</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CatNo" name="Fe_H:CatNo" datatype="char" width="5" ucd="META.ID;META.MAIN" arraysize="5">
+<DESCRIPTION>Star in the Cayrel et al. (1997A&amp;AS..124..299C) compilation</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_bibcode" name="Fe_H:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_radvel" name="GCRV:radvel" datatype="float" precision="2" width="8" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km.s-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_Q" name="GCRV:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_nmes" name="GCRV:nmes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_rem" name="GCRV:rem" datatype="char" width="5" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_Rf" name="GCRV:Rf" datatype="char" width="2" ucd="META.ID;INSTR.OBSTY" arraysize="2">
+<DESCRIPTION>Observatory code</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_dis" name="GCRV:dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="A.mm-1">
+<DESCRIPTION>Dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_bibcode" name="GCRV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_U_B" name="GEN:U_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.U;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index U-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_V_B" name="GEN:V_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index V-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_B1_B" name="GEN:B1_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index B1-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_B2_B" name="GEN:B2_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index B2-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_V1_B" name="GEN:V1_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index V1-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_G_B" name="GEN:G_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index G-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Wt_colind" name="GEN:Wt_colind" datatype="int" width="3" ucd="STAT.WEIGHT">
+<DESCRIPTION>weight on color indices</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_me_colind" name="GEN:me_colind" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>m.e. sigma on color indices</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Vmag" name="GEN:Vmag" datatype="float" precision="3" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Wt_Vmag" name="GEN:Wt_Vmag" datatype="int" width="3" ucd="STAT.WEIGHT">
+<DESCRIPTION>weight on V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_me_Vmag" name="GEN:me_Vmag" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>m.e. sigma on V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Rem" name="GEN:Rem" datatype="char" width="5" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_bibcode" name="GEN:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_plx" name="GJ:plx" datatype="float" precision="3" width="6" ucd="POS.PARALLAX.TRIG" unit="unit-plx">
+<DESCRIPTION>resulting parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_pe_plx" name="GJ:pe_plx" datatype="int" width="3" ucd="STAT.ERROR" unit="unit-plx">
+<DESCRIPTION>probable error on parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_Mabs" name="GJ:Mabs" datatype="float" precision="2" width="5" ucd="PHYS.MAGABS" unit="mag">
+<DESCRIPTION>Absolute magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_P_Mabs" name="GJ:P_Mabs" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Flag indication that Mabs=Mpg</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_Q_Mabs" name="GJ:Q_Mabs" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality on Abs. magn (A:very good-&gt;F:very poor)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_U" name="GJ:U" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.X" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=0d l=0d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_V" name="GJ:V" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.Y" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=0d l=+90d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_W" name="GJ:W" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.Z" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=+90d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_bibcode" name="GJ:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_Hbet" name="Hbet:Hbet" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.LINE.HBETA" unit="mag">
+<DESCRIPTION>Hbeta index</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_R" name="Hbet:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Qualifier for measurement number</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_nmes" name="Hbet:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_bibcode" name="Hbet:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_Hbet" name="Hbet1:Hbet" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.LINE.HBETA" unit="mag">
+<DESCRIPTION>Hbeta index</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_errHbet" name="Hbet1:errHbet" datatype="float" precision="2" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>Erreur sur Hbet</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_nmes" name="Hbet1:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r1" name="Hbet1:r1" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r2" name="Hbet1:r2" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r3" name="Hbet1:r3" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r4" name="Hbet1:r4" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_bibcode" name="Hbet1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="*">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_ObsId" name="Herschel:ObsId" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_alpha" name="Herschel:alpha" datatype="char" width="11" ucd="POS.EQ.RA;META.MAIN" arraysize="11" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_delta" name="Herschel:delta" datatype="char" width="11" ucd="POS.EQ.DEC;META.MAIN" arraysize="11" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_width" name="HGAM:width" datatype="float" precision="1" width="7" ucd="SPECT.LINE.EQWIDTH">
+<DESCRIPTION>equivalent width of H{gamma} line</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_mes" name="HGAM:mes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_Flag" name="HGAM:Flag" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Flag (E: emission  R: ???)</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_bibcode" name="HGAM:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_RA" name="IRAS:RA" datatype="char" width="10" ucd="POS.EQ.RA;META.MAIN" arraysize="10" unit="h:m:s">
+<DESCRIPTION>Right Ascension B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_DEC" name="IRAS:DEC" datatype="char" width="9" ucd="POS.EQ.DEC;META.MAIN" arraysize="9" unit="d:m:s">
+<DESCRIPTION>Declination B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errmaj" name="IRAS:errmaj" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>major axis of error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errmin" name="IRAS:errmin" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>minor axis of error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errangle" name="IRAS:errangle" datatype="int" width="3" ucd="POS.POSANG" unit="deg">
+<DESCRIPTION>position angle (east of north)</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f12" name="IRAS:f12" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.8-15UM" unit="Jy">
+<DESCRIPTION>flux density in 12mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q12" name="IRAS:Q12" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 12mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f25" name="IRAS:f25" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.15-30UM" unit="Jy">
+<DESCRIPTION>flux density in 25mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q25" name="IRAS:Q25" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 25mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f60" name="IRAS:f60" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.30-60UM" unit="Jy">
+<DESCRIPTION>flux density in 60mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q60" name="IRAS:Q60" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 60mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f100" name="IRAS:f100" datatype="float" precision="8" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.60-100UM" unit="Jy">
+<DESCRIPTION>flux density in 100mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q100" name="IRAS:Q100" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 100mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e12" name="IRAS:e12" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f12</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e25" name="IRAS:e25" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f25</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e60" name="IRAS:e60" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f60</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e100" name="IRAS:e100" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f100</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_conf" name="IRAS:conf" datatype="char" width="4" ucd="META.CODE" arraysize="4">
+<DESCRIPTION>confusion flags (c) for the four bands</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_v" name="IRAS:v" datatype="int" width="2" ucd="STAT.FIT.GOODNESS;SRC.VAR">
+<DESCRIPTION>percent likelihood of variability of the source in the far infra-red</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_ns" name="IRAS:ns" datatype="int" width="2" ucd="META.NUMBER">
+<DESCRIPTION>Number of significant low-resolution spectra</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_na" name="IRAS:na" datatype="int" width="2" ucd="META.NUMBER">
+<DESCRIPTION>Number of associated (optical) sources in the original catalog</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_bibcode" name="IRAS:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Krem" name="IRC:Krem" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>K magnitude remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Kmag" name="IRC:Kmag" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.IR.K" unit="mag">
+<DESCRIPTION>K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_mes_K" name="IRC:mes_K" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of observations</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_me_K" name="IRC:me_K" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_chi2_K" name="IRC:chi2_K" datatype="float" precision="2" width="5" ucd="STAT.FIT.CHI2">
+<DESCRIPTION>{chi}2 on K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Irem" name="IRC:Irem" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>I magnitude remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Imag" name="IRC:Imag" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.OPT.I" unit="mag">
+<DESCRIPTION>I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_mes_I" name="IRC:mes_I" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of observations</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_me_I" name="IRC:me_I" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_chi2_I" name="IRC:chi2_I" datatype="float" precision="2" width="5" ucd="STAT.FIT.CHI2">
+<DESCRIPTION>{chi}2 on I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_bibcode" name="IRC:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_R" name="IRC:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_TDT" name="ISO:TDT" datatype="char" width="8" ucd="META.ID;META.MAIN" arraysize="8">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_alpha" name="ISO:alpha" datatype="double" precision="4" width="8" ucd="POS.EQ.RA;META.MAIN" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_delta" name="ISO:delta" datatype="double" precision="4" width="8" ucd="POS.EQ.DEC;META.MAIN" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Homogenized_Name" name="IUE:Homogenized_Name" datatype="char" width="16" ucd="META.ID;META.MAIN" arraysize="*">
+<DESCRIPTION>Homogenized Name</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ComplID" name="IUE:ComplID" datatype="char" width="12" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Complementary Identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_PROG" name="IUE:PROG" datatype="char" width="5" ucd="META.ID;OBS" arraysize="5">
+<DESCRIPTION>Observing Program Identification</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CL" name="IUE:CL" datatype="int" width="2" ucd="SRC.CLASS">
+<DESCRIPTION>IUE class code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_D" name="IUE:D" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Dispersion code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CAM" name="IUE:CAM" datatype="char" width="3" ucd="META.ID;INSTR" arraysize="3">
+<DESCRIPTION>Camera id</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_IMAGE" name="IUE:IMAGE" datatype="int" width="5" ucd="OBS.IMAGE">
+<DESCRIPTION>Image number</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_A" name="IUE:A" datatype="char" width="1" ucd="INSTR.FOV" arraysize="1">
+<DESCRIPTION>Aperture designation code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_FES" name="IUE:FES" datatype="int" width="5" ucd="PHOT.COUNT;EM.OPT">
+<DESCRIPTION>FES count</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_MD" name="IUE:MD" datatype="char" width="2" ucd="META.CODE" arraysize="2">
+<DESCRIPTION>FES mode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ObsDate" name="IUE:ObsDate" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation date</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Time" name="IUE:Time" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ExpTim" name="IUE:ExpTim" datatype="int" width="6" ucd="TIME.EXPO" unit="sec">
+<DESCRIPTION>Effective exposure time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_m" name="IUE:m" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Abnormality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CEB" name="IUE:CEB" datatype="char" width="3" ucd="META.CODE.CLASS" arraysize="3">
+<DESCRIPTION>Exposure quality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_S" name="IUE:S" datatype="char" width="1" ucd="META.FLAG;INSTR.TEL" arraysize="1">
+<DESCRIPTION>Station (V=Vilspa/G=Goddard)</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Comments" name="IUE:Comments" datatype="char" width="20" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Comments</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_F" name="IUE:F" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_bibcode" name="IUE:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_U_360" name="JP11:U_360" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.U" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 360 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_U" name="JP11:sp_U" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value U magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_U" name="JP11:nmes_U" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_B_450" name="JP11:B_450" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.B" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 450 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_B" name="JP11:sp_B" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value B magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_B" name="JP11:nmes_B" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_V_555" name="JP11:V_555" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 555 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_V" name="JP11:sp_V" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_V" name="JP11:nmes_V" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_R_670" name="JP11:R_670" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.R" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 670 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_R" name="JP11:sp_R" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value R magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_R" name="JP11:nmes_R" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_I_870" name="JP11:I_870" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.I" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 870 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_I" name="JP11:sp_I" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_I" name="JP11:nmes_I" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_J_1200" name="JP11:J_1200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.J" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 1200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_J" name="JP11:sp_J" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value J magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_J" name="JP11:nmes_J" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_K_2200" name="JP11:K_2200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.K" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 2200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_K" name="JP11:sp_K" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_K" name="JP11:nmes_K" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_L_3500" name="JP11:L_3500" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.3-4UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 3500 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_L" name="JP11:sp_L" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value L magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_L" name="JP11:nmes_L" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_M_5000" name="JP11:M_5000" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.4-8UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 5000 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_M" name="JP11:sp_M" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value M magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_M" name="JP11:nmes_M" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_N_9000" name="JP11:N_9000" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.8-15UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 9000 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_N" name="JP11:sp_N" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value N magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_N" name="JP11:nmes_N" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_H_16200" name="JP11:H_16200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.H" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 16200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_H" name="JP11:sp_H" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value H magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_H" name="JP11:nmes_H" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_bibcode" name="JP11:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_ds" name="MK:ds" datatype="char" width="2" ucd="META.ID;INSTR" arraysize="2">
+<DESCRIPTION>dispersive system</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_mss" name="MK:mss" datatype="char" width="3" ucd="META.NOTE" arraysize="3">
+<DESCRIPTION>mss notes</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_Spectral_type" name="MK:Spectral_type" datatype="char" width="36" ucd="SRC.SPTYPE" arraysize="*">
+<DESCRIPTION>MK/MSS spectral type</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_bibcode" name="MK:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_RVel" name="oRV:RVel" datatype="float" precision="7" width="1" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km/s">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Q" name="oRV:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Nmes" name="oRV:Nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Rem" name="oRV:Rem" datatype="char" width="7" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Orig" name="oRV:Orig" datatype="char" width="2" ucd="META.NOTE" arraysize="2">
+<DESCRIPTION>Origin of the radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Dis" name="oRV:Dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="a.mm-1">
+<DESCRIPTION>dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_bibcode" name="oRV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_plx" name="PLX:plx" datatype="float" precision="3" width="6" ucd="POS.PARALLAX.TRIG" unit="arcsec">
+<DESCRIPTION>Parallaxe</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_me" name="PLX:me" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>sigma{plx}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_R" name="PLX:R" datatype="char" width="2" ucd="META.ID;INSTR.OBSTY" arraysize="2">
+<DESCRIPTION>Observatory code</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_bibcode" name="PLX:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmra" name="PM:pmra" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.RA" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion R.A.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmra" name="PM:me_pmra" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="arcsec.yr-1">
+<DESCRIPTION>sigma{pm-ra}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmde" name="PM:pmde" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.DEC" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion DEC.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmde" name="PM:me_pmde" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="arcsec.yr-1">
+<DESCRIPTION>sigma{pm-de}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_system" name="PM:system" datatype="char" width="4" ucd="POS.FRAME" arraysize="4">
+<DESCRIPTION>coordinates system designation</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_bibcode" name="PM:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_RA" name="pos:RA" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_DEC" name="pos:DEC" datatype="char" width="13" ucd="POS.EQ.DEC;META.MAIN" arraysize="13" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_me_al" name="pos:me_al" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="sec">
+<DESCRIPTION>sigma{RA}</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_me_de" name="pos:me_de" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="sec">
+<DESCRIPTION>sigma{DEC}</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_equi" name="pos:equi" datatype="int" width="4" ucd="TIME.EQUINOX" unit="yr">
+<DESCRIPTION>Equinox</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_epoch" name="pos:epoch" datatype="float" precision="7" width="2" ucd="TIME.EPOCH" unit="yr">
+<DESCRIPTION>Epoch</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_bibcode" name="pos:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_RA" name="posa:RA" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_DEC" name="posa:DEC" datatype="char" width="13" ucd="POS.EQ.DEC;META.MAIN" arraysize="13" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_upMajAxis" name="posa:upMajAxis" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_MajAxis" name="posa:MajAxis" datatype="float" precision="3" width="8" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Major axis of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_upMinAxis" name="posa:upMinAxis" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_MinAxis" name="posa:MinAxis" datatype="float" precision="3" width="8" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Minor axis of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_PA" name="posa:PA" datatype="float" precision="1" width="5" ucd="POS.POSANG" unit="deg">
+<DESCRIPTION>Position angle of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_equi" name="posa:equi" datatype="int" width="4" ucd="TIME.EQUINOX" unit="yr">
+<DESCRIPTION>Equinox</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_epoch" name="posa:epoch" datatype="float" precision="7" width="2" ucd="TIME.EPOCH" unit="yr">
+<DESCRIPTION>Epoch</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_bibcode" name="posa:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_upVsini" name="ROT:upVsini" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Vsini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_Vsini" name="ROT:Vsini" datatype="float" precision="2" width="6" ucd="PHYS.VELOC.ROTAT" unit="km.s-1">
+<DESCRIPTION>V sini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_err" name="ROT:err" datatype="float" precision="2" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>error</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_mes" name="ROT:mes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_qual" name="ROT:qual" datatype="char" width="1" ucd="CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_bibcode" name="ROT:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_Rvel" name="RVel:Rvel" datatype="int" width="7" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km.sec-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_nmes" name="RVel:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_rem" name="RVel:rem" datatype="char" width="5" ucd="META.NOTE" arraysize="5">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_dis" name="RVel:dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="a.mm-1">
+<DESCRIPTION>Dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_bibcode" name="RVel:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_alpha" name="SAO:alpha" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_delta" name="SAO:delta" datatype="char" width="14" ucd="POS.EQ.DEC;META.MAIN" arraysize="14" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_coo" name="SAO:me_coo" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Mean error on position</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_pm_ra" name="SAO:pm_ra" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.RA" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion {mu}alpha*cos(delta)</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_pmra" name="SAO:me_pmra" datatype="int" width="3" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma on pm-ra</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_pm_de" name="SAO:pm_de" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.DEC" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion {mu}delta</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_pmde" name="SAO:me_pmde" datatype="int" width="3" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma on pm-de</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_bibcode" name="SAO:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m2740" name="TD1:m2740" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>magnitude at 274.0 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m2740" name="TD1:se_m2740" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m2740)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m2365" name="TD1:m2365" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>magnitude at 236.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m2365" name="TD1:se_m2365" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m2365)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m1965" name="TD1:m1965" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>magnitude at 196.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m1965" name="TD1:se_m1965" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1965)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m1565" name="TD1:m1565" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>magnitude at 156.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m1565" name="TD1:se_m1565" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1565)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_bibcode" name="TD1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_Ph_syst" name="UBV:Ph_syst" datatype="char" width="3" ucd="META.ID;PHOT" arraysize="3">
+<DESCRIPTION>Photometric system</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_V" name="UBV:V" datatype="float" precision="3" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_B_V" name="UBV:B_V" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>B-V color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_U_B" name="UBV:U_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.U;EM.OPT.B" unit="mag">
+<DESCRIPTION>U-B color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_qual" name="UBV:qual" datatype="char" width="5" ucd="META.CODE.QUAL" arraysize="5">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_remarks" name="UBV:remarks" datatype="char" width="11" ucd="META.NOTE" arraysize="*" unit="char">
+<DESCRIPTION>REMARKS</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_bibcode" name="UBV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_b_y" name="uvby:b_y" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>b-y color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_m1" name="uvby:m1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>m1 index (Balmer discontinuity)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_c1" name="uvby:c1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>c1 index (line blocking)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_flag" name="uvby:flag" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_nbmes" name="uvby:nbmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_bibcode" name="uvby:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_b_y" name="uvby1:b_y" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>b-y color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_b_y" name="uvby1:me_b_y" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(b-y)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_m1" name="uvby1:m1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>m1 index (Balmer discontinuity)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_m1" name="uvby1:me_m1" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_c1" name="uvby1:c1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>c1 index (line blocking)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_c1" name="uvby1:me_c1" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(c1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_flag" name="uvby1:flag" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_nbmes" name="uvby1:nbmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f1" name="uvby1:f1" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 1</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f2" name="uvby1:f2" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 2</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f3" name="uvby1:f3" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 3</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f4" name="uvby1:f4" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 4</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_bibcode" name="uvby1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__vartyp" name="V*:vartyp" datatype="char" width="6" ucd="META.CODE;SRC.VAR" arraysize="6">
+<DESCRIPTION>Type of variability</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__LoVmax" name="V*:LoVmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Upper limit flag for Vmax</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmax" name="V*:Vmax" datatype="float" precision="2" width="5" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Maximum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmax" name="V*:R_Vmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__magtyp" name="V*:magtyp" datatype="char" width="1" ucd="META.ID;PHOT" arraysize="1">
+<DESCRIPTION>Magnitude type</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpVmin" name="V*:UpVmin" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmin" name="V*:Vmin" datatype="float" precision="2" width="5" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Minimum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmin" name="V*:R_Vmin" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpPeriod" name="V*:UpPeriod" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for the period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__period" name="V*:period" datatype="double" precision="4" width="10" ucd="TIME.PERIOD" unit="day">
+<DESCRIPTION>Period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_period" name="V*:R_period" datatype="char" width="2" ucd="META.CODE.ERROR" arraysize="2">
+<DESCRIPTION>Uncertainty flag on period (:)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__epoch" name="V*:epoch" datatype="double" precision="4" width="13" ucd="TIME.EPOCH" unit="day">
+<DESCRIPTION>Epoch of maximum or minimum</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_epoch" name="V*:R_epoch" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty on epoch (:)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__D_rt" name="V*:D_rt" datatype="float" precision="1" width="4" ucd="TIME.INTERVAL">
+<DESCRIPTION>Raising time for all other variable types</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_D_rt" name="V*:R_D_rt" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag on raising time</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__bibcode" name="V*:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="XMM_Obsno" name="XMM:Obsno" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_redshift" name="Z:redshift" datatype="double" precision="5" width="8" ucd="SRC.REDSHIFT">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_R" name="Z:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>colon is uncertain question mark is questionable</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_bibcode" name="Z:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_redshift" name="ze:redshift" datatype="double" precision="6" width="9" ucd="SRC.REDSHIFT">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_R" name="ze:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>colon is uncertain question mark is questionable</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_me" name="ze:me" datatype="double" precision="6" width="8" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_bibcode" name="ze:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="OID4" name="OID4" datatype="char" width="10" ucd="meta.record;meta.id" arraysize="*">
+<DESCRIPTION>Object internal identifier</DESCRIPTION>
+</FIELD>
+<DATA>
+<TABLEDATA>
+<TR><TD>2SLAQ J000008.13+001634.6</TD><TD></TD><TD>2SLAQ J000008.13+001634.6</TD><TD>QSO</TD><TD>000.033900</TD><TD>+00.276303</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>233509</TD><TD>1.8365</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>B</TD><TD>20.35</TD><TD></TD><TD>2010A&amp;A...518A..10V</TD><TD></TD><TD></TD><TD>D</TD><TD>B</TD><TD>V</TD><TD>20.03</TD><TD></TD><TD>2010A&amp;A...518A..10V</TD><TD></TD><TD></TD><TD>D</TD><TD>V</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>J</TD><TD>19.399</TD><TD>0.073</TD><TD>2013ApJS..206....4K</TD><TD></TD><TD></TD><TD>C</TD><TD>J</TD><TD>H</TD><TD>19.416</TD><TD>0.137</TD><TD>2013ApJS..206....4K</TD><TD></TD><TD></TD><TD>D</TD><TD>H</TD><TD>K</TD><TD>19.176</TD><TD>0.115</TD><TD>2013ApJS..206....4K</TD><TD></TD><TD></TD><TD>D</TD><TD>K</TD><TD>u</TD><TD>20.233</TD><TD>0.054</TD><TD>2007AJ....134..102S</TD><TD></TD><TD></TD><TD>C</TD><TD>u</TD><TD>g</TD><TD>20.201</TD><TD>0.021</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>g</TD><TD>r</TD><TD>19.929</TD><TD>0.021</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>r</TD><TD>i</TD><TD>19.472</TD><TD>0.023</TD><TD>2009yCat.2294....0A</TD><TD></TD><TD></TD><TD>C</TD><TD>i</TD><TD>z</TD><TD>19.191</TD><TD>0.068</TD><TD>2007AJ....134..102S</TD><TD></TD><TD></TD><TD>C</TD><TD>z</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>@4107456</TD></TR>
+
+</TABLEDATA>
+
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>

--- a/bundle/edu.gemini.catalog/src/test/resources/simbad-vega.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/simbad-vega.xml
@@ -1,0 +1,1336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<DEFINITIONS>
+<COOSYS ID="COOSYS" equinox="2000" epoch="J2000" system="ICRS"/>
+</DEFINITIONS>
+<RESOURCE name="Simbad query" type="results">
+<TABLE ID="simbad" name="simbad query"><DESCRIPTION>... query string ...</DESCRIPTION>
+<FIELD ID="TYPED_ID" name="TYPED_ID" datatype="char" width="25" ucd="meta.id" arraysize="*">
+<DESCRIPTION>Raw identifier as typed in the query</DESCRIPTION>
+</FIELD>
+<FIELD ID="ANG_DIST" name="ANG_DIST" datatype="float" precision="4" width="8" ucd="pos.posAng" unit="arcsec">
+<DESCRIPTION>Angular distance from the center</DESCRIPTION>
+</FIELD>
+<FIELD ID="MAIN_ID" name="MAIN_ID" datatype="char" width="22" ucd="meta.id;meta.main" arraysize="*">
+<DESCRIPTION>Main identifier for an object</DESCRIPTION>
+<LINK value="${MAIN_ID}" href="http://simbad.u-strasbg.fr/simbad/sim-id?Ident=${MAIN_ID}&amp;NbIdent=1"/>
+</FIELD>
+<FIELD ID="OTYPE_S" name="OTYPE_S" datatype="char" width="6" ucd="src.class" arraysize="*">
+<DESCRIPTION>Object type</DESCRIPTION>
+<LINK href="http://simbad.u-strasbg.fr/simbad/sim-display?data=otypes"/>
+</FIELD>
+<FIELD ID="RA_d" name="RA_d" datatype="double" precision="8" width="11" ucd="pos.eq.ra;meta.main" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="DEC_d" name="DEC_d" datatype="double" precision="8" width="12" ucd="pos.eq.dec;meta.main" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MAJA_d" name="COO_ERR_MAJA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_MINA_d" name="COO_ERR_MINA_d" datatype="float" precision="3" width="6" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.eq" unit="mas">
+<DESCRIPTION>Coordinate error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="COO_ERR_ANGLE_d" name="COO_ERR_ANGLE_d" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.eq" unit="deg">
+<DESCRIPTION>Coordinate error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMRA" name="PMRA" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.ra" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in RA</DESCRIPTION>
+</FIELD>
+<FIELD ID="PMDEC" name="PMDEC" datatype="double" precision="3" width="9" ucd="pos.pm;pos.eq.dec" unit="mas.yr-1">
+<DESCRIPTION>Proper motion in DEC</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MAJA" name="PM_ERR_MAJA" datatype="float" precision="3" width="5" ucd="phys.angSize.smajAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_MINA" name="PM_ERR_MINA" datatype="float" precision="3" width="5" ucd="phys.angSize.sminAxis;pos.errorEllipse;pos.pm" unit="mas.yr-1">
+<DESCRIPTION>Proper motion error minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_ERR_ANGLE" name="PM_ERR_ANGLE" datatype="short" width="3" ucd="pos.posAng;pos.errorEllipse;pos.pm" unit="deg">
+<DESCRIPTION>Proper motion error angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_VALUE" name="PLX_VALUE" datatype="double" precision="3" width="9" ucd="pos.parallax.trig" unit="mas">
+<DESCRIPTION>Parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="RV_VALUE" name="RV_VALUE" datatype="double" precision="3" ucd="spect.dopplerVeloc.opt" unit="km.s-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_VALUE" name="Z_VALUE" datatype="double" precision="7" ucd="src.redshift">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MAJAXIS" name="GALDIM_MAJAXIS" datatype="float" width="4" ucd="phys.angSize.smajAxis" unit="arcmin">
+<DESCRIPTION>Angular size major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_MINAXIS" name="GALDIM_MINAXIS" datatype="float" width="4" ucd="phys.angSize.sminAxis" unit="arcmin">
+<DESCRIPTION>Angular size minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_ANGLE" name="GALDIM_ANGLE" datatype="short" width="3" ucd="pos.posAng" unit="deg">
+<DESCRIPTION>Galaxy ellipse angle</DESCRIPTION>
+</FIELD>
+<FIELD ID="GALDIM_INCL" name="GALDIM_INCL" datatype="short" width="1" ucd="src.orbital.inclination">
+<DESCRIPTION>Galaxy inclinaison code (0-7)</DESCRIPTION>
+</FIELD>
+<FIELD ID="SP_TYPE" name="SP_TYPE" datatype="char" width="6" ucd="src.spType" arraysize="*">
+<DESCRIPTION>MK spectral type</DESCRIPTION>
+</FIELD>
+<FIELD ID="MORPH_TYPE" name="MORPH_TYPE" datatype="char" width="20" ucd="src.morph.type" arraysize="*">
+<DESCRIPTION>Morphological type</DESCRIPTION>
+</FIELD>
+<FIELD ID="NB_REF" name="NB_REF" datatype="int" width="4" ucd="meta.bib;meta.number">
+<DESCRIPTION>number of references</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_U" name="FILTER_NAME_U" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_U" name="FLUX_U" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude U</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_U" name="FLUX_ERROR_U" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_U" name="FLUX_BIBCODE_U" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_U" name="FLUX_VAR_U" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_U" name="FLUX_MULT_U" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_U" name="FLUX_QUAL_U" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_U" name="FLUX_UNIT_U" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_B" name="FILTER_NAME_B" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_B" name="FLUX_B" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude B</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_B" name="FLUX_ERROR_B" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_B" name="FLUX_BIBCODE_B" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_B" name="FLUX_VAR_B" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_B" name="FLUX_MULT_B" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_B" name="FLUX_QUAL_B" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_B" name="FLUX_UNIT_B" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_V" name="FILTER_NAME_V" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_V" name="FLUX_V" datatype="float" ucd="phot.mag;em.opt.V" unit="mag">
+<DESCRIPTION>Magnitude V</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_V" name="FLUX_ERROR_V" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_V" name="FLUX_BIBCODE_V" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_V" name="FLUX_VAR_V" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_V" name="FLUX_MULT_V" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_V" name="FLUX_QUAL_V" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_V" name="FLUX_UNIT_V" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_R" name="FILTER_NAME_R" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_R" name="FLUX_R" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude R</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_R" name="FLUX_ERROR_R" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_R" name="FLUX_BIBCODE_R" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_R" name="FLUX_VAR_R" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_R" name="FLUX_MULT_R" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_R" name="FLUX_QUAL_R" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_R" name="FLUX_UNIT_R" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_I" name="FILTER_NAME_I" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_I" name="FLUX_I" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude I</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_I" name="FLUX_ERROR_I" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_I" name="FLUX_BIBCODE_I" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_I" name="FLUX_VAR_I" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_I" name="FLUX_MULT_I" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_I" name="FLUX_QUAL_I" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_I" name="FLUX_UNIT_I" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_J" name="FILTER_NAME_J" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_J" name="FLUX_J" datatype="float" ucd="phot.mag;em.IR.J" unit="mag">
+<DESCRIPTION>Magnitude J</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_J" name="FLUX_ERROR_J" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_J" name="FLUX_BIBCODE_J" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_J" name="FLUX_VAR_J" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_J" name="FLUX_MULT_J" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_J" name="FLUX_QUAL_J" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_J" name="FLUX_UNIT_J" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_H" name="FILTER_NAME_H" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_H" name="FLUX_H" datatype="float" ucd="phot.mag;em.IR.H" unit="mag">
+<DESCRIPTION>Magnitude H</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_H" name="FLUX_ERROR_H" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_H" name="FLUX_BIBCODE_H" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_H" name="FLUX_VAR_H" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_H" name="FLUX_MULT_H" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_H" name="FLUX_QUAL_H" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_H" name="FLUX_UNIT_H" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_K" name="FILTER_NAME_K" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_K" name="FLUX_K" datatype="float" ucd="phot.mag;em.IR.K" unit="mag">
+<DESCRIPTION>Magnitude K</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_K" name="FLUX_ERROR_K" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_K" name="FLUX_BIBCODE_K" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_K" name="FLUX_VAR_K" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_K" name="FLUX_MULT_K" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_K" name="FLUX_QUAL_K" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_K" name="FLUX_UNIT_K" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_u" name="FILTER_NAME_u" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_u" name="FLUX_u" datatype="float" ucd="phot.mag;em.opt.U" unit="mag">
+<DESCRIPTION>Magnitude SDSS u</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_u" name="FLUX_ERROR_u" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_u" name="FLUX_BIBCODE_u" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_u" name="FLUX_VAR_u" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_u" name="FLUX_MULT_u" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_u" name="FLUX_QUAL_u" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_u" name="FLUX_UNIT_u" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_g" name="FILTER_NAME_g" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_g" name="FLUX_g" datatype="float" ucd="phot.mag;em.opt.B" unit="mag">
+<DESCRIPTION>Magnitude SDSS g</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_g" name="FLUX_ERROR_g" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_g" name="FLUX_BIBCODE_g" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_g" name="FLUX_VAR_g" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_g" name="FLUX_MULT_g" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_g" name="FLUX_QUAL_g" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_g" name="FLUX_UNIT_g" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_r" name="FILTER_NAME_r" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_r" name="FLUX_r" datatype="float" ucd="phot.mag;em.opt.R" unit="mag">
+<DESCRIPTION>Magnitude SDSS r</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_r" name="FLUX_ERROR_r" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_r" name="FLUX_BIBCODE_r" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_r" name="FLUX_VAR_r" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_r" name="FLUX_MULT_r" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_r" name="FLUX_QUAL_r" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_r" name="FLUX_UNIT_r" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_i" name="FILTER_NAME_i" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_i" name="FLUX_i" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS i</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_i" name="FLUX_ERROR_i" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_i" name="FLUX_BIBCODE_i" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_i" name="FLUX_VAR_i" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_i" name="FLUX_MULT_i" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_i" name="FLUX_QUAL_i" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_i" name="FLUX_UNIT_i" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="FILTER_NAME_z" name="FILTER_NAME_z" datatype="char" width="8" ucd="instr.filter" arraysize="*">
+<DESCRIPTION>flux filter name</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_z" name="FLUX_z" datatype="float" ucd="phot.mag;em.opt.I" unit="mag">
+<DESCRIPTION>Magnitude SDSS z</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_ERROR_z" name="FLUX_ERROR_z" datatype="float" precision="3" ucd="stat.error;phot.mag">
+<DESCRIPTION>flux error</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_BIBCODE_z" name="FLUX_BIBCODE_z" datatype="char" width="19" ucd="meta.bib.bibcode;phot.flux" arraysize="*">
+<DESCRIPTION>flux reference</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_VAR_z" name="FLUX_VAR_z" datatype="char" width="1" ucd="meta.code;src.var;phot.flux">
+<DESCRIPTION>flux variability flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_MULT_z" name="FLUX_MULT_z" datatype="char" width="1" ucd="meta.code.multip;phot.flux" arraysize="*">
+<DESCRIPTION>flux multiplicity flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_QUAL_z" name="FLUX_QUAL_z" datatype="char" width="1" ucd="meta.code.qual;phot.flux">
+<DESCRIPTION>flux quality flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="FLUX_UNIT_z" name="FLUX_UNIT_z" datatype="char" width="3" ucd="meta.unit;phot.flux">
+<DESCRIPTION>flux unit</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U1" name="CEL:U1" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>Magn U1 (210-320nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU1" name="CEL:meU1" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U2" name="CEL:U2" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV" unit="mag">
+<DESCRIPTION>Magn U2 (155-320nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU2" name="CEL:meU2" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U2)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U3" name="CEL:U3" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV" unit="mag">
+<DESCRIPTION>Magn U3 (135-315nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU3" name="CEL:meU3" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U3)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_U4" name="CEL:U4" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>Magn U4 (105-215nm)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_meU4" name="CEL:meU4" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>sigma(U4)</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_pec" name="CEL:pec" datatype="char" width="13" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>peculiarities</DESCRIPTION>
+</FIELD>
+<FIELD ID="CEL_bibcode" name="CEL:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_D" name="Cl.G:D" datatype="int" width="1" ucd="SRC.CLASS.DISTANCE">
+<DESCRIPTION>Distance class</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_R" name="Cl.G:R" datatype="int" width="1" ucd="SRC.CLASS.RICHNESS">
+<DESCRIPTION>Richness class</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_Nga" name="Cl.G:Nga" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>number of cluster members between m3 and m3+2</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pNga" name="Cl.G:pNga" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_Acl" name="Cl.G:Acl" datatype="char" width="3" ucd="SRC.CLASS.STRUCT" arraysize="3">
+<DESCRIPTION>Cluster classification in Abell s system</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_BMclass" name="Cl.G:BMclass" datatype="char" width="6" ucd="SRC.CLASS.STRUCT" arraysize="6">
+<DESCRIPTION>Cluster classification in the Bautz-Morgan system</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pBMclass" name="Cl.G:pBMclass" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>BMclass flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m1" name="Cl.G:m1" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the fist-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm1" name="Cl.G:pm1" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m1 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m3" name="Cl.G:m3" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the third-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm3" name="Cl.G:pm3" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m3 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m10" name="Cl.G:m10" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the tenth-ranked cluster member</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm10" name="Cl.G:pm10" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m10 flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_m10a" name="Cl.G:m10a" datatype="float" precision="1" width="4" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Weighted mean total V mag. estimate for the tenth-ranked cluster member (xxx)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_pm10a" name="Cl.G:pm10a" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>m10a flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="Cl.G_bibcode" name="Cl.G:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_diameter" name="diameter:diameter" datatype="double" precision="2" width="8" ucd="PHYS.ANGSIZE">
+<DESCRIPTION>Diameter value</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_Q" name="diameter:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_unit" name="diameter:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (mas/km)</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_error" name="diameter:error" datatype="double" precision="2" width="8" ucd="STAT.ERROR">
+<DESCRIPTION>Error</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_filter" name="diameter:filter" datatype="char" width="8" ucd="INSTR.FILTER" arraysize="8">
+<DESCRIPTION>filter or wavelength</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_method" name="diameter:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="diameter_bibcode" name="diameter:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_distance" name="distance:distance" datatype="double" precision="3" width="9" ucd="POS.DISTANCE">
+<DESCRIPTION>Distance value</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_Q" name="distance:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_unit" name="distance:unit" datatype="char" width="4" ucd="META.UNIT" arraysize="4">
+<DESCRIPTION>Unit (pc,kpc or Mpc)</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_merr" name="distance:merr" datatype="double" precision="3" width="7" ucd="STAT.ERROR">
+<DESCRIPTION>minus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_perr" name="distance:perr" datatype="double" precision="3" width="7" ucd="STAT.ERROR">
+<DESCRIPTION>plus error</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_method" name="distance:method" datatype="char" width="8" ucd="INSTR.SETUP" arraysize="8">
+<DESCRIPTION>distance calculation method</DESCRIPTION>
+</FIELD>
+<FIELD ID="distance_bibcode" name="distance:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_RA" name="Einstein:RA" datatype="char" width="10" ucd="POS.EQ.RA;META.MAIN" arraysize="10" unit="h:m:s">
+<DESCRIPTION>Right Ascension B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_DEC" name="Einstein:DEC" datatype="char" width="9" ucd="POS.EQ.DEC;META.MAIN" arraysize="9" unit="d:m:s">
+<DESCRIPTION>Declination B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Err_coo" name="Einstein:Err_coo" datatype="int" width="4" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Error on position</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Count" name="Einstein:Count" datatype="double" precision="5" width="9" ucd="PHOT.COUNT;EM.X-RAY" unit="ct/s">
+<DESCRIPTION>Count rate in the total Einstein energy band (0.16 to 3.5 keV)</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Err_count" name="Einstein:Err_count" datatype="double" precision="5" width="7" ucd="STAT.ERROR" unit="ct/s">
+<DESCRIPTION>error on count rate</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_Hard" name="Einstein:Hard" datatype="float" precision="3" width="6" ucd="PHOT.FLUX;ARITH.RATIO">
+<DESCRIPTION>Hardness ratio</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_HardErrPlus" name="Einstein:HardErrPlus" datatype="float" precision="3" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>+Hardness ratio error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_HardErrMinus" name="Einstein:HardErrMinus" datatype="float" precision="3" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>-Hardness ratio error</DESCRIPTION>
+</FIELD>
+<FIELD ID="Einstein_bibcode" name="Einstein:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Teff" name="Fe_H:Teff" datatype="int" width="5" ucd="PHYS.TEMPERATURE.EFFECTIVE" unit="unit-degK">
+<DESCRIPTION>Effective Temperature</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_log_g" name="Fe_H:log_g" datatype="float" precision="1" width="5" ucd="PHYS.GRAVITY" unit="cm/s**2">
+<DESCRIPTION>Decimal logarithm of the surface gravity</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_Fe_H" name="Fe_H:Fe_H" datatype="float" precision="2" width="5" ucd="PHYS.ABUND.FE">
+<DESCRIPTION>Metallicity index relative to the Sun</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_flag" name="Fe_H:flag" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Flag on the [Fe/H] value</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CompStar" name="Fe_H:CompStar" datatype="char" width="9" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Designates the comparison star from which the [Fe/H] value was obtained</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_CatNo" name="Fe_H:CatNo" datatype="char" width="5" ucd="META.ID;META.MAIN" arraysize="5">
+<DESCRIPTION>Star in the Cayrel et al. (1997A&amp;AS..124..299C) compilation</DESCRIPTION>
+</FIELD>
+<FIELD ID="Fe_H_bibcode" name="Fe_H:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_radvel" name="GCRV:radvel" datatype="float" precision="2" width="8" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km.s-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_Q" name="GCRV:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_nmes" name="GCRV:nmes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_rem" name="GCRV:rem" datatype="char" width="5" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_Rf" name="GCRV:Rf" datatype="char" width="2" ucd="META.ID;INSTR.OBSTY" arraysize="2">
+<DESCRIPTION>Observatory code</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_dis" name="GCRV:dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="A.mm-1">
+<DESCRIPTION>Dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="GCRV_bibcode" name="GCRV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_U_B" name="GEN:U_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.U;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index U-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_V_B" name="GEN:V_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index V-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_B1_B" name="GEN:B1_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index B1-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_B2_B" name="GEN:B2_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index B2-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_V1_B" name="GEN:V1_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index V1-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_G_B" name="GEN:G_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.V;EM.OPT.B" unit="mag">
+<DESCRIPTION>color index G-B</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Wt_colind" name="GEN:Wt_colind" datatype="int" width="3" ucd="STAT.WEIGHT">
+<DESCRIPTION>weight on color indices</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_me_colind" name="GEN:me_colind" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>m.e. sigma on color indices</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Vmag" name="GEN:Vmag" datatype="float" precision="3" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Wt_Vmag" name="GEN:Wt_Vmag" datatype="int" width="3" ucd="STAT.WEIGHT">
+<DESCRIPTION>weight on V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_me_Vmag" name="GEN:me_Vmag" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>m.e. sigma on V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_Rem" name="GEN:Rem" datatype="char" width="5" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="GEN_bibcode" name="GEN:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_plx" name="GJ:plx" datatype="float" precision="3" width="6" ucd="POS.PARALLAX.TRIG" unit="unit-plx">
+<DESCRIPTION>resulting parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_pe_plx" name="GJ:pe_plx" datatype="int" width="3" ucd="STAT.ERROR" unit="unit-plx">
+<DESCRIPTION>probable error on parallax</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_Mabs" name="GJ:Mabs" datatype="float" precision="2" width="5" ucd="PHYS.MAGABS" unit="mag">
+<DESCRIPTION>Absolute magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_P_Mabs" name="GJ:P_Mabs" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Flag indication that Mabs=Mpg</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_Q_Mabs" name="GJ:Q_Mabs" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality on Abs. magn (A:very good-&gt;F:very poor)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_U" name="GJ:U" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.X" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=0d l=0d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_V" name="GJ:V" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.Y" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=0d l=+90d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_W" name="GJ:W" datatype="int" width="4" ucd="PHYS.VELOC;POS.CARTESIAN.Z" unit="km/s">
+<DESCRIPTION>component of velocity directed to (b=+90d)</DESCRIPTION>
+</FIELD>
+<FIELD ID="GJ_bibcode" name="GJ:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_Hbet" name="Hbet:Hbet" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.LINE.HBETA" unit="mag">
+<DESCRIPTION>Hbeta index</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_R" name="Hbet:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Qualifier for measurement number</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_nmes" name="Hbet:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet_bibcode" name="Hbet:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_Hbet" name="Hbet1:Hbet" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.LINE.HBETA" unit="mag">
+<DESCRIPTION>Hbeta index</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_errHbet" name="Hbet1:errHbet" datatype="float" precision="2" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>Erreur sur Hbet</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_nmes" name="Hbet1:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r1" name="Hbet1:r1" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r2" name="Hbet1:r2" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r3" name="Hbet1:r3" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_r4" name="Hbet1:r4" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="Hbet1_bibcode" name="Hbet1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="*">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_ObsId" name="Herschel:ObsId" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_alpha" name="Herschel:alpha" datatype="char" width="11" ucd="POS.EQ.RA;META.MAIN" arraysize="11" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="Herschel_delta" name="Herschel:delta" datatype="char" width="11" ucd="POS.EQ.DEC;META.MAIN" arraysize="11" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_width" name="HGAM:width" datatype="float" precision="1" width="7" ucd="SPECT.LINE.EQWIDTH">
+<DESCRIPTION>equivalent width of H{gamma} line</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_mes" name="HGAM:mes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_Flag" name="HGAM:Flag" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Flag (E: emission  R: ???)</DESCRIPTION>
+</FIELD>
+<FIELD ID="HGAM_bibcode" name="HGAM:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_RA" name="IRAS:RA" datatype="char" width="10" ucd="POS.EQ.RA;META.MAIN" arraysize="10" unit="h:m:s">
+<DESCRIPTION>Right Ascension B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_DEC" name="IRAS:DEC" datatype="char" width="9" ucd="POS.EQ.DEC;META.MAIN" arraysize="9" unit="d:m:s">
+<DESCRIPTION>Declination B1950</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errmaj" name="IRAS:errmaj" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>major axis of error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errmin" name="IRAS:errmin" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>minor axis of error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_errangle" name="IRAS:errangle" datatype="int" width="3" ucd="POS.POSANG" unit="deg">
+<DESCRIPTION>position angle (east of north)</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f12" name="IRAS:f12" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.8-15UM" unit="Jy">
+<DESCRIPTION>flux density in 12mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q12" name="IRAS:Q12" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 12mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f25" name="IRAS:f25" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.15-30UM" unit="Jy">
+<DESCRIPTION>flux density in 25mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q25" name="IRAS:Q25" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 25mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f60" name="IRAS:f60" datatype="float" precision="7" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.30-60UM" unit="Jy">
+<DESCRIPTION>flux density in 60mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q60" name="IRAS:Q60" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 60mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_f100" name="IRAS:f100" datatype="float" precision="8" width="2" ucd="PHOT.FLUX.DENSITY;EM.IR.60-100UM" unit="Jy">
+<DESCRIPTION>flux density in 100mu-m filter</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_Q100" name="IRAS:Q100" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>quality of the 100mu-m flux density</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e12" name="IRAS:e12" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f12</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e25" name="IRAS:e25" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f25</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e60" name="IRAS:e60" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f60</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_e100" name="IRAS:e100" datatype="int" width="3" ucd="STAT.ERROR">
+<DESCRIPTION>percent relative flux density uncertainties for f100</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_conf" name="IRAS:conf" datatype="char" width="4" ucd="META.CODE" arraysize="4">
+<DESCRIPTION>confusion flags (c) for the four bands</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_v" name="IRAS:v" datatype="int" width="2" ucd="STAT.FIT.GOODNESS;SRC.VAR">
+<DESCRIPTION>percent likelihood of variability of the source in the far infra-red</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_ns" name="IRAS:ns" datatype="int" width="2" ucd="META.NUMBER">
+<DESCRIPTION>Number of significant low-resolution spectra</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_na" name="IRAS:na" datatype="int" width="2" ucd="META.NUMBER">
+<DESCRIPTION>Number of associated (optical) sources in the original catalog</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRAS_bibcode" name="IRAS:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Krem" name="IRC:Krem" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>K magnitude remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Kmag" name="IRC:Kmag" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.IR.K" unit="mag">
+<DESCRIPTION>K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_mes_K" name="IRC:mes_K" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of observations</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_me_K" name="IRC:me_K" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_chi2_K" name="IRC:chi2_K" datatype="float" precision="2" width="5" ucd="STAT.FIT.CHI2">
+<DESCRIPTION>{chi}2 on K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Irem" name="IRC:Irem" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>I magnitude remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_Imag" name="IRC:Imag" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.OPT.I" unit="mag">
+<DESCRIPTION>I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_mes_I" name="IRC:mes_I" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of observations</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_me_I" name="IRC:me_I" datatype="float" precision="2" width="4" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_chi2_I" name="IRC:chi2_I" datatype="float" precision="2" width="5" ucd="STAT.FIT.CHI2">
+<DESCRIPTION>{chi}2 on I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_bibcode" name="IRC:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IRC_R" name="IRC:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>Remark</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_TDT" name="ISO:TDT" datatype="char" width="8" ucd="META.ID;META.MAIN" arraysize="8">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_alpha" name="ISO:alpha" datatype="double" precision="4" width="8" ucd="POS.EQ.RA;META.MAIN" unit="deg">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="ISO_delta" name="ISO:delta" datatype="double" precision="4" width="8" ucd="POS.EQ.DEC;META.MAIN" unit="deg">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Homogenized_Name" name="IUE:Homogenized_Name" datatype="char" width="16" ucd="META.ID;META.MAIN" arraysize="*">
+<DESCRIPTION>Homogenized Name</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ComplID" name="IUE:ComplID" datatype="char" width="12" ucd="META.ID" arraysize="*">
+<DESCRIPTION>Complementary Identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_PROG" name="IUE:PROG" datatype="char" width="5" ucd="META.ID;OBS" arraysize="5">
+<DESCRIPTION>Observing Program Identification</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CL" name="IUE:CL" datatype="int" width="2" ucd="SRC.CLASS">
+<DESCRIPTION>IUE class code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_D" name="IUE:D" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Dispersion code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CAM" name="IUE:CAM" datatype="char" width="3" ucd="META.ID;INSTR" arraysize="3">
+<DESCRIPTION>Camera id</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_IMAGE" name="IUE:IMAGE" datatype="int" width="5" ucd="OBS.IMAGE">
+<DESCRIPTION>Image number</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_A" name="IUE:A" datatype="char" width="1" ucd="INSTR.FOV" arraysize="1">
+<DESCRIPTION>Aperture designation code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_FES" name="IUE:FES" datatype="int" width="5" ucd="PHOT.COUNT;EM.OPT">
+<DESCRIPTION>FES count</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_MD" name="IUE:MD" datatype="char" width="2" ucd="META.CODE" arraysize="2">
+<DESCRIPTION>FES mode</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ObsDate" name="IUE:ObsDate" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation date</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Time" name="IUE:Time" datatype="char" width="6" ucd="TIME.EPOCH" arraysize="6">
+<DESCRIPTION>Observation time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_ExpTim" name="IUE:ExpTim" datatype="int" width="6" ucd="TIME.EXPO" unit="sec">
+<DESCRIPTION>Effective exposure time</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_m" name="IUE:m" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Abnormality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_CEB" name="IUE:CEB" datatype="char" width="3" ucd="META.CODE.CLASS" arraysize="3">
+<DESCRIPTION>Exposure quality code</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_S" name="IUE:S" datatype="char" width="1" ucd="META.FLAG;INSTR.TEL" arraysize="1">
+<DESCRIPTION>Station (V=Vilspa/G=Goddard)</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_Comments" name="IUE:Comments" datatype="char" width="20" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Comments</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_F" name="IUE:F" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="IUE_bibcode" name="IUE:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_U_360" name="JP11:U_360" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.U" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 360 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_U" name="JP11:sp_U" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value U magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_U" name="JP11:nmes_U" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_B_450" name="JP11:B_450" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.B" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 450 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_B" name="JP11:sp_B" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value B magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_B" name="JP11:nmes_B" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_V_555" name="JP11:V_555" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 555 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_V" name="JP11:sp_V" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_V" name="JP11:nmes_V" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_R_670" name="JP11:R_670" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.R" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 670 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_R" name="JP11:sp_R" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value R magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_R" name="JP11:nmes_R" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_I_870" name="JP11:I_870" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.OPT.I" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 870 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_I" name="JP11:sp_I" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value I magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_I" name="JP11:nmes_I" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_J_1200" name="JP11:J_1200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.J" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 1200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_J" name="JP11:sp_J" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value J magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_J" name="JP11:nmes_J" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_K_2200" name="JP11:K_2200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.K" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 2200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_K" name="JP11:sp_K" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value K magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_K" name="JP11:nmes_K" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_L_3500" name="JP11:L_3500" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.3-4UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 3500 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_L" name="JP11:sp_L" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value L magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_L" name="JP11:nmes_L" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_M_5000" name="JP11:M_5000" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.4-8UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 5000 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_M" name="JP11:sp_M" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value M magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_M" name="JP11:nmes_M" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_N_9000" name="JP11:N_9000" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.8-15UM" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 9000 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_N" name="JP11:sp_N" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value N magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_N" name="JP11:nmes_N" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_H_16200" name="JP11:H_16200" datatype="float" precision="2" width="6" ucd="PHOT.MAG;EM.IR.H" unit="mag">
+<DESCRIPTION>magnitude at {lambda}eff = 16200 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_sp_H" name="JP11:sp_H" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>special value H magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_nmes_H" name="JP11:nmes_H" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="JP11_bibcode" name="JP11:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_ds" name="MK:ds" datatype="char" width="2" ucd="META.ID;INSTR" arraysize="2">
+<DESCRIPTION>dispersive system</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_mss" name="MK:mss" datatype="char" width="3" ucd="META.NOTE" arraysize="3">
+<DESCRIPTION>mss notes</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_Spectral_type" name="MK:Spectral_type" datatype="char" width="36" ucd="SRC.SPTYPE" arraysize="*">
+<DESCRIPTION>MK/MSS spectral type</DESCRIPTION>
+</FIELD>
+<FIELD ID="MK_bibcode" name="MK:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_RVel" name="oRV:RVel" datatype="float" precision="7" width="1" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km/s">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Q" name="oRV:Q" datatype="char" width="1" ucd="META.CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Nmes" name="oRV:Nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Rem" name="oRV:Rem" datatype="char" width="7" ucd="META.NOTE" arraysize="*">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Orig" name="oRV:Orig" datatype="char" width="2" ucd="META.NOTE" arraysize="2">
+<DESCRIPTION>Origin of the radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_Dis" name="oRV:Dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="a.mm-1">
+<DESCRIPTION>dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="oRV_bibcode" name="oRV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_plx" name="PLX:plx" datatype="float" precision="3" width="6" ucd="POS.PARALLAX.TRIG" unit="arcsec">
+<DESCRIPTION>Parallaxe</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_me" name="PLX:me" datatype="int" width="3" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>sigma{plx}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_R" name="PLX:R" datatype="char" width="2" ucd="META.ID;INSTR.OBSTY" arraysize="2">
+<DESCRIPTION>Observatory code</DESCRIPTION>
+</FIELD>
+<FIELD ID="PLX_bibcode" name="PLX:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmra" name="PM:pmra" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.RA" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion R.A.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmra" name="PM:me_pmra" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="arcsec.yr-1">
+<DESCRIPTION>sigma{pm-ra}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_pmde" name="PM:pmde" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.DEC" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion DEC.</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_me_pmde" name="PM:me_pmde" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="arcsec.yr-1">
+<DESCRIPTION>sigma{pm-de}</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_system" name="PM:system" datatype="char" width="4" ucd="POS.FRAME" arraysize="4">
+<DESCRIPTION>coordinates system designation</DESCRIPTION>
+</FIELD>
+<FIELD ID="PM_bibcode" name="PM:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_RA" name="pos:RA" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_DEC" name="pos:DEC" datatype="char" width="13" ucd="POS.EQ.DEC;META.MAIN" arraysize="13" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_me_al" name="pos:me_al" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="sec">
+<DESCRIPTION>sigma{RA}</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_me_de" name="pos:me_de" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="sec">
+<DESCRIPTION>sigma{DEC}</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_equi" name="pos:equi" datatype="int" width="4" ucd="TIME.EQUINOX" unit="yr">
+<DESCRIPTION>Equinox</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_epoch" name="pos:epoch" datatype="float" precision="7" width="2" ucd="TIME.EPOCH" unit="yr">
+<DESCRIPTION>Epoch</DESCRIPTION>
+</FIELD>
+<FIELD ID="pos_bibcode" name="pos:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_RA" name="posa:RA" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_DEC" name="posa:DEC" datatype="char" width="13" ucd="POS.EQ.DEC;META.MAIN" arraysize="13" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_upMajAxis" name="posa:upMajAxis" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Major axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_MajAxis" name="posa:MajAxis" datatype="float" precision="3" width="8" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Major axis of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_upMinAxis" name="posa:upMinAxis" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Minor axis</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_MinAxis" name="posa:MinAxis" datatype="float" precision="3" width="8" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Minor axis of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_PA" name="posa:PA" datatype="float" precision="1" width="5" ucd="POS.POSANG" unit="deg">
+<DESCRIPTION>Position angle of the error ellipse</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_equi" name="posa:equi" datatype="int" width="4" ucd="TIME.EQUINOX" unit="yr">
+<DESCRIPTION>Equinox</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_epoch" name="posa:epoch" datatype="float" precision="7" width="2" ucd="TIME.EPOCH" unit="yr">
+<DESCRIPTION>Epoch</DESCRIPTION>
+</FIELD>
+<FIELD ID="posa_bibcode" name="posa:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_upVsini" name="ROT:upVsini" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Upper value of Vsini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_Vsini" name="ROT:Vsini" datatype="float" precision="2" width="6" ucd="PHYS.VELOC.ROTAT" unit="km.s-1">
+<DESCRIPTION>V sini</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_err" name="ROT:err" datatype="float" precision="2" width="5" ucd="STAT.ERROR">
+<DESCRIPTION>error</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_mes" name="ROT:mes" datatype="int" width="3" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_qual" name="ROT:qual" datatype="char" width="1" ucd="CODE.QUAL" arraysize="1">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="ROT_bibcode" name="ROT:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_Rvel" name="RVel:Rvel" datatype="int" width="7" ucd="PHYS.VELOC;POS.HELIOCENTRIC" unit="km.sec-1">
+<DESCRIPTION>Radial velocity</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_nmes" name="RVel:nmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_rem" name="RVel:rem" datatype="char" width="5" ucd="META.NOTE" arraysize="5">
+<DESCRIPTION>Remarks</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_dis" name="RVel:dis" datatype="int" width="3" ucd="INSTR.DISPERSION" unit="a.mm-1">
+<DESCRIPTION>Dispersion</DESCRIPTION>
+</FIELD>
+<FIELD ID="RVel_bibcode" name="RVel:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_alpha" name="SAO:alpha" datatype="char" width="13" ucd="POS.EQ.RA;META.MAIN" arraysize="13" unit="h:m:s">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_delta" name="SAO:delta" datatype="char" width="14" ucd="POS.EQ.DEC;META.MAIN" arraysize="14" unit="d:m:s">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_coo" name="SAO:me_coo" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="arcsec">
+<DESCRIPTION>Mean error on position</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_pm_ra" name="SAO:pm_ra" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.RA" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion {mu}alpha*cos(delta)</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_pmra" name="SAO:me_pmra" datatype="int" width="3" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma on pm-ra</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_pm_de" name="SAO:pm_de" datatype="float" precision="3" width="7" ucd="POS.PM;POS.EQ.DEC" unit="arcsec.yr-1">
+<DESCRIPTION>Proper motion {mu}delta</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_me_pmde" name="SAO:me_pmde" datatype="int" width="3" ucd="STAT.ERROR" unit="mas.yr-1">
+<DESCRIPTION>sigma on pm-de</DESCRIPTION>
+</FIELD>
+<FIELD ID="SAO_bibcode" name="SAO:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m2740" name="TD1:m2740" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>magnitude at 274.0 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m2740" name="TD1:se_m2740" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m2740)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m2365" name="TD1:m2365" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.200-300NM" unit="mag">
+<DESCRIPTION>magnitude at 236.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m2365" name="TD1:se_m2365" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m2365)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m1965" name="TD1:m1965" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>magnitude at 196.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m1965" name="TD1:se_m1965" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1965)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_m1565" name="TD1:m1565" datatype="float" precision="2" width="5" ucd="PHOT.MAG;EM.UV.100-200NM" unit="mag">
+<DESCRIPTION>magnitude at 156.5 nm</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_se_m1565" name="TD1:se_m1565" datatype="float" precision="2" width="4" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1565)</DESCRIPTION>
+</FIELD>
+<FIELD ID="TD1_bibcode" name="TD1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_Ph_syst" name="UBV:Ph_syst" datatype="char" width="3" ucd="META.ID;PHOT" arraysize="3">
+<DESCRIPTION>Photometric system</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_V" name="UBV:V" datatype="float" precision="3" width="6" ucd="PHOT.MAG;EM.OPT.V" unit="mag">
+<DESCRIPTION>V magnitude</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_B_V" name="UBV:B_V" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>B-V color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_U_B" name="UBV:U_B" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.U;EM.OPT.B" unit="mag">
+<DESCRIPTION>U-B color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_qual" name="UBV:qual" datatype="char" width="5" ucd="META.CODE.QUAL" arraysize="5">
+<DESCRIPTION>Quality</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_remarks" name="UBV:remarks" datatype="char" width="11" ucd="META.NOTE" arraysize="*" unit="char">
+<DESCRIPTION>REMARKS</DESCRIPTION>
+</FIELD>
+<FIELD ID="UBV_bibcode" name="UBV:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_b_y" name="uvby:b_y" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>b-y color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_m1" name="uvby:m1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>m1 index (Balmer discontinuity)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_c1" name="uvby:c1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>c1 index (line blocking)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_flag" name="uvby:flag" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_nbmes" name="uvby:nbmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby_bibcode" name="uvby:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_b_y" name="uvby1:b_y" datatype="float" precision="3" width="6" ucd="PHOT.COLOR;EM.OPT.B;EM.OPT.V" unit="mag">
+<DESCRIPTION>b-y color index</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_b_y" name="uvby1:me_b_y" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(b-y)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_m1" name="uvby1:m1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>m1 index (Balmer discontinuity)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_m1" name="uvby1:me_m1" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(m1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_c1" name="uvby1:c1" datatype="float" precision="3" width="6" ucd="PHOT.COLOR" unit="mag">
+<DESCRIPTION>c1 index (line blocking)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_me_c1" name="uvby1:me_c1" datatype="float" precision="3" width="5" ucd="STAT.ERROR" unit="mag">
+<DESCRIPTION>{sigma}(c1)</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_flag" name="uvby1:flag" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_nbmes" name="uvby1:nbmes" datatype="int" width="4" ucd="META.NUMBER">
+<DESCRIPTION>Number of measurements</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f1" name="uvby1:f1" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 1</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f2" name="uvby1:f2" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 2</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f3" name="uvby1:f3" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 3</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_f4" name="uvby1:f4" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>flag 4</DESCRIPTION>
+</FIELD>
+<FIELD ID="uvby1_bibcode" name="uvby1:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__vartyp" name="V*:vartyp" datatype="char" width="6" ucd="META.CODE;SRC.VAR" arraysize="6">
+<DESCRIPTION>Type of variability</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__LoVmax" name="V*:LoVmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Upper limit flag for Vmax</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmax" name="V*:Vmax" datatype="float" precision="2" width="5" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Maximum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmax" name="V*:R_Vmax" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__magtyp" name="V*:magtyp" datatype="char" width="1" ucd="META.ID;PHOT" arraysize="1">
+<DESCRIPTION>Magnitude type</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpVmin" name="V*:UpVmin" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__Vmin" name="V*:Vmin" datatype="float" precision="2" width="5" ucd="PHOT.MAG" unit="mag">
+<DESCRIPTION>Minimum of brightness</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_Vmin" name="V*:R_Vmin" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag for Vmin</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__UpPeriod" name="V*:UpPeriod" datatype="char" width="1" ucd="META.CODE" arraysize="1">
+<DESCRIPTION>Lower limit flag for the period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__period" name="V*:period" datatype="double" precision="4" width="10" ucd="TIME.PERIOD" unit="day">
+<DESCRIPTION>Period</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_period" name="V*:R_period" datatype="char" width="2" ucd="META.CODE.ERROR" arraysize="2">
+<DESCRIPTION>Uncertainty flag on period (:)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__epoch" name="V*:epoch" datatype="double" precision="4" width="13" ucd="TIME.EPOCH" unit="day">
+<DESCRIPTION>Epoch of maximum or minimum</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_epoch" name="V*:R_epoch" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty on epoch (:)</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__D_rt" name="V*:D_rt" datatype="float" precision="1" width="4" ucd="TIME.INTERVAL">
+<DESCRIPTION>Raising time for all other variable types</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__R_D_rt" name="V*:R_D_rt" datatype="char" width="1" ucd="META.CODE.ERROR" arraysize="1">
+<DESCRIPTION>Uncertainty flag on raising time</DESCRIPTION>
+</FIELD>
+<FIELD ID="V__bibcode" name="V*:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="XMM_Obsno" name="XMM:Obsno" datatype="char" width="10" ucd="META.ID;META.MAIN" arraysize="10">
+<DESCRIPTION>Observation identifier</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_redshift" name="Z:redshift" datatype="double" precision="5" width="8" ucd="SRC.REDSHIFT">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_R" name="Z:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>colon is uncertain question mark is questionable</DESCRIPTION>
+</FIELD>
+<FIELD ID="Z_bibcode" name="Z:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_redshift" name="ze:redshift" datatype="double" precision="6" width="9" ucd="SRC.REDSHIFT">
+<DESCRIPTION>Redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_R" name="ze:R" datatype="char" width="1" ucd="META.NOTE" arraysize="1">
+<DESCRIPTION>colon is uncertain question mark is questionable</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_me" name="ze:me" datatype="double" precision="6" width="8" ucd="STAT.ERROR">
+<DESCRIPTION>{sigma} on redshift</DESCRIPTION>
+</FIELD>
+<FIELD ID="ze_bibcode" name="ze:bibcode" datatype="char" width="19" ucd="META.BIB.BIBCODE" arraysize="19">
+<DESCRIPTION>Bibcode</DESCRIPTION>
+</FIELD>
+<FIELD ID="OID4" name="OID4" datatype="char" width="10" ucd="meta.record;meta.id" arraysize="*">
+<DESCRIPTION>Object internal identifier</DESCRIPTION>
+</FIELD>
+<DATA>
+<TABLEDATA>
+<TR><TD>Vega</TD><TD></TD><TD>* alf Lyr</TD><TD>PulsV*delSct</TD><TD>279.23473479</TD><TD>+38.78368896</TD><TD>3.51</TD><TD>2.81</TD><TD>90</TD><TD>200.94</TD><TD>286.23</TD><TD>0.32</TD><TD>0.40</TD><TD>0</TD><TD>130.23</TD><TD>-20.60</TD><TD>-0.000069</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>A0Va</TD><TD></TD><TD></TD><TD>U</TD><TD>0.03</TD><TD></TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>U</TD><TD>B</TD><TD>0.03</TD><TD></TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>B</TD><TD>V</TD><TD>0.03</TD><TD></TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>V</TD><TD>R</TD><TD>0.07</TD><TD></TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>R</TD><TD>I</TD><TD>0.10</TD><TD></TD><TD>2002yCat.2237....0D</TD><TD></TD><TD></TD><TD>C</TD><TD>I</TD><TD>J</TD><TD>-0.18</TD><TD></TD><TD>2003yCat.2246....0C</TD><TD></TD><TD></TD><TD>C</TD><TD>J</TD><TD>H</TD><TD>-0.03</TD><TD></TD><TD>2003yCat.2246....0C</TD><TD></TD><TD></TD><TD>C</TD><TD>H</TD><TD>K</TD><TD>0.13</TD><TD></TD><TD>2003yCat.2246....0C</TD><TD></TD><TD></TD><TD>C</TD><TD>K</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>6.71</TD><TD>0.25</TD><TD>4.56</TD><TD>0.02</TD><TD>5.66</TD><TD>0.23</TD><TD></TD><TD></TD><TD>V</TD><TD>1973SAOSR.350....1D</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>1.80E+06</TD><TD></TD><TD>km</TD><TD></TD><TD></TD><TD></TD><TD>2007ApJ...660.1556R</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>9519</TD><TD>3.88</TD><TD>|</TD><TD></TD><TD>|SUN</TD><TD>|</TD><TD>|2003AJ....126.2048</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>1.505</TD><TD>0.959</TD><TD>0.900</TD><TD>1.510</TD><TD>1.662</TD><TD>2.168</TD><TD>10</TD><TD>0.010</TD><TD>0.060</TD><TD>8</TD><TD>0.027</TD><TD></TD><TD>1976A&amp;AS...26..275R</TD><TD>0.124</TD><TD>005</TD><TD>0.50</TD><TD></TD><TD>B</TD><TD>-17</TD><TD>-6</TD><TD>-8</TD><TD>1969VeARI..22....1G</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>2.903</TD><TD></TD><TD>9</TD><TD></TD><TD></TD><TD>V</TD><TD></TD><TD>1998A&amp;AS..129..431H</TD><TD>1342237138</TD><TD>18 36 56.34</TD><TD>+38 47 01.3</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>18 35 15.1</TD><TD>+38 44 16</TD><TD>25</TD><TD>5</TD><TD>72</TD><TD>41.56</TD><TD></TD><TD>11.02</TD><TD></TD><TD>9.51</TD><TD></TD><TD>7.76</TD><TD></TD><TD>4</TD><TD>5</TD><TD>8</TD><TD>9</TD><TD>----</TD><TD>24</TD><TD>3</TD><TD>8</TD><TD>1988NASAR1190....1B</TD><TD></TD><TD>-0.06</TD><TD>3</TD><TD>0.06</TD><TD>1.03</TD><TD>*</TD><TD>-4.99</TD><TD>1</TD><TD>0.01</TD><TD>0.03</TD><TD>1969IRC...C......0N</TD><TD></TD><TD>50301801</TD><TD>279.3998</TD><TD>+38.9664</TD><TD>HD 172167</TD><TD></TD><TD>PHCAL</TD><TD>30</TD><TD>L</TD><TD>SWP</TD><TD>30549</TD><TD>L</TD><TD>15984</TD><TD>FU</TD><TD>870317</TD><TD>004700</TD><TD>000001</TD><TD>T</TD><TD>500</TD><TD>G</TD><TD>C=180,B=15</TD><TD>*</TD><TD>1996IUEML.C......0I</TD><TD>0.03</TD><TD></TD><TD></TD><TD>0.03</TD><TD></TD><TD></TD><TD>0.03</TD><TD></TD><TD></TD><TD>0.07</TD><TD></TD><TD></TD><TD>0.10</TD><TD></TD><TD></TD><TD>0.00</TD><TD></TD><TD></TD><TD>0.00</TD><TD></TD><TD></TD><TD>0.00</TD><TD></TD><TD></TD><TD>-0.01</TD><TD></TD><TD></TD><TD>-0.01</TD><TD></TD><TD></TD><TD>0.00</TD><TD></TD><TD></TD><TD>2002yCat.2237.....D</TD><TD></TD><TD></TD><TD>A0V</TD><TD>2009MNRAS.396.1895C</TD><TD>-13.9</TD><TD>A</TD><TD>308</TD><TD></TD><TD>##</TD><TD></TD><TD>1979IAUS...30...57E</TD><TD>0.130</TD><TD>000</TD><TD></TD><TD>2007A&amp;A...474..653V</TD><TD>+0.201</TD><TD>0.000</TD><TD>+0.286</TD><TD>0.000</TD><TD>ICRS</TD><TD>2007A&amp;A...474..653V</TD><TD>18 36 56.34 +</TD><TD>38 47  1.29</TD><TD>0.094</TD><TD>0.081</TD><TD>2000</TD><TD>1991.25</TD><TD>1997A&amp;A...323L..49P</TD><TD>18 36 56.186</TD><TD>+38 46 58.78</TD><TD></TD><TD>0.000</TD><TD></TD><TD>0.000</TD><TD>0</TD><TD>2000</TD><TD>1991.25</TD><TD>2007A&amp;A...474..653V</TD><TD></TD><TD>24</TD><TD></TD><TD>0</TD><TD>D</TD><TD>2007A&amp;A...463..671R</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>18 35 14.655</TD><TD>+38 44 09.68</TD><TD>0.03</TD><TD>+0.200</TD><TD>001</TD><TD>+0.285</TD><TD>001</TD><TD>1966SAO...C......0S</TD><TD>0.09</TD><TD>1.10</TD><TD>-0.10</TD><TD>1.14</TD><TD>-0.41</TD><TD>0.35</TD><TD>-0.56</TD><TD>0.33</TD><TD>1978TD1...C......0T</TD><TD>(E)</TD><TD>0.03</TD><TD>+0.00</TD><TD>-0.01</TD><TD>?  1</TD><TD>V</TD><TD>1986EgUBV........0M</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>0.003</TD><TD>0.003</TD><TD>0.157</TD><TD>0.003</TD><TD>1.088</TD><TD>0.004</TD><TD></TD><TD>41</TD><TD></TD><TD></TD><TD>V</TD><TD></TD><TD>1998A&amp;AS..129..431H</TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD></TD><TD>@2900336</TD></TR>
+
+</TABLEDATA>
+
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
@@ -1,5 +1,7 @@
 package edu.gemini.catalog.votable
 
+import java.net.URL
+
 import edu.gemini.catalog.api._
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
@@ -13,7 +15,7 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
   val coneSearch = Angle.fromDegrees(0.1)
 
   val xmlFile = "votable-ucac4.xml"
-  val targets = VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile"))
+  val targets = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile"))
   val unfiltered = CatalogQueryResult(targets | ParsedVoResource(Nil))
 
   val noMagnitudeConstraint = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(100), None)

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
@@ -1,12 +1,17 @@
 package edu.gemini.catalog.votable
 
+import java.net.URL
+
 import edu.gemini.catalog.api.CatalogQuery
 import scala.concurrent.future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scalaz.NonEmptyList
 
 // Backend for tests, reads votable xml files from the classpath
 case class TestVoTableBackend(file: String) extends VoTableBackend {
-  override def doQuery(query: CatalogQuery, url: String) = future {
+  override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
+
+  override def doQuery(query: CatalogQuery, url: URL) = future {
     VoTableParser.parse(url, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
   }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -48,7 +48,6 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
     }
     "make a query" in {
       // This test loads a file. There is not much to test but it exercises the query backend chain
-      println(Await.result(VoTableClient.catalog(query, TestVoTableBackend("/votable-ucac4.xml")), 5.seconds).result.problems)
       Await.result(VoTableClient.catalog(query, TestVoTableBackend("/votable-ucac4.xml")), 5.seconds).result.containsError should beFalse
     }
     "use the cache to skip queries" in {

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -37,7 +37,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
       RemoteBackend.queryParams(query) should beEqualTo(Array(new NameValuePair("CATALOG", "ucac4"), new NameValuePair("RA", "10.000"), new NameValuePair("DEC", "20.000"), new NameValuePair("SR", "0.100")))
     }
     "make a query to a bad site" in {
-      Await.result(doQuery(query, new URL("http://unknown site"), RemoteBackend), 1.seconds) should throwA[UnknownHostException]
+      Await.result(doQuery(query, new URL("http://unknown site"), RemoteBackend), 2.seconds) should throwA[UnknownHostException]
     }
     "be able to select the first successful of several futures" in {
       def f1 = Future { Thread.sleep(1000); throw new RuntimeException("oops") }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -112,9 +112,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
 
       val result = Await.result(VoTableClient.catalog(query, countingBackend), 10.seconds)
       // Extract the query params from the results
-      result.query.base should beEqualTo(coordinates)
-      result.query.radiusConstraint should beEqualTo(RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)))
-      result.query.magnitudeConstraints.head should beEqualTo(mc)
+      result.query should beEqualTo(query)
     }
 
   }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -557,5 +557,28 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       result.map(_.magnitudeIn(MagnitudeBand._i)) should beEqualTo(\/.right(Some(new Magnitude(16.902, MagnitudeBand._i, 0.005))))
       result.map(_.magnitudeIn(MagnitudeBand._z)) should beEqualTo(\/.right(Some(new Magnitude(17.015, MagnitudeBand._z, 0.011))))
     }
+    "parse simbad named queries with mixed magnitudes" in {
+      val xmlFile = "simbad-J000008.13.xml"
+      // The sample has only one row
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+
+      // id and coordinates
+      result.map(_.name) should beEqualTo(\/.right("2SLAQ J000008.13+001634.6"))
+      result.map(_.coordinates.ra) should beEqualTo(\/.right(RightAscension.fromAngle(Angle.fromHMS(0, 0, 8.136).getOrElse(Angle.zero))))
+      result.map(_.coordinates.dec) should beEqualTo(\/.right(Declination.fromAngle(Angle.fromDMS(0, 16, 34.6908).getOrElse(Angle.zero)).getOrElse(Declination.zero)))
+      // proper motions
+      result.map(_.properMotion) should beEqualTo(\/.right(None))
+      // magnitudes
+      result.map(_.magnitudeIn(MagnitudeBand.B)) should beEqualTo(\/.right(Some(new Magnitude(20.35, MagnitudeBand.B))))
+      result.map(_.magnitudeIn(MagnitudeBand.V)) should beEqualTo(\/.right(Some(new Magnitude(20.03, MagnitudeBand.V))))
+      result.map(_.magnitudeIn(MagnitudeBand.J)) should beEqualTo(\/.right(Some(new Magnitude(19.399, MagnitudeBand.J, 0.073))))
+      result.map(_.magnitudeIn(MagnitudeBand.H)) should beEqualTo(\/.right(Some(new Magnitude(19.416, MagnitudeBand.H, 0.137))))
+      result.map(_.magnitudeIn(MagnitudeBand.K)) should beEqualTo(\/.right(Some(new Magnitude(19.176, MagnitudeBand.K, 0.115))))
+      result.map(_.magnitudeIn(MagnitudeBand._u)) should beEqualTo(\/.right(Some(new Magnitude(20.233, MagnitudeBand._u, 0.054))))
+      result.map(_.magnitudeIn(MagnitudeBand._g)) should beEqualTo(\/.right(Some(new Magnitude(20.201, MagnitudeBand._g, 0.021))))
+      result.map(_.magnitudeIn(MagnitudeBand._r)) should beEqualTo(\/.right(Some(new Magnitude(19.929, MagnitudeBand._r, 0.021))))
+      result.map(_.magnitudeIn(MagnitudeBand._i)) should beEqualTo(\/.right(Some(new Magnitude(19.472, MagnitudeBand._i, 0.023))))
+      result.map(_.magnitudeIn(MagnitudeBand._z)) should beEqualTo(\/.right(Some(new Magnitude(19.191, MagnitudeBand._z, 0.068))))
+    }
   }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -1,5 +1,7 @@
 package edu.gemini.catalog.votable
 
+import java.net.URL
+
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.Target.SiderealTarget
 import org.specs2.mutable.SpecificationWithJUnit
@@ -391,11 +393,11 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to validate and parse an xml from sds9" in {
       val badXml = "votable-non-validating.xml"
-      VoTableParser.parse(badXml, getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(badXml)))
+      VoTableParser.parse(new URL(s"file:////$badXml"), getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(new URL(s"file:////$badXml"))))
     }
     "be able to detect unknown catalogs" in {
       val xmlFile = "votable-unknown.xml"
-      val result  = VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile"))
+      val result  = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile"))
       result.map { parsed =>
         parsed.containsError must beEqualTo(true)
         parsed.tables.map { table =>
@@ -407,17 +409,17 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to validate and parse an xml from ucac4" in {
       val xmlFile = "votable-ucac4.xml"
-      VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
-      VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
+      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
     }
     "be able to validate and parse an xml from ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
-      VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
-      VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
+      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
     }
     "be able to select r1mag over r2mag and b2mag when b1mag is absent in ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
-      val result = VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
 
       val magR = result >>= {_.magnitudeIn(MagnitudeBand.R)}
       magR.map(_.value) should beSome(18.149999999999999)
@@ -427,7 +429,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "be able to ignore bogus magnitudes on ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
       // Check a well-known target containing invalid magnitude values an bands H, I, K and J
-      val result = VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
       val magH = result >>= {_.magnitudeIn(MagnitudeBand.H)}
       val magI = result >>= {_.magnitudeIn(MagnitudeBand.I)}
       val magK = result >>= {_.magnitudeIn(MagnitudeBand.K)}
@@ -439,9 +441,9 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to filter out bad magnitudes" in {
       val xmlFile = "fmag.xml"
-      VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
       // The sample has only one row
-      val result = VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val mags = result.map(_.magnitudeIn(MagnitudeBand.R))
       // Does not contain R as it is filtered out being magnitude 20 and error 99
@@ -449,9 +451,9 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "convert fmag to UC" in {
       val xmlFile = "fmag.xml"
-      VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
       // The sample has only one row
-      val result = VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val mags = result.map(_.magnitudeIn(MagnitudeBand.UC))
       // Fmag gets converted to UC
@@ -460,7 +462,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "extract Sloan's band" in {
       val xmlFile = "sloan.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(xmlFile, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val gmag = result.map(_.magnitudeIn(MagnitudeBand._g))
       // gmag gets converted to g'

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -390,7 +390,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
         \/-(SiderealTarget("550-001324", Coordinates(RightAscension.fromDegrees(9.91958055555557), Declination.fromAngle(Angle.parseDegrees("19.997709722222226").getOrElse(Angle.zero)).getOrElse(Declination.zero)), pm2, magsTarget2, None))
       ))
       parse(voTableWithProperMotion).tables.head should beEqualTo(result)
-    }.pendingUntilFixed("pm")
+    }
     "be able to validate and parse an xml from sds9" in {
       val badXml = "votable-non-validating.xml"
       VoTableParser.parse(new URL(s"file:////$badXml"), getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(new URL(s"file:////$badXml"))))
@@ -479,9 +479,13 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       // The sample has only one row
       val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
+      // id and coordinates
       result.map(_.name) should beEqualTo(\/.right("* alf Lyr"))
       result.map(_.coordinates.ra) should beEqualTo(\/.right(RightAscension.fromAngle(Angle.fromDegrees(279.23473479))))
       result.map(_.coordinates.dec) should beEqualTo(\/.right(Declination.fromAngle(Angle.fromDegrees(38.78368896)).getOrElse(Declination.zero)))
+      // proper motions
+      result.map(_.properMotion.map(_.deltaRA)) should beEqualTo(\/.right(Some(RightAscensionAngularVelocity(AngularVelocity(200.94)))))
+      result.map(_.properMotion.map(_.deltaDec)) should beEqualTo(\/.right(Some(DeclinationAngularVelocity(AngularVelocity(286.23)))))
     }
   }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -486,6 +486,15 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       // proper motions
       result.map(_.properMotion.map(_.deltaRA)) should beEqualTo(\/.right(Some(RightAscensionAngularVelocity(AngularVelocity(200.94)))))
       result.map(_.properMotion.map(_.deltaDec)) should beEqualTo(\/.right(Some(DeclinationAngularVelocity(AngularVelocity(286.23)))))
+      // magnitudes
+      result.map(_.magnitudeIn(MagnitudeBand.U)) should beEqualTo(\/.right(Some(new Magnitude(0.03, MagnitudeBand.U))))
+      result.map(_.magnitudeIn(MagnitudeBand.B)) should beEqualTo(\/.right(Some(new Magnitude(0.03, MagnitudeBand.B))))
+      result.map(_.magnitudeIn(MagnitudeBand.V)) should beEqualTo(\/.right(Some(new Magnitude(0.03, MagnitudeBand.V))))
+      result.map(_.magnitudeIn(MagnitudeBand.R)) should beEqualTo(\/.right(Some(new Magnitude(0.07, MagnitudeBand.R))))
+      result.map(_.magnitudeIn(MagnitudeBand.I)) should beEqualTo(\/.right(Some(new Magnitude(0.10, MagnitudeBand.I))))
+      result.map(_.magnitudeIn(MagnitudeBand.J)) should beEqualTo(\/.right(Some(new Magnitude(-0.18, MagnitudeBand.J))))
+      result.map(_.magnitudeIn(MagnitudeBand.H)) should beEqualTo(\/.right(Some(new Magnitude(-0.03, MagnitudeBand.H))))
+      result.map(_.magnitudeIn(MagnitudeBand.K)) should beEqualTo(\/.right(Some(new Magnitude(0.13, MagnitudeBand.K))))
     }
   }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -323,39 +323,82 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "be able to parse magnitude bands in PPMXL" in {
       val iMagField = Ucd("phot.mag;em.opt.i")
       // Optical band
-      parseBands(PPMXLAdapter)((FieldId("id", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("id", iMagField), MagnitudeBand.I, 20.3051)))
+      PPMXLAdapter.parseMagnitude((FieldId("id", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("id", iMagField), MagnitudeBand.I, 20.3051)))
 
       val jIRMagField = Ucd("phot.mag;em.IR.J")
       // IR band
-      parseBands(PPMXLAdapter)((FieldId("id", jIRMagField), "13.2349")) should beEqualTo(\/-((FieldId("id", jIRMagField), MagnitudeBand.J, 13.2349)))
+      PPMXLAdapter.parseMagnitude((FieldId("id", jIRMagField), "13.2349")) should beEqualTo(\/-((FieldId("id", jIRMagField), MagnitudeBand.J, 13.2349)))
 
       val jIRErrMagField = Ucd("stat.error;phot.mag;em.IR.J")
       // IR Error
-      parseBands(PPMXLAdapter)((FieldId("id", jIRErrMagField), "0.02")) should beEqualTo(\/-((FieldId("id", jIRErrMagField), MagnitudeBand.J, 0.02)))
+      PPMXLAdapter.parseMagnitude((FieldId("id", jIRErrMagField), "0.02")) should beEqualTo(\/-((FieldId("id", jIRErrMagField), MagnitudeBand.J, 0.02)))
 
       // No magnitude field
       val badField = Ucd("meta.name")
-      parseBands(PPMXLAdapter)((FieldId("id", badField), "id")) should beEqualTo(-\/(UnmatchedField(badField)))
+      PPMXLAdapter.parseMagnitude((FieldId("id", badField), "id")) should beEqualTo(-\/(UnmatchedField(badField)))
 
       // Bad value
-      parseBands(PPMXLAdapter)((FieldId("id", iMagField), "stringValue")) should beEqualTo(-\/(FieldValueProblem(iMagField, "stringValue")))
+      PPMXLAdapter.parseMagnitude((FieldId("id", iMagField), "stringValue")) should beEqualTo(-\/(FieldValueProblem(iMagField, "stringValue")))
 
       // Unknown magnitude
       val noBandField = Ucd("phot.mag;em.opt.p")
-      parseBands(PPMXLAdapter)((FieldId("id", noBandField), "stringValue")) should beEqualTo(-\/(UnmatchedField(noBandField)))
+      PPMXLAdapter.parseMagnitude((FieldId("id", noBandField), "stringValue")) should beEqualTo(-\/(UnmatchedField(noBandField)))
     }
     "be able to map sloan magnitudes in UCAC4, OCSADV-245" in {
       val gMagField = Ucd("phot.mag;em.opt.R")
       // gmag maps to g'
-      parseBands(UCAC4Adapter)((FieldId("gmag", gMagField), "20.3051")) should beEqualTo(\/-((FieldId("gmag", gMagField), MagnitudeBand._g, 20.3051)))
+      UCAC4Adapter.parseMagnitude((FieldId("gmag", gMagField), "20.3051")) should beEqualTo(\/-((FieldId("gmag", gMagField), MagnitudeBand._g, 20.3051)))
 
       val rMagField = Ucd("phot.mag;em.opt.R")
       // rmag maps to r'
-      parseBands(UCAC4Adapter)((FieldId("rmag", rMagField), "20.3051")) should beEqualTo(\/-((FieldId("rmag", rMagField), MagnitudeBand._r, 20.3051)))
+      UCAC4Adapter.parseMagnitude((FieldId("rmag", rMagField), "20.3051")) should beEqualTo(\/-((FieldId("rmag", rMagField), MagnitudeBand._r, 20.3051)))
 
       val iMagField = Ucd("phot.mag;em.opt.I")
       // imag maps to r'
-      parseBands(UCAC4Adapter)((FieldId("imag", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("imag", iMagField), MagnitudeBand._i, 20.3051)))
+      UCAC4Adapter.parseMagnitude((FieldId("imag", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("imag", iMagField), MagnitudeBand._i, 20.3051)))
+    }
+    "be able to map sloan magnitudes in Simbad" in {
+      val zMagField = Ucd("phot.mag;em.opt.I")
+      // FLUX_z maps to z'
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_z", zMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_z", zMagField), MagnitudeBand._z, 20.3051)))
+
+      val rMagField = Ucd("phot.mag;em.opt.R")
+      // FLUX_r maps to r'
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_r", rMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_r", rMagField), MagnitudeBand._r, 20.3051)))
+
+      val uMagField = Ucd("phot.mag;em.opt.u")
+      // FLUX_u maps to u'
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_u", uMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_u", uMagField), MagnitudeBand._u, 20.3051)))
+
+      val gMagField = Ucd("phot.mag;em.opt.b")
+      // FLUX_g maps to g'
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_g", gMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_g", gMagField), MagnitudeBand._g, 20.3051)))
+
+      val iMagField = Ucd("phot.mag;em.opt.i")
+      // FLUX_u maps to u'
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_i", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_i", iMagField), MagnitudeBand._i, 20.3051)))
+    }
+    "be able to map non-sloan magnitudes in Simbad" in {
+      val rMagField = Ucd("phot.mag;em.opt.R")
+      // FLUX_R maps to R
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_R", rMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_R", rMagField), MagnitudeBand.R, 20.3051)))
+
+      val uMagField = Ucd("phot.mag;em.opt.U")
+      // FLUX_U maps to U
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_U", uMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_U", uMagField), MagnitudeBand.U, 20.3051)))
+
+      val iMagField = Ucd("phot.mag;em.opt.I")
+      // FLUX_I maps to I
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_I", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_I", iMagField), MagnitudeBand.I, 20.3051)))
+    }
+    "be able to map magnitude errors in Simbad" in {
+      // Magnitude errors in simbad don't include the band in the UCD, we must get it from the ID :(
+      val magErrorUcd = Ucd("stat.error;phot.mag")
+      // FLUX_r maps to r'
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_ERROR_r", magErrorUcd), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_ERROR_r", magErrorUcd), MagnitudeBand._r, 20.3051)))
+
+      // FLUX_R maps to R
+      SimbadAdapter.parseMagnitude((FieldId("FLUX_ERROR_R", magErrorUcd), "20.3051")) should beEqualTo(\/-((FieldId("FLUX_ERROR_R", magErrorUcd), MagnitudeBand.R, 20.3051)))
     }
     "be able to parse an xml into a list of SiderealTargets list of rows with a list of fields" in {
       val magsTarget1 = List(new Magnitude(23.0888, MagnitudeBand.U), new Magnitude(22.082, MagnitudeBand._g), new Magnitude(20.88, MagnitudeBand.R), new Magnitude(20.3051, MagnitudeBand.I), new Magnitude(19.8812, MagnitudeBand._z))
@@ -495,6 +538,24 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       result.map(_.magnitudeIn(MagnitudeBand.J)) should beEqualTo(\/.right(Some(new Magnitude(-0.18, MagnitudeBand.J))))
       result.map(_.magnitudeIn(MagnitudeBand.H)) should beEqualTo(\/.right(Some(new Magnitude(-0.03, MagnitudeBand.H))))
       result.map(_.magnitudeIn(MagnitudeBand.K)) should beEqualTo(\/.right(Some(new Magnitude(0.13, MagnitudeBand.K))))
+    }
+    "parse simbad named queries with sloan magnitudes" in {
+      val xmlFile = "simbad-2MFGC6625.xml"
+      // The sample has only one row
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+
+      // id and coordinates
+      result.map(_.name) should beEqualTo(\/.right("2MFGC 6625"))
+      result.map(_.coordinates.ra) should beEqualTo(\/.right(RightAscension.fromAngle(Angle.fromHMS(8, 23, 54.966).getOrElse(Angle.zero))))
+      result.map(_.coordinates.dec) should beEqualTo(\/.right(Declination.fromAngle(Angle.fromDMS(28, 6, 21.6792).getOrElse(Angle.zero)).getOrElse(Declination.zero)))
+      // proper motions
+      result.map(_.properMotion) should beEqualTo(\/.right(None))
+      // magnitudes
+      result.map(_.magnitudeIn(MagnitudeBand._u)) should beEqualTo(\/.right(Some(new Magnitude(17.353, MagnitudeBand._u, 0.009))))
+      result.map(_.magnitudeIn(MagnitudeBand._g)) should beEqualTo(\/.right(Some(new Magnitude(16.826, MagnitudeBand._g, 0.004))))
+      result.map(_.magnitudeIn(MagnitudeBand._r)) should beEqualTo(\/.right(Some(new Magnitude(17.286, MagnitudeBand._r, 0.005))))
+      result.map(_.magnitudeIn(MagnitudeBand._i)) should beEqualTo(\/.right(Some(new Magnitude(16.902, MagnitudeBand._i, 0.005))))
+      result.map(_.magnitudeIn(MagnitudeBand._z)) should beEqualTo(\/.right(Some(new Magnitude(17.015, MagnitudeBand._z, 0.011))))
     }
   }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -60,7 +60,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
         <FIELD ID="umag" datatype="double" name="umag" ucd="phot.mag;em.opt.u"/>
         <FIELD ID="flags2" datatype="int" name="flags2" ucd="meta.code"/>
         <FIELD ID="imag" datatype="double" name="imag" ucd="phot.mag;em.opt.i"/>
-        <FIELD ID="dej2000" datatype="double" name="dej2000" ucd="pos.eq.dec;meta.main"/>
+        <FIELD ID="decj2000" datatype="double" name="dej2000" ucd="pos.eq.dec;meta.main"/>
         <FIELD ID="raj2000" datatype="double" name="raj2000" ucd="pos.eq.ra;meta.main"/>
         <FIELD ID="rmag" datatype="double" name="rmag" ucd="phot.mag;em.opt.r"/>
         <FIELD ID="objid" datatype="int" name="objid" ucd="meta.id;meta.main"/>
@@ -111,7 +111,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
         <FIELD ID="flags2" datatype="int" name="flags2" ucd="meta.code"/>
         <FIELD ID="imag" datatype="double" name="imag" ucd="phot.mag;em.opt.i"/>
         <FIELD ID="zmag_err" datatype="double" name="zmag_err" ucd="stat.error;phot.mag;em.opt.z"/>
-        <FIELD ID="dej2000" datatype="double" name="dej2000" ucd="pos.eq.dec;meta.main"/>
+        <FIELD ID="decj2000" datatype="double" name="dej2000" ucd="pos.eq.dec;meta.main"/>
         <FIELD ID="umag_err" datatype="double" name="umag_err" ucd="stat.error;phot.mag;em.opt.u"/>
         <FIELD ID="imag_err" datatype="double" name="imag_err" ucd="stat.error;phot.mag;em.opt.i"/>
         <FIELD ID="raj2000" datatype="double" name="raj2000" ucd="pos.eq.ra;meta.main"/>
@@ -301,61 +301,61 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       val fields = parseFields(fieldsNode)
 
       val validRow = TableRow(
-                TableRowItem(FieldDescriptor(FieldId("objid", Ucd("meta.id;meta.main")), "objid"), "123456") ::
-                TableRowItem(FieldDescriptor(FieldId("dej2000", Ucd("pos.eq.dec;meta.main")),"dej2000"), "0.209323681906") ::
+                TableRowItem(FieldDescriptor(FieldId("ppmxl", Ucd("meta.id;meta.main")), "ppmxl"), "123456") ::
+                TableRowItem(FieldDescriptor(FieldId("decj2000", Ucd("pos.eq.dec;meta.main")),"dej2000"), "0.209323681906") ::
                 TableRowItem(FieldDescriptor(FieldId("raj2000", Ucd("pos.eq.ra;meta.main")), "raj2000"), "359.745951955") :: Nil
               )
-      tableRow2Target(fields)(validRow) should beEqualTo(\/-(SiderealTarget("123456", Coordinates(RightAscension.fromAngle(Angle.parseDegrees("359.745951955").getOrElse(Angle.zero)), Declination.fromAngle(Angle.parseDegrees("0.209323681906").getOrElse(Angle.zero)).getOrElse(Declination.zero)), None, Nil, None)))
+      tableRow2Target(None, fields)(validRow) should beEqualTo(\/-(SiderealTarget("123456", Coordinates(RightAscension.fromAngle(Angle.parseDegrees("359.745951955").getOrElse(Angle.zero)), Declination.fromAngle(Angle.parseDegrees("0.209323681906").getOrElse(Angle.zero)).getOrElse(Declination.zero)), None, Nil, None)))
 
       val rowWithMissingId = TableRow(
-                TableRowItem(FieldDescriptor(FieldId("dej2000", Ucd("pos.eq.dec;meta.main")), "dej2000"), "0.209323681906") ::
+                TableRowItem(FieldDescriptor(FieldId("decj2000", Ucd("pos.eq.dec;meta.main")), "dej2000"), "0.209323681906") ::
                 TableRowItem(FieldDescriptor(FieldId("raj2000", Ucd("pos.eq.ra;meta.main")), "raj2000"), "359.745951955") :: Nil
               )
-      tableRow2Target(fields)(rowWithMissingId) should beEqualTo(-\/(MissingValues(List(VoTableParser.UCD_OBJID))))
+      tableRow2Target(None, fields)(rowWithMissingId) should beEqualTo(-\/(MissingValue(FieldId("ppmxl", VoTableParser.UCD_OBJID))))
 
       val rowWithBadRa = TableRow(
-                TableRowItem(FieldDescriptor(FieldId("objid", Ucd("meta.id;meta.main")), "objid"), "123456") ::
-                TableRowItem(FieldDescriptor(FieldId("dej2000", Ucd("pos.eq.dec;meta.main")), "dej2000"), "0.209323681906") ::
+                TableRowItem(FieldDescriptor(FieldId("ppmxl", Ucd("meta.id;meta.main")), "ppmxl"), "123456") ::
+                TableRowItem(FieldDescriptor(FieldId("decj2000", Ucd("pos.eq.dec;meta.main")), "dej2000"), "0.209323681906") ::
                 TableRowItem(FieldDescriptor(FieldId("raj2000", Ucd("pos.eq.ra;meta.main")), "raj2000"), "ABC") :: Nil
             )
-      tableRow2Target(fields)(rowWithBadRa) should beEqualTo(-\/(FieldValueProblem(VoTableParser.UCD_RA, "ABC")))
+      tableRow2Target(None, fields)(rowWithBadRa) should beEqualTo(-\/(FieldValueProblem(VoTableParser.UCD_RA, "ABC")))
     }
     "be able to parse magnitude bands in PPMXL" in {
       val iMagField = Ucd("phot.mag;em.opt.i")
       // Optical band
-      parseBands(PPMXLFilter)((FieldId("id", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("id", iMagField), MagnitudeBand.I, 20.3051)))
+      parseBands(PPMXLAdapter)((FieldId("id", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("id", iMagField), MagnitudeBand.I, 20.3051)))
 
       val jIRMagField = Ucd("phot.mag;em.IR.J")
       // IR band
-      parseBands(PPMXLFilter)((FieldId("id", jIRMagField), "13.2349")) should beEqualTo(\/-((FieldId("id", jIRMagField), MagnitudeBand.J, 13.2349)))
+      parseBands(PPMXLAdapter)((FieldId("id", jIRMagField), "13.2349")) should beEqualTo(\/-((FieldId("id", jIRMagField), MagnitudeBand.J, 13.2349)))
 
       val jIRErrMagField = Ucd("stat.error;phot.mag;em.IR.J")
       // IR Error
-      parseBands(PPMXLFilter)((FieldId("id", jIRErrMagField), "0.02")) should beEqualTo(\/-((FieldId("id", jIRErrMagField), MagnitudeBand.J, 0.02)))
+      parseBands(PPMXLAdapter)((FieldId("id", jIRErrMagField), "0.02")) should beEqualTo(\/-((FieldId("id", jIRErrMagField), MagnitudeBand.J, 0.02)))
 
       // No magnitude field
       val badField = Ucd("meta.name")
-      parseBands(PPMXLFilter)((FieldId("id", badField), "id")) should beEqualTo(-\/(UnmatchedField(badField)))
+      parseBands(PPMXLAdapter)((FieldId("id", badField), "id")) should beEqualTo(-\/(UnmatchedField(badField)))
 
       // Bad value
-      parseBands(PPMXLFilter)((FieldId("id", iMagField), "stringValue")) should beEqualTo(-\/(FieldValueProblem(iMagField, "stringValue")))
+      parseBands(PPMXLAdapter)((FieldId("id", iMagField), "stringValue")) should beEqualTo(-\/(FieldValueProblem(iMagField, "stringValue")))
 
       // Unknown magnitude
       val noBandField = Ucd("phot.mag;em.opt.p")
-      parseBands(PPMXLFilter)((FieldId("id", noBandField), "stringValue")) should beEqualTo(-\/(UnmatchedField(noBandField)))
+      parseBands(PPMXLAdapter)((FieldId("id", noBandField), "stringValue")) should beEqualTo(-\/(UnmatchedField(noBandField)))
     }
     "be able to map sloan magnitudes in UCAC4, OCSADV-245" in {
       val gMagField = Ucd("phot.mag;em.opt.R")
       // gmag maps to g'
-      parseBands(UCAC4Filter)((FieldId("gmag", gMagField), "20.3051")) should beEqualTo(\/-((FieldId("gmag", gMagField), MagnitudeBand._g, 20.3051)))
+      parseBands(UCAC4Adapter)((FieldId("gmag", gMagField), "20.3051")) should beEqualTo(\/-((FieldId("gmag", gMagField), MagnitudeBand._g, 20.3051)))
 
       val rMagField = Ucd("phot.mag;em.opt.R")
       // rmag maps to r'
-      parseBands(UCAC4Filter)((FieldId("rmag", rMagField), "20.3051")) should beEqualTo(\/-((FieldId("rmag", rMagField), MagnitudeBand._r, 20.3051)))
+      parseBands(UCAC4Adapter)((FieldId("rmag", rMagField), "20.3051")) should beEqualTo(\/-((FieldId("rmag", rMagField), MagnitudeBand._r, 20.3051)))
 
       val iMagField = Ucd("phot.mag;em.opt.I")
       // imag maps to r'
-      parseBands(UCAC4Filter)((FieldId("imag", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("imag", iMagField), MagnitudeBand._i, 20.3051)))
+      parseBands(UCAC4Adapter)((FieldId("imag", iMagField), "20.3051")) should beEqualTo(\/-((FieldId("imag", iMagField), MagnitudeBand._i, 20.3051)))
     }
     "be able to parse an xml into a list of SiderealTargets list of rows with a list of fields" in {
       val magsTarget1 = List(new Magnitude(23.0888, MagnitudeBand.U), new Magnitude(22.082, MagnitudeBand._g), new Magnitude(20.88, MagnitudeBand.R), new Magnitude(20.3051, MagnitudeBand.I), new Magnitude(19.8812, MagnitudeBand._z))
@@ -390,7 +390,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
         \/-(SiderealTarget("550-001324", Coordinates(RightAscension.fromDegrees(9.91958055555557), Declination.fromAngle(Angle.parseDegrees("19.997709722222226").getOrElse(Angle.zero)).getOrElse(Declination.zero)), pm2, magsTarget2, None))
       ))
       parse(voTableWithProperMotion).tables.head should beEqualTo(result)
-    }
+    }.pendingUntilFixed("pm")
     "be able to validate and parse an xml from sds9" in {
       val badXml = "votable-non-validating.xml"
       VoTableParser.parse(new URL(s"file:////$badXml"), getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(new URL(s"file:////$badXml"))))
@@ -473,6 +473,15 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       val imag = result.map(_.magnitudeIn(MagnitudeBand._i))
       // rmag gets converted to r'
       imag should beEqualTo(\/.right(Some(Magnitude(5, MagnitudeBand._i, 0.34.some, MagnitudeSystem.AB))))
+    }
+    "parse simbad named queries" in {
+      val xmlFile = "simbad-vega.xml"
+      // The sample has only one row
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+
+      result.map(_.name) should beEqualTo(\/.right("* alf Lyr"))
+      result.map(_.coordinates.ra) should beEqualTo(\/.right(RightAscension.fromAngle(Angle.fromDegrees(279.23473479))))
+      result.map(_.coordinates.dec) should beEqualTo(\/.right(Declination.fromAngle(Angle.fromDegrees(38.78368896)).getOrElse(Declination.zero)))
     }
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -291,7 +291,7 @@ object QueryResultsWindow {
       /**
        * Called after  a query completes to update the UI according to the results
        */
-      def updateResults(queryResult: QueryResult): Unit = {
+      def updateResults(info: Option[ObservationInfo], queryResult: QueryResult): Unit = {
         queryResult.query match {
           case q: ConeSearchCatalogQuery =>
             val model = TargetsModel(q.base, queryResult.result.targets.rows)
@@ -307,8 +307,10 @@ object QueryResultsWindow {
             // Update the count of rows
             resultsLabel.updateCount(queryResult.result.targets.rows.length)
 
-        // Update the query form
-        QueryForm.updateQuery(info, queryResult.query)
+            // Update the query form
+            QueryForm.updateQuery(info, q)
+          case _ =>
+        }
       }
 
       protected def revalidateFrame(): Unit = {
@@ -448,7 +450,7 @@ object QueryResultsWindow {
         /**
          * Update query form according to the passed values
          */
-        def updateQuery(info: Option[ObservationInfo], query: CatalogQuery): Unit = {
+        def updateQuery(info: Option[ObservationInfo], query: ConeSearchCatalogQuery): Unit = {
           info.foreach { i =>
             objectName.text = ~i.objectName
             instrumentName.text = ~i.instrumentName
@@ -511,7 +513,7 @@ object QueryResultsWindow {
             val conditions = Conditions.NOMINAL.sb(sbBox.selection.item).cc(ccBox.selection.item).iq(iqBox.selection.item)
             // TODO Change the search query for different conditions OCSADV-416
             val info = ObservationInfo(objectName.text.some, instrumentName.text.some, Option(guider.selection.item), guiders.toList, conditions.some).some
-            (info, CatalogQuery(None, coordinates, radius, currentFilters, ucac4))
+            (info, CatalogQuery(coordinates, radius, currentFilters, ucac4))
           }
         }
 

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -291,19 +291,21 @@ object QueryResultsWindow {
       /**
        * Called after  a query completes to update the UI according to the results
        */
-      def updateResults(info: Option[ObservationInfo], queryResult: QueryResult): Unit = {
-        val model = TargetsModel(queryResult.query.base, queryResult.result.targets.rows)
-        resultsTable.model = model
+      def updateResults(queryResult: QueryResult): Unit = {
+        queryResult.query match {
+          case q: ConeSearchCatalogQuery =>
+            val model = TargetsModel(q.base, queryResult.result.targets.rows)
+            resultsTable.model = model
 
-        // The sorting logic may change if the list of magnitudes changes
-        new TableRowSorter[TargetsModel](model) <| {_.toggleSortOrder(0)} <| {_.sort()} <| {resultsTable.peer.setRowSorter}
+            // The sorting logic may change if the list of magnitudes changes
+            new TableRowSorter[TargetsModel](model) <| {_.toggleSortOrder(0)} <| {_.sort()} <| {resultsTable.peer.setRowSorter}
 
-        // Adjust the width of the columns
-        val insets = queryFrame.scrollPane.border.getBorderInsets(queryFrame.scrollPane.peer)
-        resultsTable.adjustColumns(queryFrame.scrollPane.bounds.width - insets.left - insets.right)
+            // Adjust the width of the columns
+            val insets = queryFrame.scrollPane.border.getBorderInsets(queryFrame.scrollPane.peer)
+            resultsTable.adjustColumns(queryFrame.scrollPane.bounds.width - insets.left - insets.right)
 
-        // Update the count of rows
-        resultsLabel.updateCount(queryResult.result.targets.rows.length)
+            // Update the count of rows
+            resultsLabel.updateCount(queryResult.result.targets.rows.length)
 
         // Update the query form
         QueryForm.updateQuery(info, queryResult.query)
@@ -619,7 +621,7 @@ object CatalogQueryDemo extends SwingApplication {
   import edu.gemini.spModel.target.SPTarget
   import edu.gemini.spModel.target.env.TargetEnvironment
 
-  val query = CatalogQuery(None,Coordinates(RightAscension.fromAngle(Angle.fromDegrees(3.1261166666666895)),Declination.fromAngle(Angle.fromDegrees(337.93268333333333)).getOrElse(Declination.zero)),RadiusConstraint.between(Angle.zero,Angle.fromDegrees(0.16459874517619255)),List(MagnitudeConstraints(RBandsList,FaintnessConstraint(16.0),Some(SaturationConstraint(3.1999999999999993)))),ucac4)
+  val query = CatalogQuery(Coordinates(RightAscension.fromAngle(Angle.fromDegrees(3.1261166666666895)),Declination.fromAngle(Angle.fromDegrees(337.93268333333333)).getOrElse(Declination.zero)),RadiusConstraint.between(Angle.zero,Angle.fromDegrees(0.16459874517619255)),List(MagnitudeConstraints(RBandsList,FaintnessConstraint(16.0),Some(SaturationConstraint(3.1999999999999993)))),ucac4)
 
   def startup(args: Array[String]) {
     System.setProperty("apple.awt.antialiasing", "on")


### PR DESCRIPTION
This is the first PR to support Simbad catalogs in the catalog code. This PR contains substantial changes to `VoTableParser` to support simbad VoTable format and initial support to make remote queries no simbad in `VoTableClient`

These changes are contained to the catalog bundle, while next PR will include updates to the target model to capture extra metadata about the targets (Radial Velocity, etc) and integration with the OT

As usual I include sample votable queries for tests