### PR TITLE
OCSADV-406: Support changing the gemini-hosted catalog (e.g. to PPMXL)

### DIFF
--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsGuideStarSearchOptions.java
@@ -1,8 +1,8 @@
 package edu.gemini.ags.gems;
 
 import edu.gemini.catalog.api.CatalogName;
-import edu.gemini.catalog.api.ppmxl$;
-import edu.gemini.catalog.api.ucac4$;
+import edu.gemini.catalog.api.PPMXL$;
+import edu.gemini.catalog.api.UCAC4$;
 import edu.gemini.catalog.api.MagnitudeConstraints;
 import edu.gemini.pot.ModelConverters;
 import edu.gemini.spModel.core.Angle;
@@ -48,9 +48,9 @@ public class GemsGuideStarSearchOptions {
 
         public CatalogName catalog() {
             if (this == PPMXL_GEMINI) {
-                return ppmxl$.MODULE$;
+                return PPMXL$.MODULE$;
             } else {
-                return ucac4$.MODULE$;
+                return UCAC4$.MODULE$;
             }
         }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
@@ -24,7 +24,7 @@ import jsky.util.gui.StatusLogger
  * The catalog search will provide the inputs to the analysis phase, which actually assigns guide stars to guiders.
  * See OT-26
  */
-case class GemsVoTableCatalog(backend: VoTableBackend = ConeSearchBackend, catalog: CatalogName = ucac4) {
+case class GemsVoTableCatalog(backend: VoTableBackend = ConeSearchBackend, catalog: CatalogName = UCAC4) {
 
   /**
    * Searches for the given base position according to the given options.

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -169,7 +169,7 @@ trait GemsStrategy extends AgsStrategy {
     val gemsOptions = new GemsGuideStarSearchOptions(gemsInstrument, tipTiltMode, posAngles.asJava)
 
     // Perform the catalog search, using GemsStrategy's backend
-    val results = GemsVoTableCatalog(backend, ucac4).search(ctx, base.toNewModel, gemsOptions, nirBand, null)
+    val results = GemsVoTableCatalog(backend, UCAC4).search(ctx, base.toNewModel, gemsOptions, nirBand, null)
 
     // Now check that the results are valid: there must be a valid tip-tilt and flexure star each.
     results.map { r =>
@@ -218,8 +218,8 @@ trait GemsStrategy extends AgsStrategy {
         (ml |@| lim(can))(_ union _).flatten
       }
 
-      val canopusConstraint = canMagLimits.map(c => CatalogQuery(CanopusTipTiltId, base.toNewModel, RadiusConstraint.between(Angle.zero, Canopus.Wfs.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), ucac4))
-      val odgwConstraint    = odgwMagLimits.map(c => CatalogQuery(OdgwFlexureId,   base.toNewModel, RadiusConstraint.between(Angle.zero, GsaoiOdgw.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), ucac4))
+      val canopusConstraint = canMagLimits.map(c => CatalogQuery(CanopusTipTiltId, base.toNewModel, RadiusConstraint.between(Angle.zero, Canopus.Wfs.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), UCAC4))
+      val odgwConstraint    = odgwMagLimits.map(c => CatalogQuery(OdgwFlexureId,   base.toNewModel, RadiusConstraint.between(Angle.zero, GsaoiOdgw.Group.instance.getRadiusLimits.toNewModel), List(ctx.getConditions.adjust(c)), UCAC4))
       List(canopusConstraint, odgwConstraint).flatten
     }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
@@ -29,7 +29,7 @@ sealed trait SingleProbeStrategyParams {
       mc   <- magnitudeCalc(ctx, mt)
       rc   <- radiusConstraint(ctx)
       ml   <- AgsMagnitude.manualSearchConstraints(mc)
-    } yield CatalogQuery(base.toNewModel, rc, ml, ucac4)
+    } yield CatalogQuery(base.toNewModel, rc, ml, UCAC4)
 
   def radiusConstraint(ctx: ObsContext): Option[RadiusConstraint] =
     RadiusLimitCalc.getAgsQueryRadiusLimits(guideProbe, ctx)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
@@ -1,7 +1,7 @@
 package edu.gemini.ags.gems.mascot
 
 import edu.gemini.ags.gems.UCAC3Regression
-import edu.gemini.catalog.api.{ppmxl, RadiusConstraint, CatalogQuery}
+import edu.gemini.catalog.api.{PPMXL, RadiusConstraint, CatalogQuery}
 import edu.gemini.catalog.votable.{TestVoTableBackend, VoTableClient}
 import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
@@ -244,7 +244,7 @@ class MascotGuideStarSpec extends Specification {
     "find best asterism by query result" in {
       val coordinates = Coordinates(RightAscension.fromAngle(Angle.fromHMS(3, 19, 48.2341).getOrElse(Angle.zero)), Declination.fromAngle(Angle.fromDMS(41, 30, 42.078).getOrElse(Angle.zero)).getOrElse(Declination.zero))
 
-      val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromArcmin(MascotCat.defaultMinRadius), Angle.fromArcmin(MascotCat.defaultMaxRadius)), ppmxl)
+      val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromArcmin(MascotCat.defaultMinRadius), Angle.fromArcmin(MascotCat.defaultMaxRadius)), PPMXL)
       val r = VoTableClient.catalog(query, TestVoTableBackend("/mascotquery.xml")).map { t =>
         val base = new SPTarget(coordinates.ra.toAngle.toDegrees, coordinates.dec.toDegrees)
         val env = TargetEnvironment.create(base)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -18,6 +18,21 @@ case class MagnitudeQueryFilter(mc: MagnitudeConstraints) extends QueryResultsFi
   def filter(t: SiderealTarget): Boolean = mc.filter(t)
 }
 
+sealed abstract class CatalogName(val id: String, val displayName: String)
+
+case object sdss extends CatalogName("sdss9", "SDSS9 @ Gemini")
+case object gsc234 extends CatalogName("gsc234", "GSC234 @ Gemini")
+case object ppmxl extends CatalogName("ppmxl", "PPMXL @ Gemini")
+case object ucac4 extends CatalogName("ucac4", "UCAC4 @ Gemini")
+case object twomass_psc extends CatalogName("twomass_psc", "TwoMass PSC @ Gemini")
+case object twomass_xsc extends CatalogName("twomass_xsc", "TwoMass XSC @ Gemini")
+case object simbad extends CatalogName("simbad", "Simbad")
+
+object CatalogName {
+  implicit val equals = Equal.equal[CatalogName]((a, b) => a.id === b.id)
+
+}
+
 /**
  * Represents a query on a catalog
  */
@@ -39,6 +54,7 @@ case class ConeSearchCatalogQuery(id: Option[Int], base: Coordinates, radiusCons
 
   override def isSuperSetOf(q: CatalogQuery) = q match {
     case c: ConeSearchCatalogQuery =>
+
       // Angular separation, or distance between the two.
       val distance = Coordinates.difference(base, c.base).distance
 
@@ -48,7 +64,7 @@ case class ConeSearchCatalogQuery(id: Option[Int], base: Coordinates, radiusCons
 
       // See whether the other base position falls out of range of our
       // radius limits.
-      radiusConstraint.maxLimit >= max
+      radiusConstraint.maxLimit >= max && q.catalog === catalog
     case _ => false
   }
 }
@@ -80,13 +96,3 @@ object CatalogQuery {
 
   implicit val equals = Equal.equalA[CatalogQuery]
 }
-
-sealed abstract class CatalogName(val id: String)
-
-case object sdss extends CatalogName("sdss9")
-case object gsc234 extends CatalogName("gsc234")
-case object ppmxl extends CatalogName("ppmxl")
-case object ucac4 extends CatalogName("ucac4")
-case object twomass_psc extends CatalogName("twomass_psc")
-case object twomass_xsc extends CatalogName("twomass_xsc")
-case object simbad extends CatalogName("simbad")

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -20,13 +20,13 @@ case class MagnitudeQueryFilter(mc: MagnitudeConstraints) extends QueryResultsFi
 
 sealed abstract class CatalogName(val id: String, val displayName: String)
 
-case object sdss extends CatalogName("sdss9", "SDSS9 @ Gemini")
-case object gsc234 extends CatalogName("gsc234", "GSC234 @ Gemini")
-case object ppmxl extends CatalogName("ppmxl", "PPMXL @ Gemini")
-case object ucac4 extends CatalogName("ucac4", "UCAC4 @ Gemini")
-case object twomass_psc extends CatalogName("twomass_psc", "TwoMass PSC @ Gemini")
-case object twomass_xsc extends CatalogName("twomass_xsc", "TwoMass XSC @ Gemini")
-case object simbad extends CatalogName("simbad", "Simbad")
+case object SDSS extends CatalogName("sdss9", "SDSS9 @ Gemini")
+case object GSC234 extends CatalogName("gsc234", "GSC234 @ Gemini")
+case object PPMXL extends CatalogName("ppmxl", "PPMXL @ Gemini")
+case object UCAC4 extends CatalogName("ucac4", "UCAC4 @ Gemini")
+case object TWOMASS_PSC extends CatalogName("twomass_psc", "TwoMass PSC @ Gemini")
+case object TWOMASS_XSC extends CatalogName("twomass_xsc", "TwoMass XSC @ Gemini")
+case object SIMBAD extends CatalogName("simbad", "Simbad")
 
 object CatalogName {
   implicit val equals = Equal.equal[CatalogName]((a, b) => a.id === b.id)
@@ -92,7 +92,7 @@ object CatalogQuery {
 
   def apply(base: Coordinates, radiusConstraint: RadiusConstraint, catalog: CatalogName):CatalogQuery = ConeSearchCatalogQuery(None, base, radiusConstraint, Nil, catalog)
 
-  def apply(search: String):CatalogQuery = NameCatalogQuery(search, simbad)
+  def apply(search: String):CatalogQuery = NameCatalogQuery(search, SIMBAD)
 
   implicit val equals = Equal.equalA[CatalogQuery]
 }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/skycat/binding/skyobj/UCAC4.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/skycat/binding/skyobj/UCAC4.scala
@@ -1,8 +1,0 @@
-package edu.gemini.catalog.skycat.binding.skyobj
-
-import edu.gemini.spModel.core.MagnitudeBand
-
-object UCAC4 {
-  // UCAC bands
-  val magnitudeBands = List(MagnitudeBand.UC, MagnitudeBand.B, MagnitudeBand.V, MagnitudeBand._g, MagnitudeBand._r, MagnitudeBand._i, MagnitudeBand.J, MagnitudeBand.H, MagnitudeBand.K)
-}

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/skycat/binding/skyobj/Votable2SkyCatalogServlet.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/skycat/binding/skyobj/Votable2SkyCatalogServlet.scala
@@ -18,8 +18,11 @@ import Scalaz._
 
 @Deprecated
 class Votable2SkyCatalogServlet extends HttpServlet {
+  // UCAC bands
+  val magnitudeBands = List(MagnitudeBand.UC, MagnitudeBand.B, MagnitudeBand.V, MagnitudeBand._g, MagnitudeBand._r, MagnitudeBand._i, MagnitudeBand.J, MagnitudeBand.H, MagnitudeBand.K)
+
   private def magnitudes(t: SiderealTarget):String = {
-    UCAC4.magnitudeBands.map {b =>
+    magnitudeBands.map {b =>
       t.magnitudeIn(b).map(m => f"${m.value}%3.3f").getOrElse(" ")
     }.mkString("\t")
   }
@@ -29,7 +32,7 @@ class Votable2SkyCatalogServlet extends HttpServlet {
     s"$raV\t$decV"
   }
   private def toRow(t: SiderealTarget):String = f"${t.name}%-10s\t${t.coordinates.ra.toAngle.toDegrees}%+03.07f\t${t.coordinates.dec.toDegrees}%+03.07f\t${properMotion(t)}\t${magnitudes(t)}"
-  private def headers:String = s"4UC\tRA\tDEC\tpmRA\tpmDEC\t${UCAC4.magnitudeBands.map(_.name).mkString("\t")}\n-"
+  private def headers:String = s"4UC\tRA\tDEC\tpmRA\tpmDEC\t${magnitudeBands.map(_.name).mkString("\t")}\n-"
 
   private val lowLimitMagRegex = """(.*)magLL""".r
   private val highLimitMagRegex = """(.*)magHL""".r
@@ -107,9 +110,9 @@ class Votable2SkyCatalogServlet extends HttpServlet {
           }
 
         val query: CatalogQuery = (mr >>= (_.toOption)).map { const =>
-            CatalogQuery(coordinates, rc, const, ucac4)
+            CatalogQuery(coordinates, rc, const, UCAC4)
           }.getOrElse {
-            CatalogQuery(coordinates, rc, Nil, ucac4)
+            CatalogQuery(coordinates, rc, Nil, UCAC4)
           }
 
         // Execute query

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
@@ -1,9 +1,6 @@
 package edu.gemini.catalog.votable
 
-import java.net.URL
-
-import edu.gemini.catalog.api.CatalogQuery
-import edu.gemini.spModel.core.MagnitudeBand
+import edu.gemini.catalog.api.{CatalogName, CatalogQuery}
 import edu.gemini.spModel.core.Target.SiderealTarget
 
 import scala.util.matching.Regex
@@ -81,8 +78,8 @@ sealed trait CatalogProblem {
   def displayValue: String
 }
 
-case class ValidationError(url: URL) extends CatalogProblem {
-  val displayValue = s"Invalid url $url"
+case class ValidationError(catalog: CatalogName) extends CatalogProblem {
+  val displayValue = s"Invalid response from ${catalog.displayName}"
 }
 case class GenericError(msg: String) extends CatalogProblem {
   val displayValue = msg

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Logger
 
 import edu.gemini.catalog.api.{NameCatalogQuery, ConeSearchCatalogQuery, CatalogQuery}
-import edu.gemini.catalog.votable.ConeSearchBackend._
 import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.core.Target.SiderealTarget
 import org.apache.commons.httpclient.{NameValuePair, HttpClient}
@@ -165,7 +164,7 @@ trait RemoteCallBackend {this: CachedBackend =>
 
     try {
       client.executeMethod(method)
-      VoTableParser.parse(e.url, method.getResponseBodyAsStream, validate) match {
+      VoTableParser.parse(e.query.catalog, method.getResponseBodyAsStream, validate) match {
         case -\/(p) => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p)))
         case \/-(y) => QueryResult(e.query, CatalogQueryResult(y))
       }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -3,6 +3,7 @@ package edu.gemini.catalog.votable
 import java.io.{ByteArrayInputStream, InputStream}
 import java.net.URL
 
+import edu.gemini.catalog.api.CatalogName
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.Target.SiderealTarget
 
@@ -46,12 +47,12 @@ object VoTableParser extends VoTableParser {
   /**
    * parse takes an input stream and attempts to read the xml content and convert it to a VoTable resource
    */
-  def parse(url: URL, is: InputStream, checkValidity: Boolean = true): CatalogResult = {
+  def parse(catalog: CatalogName, is: InputStream, checkValidity: Boolean = true): CatalogResult = {
     // Load in memory (Could be a problem for large responses)
     val xmlText = Source.fromInputStream(is, "UTF-8").getLines().mkString
 
     (checkValidity, validate(xmlText)) match {
-      case (true, -\/(e))  => \/.left(ValidationError(url))
+      case (true, -\/(e))  => \/.left(ValidationError(catalog))
       case (false, -\/(e)) => \/.right(parse(XML.loadString(xmlText)))
       case (_, \/-(r))     => \/.right(parse(XML.loadString(r)))
     }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
@@ -1,7 +1,5 @@
 package edu.gemini.catalog.votable
 
-import java.net.URL
-
 import edu.gemini.catalog.api._
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
@@ -15,7 +13,7 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
   val coneSearch = Angle.fromDegrees(0.1)
 
   val xmlFile = "votable-ucac4.xml"
-  val targets = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile"))
+  val targets = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile"))
   val unfiltered = CatalogQueryResult(targets | ParsedVoResource(Nil))
 
   val noMagnitudeConstraint = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(100), None)

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQueryResultSpec.scala
@@ -13,26 +13,26 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
   val coneSearch = Angle.fromDegrees(0.1)
 
   val xmlFile = "votable-ucac4.xml"
-  val targets = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile"))
+  val targets = VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile"))
   val unfiltered = CatalogQueryResult(targets | ParsedVoResource(Nil))
 
   val noMagnitudeConstraint = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(100), None)
 
   "CatalogQueryResultSpec" should {
     "be able to filter targets inside the requested range limit" in {
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, coneSearch), noMagnitudeConstraint, ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, coneSearch), noMagnitudeConstraint, UCAC4)
       // Filtering on search radius should give all back
       unfiltered.filter(qc).targets.rows should be size 11
     }
     "be able to filter targets to a specific ring" in {
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.fromDegrees(0.05), coneSearch), noMagnitudeConstraint, ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.fromDegrees(0.05), coneSearch), noMagnitudeConstraint, UCAC4)
       val filtered = unfiltered.filter(qc)
 
       // Filtering on search radius filters out 4 targets
       filtered.targets.rows should be size 7
     }
     "be able to filter by band" in {
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.fromDegrees(0.05), coneSearch), noMagnitudeConstraint, ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.fromDegrees(0.05), coneSearch), noMagnitudeConstraint, UCAC4)
       val filtered = unfiltered.filter(qc)
 
       // Filtering on search radius filters out 4 targets
@@ -40,7 +40,7 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
     }
     "be able to filter by faintness on band j" in {
       val mc = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, coneSearch), mc, ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, coneSearch), mc, UCAC4)
       val filtered = unfiltered.filter(qc)
 
       // Filtering on magnitude discards 3 targets
@@ -48,7 +48,7 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
     }
     "be able to filter by faintness and saturation on band j" in {
       val mc = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), Some(SaturationConstraint(14.0)))
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, coneSearch), mc, ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, coneSearch), mc, UCAC4)
       val filtered = unfiltered.filter(qc)
 
       // Filtering on magnitude leaves only 4 targets
@@ -57,8 +57,8 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
     "be able to filter with a band and range" in {
       val mc1 = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
       val mc2 = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
-      val qc1 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc1, ucac4)
-      val qc2 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc2, ucac4)
+      val qc1 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc1, UCAC4)
+      val qc2 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc2, UCAC4)
       val filtered = unfiltered.filter(qc1)
       val filtered2 = unfiltered.filter(qc2)
       filtered should beEqualTo(filtered2)
@@ -68,11 +68,11 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
     }
     "be able to filter with a band range with Nil) adjustments" in {
       val mc = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc, ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc, UCAC4)
 
       def nilAdjustment(v: Double) = v
 
-      val qc2 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc.adjust(nilAdjustment), ucac4)
+      val qc2 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc.adjust(nilAdjustment), UCAC4)
       val filtered = unfiltered.filter(qc)
       val filtered2 = unfiltered.filter(qc2)
       filtered should beEqualTo(filtered2)
@@ -83,12 +83,12 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
     }
     "be able to filter with a band range with nominal conditions" in {
       val mc = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc, ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc, UCAC4)
 
       // Nominal conditions don't change the MagnitudeRange
       val conditions = SPSiteQuality.Conditions.NOMINAL
 
-      val qc2 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), conditions.adjust(mc), ucac4)
+      val qc2 = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), conditions.adjust(mc), UCAC4)
       val filtered = unfiltered.filter(qc)
       val filtered2 = unfiltered.filter(qc2)
       filtered should beEqualTo(filtered2)
@@ -99,7 +99,7 @@ class CatalogQueryResultSpec extends SpecificationWithJUnit {
     "be able to filter with a band range with extreme adjustments" in {
       val mc = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
 
-      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc.adjust(k => k - 20), ucac4)
+      val qc = CatalogQuery(c, RadiusConstraint.between(Angle.zero, Angle.fromDegrees(90)), mc.adjust(k => k - 20), UCAC4)
       val filtered = unfiltered.filter(qc)
 
       // Filtering on magnitude and with the given adjustment takes all the targets out

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQuerySpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQuerySpec.scala
@@ -22,8 +22,8 @@ class CatalogQuerySpec extends SpecificationWithJUnit {
   val saturation0= SaturationConstraint(0)
   val mag10 = MagnitudeConstraints(RBandsList, faint10, Some(saturation0))
   val base = Coordinates.zero
-  val par10_10 = CatalogQuery(base, rad10, mag10, ucac4)
-  val par5_10 = CatalogQuery(base, rad5, mag10, ucac4)
+  val par10_10 = CatalogQuery(base, rad10, mag10, UCAC4)
+  val par5_10 = CatalogQuery(base, rad5, mag10, UCAC4)
   val ma2 = Angle.zero - Angle.fromArcsecs(2)
   val ma4_9 = Angle.zero - Angle.fromArcsecs(4.99999)
   val ma7   = Angle.zero - Angle.fromArcsecs(7.0)
@@ -62,25 +62,25 @@ class CatalogQuerySpec extends SpecificationWithJUnit {
           Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma2).getOrElse(Declination.zero)),
           Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma4_9).getOrElse(Declination.zero)))
       coordinates.map(c =>
-        par10_10 should beSuperSetOf(CatalogQuery(c, rad5, mag10, ucac4))
+        par10_10 should beSuperSetOf(CatalogQuery(c, rad5, mag10, UCAC4))
       )
     }
     "be a superset at the pole" in {
       val pole = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0)).getOrElse(Declination.zero))
       val close = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0) - Angle.fromArcsecs(2)).getOrElse(Declination.zero))
       // 10 arcsec radius at the pole
-      val poleP = CatalogQuery(pole, rad10, mag10, ucac4)
+      val poleP = CatalogQuery(pole, rad10, mag10, UCAC4)
       // 5 arcsec radius close to the pole
-      val closeP = CatalogQuery(close, rad5, mag10, ucac4)
+      val closeP = CatalogQuery(close, rad5, mag10, UCAC4)
       poleP should beSuperSetOf(closeP)
     }
     "not be a superset far of the pole" in {
       val pole = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0)).getOrElse(Declination.zero))
       val far = Coordinates(RightAscension.zero, Declination.fromAngle(Angle.fromDegrees(90.0) - Angle.fromArcsecs(7)).getOrElse(Declination.zero))
       // 10 arcsec radius at the pole
-      val poleP = CatalogQuery(pole, rad10, mag10, ucac4)
+      val poleP = CatalogQuery(pole, rad10, mag10, UCAC4)
       // 5 arcsec radius, but a bit too far from the pole
-      val farP = CatalogQuery(far, rad5, mag10, ucac4)
+      val farP = CatalogQuery(far, rad5, mag10, UCAC4)
       poleP should beNoSuperSetOf(farP)
     }
     "not be a superset out of the range limits" in {
@@ -103,11 +103,11 @@ class CatalogQuerySpec extends SpecificationWithJUnit {
         Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(a20).getOrElse(Declination.zero)),
         Coordinates(RightAscension.fromAngle(a0),    Declination.fromAngle(ma20).getOrElse(Declination.zero)))
       coordinates.map(c =>
-        par10_10 should beNoSuperSetOf(CatalogQuery(c, rad5, mag10, ucac4))
+        par10_10 should beNoSuperSetOf(CatalogQuery(c, rad5, mag10, UCAC4))
       )
     }
     "not be a supersef far out of range" in {
-      val far = CatalogQuery(Coordinates(RightAscension.fromDegrees(180), Declination.zero), rad5, mag10, ucac4)
+      val far = CatalogQuery(Coordinates(RightAscension.fromDegrees(180), Declination.zero), rad5, mag10, UCAC4)
       par10_10 should beNoSuperSetOf(far)
     }
   }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
@@ -2,7 +2,7 @@ package edu.gemini.catalog.votable
 
 import java.net.URL
 
-import edu.gemini.catalog.api.CatalogQuery
+import edu.gemini.catalog.api.{ucac4, CatalogQuery}
 import scala.concurrent.future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scalaz.NonEmptyList
@@ -12,6 +12,6 @@ case class TestVoTableBackend(file: String) extends VoTableBackend {
   override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
 
   override def doQuery(query: CatalogQuery, url: URL) = future {
-    VoTableParser.parse(url, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
+    VoTableParser.parse(ucac4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
   }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
@@ -2,7 +2,7 @@ package edu.gemini.catalog.votable
 
 import java.net.URL
 
-import edu.gemini.catalog.api.{ucac4, CatalogQuery}
+import edu.gemini.catalog.api.{UCAC4, CatalogQuery}
 import scala.concurrent.future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scalaz.NonEmptyList
@@ -12,6 +12,6 @@ case class TestVoTableBackend(file: String) extends VoTableBackend {
   override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
 
   override def doQuery(query: CatalogQuery, url: URL) = future {
-    VoTableParser.parse(ucac4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
+    VoTableParser.parse(UCAC4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
   }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -24,12 +24,12 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
     val dec = Declination.fromAngle(Angle.fromDegrees(20)).getOrElse(Declination.zero)
     val coordinates = Coordinates(ra, dec)
 
-    val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, ucac4)
+    val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, UCAC4)
     case class CountingCachedBackend(counter: AtomicInteger, file: String) extends CachedBackend {
       override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
       override protected def query(e: SearchKey) = {
         counter.incrementAndGet()
-        VoTableParser.parse(ucac4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(e.query, CatalogQueryResult(y)))
+        VoTableParser.parse(UCAC4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(e.query, CatalogQueryResult(y)))
       }
     }
 
@@ -68,7 +68,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
       val counter = new AtomicInteger(0)
       val countingBackend = CountingCachedBackend(counter, "/votable-ucac4.xml")
       // query2 has smaller radius
-      val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, ucac4)
+      val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, UCAC4)
       // Backend should be hit at most once per url
       val r = for {
           f1 <- VoTableClient.catalog(query, countingBackend)
@@ -82,7 +82,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
       val counter = new AtomicInteger(0)
       val countingBackend = CountingCachedBackend(counter, "/votable-ucac4.xml")
       // query2 has smaller radius
-      val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, ucac4)
+      val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, UCAC4)
       // Backend should be hit at most once per url
       val r = for {
           f1 <- VoTableClient.catalog(query, countingBackend)
@@ -97,7 +97,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
       val counter = new AtomicInteger(0)
       val countingBackend = CountingCachedBackend(counter, "/votable-ucac4.xml")
       // query2 has smaller radius
-      val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.05)), noMagnitudeConstraint, ucac4)
+      val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.05)), noMagnitudeConstraint, UCAC4)
       //
       val r = for {
           f1 <- VoTableClient.catalog(query, countingBackend)
@@ -112,7 +112,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
       val counter = new AtomicInteger(0)
       val countingBackend = CountingCachedBackend(counter, "/votable-ucac4.xml")
       val mc = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
-      val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), mc, ucac4)
+      val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), mc, UCAC4)
 
       val result = Await.result(VoTableClient.catalog(query, countingBackend), 10.seconds)
       // Extract the query params from the results

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -29,7 +29,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
       override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
       override protected def query(e: SearchKey) = {
         counter.incrementAndGet()
-        VoTableParser.parse(e.url, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(e.query, CatalogQueryResult(y)))
+        VoTableParser.parse(ucac4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(e.query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(e.query, CatalogQueryResult(y)))
       }
     }
 

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -2,6 +2,7 @@ package edu.gemini.catalog.votable
 
 import java.net.URL
 
+import edu.gemini.catalog.api.{simbad, ppmxl, ucac4}
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.Target.SiderealTarget
 import org.specs2.mutable.SpecificationWithJUnit
@@ -436,11 +437,11 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to validate and parse an xml from sds9" in {
       val badXml = "votable-non-validating.xml"
-      VoTableParser.parse(new URL(s"file:////$badXml"), getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(new URL(s"file:////$badXml"))))
+      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(ucac4)))
     }
     "be able to detect unknown catalogs" in {
       val xmlFile = "votable-unknown.xml"
-      val result  = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile"))
+      val result  = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile"))
       result.map { parsed =>
         parsed.containsError must beEqualTo(true)
         parsed.tables.map { table =>
@@ -452,17 +453,17 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to validate and parse an xml from ucac4" in {
       val xmlFile = "votable-ucac4.xml"
-      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
-      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
+      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
     }
     "be able to validate and parse an xml from ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
-      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
-      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
+      VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
     }
     "be able to select r1mag over r2mag and b2mag when b1mag is absent in ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
+      val result = VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
 
       val magR = result >>= {_.magnitudeIn(MagnitudeBand.R)}
       magR.map(_.value) should beSome(18.149999999999999)
@@ -472,7 +473,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "be able to ignore bogus magnitudes on ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
       // Check a well-known target containing invalid magnitude values an bands H, I, K and J
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
+      val result = VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
       val magH = result >>= {_.magnitudeIn(MagnitudeBand.H)}
       val magI = result >>= {_.magnitudeIn(MagnitudeBand.I)}
       val magK = result >>= {_.magnitudeIn(MagnitudeBand.K)}
@@ -484,9 +485,9 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to filter out bad magnitudes" in {
       val xmlFile = "fmag.xml"
-      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
       // The sample has only one row
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val mags = result.map(_.magnitudeIn(MagnitudeBand.R))
       // Does not contain R as it is filtered out being magnitude 20 and error 99
@@ -494,9 +495,9 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "convert fmag to UC" in {
       val xmlFile = "fmag.xml"
-      VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
       // The sample has only one row
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val mags = result.map(_.magnitudeIn(MagnitudeBand.UC))
       // Fmag gets converted to UC
@@ -505,7 +506,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "extract Sloan's band" in {
       val xmlFile = "sloan.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val gmag = result.map(_.magnitudeIn(MagnitudeBand._g))
       // gmag gets converted to g'
@@ -520,7 +521,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad named queries" in {
       val xmlFile = "simbad-vega.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       // id and coordinates
       result.map(_.name) should beEqualTo(\/.right("* alf Lyr"))
@@ -542,7 +543,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad named queries with sloan magnitudes" in {
       val xmlFile = "simbad-2MFGC6625.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       // id and coordinates
       result.map(_.name) should beEqualTo(\/.right("2MFGC 6625"))
@@ -560,7 +561,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad named queries with mixed magnitudes" in {
       val xmlFile = "simbad-J000008.13.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       // id and coordinates
       result.map(_.name) should beEqualTo(\/.right("2SLAQ J000008.13+001634.6"))
@@ -583,7 +584,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad with a not-found name" in {
       val xmlFile = "simbad-not-found.xml"
       // Simbad returns non-valid xml when an element is not found, we need to skip validation :S
-      val result = VoTableParser.parse(new URL(s"file:////$xmlFile"), getClass.getResourceAsStream(s"/$xmlFile"), false)
+      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile"), checkValidity = false)
       result must beEqualTo(\/.right(ParsedVoResource(List())))
     }
   }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -2,7 +2,7 @@ package edu.gemini.catalog.votable
 
 import java.net.URL
 
-import edu.gemini.catalog.api.{simbad, ppmxl, ucac4}
+import edu.gemini.catalog.api.{SIMBAD, PPMXL, UCAC4}
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.Target.SiderealTarget
 import org.specs2.mutable.SpecificationWithJUnit
@@ -437,11 +437,11 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to validate and parse an xml from sds9" in {
       val badXml = "votable-non-validating.xml"
-      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(ucac4)))
+      VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$badXml")) should beEqualTo(-\/(ValidationError(UCAC4)))
     }
     "be able to detect unknown catalogs" in {
       val xmlFile = "votable-unknown.xml"
-      val result  = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile"))
+      val result  = VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile"))
       result.map { parsed =>
         parsed.containsError must beEqualTo(true)
         parsed.tables.map { table =>
@@ -453,17 +453,17 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to validate and parse an xml from ucac4" in {
       val xmlFile = "votable-ucac4.xml"
-      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
-      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
+      VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
     }
     "be able to validate and parse an xml from ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
-      VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
-      VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
+      VoTableParser.parse(PPMXL, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(PPMXL, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
     }
     "be able to select r1mag over r2mag and b2mag when b1mag is absent in ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
-      val result = VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
+      val result = VoTableParser.parse(PPMXL, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
 
       val magR = result >>= {_.magnitudeIn(MagnitudeBand.R)}
       magR.map(_.value) should beSome(18.149999999999999)
@@ -473,7 +473,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "be able to ignore bogus magnitudes on ppmxl" in {
       val xmlFile = "votable-ppmxl.xml"
       // Check a well-known target containing invalid magnitude values an bands H, I, K and J
-      val result = VoTableParser.parse(ppmxl, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
+      val result = VoTableParser.parse(PPMXL, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.map(TargetsTable.apply).map(_.rows).flatMap(_.find(_.name == "-1471224894")).headOption
       val magH = result >>= {_.magnitudeIn(MagnitudeBand.H)}
       val magI = result >>= {_.magnitudeIn(MagnitudeBand.I)}
       val magK = result >>= {_.magnitudeIn(MagnitudeBand.K)}
@@ -485,9 +485,9 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "be able to filter out bad magnitudes" in {
       val xmlFile = "fmag.xml"
-      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
       // The sample has only one row
-      val result = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val mags = result.map(_.magnitudeIn(MagnitudeBand.R))
       // Does not contain R as it is filtered out being magnitude 20 and error 99
@@ -495,9 +495,9 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     }
     "convert fmag to UC" in {
       val xmlFile = "fmag.xml"
-      VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
+      VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
       // The sample has only one row
-      val result = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val mags = result.map(_.magnitudeIn(MagnitudeBand.UC))
       // Fmag gets converted to UC
@@ -506,7 +506,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "extract Sloan's band" in {
       val xmlFile = "sloan.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(ucac4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       val gmag = result.map(_.magnitudeIn(MagnitudeBand._g))
       // gmag gets converted to g'
@@ -521,7 +521,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad named queries" in {
       val xmlFile = "simbad-vega.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       // id and coordinates
       result.map(_.name) should beEqualTo(\/.right("* alf Lyr"))
@@ -543,7 +543,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad named queries with sloan magnitudes" in {
       val xmlFile = "simbad-2MFGC6625.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       // id and coordinates
       result.map(_.name) should beEqualTo(\/.right("2MFGC 6625"))
@@ -561,7 +561,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad named queries with mixed magnitudes" in {
       val xmlFile = "simbad-J000008.13.xml"
       // The sample has only one row
-      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
+      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables.headOption.flatMap(_.rows.headOption).get
 
       // id and coordinates
       result.map(_.name) should beEqualTo(\/.right("2SLAQ J000008.13+001634.6"))
@@ -584,7 +584,7 @@ class VoTableParserSpec extends SpecificationWithJUnit with VoTableParser {
     "parse simbad with a not-found name" in {
       val xmlFile = "simbad-not-found.xml"
       // Simbad returns non-valid xml when an element is not found, we need to skip validation :S
-      val result = VoTableParser.parse(simbad, getClass.getResourceAsStream(s"/$xmlFile"), checkValidity = false)
+      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile"), checkValidity = false)
       result must beEqualTo(\/.right(ParsedVoResource(List())))
     }
   }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -2,7 +2,7 @@ package jsky.app.ot.tpe.gems;
 
 import edu.gemini.ags.gems.GemsUtils4Java;
 import edu.gemini.spModel.core.Target;
-import edu.gemini.catalog.api.ucac4$;
+import edu.gemini.catalog.api.UCAC4$;
 import jsky.catalog.Catalog;
 import jsky.catalog.FieldDesc;
 import jsky.catalog.FieldDescAdapter;
@@ -49,7 +49,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
         _model = model;
         _nirBand = _model.getBand().name();
         _unusedBands = getOtherNirBands(_nirBand);
-        _isUCAC4 = model.getCatalog().catalog() == ucac4$.MODULE$;
+        _isUCAC4 = model.getCatalog().catalog() == UCAC4$.MODULE$;
         _columnNames = makeColumnNames();
         setDataVector(makeDataVector(), _columnNames);
     }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -78,7 +78,7 @@ object ObservationInfo {
     AgsRegistrar.currentStrategy(ctx),
     AgsRegistrar.validStrategies(ctx).map(toSupportedStrategy(ctx, _, mt)),
     ctx.getConditions.some,
-    ucac4)
+    UCAC4)
 
 }
 
@@ -413,7 +413,7 @@ object QueryResultsWindow {
           }
         }
         lazy val instrumentName = new Label("")
-        lazy val catalogBox = new ComboBox(List[CatalogName](ucac4, ppmxl)) with TextRenderer[CatalogName] {
+        lazy val catalogBox = new ComboBox(List[CatalogName](UCAC4, PPMXL)) with TextRenderer[CatalogName] {
           override def text(a: CatalogName) = ~Option(a).map(_.displayName)
         }
         lazy val guider = new ComboBox(List.empty[SupportedStrategy]) with TextRenderer[SupportedStrategy] {
@@ -762,7 +762,7 @@ object CatalogQueryDemo extends SwingApplication {
   import edu.gemini.spModel.target.SPTarget
   import edu.gemini.spModel.target.env.TargetEnvironment
 
-  val query = CatalogQuery(Coordinates(RightAscension.fromAngle(Angle.fromDegrees(3.1261166666666895)),Declination.fromAngle(Angle.fromDegrees(337.93268333333333)).getOrElse(Declination.zero)),RadiusConstraint.between(Angle.zero,Angle.fromDegrees(0.16459874517619255)),List(MagnitudeConstraints(RBandsList,FaintnessConstraint(16.0),Some(SaturationConstraint(3.1999999999999993)))),ucac4)
+  val query = CatalogQuery(Coordinates(RightAscension.fromAngle(Angle.fromDegrees(3.1261166666666895)),Declination.fromAngle(Angle.fromDegrees(337.93268333333333)).getOrElse(Declination.zero)),RadiusConstraint.between(Angle.zero,Angle.fromDegrees(0.16459874517619255)),List(MagnitudeConstraints(RBandsList,FaintnessConstraint(16.0),Some(SaturationConstraint(3.1999999999999993)))),UCAC4)
 
   def startup(args: Array[String]) {
     System.setProperty("apple.awt.antialiasing", "on")

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -623,14 +623,15 @@ object QueryResultsWindow {
             // TODO Change the search query for different conditions OCSADV-416
             val conditions = Conditions.NOMINAL.sb(sbBox.selection.item).cc(ccBox.selection.item).iq(iqBox.selection.item)
 
-            val info = ObservationInfo(objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some)
-            val defaultQuery = CatalogQuery(coordinates, radiusConstraint, currentFilters, ucac4)
+            val selectedCatalog = catalogBox.selection.item
+            val info = ObservationInfo(objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog)
+            val defaultQuery = CatalogQuery(coordinates, radiusConstraint, currentFilters, selectedCatalog)
             // Start with the guider's query and update it with the values on the UI
             val calculatedQuery = guider.selection.item.query.headOption.collect {
-              case c: ConeSearchCatalogQuery if currentFilters.nonEmpty => c.copy(base = coordinates, radiusConstraint = radiusConstraint, magnitudeConstraints = currentFilters)
-              case c: ConeSearchCatalogQuery                            => c.copy(base = coordinates, radiusConstraint = radiusConstraint) // Use the magnitude constraints from the guider
+              case c: ConeSearchCatalogQuery if currentFilters.nonEmpty => c.copy(base = coordinates, radiusConstraint = radiusConstraint, magnitudeConstraints = currentFilters, catalog = selectedCatalog)
+              case c: ConeSearchCatalogQuery                            => c.copy(base = coordinates, radiusConstraint = radiusConstraint, catalog = selectedCatalog) // Use the magnitude constraints from the guider
             }
-            (info.some, guiderQuery.getOrElse(defaultQuery))
+            (info.some, calculatedQuery.getOrElse(defaultQuery))
           }
         }
 


### PR DESCRIPTION
This is a small update to the Catalog Navigator adding  a combo box to choose among the available catalogs (Right now just UCAC4 and PPMXL hosted at Gemini)

see the screenshot below:

![screenshot 2015-10-02 10 20 59](https://cloud.githubusercontent.com/assets/3615303/10247454/92cfd344-68ef-11e5-977d-a56e3ed9b97b.png)
