### PR TITLE
OCSADV-379: Compress ITC output table.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceCellRenderer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceCellRenderer.java
@@ -1,13 +1,10 @@
-//
-// $Id$
-//
-
 package jsky.app.ot.editor.seq;
 
 import edu.gemini.spModel.config2.ItemKey;
 import jsky.app.ot.util.OtColor;
 
 import java.awt.*;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,28 +14,24 @@ import java.util.Set;
 final class DynamicSequenceCellRenderer extends SequenceCellRenderer {
     private static final Color VERY_LIGHT_GREY = new Color(247, 243, 239);
 
-    private static final Set<ItemKey> FIXED_ITEMS = new HashSet<ItemKey>();
-
-    static {
-        for (ItemKey key : DynamicSequenceTableModel.SORT_ORDER) {
-            FIXED_ITEMS.add(key);
-        }
-    }
+    private static final Set<ItemKey> FIXED_ITEMS = new HashSet<ItemKey>() {{
+        Collections.addAll(this, DynamicSequenceTableModel.SORT_ORDER);
+    }};
 
     private DynamicSequenceTableModel _model;
 
-    DynamicSequenceCellRenderer(DynamicSequenceTableModel model) {
+    DynamicSequenceCellRenderer(final DynamicSequenceTableModel model) {
         _model  = model;
     }
 
-    protected Color lookupTextColor(int row, int column) {
+    protected Color lookupTextColor(final int row, final int column) {
         return _model.matchesNodeId(row) ?
                 super.lookupTextColor(row, column) :
                 Color.LIGHT_GRAY;
     }
 
-    protected Color lookupColor(int row, int column) {
-        ItemKey key = _model.getItemKeyAt(column);
+    protected Color lookupColor(final int row, final int column) {
+        final ItemKey key = _model.getItemKeyAt(column);
         Color color = VERY_LIGHT_GREY;
         if (!FIXED_ITEMS.contains(key)) color = lookupColor(key);
         if (_model.isError(row)) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceCellRenderer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceCellRenderer.java
@@ -18,7 +18,7 @@ final class DynamicSequenceCellRenderer extends SequenceCellRenderer {
         Collections.addAll(this, DynamicSequenceTableModel.SORT_ORDER);
     }};
 
-    private DynamicSequenceTableModel _model;
+    private final DynamicSequenceTableModel _model;
 
     DynamicSequenceCellRenderer(final DynamicSequenceTableModel model) {
         _model  = model;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceTableModel.java
@@ -1,7 +1,3 @@
-//
-// $Id$
-//
-
 package jsky.app.ot.editor.seq;
 
 import edu.gemini.pot.sp.SPNodeKey;
@@ -25,7 +21,7 @@ import static jsky.app.ot.editor.seq.Keys.*;
  * Table model that holds the values in the configuration that change over its
  * course.
  */
-public class DynamicSequenceTableModel extends AbstractTableModel {
+public final class DynamicSequenceTableModel extends AbstractTableModel {
     public static final ItemKey[] SORT_ORDER = new ItemKey[] {
             DATALABEL_KEY,
             OBS_CLASS_KEY,
@@ -40,22 +36,22 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
 
     private SPNodeKey _nodeKey;
 
-    public void setSequence(ConfigSequence sequence, SPNodeKey key, List<ItemKey> alwaysShow) {
+    public void setSequence(final ConfigSequence sequence, final SPNodeKey key, final List<ItemKey> alwaysShow) {
         _sequence     = sequence;
         _nodeKey      = key;
 
         final ItemKey[] newIteratedKeys = sort(getIteratedKeys(sequence, alwaysShow));
-        if (newIteratedKeys.equals(_iteratedKeys)) {
+        if (Arrays.equals(newIteratedKeys, _iteratedKeys)) {
             fireTableDataChanged();
         } else {
-            _iteratedKeys = sort(getIteratedKeys(sequence, alwaysShow));
+            _iteratedKeys = newIteratedKeys;
             fireTableStructureChanged();
         }
     }
 
-    private Set<ItemKey> getIteratedKeys(ConfigSequence seq, List<ItemKey> alwaysShow) {
-        Set<ItemKey> res = new HashSet<ItemKey>();
-        ItemKey[]   keys = seq.getIteratedKeys();
+    private Set<ItemKey> getIteratedKeys(final ConfigSequence seq, final List<ItemKey> alwaysShow) {
+        final Set<ItemKey> res = new HashSet<>();
+        final ItemKey[]   keys = seq.getIteratedKeys();
         for (ItemKey key : keys) {
             // Strip out all the smart gcal metadata.
             if (MetaDataConfig.MATCHER.matches(key) || SmartgcalSysConfig.MATCHER.matches(key)) continue;
@@ -111,8 +107,8 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
         return res;
     }
 
-    private ItemKey[] sort(Set<ItemKey> keys) {
-        List<ItemKey> res = new ArrayList<ItemKey>(keys.size());
+    private ItemKey[] sort(final Set<ItemKey> keys) {
+        final List<ItemKey> res = new ArrayList<>(keys.size());
 
         // First put in the keys from the sort order that are present in the
         // iterated keys set.
@@ -123,13 +119,13 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
         }
 
         // Now sort everything that's left by name.
-        List<ItemKey> sortedKeys = new ArrayList<ItemKey>(keys);
+        final List<ItemKey> sortedKeys = new ArrayList<>(keys);
         Collections.sort(sortedKeys);
 
         // Now we're left with the everything whose order isn't fixed.  Split
         // them up by path prefix.  In other words, group the instrument items,
         // telescope items, etc.
-        Map<String, List<ItemKey>> groupedItems = new HashMap<String, List<ItemKey>>();
+        final Map<String, List<ItemKey>> groupedItems = new HashMap<>();
         for (ItemKey key : sortedKeys) {
 
             // Get the broad category for the item -- the root parent
@@ -143,7 +139,7 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
             // Add it to the list for that parent.
             List<ItemKey> lst = groupedItems.get(parent.getName());
             if (lst == null) {
-                lst = new ArrayList<ItemKey>();
+                lst = new ArrayList<>();
                 groupedItems.put(parent.getName(), lst);
             }
             lst.add(key);
@@ -166,7 +162,7 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
             res.addAll(groupedItems.get(category));
         }
 
-        return res.toArray(new ItemKey[0]);
+        return res.toArray(new ItemKey[res.size()]);
     }
 
     public int getRowCount() {
@@ -179,18 +175,18 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
         return _iteratedKeys.length;
     }
 
-    private boolean isGcal(Config config) {
-        String type = (String) config.getItemValue(OBS_TYPE_KEY);
+    private boolean isGcal(final Config config) {
+        final String type = (String) config.getItemValue(OBS_TYPE_KEY);
         return InstConstants.FLAT_OBSERVE_TYPE.equals(type) ||
                InstConstants.ARC_OBSERVE_TYPE.equals(type);
     }
 
-    public Object getValueAt(int rowIndex, int columnIndex) {
+    public Object getValueAt(final int rowIndex, final int columnIndex) {
         if (_sequence == null) return null;
         if (_sequence.size() == 0) return null;
 
-        Config config = _sequence.getStep(rowIndex);
-        ItemKey   key = _iteratedKeys[columnIndex];
+        final Config config = _sequence.getStep(rowIndex);
+        final ItemKey   key = _iteratedKeys[columnIndex];
         if (!isGcal(config) && "calibration".equals(key.getParent().toString())) return "";
         Object    val = config.getItemValue(key);
 
@@ -203,12 +199,12 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
         return val;
     }
 
-    public ItemKey getItemKeyAt(int columnIndex) {
+    public ItemKey getItemKeyAt(final int columnIndex) {
         if ((_iteratedKeys == null) || (_iteratedKeys.length == 0)) return null;
         return _iteratedKeys[columnIndex];
     }
 
-    public Class getColumnClass(int columnIndex) {
+    public Class<?> getColumnClass(final int columnIndex) {
         return Object.class; // sorry, the columns are dynamically generated
     }
 
@@ -223,22 +219,22 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
         return "<html>" + res.replaceFirst(" ", "<br/>") + "</html>";
     }
 
-    public boolean isComplete(int step) {
+    public boolean isComplete(final int step) {
         if (_sequence == null) return false;
-        Object val = _sequence.getItemValue(step, OBS_STATUS_KEY);
+        final Object val = _sequence.getItemValue(step, OBS_STATUS_KEY);
         return "complete".equals(val);
     }
 
-    public boolean isError(int step) {
+    public boolean isError(final int step) {
         if (_sequence == null) return false;
-        Object val = _sequence.getItemValue(step, SmartgcalSysConfig.MAPPING_ERROR_KEY);
+        final Object val = _sequence.getItemValue(step, SmartgcalSysConfig.MAPPING_ERROR_KEY);
         return Boolean.TRUE.equals(val);
     }
 
-    public boolean matchesNodeId(int step) {
+    public boolean matchesNodeId(final int step) {
         if (_nodeKey == null) return true;
-        Object val = _sequence.getItemValue(step, SP_NODE_KEY);
-        List<SPNodeKey> keys = (List<SPNodeKey>) val;
+        final Object val = _sequence.getItemValue(step, SP_NODE_KEY);
+        final List<SPNodeKey> keys = (List<SPNodeKey>) val;
         return (keys == null) || keys.contains(_nodeKey);
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceTableModel.java
@@ -212,14 +212,15 @@ public class DynamicSequenceTableModel extends AbstractTableModel {
         return Object.class; // sorry, the columns are dynamically generated
     }
 
-    public String getColumnName(int columnIndex) {
+    public String getColumnName(final int columnIndex) {
         if (_iteratedKeys == null) return null;
-        ItemKey key = _iteratedKeys[columnIndex];
-        String path = key.getPath();
+        final ItemKey key = _iteratedKeys[columnIndex];
+        final String path = key.getPath();
 
-        String res = StringUtil.toDisplayName(key.getName());
-        if (path.startsWith("calibration")) res = "Cal " + res;
-        return res;
+        final String name  = StringUtil.toDisplayName(key.getName());
+        final String res   = path.startsWith("calibration") ? "Cal " + name : name;
+        // returning an html snippet allows for column headers with multiple lines
+        return "<html>" + res.replaceFirst(" ", "<br/>") + "</html>";
     }
 
     public boolean isComplete(int step) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/DynamicSequenceTableModel.java
@@ -126,7 +126,7 @@ public final class DynamicSequenceTableModel extends AbstractTableModel {
         // them up by path prefix.  In other words, group the instrument items,
         // telescope items, etc.
         final Map<String, List<ItemKey>> groupedItems = new HashMap<>();
-        for (ItemKey key : sortedKeys) {
+        for (final ItemKey key : sortedKeys) {
 
             // Get the broad category for the item -- the root parent
             ItemKey parent = key;
@@ -158,7 +158,7 @@ public final class DynamicSequenceTableModel extends AbstractTableModel {
         if (lst != null) res.addAll(lst);
 
         // Now what ever is remaining.
-        for (String category : groupedItems.keySet()) {
+        for (final String category : groupedItems.keySet()) {
             res.addAll(groupedItems.get(category));
         }
 
@@ -187,6 +187,7 @@ public final class DynamicSequenceTableModel extends AbstractTableModel {
 
         final Config config = _sequence.getStep(rowIndex);
         final ItemKey   key = _iteratedKeys[columnIndex];
+        if (key.getParent() == null) return null;
         if (!isGcal(config) && "calibration".equals(key.getParent().toString())) return "";
         Object    val = config.getItemValue(key);
 
@@ -234,7 +235,7 @@ public final class DynamicSequenceTableModel extends AbstractTableModel {
     public boolean matchesNodeId(final int step) {
         if (_nodeKey == null) return true;
         final Object val = _sequence.getItemValue(step, SP_NODE_KEY);
-        final List<SPNodeKey> keys = (List<SPNodeKey>) val;
+        final List<?> keys = (List<?>) val;
         return (keys == null) || keys.contains(_nodeKey);
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/SequenceTabUtil.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/SequenceTabUtil.java
@@ -16,6 +16,7 @@ import java.awt.*;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -95,15 +96,15 @@ final class SequenceTabUtil {
         return fc;
     }
 
-    static void resizeTableColumns(JTable table, TableModel model) {
+    static void resizeTableColumns(final JTable table, final TableModel model) {
         final TableColumnModel colModel = table.getColumnModel();
         final FontMetrics fm = table.getFontMetrics(table.getFont());
         final int rows = model.getRowCount();
 
         for (int col=0; col<model.getColumnCount(); ++col) {
-            final String title = model.getColumnName(col);
 
             // Start with the width of the column header
+            final String title = getLongestHeaderLine(model, col).trim();
             int size = fm.stringWidth(title);
 
             // Check the width of each item in the column to get the maximum width
@@ -119,6 +120,22 @@ final class SequenceTabUtil {
             // Resize the column
             final TableColumn tc = colModel.getColumn(col);
             _setColumnWidth(tc, size, size, size);
+        }
+    }
+
+    /**
+     * Gets the (longest) column header line.
+     * In case of html headers which may contain several lines separated by <br> tags we need to ignore
+     * all html tags and return the longest of the given lines.
+     */
+    private static String getLongestHeaderLine(final TableModel model, final int col) {
+        final String title = model.getColumnName(col);
+        if (title.startsWith("<html>")) {
+            return Arrays.stream(title.split("<br/?>")).                    // split around html breaks
+                    map(s -> s.replaceAll("<.*?>", "")).                    // get rid of html tags
+                    reduce("", (a, s) -> a.length() > s.length() ? a : s);  // find longest line
+        } else {
+            return title;
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -129,13 +129,9 @@ sealed trait ItcTableModel extends AbstractTableModel {
   }
 
   override def getColumnName(col: Int): String = {
-    def multiLineHeader(label: String, separator: String): String = {
-      if (label.contains(separator))
-        // returning an html snippet allows for column headers with multiple lines
-        "<html>" + label.replaceFirst(separator, "<br/>") + "</html>"
-      else
-        label
-    }
+    def multiLineHeader(label: String, separator: String): String =
+      // returning an html snippet allows for column headers with multiple lines
+      "<html>" + label.replaceFirst(separator, "<br/>") + "</html>"
 
     column(col) match {
       case Some(c) => multiLineHeader(c.label, "\n")

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -12,27 +12,41 @@ import scala.util.{Failure, Success}
 import scalaz._
 
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
-case class Column(label: String, value: (ItcUniqueConfig, String\/ItcInputs, Future[ItcService.Result]) => AnyRef, tooltip: String = "")
+class Column private (val label: String, val value: (ItcUniqueConfig, String\/ItcInputs, Future[ItcService.Result]) => AnyRef, val tooltip: String = "")
+
+object Column {
+  /** Creates a Column transforming a label with newlines into a corresponding html snippet for multiline rendering in table headers. */
+  def apply(label: String, value: (ItcUniqueConfig, String\/ItcInputs, Future[ItcService.Result]) => AnyRef, tooltip: String = ""): Column = {
+    new Column(multiLineHeader(label), value, tooltip)
+  }
+  /** Transforms a string with newlines into a html snippet for multiline rendering. */
+  private def multiLineHeader(label: String): String = {
+    if (label.contains('\n'))
+      "<html>" + label.replaceAll("\n", "<br/>") + "</html>"
+    else
+      label
+  }
+}
 
 object ItcTableModel {
   val PeakPixelTooltip    = "Peak pixel value = signal + background"
   val PeakElectronTooltip = "Peak e- per exposure"
 }
 
-/** ITC tables have three types of columns: a series of header columns, then all the values that change and are
+/** ITC tables have three types of columns: a series of header columns, then all the dynamic values that change and are
   * relevant for the different unique configs (denoted by their {{{ItemKey}}} values) and finally the ITC calculation
   * results. The static columns (headers and results) are represented by a {{{Column}}} object.
   */
 sealed trait ItcTableModel extends AbstractTableModel {
 
   /// Define some generic columns. Values are rendered as strings in order to have them left aligned, similar to other sequence tables.
-  val LabelsColumn  = Column("Data Labels",     (c, i, r) => (resultIcon(r).orNull, c.labels))
-  val ImagesColumn  = Column("Images",          (c, i, r) => s"${c.count}",                      tooltip = "Number of exposures used in S/N calculation")
-  val CoaddsColumn  = Column("Coadds",          (c, i, r) => s"${c.coadds.getOrElse(1.0)}",      tooltip = "Number of coadds")
-  val ExpTimeColumn = Column("Exposure Time",   (c, i, r) => f"${c.singleExposureTime}%.1f",     tooltip = "Exposure time of each image [s]")
-  val TotTimeColumn = Column("Total Exp. Time", (c, i, r) => f"${c.totalExposureTime}%.1f",      tooltip = "Total exposure time [s]")
-  val SrcMagColumn  = Column("Source Mag",      (c, i, r) => i.map(sourceMag).toOption,          tooltip = "Source magnitude [mag]")
-  val SrcFracColumn = Column("Source Fraction", (c, i, r) => i.map(sourceFraction).toOption,     tooltip = "Fraction of images on source")
+  val LabelsColumn  = Column("Data\nLabels",     (c, i, r) => (resultIcon(r).orNull, c.labels))
+  val ImagesColumn  = Column("Images",           (c, i, r) => s"${c.count}",                      tooltip = "Number of exposures used in S/N calculation")
+  val CoaddsColumn  = Column("Coadds",           (c, i, r) => s"${c.coadds.getOrElse(1.0)}",      tooltip = "Number of coadds")
+  val ExpTimeColumn = Column("Exposure\nTime",   (c, i, r) => f"${c.singleExposureTime}%.1f",     tooltip = "Exposure time of each image [s]")
+  val TotTimeColumn = Column("Total\nExp. Time", (c, i, r) => f"${c.totalExposureTime}%.1f",      tooltip = "Total exposure time [s]")
+  val SrcMagColumn  = Column("Source\nMag",      (c, i, r) => i.map(sourceMag).toOption,          tooltip = "Source magnitude [mag]")
+  val SrcFracColumn = Column("Source\nFraction", (c, i, r) => i.map(sourceFraction).toOption,     tooltip = "Fraction of images on source")
 
 
   // Define different sets of columns as headers
@@ -179,15 +193,15 @@ class ItcGenericImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List
 class ItcGmosImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcInputs], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = Headers
   val results = List(
-    Column("CCD1 Peak",       (c, i, r) => imgPeakPixelFlux(r, ccd=0),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 1"),
-    Column("CCD1 S/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=0)),
-    Column("CCD1 S/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=0)),
-    Column("CCD2 Peak",       (c, i, r) => imgPeakPixelFlux(r, ccd=1),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 2"),
-    Column("CCD2 S/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=1)),
-    Column("CCD2 S/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=1)),
-    Column("CCD3 Peak",       (c, i, r) => imgPeakPixelFlux(r, ccd=2),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 3"),
-    Column("CCD3 S/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=2)),
-    Column("CCD3 S/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=2))
+    Column("CCD1\nPeak",       (c, i, r) => imgPeakPixelFlux(r, ccd=0),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 1"),
+    Column("CCD1\nS/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=0)),
+    Column("CCD1\nS/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=0)),
+    Column("CCD2\nPeak",       (c, i, r) => imgPeakPixelFlux(r, ccd=1),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 2"),
+    Column("CCD2\nS/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=1)),
+    Column("CCD2\nS/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=1)),
+    Column("CCD3\nPeak",       (c, i, r) => imgPeakPixelFlux(r, ccd=2),   tooltip = ItcTableModel.PeakPixelTooltip + " for CCD 3"),
+    Column("CCD3\nS/N Single", (c, i, r) => imgSingleSNRatio(r, ccd=2)),
+    Column("CCD3\nS/N Total",  (c, i, r) => imgTotalSNRatio (r, ccd=2))
   )
 }
 


### PR DESCRIPTION
Requirement: Allow multiple-word titles like "Exposure Time" and "Source Fraction" in ITC tables to be split into two rows, and those columns could be made narrower.

This is implemented by taking advantage of the little known fact that cell renderers in Swing tables support HTML. To simplify the definition of `Column`s in the code the HTML for the column header is created from a string that can contain newline characters `'\n'` to mark line breaks.

I also had to tweak the util method `SequenceTabUtil.resizeTableColumns`, which optimizes the column width of a table given the column headers and contents and needs to take multi line column headers into account properly.

[**Edit:** In an additional commit the multi line headers have been extended to the sequence table columns.]

![image](https://cloud.githubusercontent.com/assets/7856060/10301680/642d1bba-6ba0-11e5-80b3-ddd4645319ba.png)

![image](https://cloud.githubusercontent.com/assets/7856060/10301675/58cfa54e-6ba0-11e5-911f-59f7a37ba27e.png)
