### PR TITLE
OCSADV-403: Let the user choose the selected AGS strategy on manual search

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -558,7 +558,7 @@ object QueryResultsWindow {
             val conditions = Conditions.NOMINAL.sb(sbBox.selection.item).cc(ccBox.selection.item).iq(iqBox.selection.item)
 
             val info = ObservationInfo(objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some)
-            val defaultQuery = CatalogQuery(None, coordinates, radius, currentFilters, ucac4)
+            val defaultQuery = CatalogQuery(coordinates, radius, currentFilters, ucac4)
             (info.some, guider.selection.item.query.headOption.getOrElse(defaultQuery))
           }
         }
@@ -649,9 +649,12 @@ object QueryResultsWindow {
     AgsRegistrar.currentStrategy(obsCtx).foreach { strategy =>
       val mt = ProbeLimitsTable.loadOrThrow()
       // TODO Use only the first query, GEMS isn't supported yet OCSADV-242, OCSADV-239
-      strategy.catalogQueries(obsCtx, mt).headOption.foreach { q =>
-        // OCSADV-403 Display all the rows, removing the magnitude constraints
-        showWithQuery(obsCtx, mt, q.copy(magnitudeConstraints = Nil))
+      strategy.catalogQueries(obsCtx, mt).headOption.foreach {
+        case q: ConeSearchCatalogQuery =>
+          // OCSADV-403 Display all the rows, removing the magnitude constraints
+          showWithQuery(obsCtx, mt, q.copy(magnitudeConstraints = Nil))
+        case _                         =>
+          // Ignore named queries
       }
     }
   }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -619,7 +619,8 @@ object QueryResultsWindow {
       val mt = ProbeLimitsTable.loadOrThrow()
       // TODO Use only the first query, GEMS isn't supported yet OCSADV-242, OCSADV-239
       strategy.catalogQueries(obsCtx, mt).headOption.foreach { q =>
-        showWithQuery(obsCtx, mt, q)
+        // OCSADV-415 Display all the rows by removing the magnitude constraints
+        showWithQuery(obsCtx, mt, q.copy(magnitudeConstraints = Nil))
       }
     }
   }


### PR DESCRIPTION
This is the next step on the catalog navigator. With this PR the user can select a different guider and re-query with updated limits. By user request the initial load will read all the available rows without magnitude limits.
Note that the limits for different guide speeds for each guider are displayed too

![screenshot 2015-09-25 10 11 47](https://cloud.githubusercontent.com/assets/3615303/10101516/97e12412-636f-11e5-8263-56019de5fd92.png)

