### PR TITLE
OCSADV-420: Search by name to import targets

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
@@ -24,7 +24,7 @@ import jsky.util.gui.StatusLogger
  * The catalog search will provide the inputs to the analysis phase, which actually assigns guide stars to guiders.
  * See OT-26
  */
-case class GemsVoTableCatalog(backend: VoTableBackend = RemoteBackend, catalog: CatalogName = ucac4) {
+case class GemsVoTableCatalog(backend: VoTableBackend = ConeSearchBackend, catalog: CatalogName = ucac4) {
 
   /**
    * Searches for the given base position according to the given options.

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -234,5 +234,5 @@ trait GemsStrategy extends AgsStrategy {
 }
 
 object GemsStrategy extends GemsStrategy {
-  override private [impl] val backend = RemoteBackend
+  override private [impl] val backend = ConeSearchBackend
 }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -3,7 +3,7 @@ package edu.gemini.ags.impl
 import edu.gemini.ags.api._
 import edu.gemini.ags.api.AgsMagnitude._
 import edu.gemini.catalog.api.CatalogQuery
-import edu.gemini.catalog.votable.{RemoteBackend, VoTableBackend, CatalogException, VoTableClient}
+import edu.gemini.catalog.votable.{ConeSearchBackend, VoTableBackend, CatalogException, VoTableClient}
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.skycalc
 import edu.gemini.spModel.ags.AgsStrategyKey
@@ -28,7 +28,7 @@ import Scalaz._
  * The same logic is applied to various single-star guiding scenarios (i.e.,
  * everything except for GeMS).
  */
-case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyParams, backend: VoTableBackend = RemoteBackend) extends AgsStrategy {
+case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyParams, backend: VoTableBackend = ConeSearchBackend) extends AgsStrategy {
   import SingleProbeStrategy._
 
   override def magnitudes(ctx: ObsContext, mt: MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -1,7 +1,7 @@
 package edu.gemini.ags.impl
 
 import edu.gemini.ags.api.AgsStrategy
-import edu.gemini.catalog.votable.RemoteBackend
+import edu.gemini.catalog.votable.ConeSearchBackend
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.ags.AgsStrategyKey._
@@ -22,7 +22,7 @@ object Strategy {
   import SingleProbeStrategyParams._
 
   // Backend for searching on catalogs
-  val backend = RemoteBackend
+  val backend = ConeSearchBackend
 
   val AltairAowfs     = SingleProbeStrategy(AltairAowfsKey,     AltairAowfsParams)
   val Flamingos2Oiwfs = SingleProbeStrategy(Flamingos2OiwfsKey, Flamingos2OiwfsParams)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsRegistrarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsRegistrarSpec.scala
@@ -2,7 +2,7 @@ package edu.gemini.ags.api
 
 import edu.gemini.ags.impl.SingleProbeStrategy
 import edu.gemini.ags.impl.SingleProbeStrategyParams.PwfsParams
-import edu.gemini.catalog.votable.RemoteBackend
+import edu.gemini.catalog.votable.ConeSearchBackend
 import edu.gemini.shared.util.immutable.{None => JNone, Some => JSome}
 import edu.gemini.spModel.ags.AgsStrategyKey.Pwfs2SouthKey
 import edu.gemini.spModel.core.{Site, Declination, Angle}
@@ -27,7 +27,7 @@ class AgsRegistrarSpec extends Specification {
 
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), null, null, null, JNone.instance())
 
-      AgsRegistrar.defaultStrategy(ctx) should beSome(SingleProbeStrategy(Pwfs2SouthKey,PwfsParams(Site.GS, PwfsGuideProbe.pwfs2),RemoteBackend))
+      AgsRegistrar.defaultStrategy(ctx) should beSome(SingleProbeStrategy(Pwfs2SouthKey,PwfsParams(Site.GS, PwfsGuideProbe.pwfs2),ConeSearchBackend))
     }
   }
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
@@ -15,7 +15,7 @@ case class UcdWord(token: String)
 case class Ucd(tokens: List[UcdWord]) {
   def includes(ucd: UcdWord): Boolean = tokens.contains(ucd)
   def matches(r: Regex): Boolean = tokens.exists(t => r.findFirstIn(t.token).isDefined)
-  override def toString = tokens.mkString(", ")
+  override def toString = tokens.map(_.token).mkString(", ")
 }
 
 object Ucd {

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Logger
 
 import edu.gemini.catalog.api.{NameCatalogQuery, ConeSearchCatalogQuery, CatalogQuery}
+import edu.gemini.catalog.votable.ConeSearchBackend._
 import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.core.Target.SiderealTarget
 import org.apache.commons.httpclient.{NameValuePair, HttpClient}
@@ -140,61 +141,19 @@ trait CachedBackend extends VoTableBackend {
 
 }
 
-case object RemoteBackend extends CachedBackend {
-  val instance = this
-  override val catalogUrls = NonEmptyList(new URL("http://gscatalog.gemini.edu"), new URL("http://gncatalog.gemini.edu"))
-
-  val Log = Logger.getLogger(getClass.getName)
-
-  private val timeout = 30 * 1000 // Max time to wait
-
-  private def format(a: Angle)= f"${a.toDegrees}%4.03f"
-
-  protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair] = q match {
-    case qs: ConeSearchCatalogQuery => Array(
-      new NameValuePair("CATALOG", qs.catalog.id),
-      new NameValuePair("RA", format(qs.base.ra.toAngle)),
-      new NameValuePair("DEC", f"${qs.base.dec.toDegrees}%4.03f"),
-      new NameValuePair("SR", format(qs.radiusConstraint.maxLimit)))
-    case _                          => Array.empty
-  }
-
-  override protected def query(e: SearchKey): QueryResult = {
-    val method = new GetMethod(s"${e.url}/cgi-bin/conesearch.py")
-    val qs = queryParams(e.query)
-    method.setQueryString(qs)
-    Log.info(s"Catalog query to ${method.getURI}")
-
-    val client = new HttpClient
-    client.setConnectionTimeout(timeout)
-
-    try {
-      client.executeMethod(method)
-      VoTableParser.parse(e.url, method.getResponseBodyAsStream).fold(p => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(e.query, CatalogQueryResult(y)))
-    } finally {
-      method.releaseConnection()
-    }
-  }
-
-}
-
-case object SimbadNameBackend extends CachedBackend {
-  val instance = this
-  override val catalogUrls = NonEmptyList(new URL("http://simbad.cfa.harvard.edu/simbad/"), new URL("http://simbad.u-strasbg.fr/simbad"))
-
-  val Log = Logger.getLogger(getClass.getName)
+/**
+ * Common methods to do query calls to remote servers
+ */
+trait RemoteCallBackend {this: CachedBackend =>
+  val Log = Logger.getLogger(this.getClass.getName)
 
   private val timeout = 30 * 1000 // Max time to wait
 
-  protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair] = q match {
-    case qs: NameCatalogQuery => Array(
-      new NameValuePair("output.format", "VOTable"),
-      new NameValuePair("Ident", qs.search))
-    case _                    => Array.empty
-  }
+  protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair]
+  protected [votable] def queryUrl(e: SearchKey): String
 
   override protected def query(e: SearchKey): QueryResult = {
-    val method = new GetMethod(s"${e.url}/sim-id")
+    val method = new GetMethod(queryUrl(e))
     val qs = queryParams(e.query)
     method.setQueryString(qs)
     Log.info(s"Catalog query to ${method.getURI}")
@@ -212,6 +171,39 @@ case object SimbadNameBackend extends CachedBackend {
       method.releaseConnection()
     }
   }
+}
+
+case object ConeSearchBackend extends CachedBackend with RemoteCallBackend {
+  val instance = this
+  override val catalogUrls = NonEmptyList(new URL("http://gscatalog.gemini.edu"), new URL("http://gncatalog.gemini.edu"))
+
+  private def format(a: Angle)= f"${a.toDegrees}%4.03f"
+
+  protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair] = q match {
+    case qs: ConeSearchCatalogQuery => Array(
+      new NameValuePair("CATALOG", qs.catalog.id),
+      new NameValuePair("RA", format(qs.base.ra.toAngle)),
+      new NameValuePair("DEC", f"${qs.base.dec.toDegrees}%4.03f"),
+      new NameValuePair("SR", format(qs.radiusConstraint.maxLimit)))
+    case _                          => Array.empty
+  }
+
+  override def queryUrl(e: SearchKey): String = s"${e.url}/cgi-bin/conesearch.py"
+}
+
+case object SimbadNameBackend extends CachedBackend with RemoteCallBackend {
+  override val catalogUrls = NonEmptyList(new URL("http://simbad.cfa.harvard.edu/simbad/"), new URL("http://simbad.u-strasbg.fr/simbad"))
+
+  private val timeout = 30 * 1000 // Max time to wait
+
+  protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair] = q match {
+    case qs: NameCatalogQuery => Array(
+      new NameValuePair("output.format", "VOTable"),
+      new NameValuePair("Ident", qs.search))
+    case _                    => Array.empty
+  }
+
+  override def queryUrl(e: SearchKey): String = s"${e.url}/sim-id"
 
 }
 
@@ -247,7 +239,7 @@ object VoTableClient extends VoTableClient {
   /**
    * Do a query for targets, it returns a list of targets and possible problems found
    */
-  def catalog(query: CatalogQuery, backend: VoTableBackend = RemoteBackend): Future[QueryResult] = {
+  def catalog(query: CatalogQuery, backend: VoTableBackend = ConeSearchBackend): Future[QueryResult] = {
     val f = for {
       url <- backend.catalogUrls
     } yield doQuery(query, url, backend)
@@ -260,7 +252,7 @@ object VoTableClient extends VoTableClient {
   /**
    * Do multiple parallel queries, it returns a consolidated list of targets and possible problems found
    */
-  def catalogs(queries: List[CatalogQuery], backend: VoTableBackend = RemoteBackend): Future[List[QueryResult]] = {
+  def catalogs(queries: List[CatalogQuery], backend: VoTableBackend = ConeSearchBackend): Future[List[QueryResult]] = {
     val r = queries.strengthR(backend).map(Function.tupled(catalog))
     Future.sequence(r)
   }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -192,9 +192,7 @@ case object ConeSearchBackend extends CachedBackend with RemoteCallBackend {
 }
 
 case object SimbadNameBackend extends CachedBackend with RemoteCallBackend {
-  override val catalogUrls = NonEmptyList(new URL("http://simbad.cfa.harvard.edu/simbad/"), new URL("http://simbad.u-strasbg.fr/simbad"))
-
-  private val timeout = 30 * 1000 // Max time to wait
+  override val catalogUrls = NonEmptyList(new URL("http://simbad.cfa.harvard.edu/simbad"), new URL("http://simbad.u-strasbg.fr/simbad"))
 
   protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair] = q match {
     case qs: NameCatalogQuery => Array(

--- a/bundle/edu.gemini.catalog/src/test/resources/simbad-not-found.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/simbad-not-found.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<INFO name="Error" value="Identifier not found in the database : NAME COMET"/>
+</VOTABLE>

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/QueryCacheSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/QueryCacheSpec.scala
@@ -3,7 +3,7 @@ package edu.gemini.catalog.votable
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.specs2.mutable.Specification
-import RemoteBackend.QueryCache
+import ConeSearchBackend.QueryCache
 
 import scala.annotation.tailrec
 

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -34,10 +34,10 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
     }
 
     "produce query params" in {
-      RemoteBackend.queryParams(query) should beEqualTo(Array(new NameValuePair("CATALOG", "ucac4"), new NameValuePair("RA", "10.000"), new NameValuePair("DEC", "20.000"), new NameValuePair("SR", "0.100")))
+      ConeSearchBackend.queryParams(query) should beEqualTo(Array(new NameValuePair("CATALOG", "ucac4"), new NameValuePair("RA", "10.000"), new NameValuePair("DEC", "20.000"), new NameValuePair("SR", "0.100")))
     }
     "make a query to a bad site" in {
-      Await.result(doQuery(query, new URL("http://unknown site"), RemoteBackend), 2.seconds) should throwA[UnknownHostException]
+      Await.result(doQuery(query, new URL("http://unknown site"), ConeSearchBackend), 2.seconds) should throwA[UnknownHostException]
     }
     "be able to select the first successful of several futures" in {
       def f1 = Future { Thread.sleep(1000); throw new RuntimeException("oops") }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -580,5 +580,11 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
       result.map(_.magnitudeIn(MagnitudeBand._i)) should beEqualTo(\/.right(Some(new Magnitude(19.472, MagnitudeBand._i, 0.023))))
       result.map(_.magnitudeIn(MagnitudeBand._z)) should beEqualTo(\/.right(Some(new Magnitude(19.191, MagnitudeBand._z, 0.068))))
     }
+    "parse simbad with a not-found name" in {
+      val xmlFile = "simbad-not-found.xml"
+      // Simbad returns non-valid xml when an element is not found, we need to skip validation :S
+      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile"), false)
+      result must beEqualTo(\/.right(ParsedVoResource(List())))
+    }
   }
 }

--- a/bundle/edu.gemini.ui.miglayout/src/main/scala/edu/gemini/ui/miglayout/MigPanel.scala
+++ b/bundle/edu.gemini.ui.miglayout/src/main/scala/edu/gemini/ui/miglayout/MigPanel.scala
@@ -17,6 +17,7 @@ object constraints {
   sealed abstract class VMigAlign(protected [constraints] val toAlign: String)
   case object TopAlign extends VMigAlign("top")
   case object BottomAlign extends VMigAlign("bottom")
+  case object BaselineAlign extends VMigAlign("baseline")
   // MigLayout horizontal align objects
   sealed abstract class HMigAlign(protected [constraints] val toAlign: String)
   case object RightAlign extends HMigAlign("right")

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -4,7 +4,7 @@ import edu.gemini.ags.gems.*;
 import edu.gemini.ags.gems.mascot.Strehl;
 import edu.gemini.ags.gems.mascot.MascotProgress;
 import edu.gemini.catalog.votable.CatalogException;
-import edu.gemini.catalog.votable.RemoteBackend;
+import edu.gemini.catalog.votable.ConeSearchBackend;
 import edu.gemini.pot.ModelConverters;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
@@ -224,7 +224,7 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
             GemsInstrument instrument = inst instanceof Flamingos2 ? GemsInstrument.flamingos2 : GemsInstrument.gsaoi;
             GemsGuideStarSearchOptions options = new GemsGuideStarSearchOptions(instrument, tipTiltMode, posAngles);
 
-            List<GemsCatalogSearchResults> results = new GemsVoTableCatalog(RemoteBackend.instance(), catalog.catalog()).search4Java(obsContext, ModelConverters.toCoordinates(base), options, nirBand, statusLogger, 30);
+            List<GemsCatalogSearchResults> results = new GemsVoTableCatalog(ConeSearchBackend.instance(), catalog.catalog()).search4Java(obsContext, ModelConverters.toCoordinates(base), options, nirBand, statusLogger, 30);
             if (interrupted) {
                 throw new CancellationException("Canceled");
             }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -12,7 +12,7 @@ import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api._
 import edu.gemini.catalog.votable.{SimbadNameBackend, QueryResult, VoTableClient}
 import edu.gemini.pot.sp.ISPNode
-import edu.gemini.shared.gui.textComponent.{TextRenderer, NumberField}
+import edu.gemini.shared.gui.textComponent.{SelectOnFocus, TextRenderer, NumberField}
 import edu.gemini.shared.gui.{ButtonFlattener, GlassLabel, SizePreference, SortableTable}
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
@@ -385,16 +385,18 @@ object QueryResultsWindow {
             }
         }
 
-        lazy val objectName = new TextField("") {
+        lazy val objectName = new TextField("") with SelectOnFocus {
           val foregroundColor = UIManager.getColor("TextField.foreground")
           listenTo(keys)
           reactions += {
+            case KeyPressed(_, Key.Enter, _, _) if text.nonEmpty =>
+              doNameSearch(text)
             case KeyTyped(_, _, _, _) =>
               errorLabel.reset()
               foreground = foregroundColor
           }
         }
-        lazy val searchByName =   new Button("") {
+        lazy val searchByName = new Button("") {
           icon = Resources.getIcon("eclipse/search.gif")
           ButtonFlattener.flatten(peer)
           reactions += {


### PR DESCRIPTION
This PR uses the support for Simbad queries added on PR #558 with the Catalog Navigator. It will do named queries and take the first result and replace the coordinates on the query form:

![screenshot 2015-09-30 15 45 51](https://cloud.githubusercontent.com/assets/3615303/10203101/89be2334-678a-11e5-8eca-b4d65e27539d.png)

Unlike the target editor, errors are displayed without a popup, instead a message is displayed on the form and at the window's bottom:
![screenshot 2015-09-30 17 13 15](https://cloud.githubusercontent.com/assets/3615303/10205431/945db414-6797-11e5-991f-da749102b3de.png)

Simbad returns non-valid votable documents if no targets are found, this PR handles that case too