### PR TITLE
OCSADV-399-P

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/ITarget.java
@@ -79,10 +79,6 @@ public abstract class ITarget implements Cloneable, Serializable {
         return new Some(getRa().getAs(CoordinateParam.Units.HMS));
     }
 
-    public double getRaHours() {
-        return getRa().getAs(CoordinateParam.Units.HMS);
-    }
-
     public Option<String> getRaString(Option<Long> time) {
         return new Some(getRa().toString());
     }
@@ -119,12 +115,7 @@ public abstract class ITarget implements Cloneable, Serializable {
     protected abstract DMS getDec();
 
     public Option<Double> getDecDegrees(Option<Long> time) {
-        return new Some(getDecDegrees());
-    }
-
-    // TRANSITIONAL
-    public double getDecDegrees() {
-        return getDec().getAs(CoordinateParam.Units.DEGREES);
+        return new Some(getDec().getAs(CoordinateParam.Units.DEGREES));
     }
 
     // TRANSITIONAL

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -8,6 +8,9 @@ import edu.gemini.spModel.target.system.{ConicTarget, HmsDegTarget, ITarget}
 import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
+import edu.gemini.shared.util.immutable.{ None => JNone }
+import edu.gemini.shared.util.immutable.ScalaConverters._
+
 
 import squants.motion.VelocityConversions._
 import squants.radio.IrradianceConversions._

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -3,7 +3,7 @@ package jsky.app.ot.editor.template
 import edu.gemini.pot.sp.ISPTemplateParameters
 import edu.gemini.shared.skyobject.Magnitude
 import edu.gemini.shared.util.TimeValue
-import edu.gemini.shared.util.immutable.DefaultImList
+import edu.gemini.shared.util.immutable.{ DefaultImList, None => JNone, Option => JOption }
 import edu.gemini.spModel.`type`.ObsoletableSpType
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{PercentageContainer, ImageQuality, CloudCover, SkyBackground, WaterVapor}
@@ -257,11 +257,13 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         })}
       )
 
+      val JNoneLong: JOption[java.lang.Long] = JNone.instance[java.lang.Long]
+
       val hms = new HMSFormat()
       val raField = new BoundTextField[Double](10)(
         read = s => hms.parse(s),
         show = hms.format,
-        get  = _.getTarget.getTarget.getRaHours,
+        get  = _.getTarget.getTarget.getRaHours(JNoneLong).getOrElse(0.0),
         set  = setTarget((a, b) => a.setRaHours(b))
       )
 
@@ -269,7 +271,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val decField = new BoundTextField[Double](10)(
         read = s => dms.parse(s),
         show = dms.format,
-        get  = _.getTarget.getTarget.getDecDegrees,
+        get  = _.getTarget.getTarget.getDecDegrees(JNoneLong).getOrElse(0.0),
         set  = setTarget((a, b) => a.setDecDegrees(b))
       )
 


### PR DESCRIPTION
This PR addresses the last few uses of non-time-based coordinate access on `ITarget`. This doesn't affect the behavior of the template parameter editor yet, but the UI will need to be revisited when the model is swapped out because "set RA" for example only makes sense for sidereal targets.