### PR TITLE
OCSADV-417: Display Guide Quality icon on the catalog navigator

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsTable.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsTable.scala
@@ -55,7 +55,7 @@ case class ProbeLimitsTable(tab: CalcMap) extends MagnitudeTable {
       case _: Canopus.Wfs => GemsMagnitudeTable(ctx, probe)
       case _              =>
         for {
-          s <- ctx.getSite.asScalaOpt
+          s  <- ctx.getSite.asScalaOpt
           id <- lookup(s, ctx, probe)
           ct <- tab.get(id)
         } yield ct

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/config/injector/ConfigInjector.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/config/injector/ConfigInjector.java
@@ -42,7 +42,7 @@ public final class ConfigInjector<R> implements Serializable {
         Adapter1(ConfigInjectorCalc1<A, R> calc) {
             this.calc = calc;
 
-            List<PropertyDescriptor> tmp = new ArrayList<PropertyDescriptor>();
+            List<PropertyDescriptor> tmp = new ArrayList<>();
             tmp.add(calc.descriptor1());
             props = Collections.unmodifiableList(tmp);
             result = calc.resultPropertyName();
@@ -71,7 +71,7 @@ public final class ConfigInjector<R> implements Serializable {
         Adapter2(ConfigInjectorCalc2<A, B, R> calc) {
             this.calc = calc;
 
-            List<PropertyDescriptor> tmp = new ArrayList<PropertyDescriptor>();
+            List<PropertyDescriptor> tmp = new ArrayList<>();
             tmp.add(calc.descriptor1());
             tmp.add(calc.descriptor2());
             props = Collections.unmodifiableList(tmp);
@@ -103,7 +103,7 @@ public final class ConfigInjector<R> implements Serializable {
         Adapter3(ConfigInjectorCalc3<A, B, C, R> calc) {
             this.calc = calc;
 
-            List<PropertyDescriptor> tmp = new ArrayList<PropertyDescriptor>();
+            List<PropertyDescriptor> tmp = new ArrayList<>();
             tmp.add(calc.descriptor1());
             tmp.add(calc.descriptor2());
             tmp.add(calc.descriptor3());
@@ -133,8 +133,8 @@ public final class ConfigInjector<R> implements Serializable {
      *
      * @param calc calculator for observing wavelengths.
      */
-    public static <A, R> ConfigInjector create(ConfigInjectorCalc1<A, R> calc) {
-        return new ConfigInjector<R>(new Adapter1<A, R>(calc));
+    public static <A, R> ConfigInjector<R> create(ConfigInjectorCalc1<A, R> calc) {
+        return new ConfigInjector<>(new Adapter1<>(calc));
     }
 
     /**
@@ -143,8 +143,8 @@ public final class ConfigInjector<R> implements Serializable {
      *
      * @param calc calculator for observing wavelengths.
      */
-    public static <A, B, R> ConfigInjector create(ConfigInjectorCalc2<A, B, R> calc) {
-        return new ConfigInjector<R>(new Adapter2<A, B, R>(calc));
+    public static <A, B, R> ConfigInjector<R> create(ConfigInjectorCalc2<A, B, R> calc) {
+        return new ConfigInjector<>(new Adapter2<>(calc));
     }
 
     /**
@@ -153,8 +153,8 @@ public final class ConfigInjector<R> implements Serializable {
      *
      * @param calc calculator for observing wavelengths.
      */
-    public static <A, B, C, R> ConfigInjector create(ConfigInjectorCalc3<A, B, C, R> calc) {
-        return new ConfigInjector<R>(new Adapter3<A, B, C, R>(calc));
+    public static <A, B, C, R> ConfigInjector<R> create(ConfigInjectorCalc3<A, B, C, R> calc) {
+        return new ConfigInjector<>(new Adapter3<>(calc));
     }
 
     private final CalcAdapter<R> adapter;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -1,10 +1,3 @@
-// Copyright 2003
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: InstGNIRS.java 47108 2012-08-01 01:30:06Z swalker $
-//
-
 package edu.gemini.spModel.gemini.gnirs;
 
 import edu.gemini.pot.sp.ISPObservation;
@@ -86,11 +79,9 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     public static final PropertyDescriptor ACQUISITION_MIRROR_PROP;
     public static final PropertyDescriptor POS_ANGLE_CONSTRAINT_PROP;
 
-
     public static final PropertyDescriptor PORT_PROP;
 
-
-    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<String, PropertyDescriptor>();
+    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<>();
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     private static PropertyDescriptor initProp(String propName, boolean query, boolean iter) {
@@ -681,11 +672,9 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
 
     /**
      * Return a parameter set describing the current state of this object.
-     *
-     * @param factory
      */
-    public ParamSet getParamSet(PioFactory factory) {
-        ParamSet paramSet = super.getParamSet(factory);
+    public ParamSet getParamSet(final PioFactory factory) {
+        final ParamSet paramSet = super.getParamSet(factory);
 
         Pio.addParam(factory, paramSet, GNIRSConstants.PIXEL_SCALE_PROP, getPixelScale().name());
         Pio.addParam(factory, paramSet, GNIRSConstants.DISPERSER_PROP, getDisperser().name());
@@ -812,7 +801,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
      * queryable configuration parameters.
      */
     public static List<InstConfigInfo> getInstConfigInfo() {
-        List<InstConfigInfo> configInfo = new LinkedList<InstConfigInfo>();
+        final List<InstConfigInfo> configInfo = new LinkedList<>();
 
         configInfo.add(new InstConfigInfo(PIXEL_SCALE_PROP));
         configInfo.add(new InstConfigInfo(DISPERSER_PROP));

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -1133,7 +1133,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     /**
-     * The name of the Flamingos2 instrument configuration
+     * The name of the GPI instrument configuration
      */
     public static final String INSTRUMENT_NAME_PROP = "GPI";
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/InstMichelle.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/InstMichelle.java
@@ -1,11 +1,3 @@
-// Copyright 2002
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: InstMichelle.java 45662 2012-05-31 02:54:05Z fnussber $
-//
-
 package edu.gemini.spModel.gemini.michelle;
 
 import edu.gemini.pot.sp.ISPObservation;
@@ -140,7 +132,7 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
     public static final PropertyDescriptor NEXP_PROP;
 
 
-    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<String, PropertyDescriptor>();
+    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<>();
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     static {
@@ -269,11 +261,7 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
             }
         }
 
-        if (maybeChopMode.getValue().equals(ChopMode.CHOP)) {
-            return true;
-        }
-
-        return false;
+        return maybeChopMode.getValue().equals(ChopMode.CHOP);
     }
 
     /**
@@ -899,7 +887,7 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
         v = Pio.getValue(paramSet, FIELD_ROTATOR_ANGLE_PROP.getName());
         if (v != null) {
             try {
-                setFieldRotatorAngle(new Some<Double>(Double.parseDouble(v)));
+                setFieldRotatorAngle(new Some<>(Double.parseDouble(v)));
             } catch (Exception ex) {
                 LOG.warning("Could not parse field rotator angle " + v);
             }
@@ -907,7 +895,7 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
         v = Pio.getValue(paramSet, SLIT_ANGLE_PROP.getName());
         if (v != null) {
             try {
-                setSlitAngle(new Some<Double>(Double.parseDouble(v)));
+                setSlitAngle(new Some<>(Double.parseDouble(v)));
             } catch (Exception ex) {
                 LOG.warning("Could not parse slit angle " + v);
             }
@@ -929,17 +917,17 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
      * Return the configuration for this component.
      */
     public ISysConfig getSysConfig() {
-        ISysConfig sc = new DefaultSysConfig(SeqConfigNames.INSTRUMENT_CONFIG_NAME);
+        final ISysConfig sc = new DefaultSysConfig(SeqConfigNames.INSTRUMENT_CONFIG_NAME);
 
         // Fill in the current values.
         sc.putParameter(StringParameter.getInstance(ISPDataObject.VERSION_PROP, getVersion()));
 
-        Option<DisperserOrder> dorder = getDisperserOrder();
+        final Option<DisperserOrder> dorder = getDisperserOrder();
         if (!dorder.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(DISPERSER_ORDER_PROP.getName(), dorder.getValue()));
         }
 
-        Disperser d = getDisperser();
+        final Disperser d = getDisperser();
         sc.putParameter(DefaultParameter.getInstance(DISPERSER_PROP.getName(), d));
         if (d != Disperser.MIRROR) {
             sc.putParameter(DefaultParameter.getInstance(DISPERSER_LAMBDA_PROP.getName(), getDisperserLambda()));
@@ -960,11 +948,11 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
         sc.putParameter(DefaultParameter.getInstance(POLARIMETRY_PROP.getName(), getPolarimetry()));
         sc.putParameter(DefaultParameter.getInstance(POS_ANGLE_PROP.getName(), getPosAngleDegrees()));
 
-        Option<FilterWheelA> filtA = getFilterWheelA();
+        final Option<FilterWheelA> filtA = getFilterWheelA();
         if (!filtA.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(FILTER_A_PROP.getName(), filtA.getValue()));
         }
-        Option<FilterWheelB> filtB = getFilterWheelB();
+        final Option<FilterWheelB> filtB = getFilterWheelB();
         if (!filtB.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(FILTER_B_PROP.getName(), filtB.getValue()));
         }
@@ -977,24 +965,24 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
         if (!pos.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(EXTRACTOR_POSITION_PROP.getName(), pos.getValue()));
         }
-        Option<Double> rotAngle = getFieldRotatorAngle();
+        final Option<Double> rotAngle = getFieldRotatorAngle();
         if (!rotAngle.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(FIELD_ROTATOR_ANGLE_PROP.getName(), rotAngle.getValue()));
         }
-        Option<Double> slitAngle = getSlitAngle();
+        final Option<Double> slitAngle = getSlitAngle();
         if (!slitAngle.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(SLIT_ANGLE_PROP.getName(), getSlitAngle().getValue()));
         }
-        Option<EngMask> engMask = getEngineeringMask();
+        final Option<EngMask> engMask = getEngineeringMask();
         if (!engMask.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(ENG_MASK_PROP.getName(), engMask.getValue()));
         }
-        Option<ChopMode> chopMode = getChopMode();
+        final Option<ChopMode> chopMode = getChopMode();
         if (!chopMode.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(CHOP_MODE_PROP.getName(), chopMode.getValue()));
             sc.putParameter(DefaultParameter.getInstance(NEXP_PROP.getName(), getNexp()));
         }
-        Option<ChopWaveform> chopWaveform = getChopWaveform();
+        final Option<ChopWaveform> chopWaveform = getChopWaveform();
         if (!chopWaveform.isEmpty()) {
             sc.putParameter(DefaultParameter.getInstance(CHOP_WAVEFORM_PROP.getName(), chopWaveform.getValue()));
         }
@@ -1006,8 +994,8 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
      * Return a list of InstConfigInfo objects describing the instrument's
      * queryable configuration parameters.
      */
-    public static List getInstConfigInfo() {
-        List<InstConfigInfo> configInfo = new LinkedList<InstConfigInfo>();
+    public static List<InstConfigInfo> getInstConfigInfo() {
+        final List<InstConfigInfo> configInfo = new LinkedList<>();
 
         configInfo.add(new InstConfigInfo(DISPERSER_PROP));
         configInfo.add(new InstConfigInfo(MASK_PROP));
@@ -1025,7 +1013,7 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
         return false;
     }
 
-    public static final ConfigInjector WAVELENGTH_INJECTOR = ConfigInjector.create(
+    public static final ConfigInjector<String> WAVELENGTH_INJECTOR = ConfigInjector.create(
         new ObsWavelengthCalc3<Disperser, Filter, Double>() {
             public PropertyDescriptor descriptor1() { return DISPERSER_PROP; }
             public PropertyDescriptor descriptor2() { return FILTER_PROP; }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/InstNICI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/InstNICI.java
@@ -1,7 +1,3 @@
-//
-// $Id: InstNICI.java 45259 2012-05-14 23:58:29Z fnussber $
-//
-
 package edu.gemini.spModel.gemini.nici;
 
 import edu.gemini.pot.sp.ISPObservation;
@@ -70,9 +66,6 @@ import static edu.gemini.spModel.gemini.nici.NICIParams.*;
 // value associated with the not active CR mode.  When the CR mode is switched,
 // we also swap the not-active angle and the base class "pos angle".  Grim.
 //
-
-
-
 public final class InstNICI extends SPInstObsComp implements PropertyProvider, GuideProbeProvider, IssPortProvider, StepCalculator {
     private static final Logger LOG = Logger.getLogger(InstNICI.class.getName());
 
@@ -80,7 +73,7 @@ public final class InstNICI extends SPInstObsComp implements PropertyProvider, G
 
     public static final SPComponentType SP_TYPE = SPComponentType.INSTRUMENT_NICI;
 
-    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<String, PropertyDescriptor>();
+    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<>();
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     //Properties
@@ -253,12 +246,8 @@ public final class InstNICI extends SPInstObsComp implements PropertyProvider, G
     }
 
     // Predicate that leaves all CategorizedTime except for the offset overhead.
-    private static final PredicateOp<CategorizedTime> RM_OFFSET_OVERHEAD = new PredicateOp<CategorizedTime>() {
-        @Override public Boolean apply(CategorizedTime ct) {
-            return !((ct.category == Category.CONFIG_CHANGE) &&
-                     (ct.detail == OffsetOverheadCalculator.DETAIL));
-        }
-    };
+    private static final PredicateOp<CategorizedTime> RM_OFFSET_OVERHEAD = ct -> !((ct.category == Category.CONFIG_CHANGE) &&
+             OffsetOverheadCalculator.DETAIL.equals(ct.detail));
 
     // Get correct offset overhead in the common group.  If a small offset,
     // we remove the offset overhead put there by the common step calculator
@@ -271,7 +260,7 @@ public final class InstNICI extends SPInstObsComp implements PropertyProvider, G
     }
 
     @Override public CategorizedTimeGroup calc(Config cur, Option<Config> prev) {
-        Collection<CategorizedTime> times = new ArrayList<CategorizedTime>();
+        Collection<CategorizedTime> times = new ArrayList<>();
 
         // Add time for any configuration change.
         if (PlannedTime.isUpdated(cur, prev,
@@ -496,8 +485,8 @@ public final class InstNICI extends SPInstObsComp implements PropertyProvider, G
     /**
      * This method is called by the OT Browser to determine how to query the instrument
      */
-    public static List getInstConfigInfo() {
-        List<InstConfigInfo> configInfo = new LinkedList<InstConfigInfo>();
+    public static List<InstConfigInfo> getInstConfigInfo() {
+        final List<InstConfigInfo> configInfo = new LinkedList<>();
         configInfo.add(new InstConfigInfo(FOCAL_PLANE_MASK_PROP));
         configInfo.add(new InstConfigInfo(PUPIL_MASK_PROP));
         configInfo.add(new InstConfigInfo(CASS_ROTATOR_PROP));
@@ -561,7 +550,7 @@ public final class InstNICI extends SPInstObsComp implements PropertyProvider, G
         return res;
     }
 
-    public static ConfigInjector WAVELENGTH_INJECTOR = ConfigInjector.create(
+    public static ConfigInjector<String> WAVELENGTH_INJECTOR = ConfigInjector.create(
         new ObsWavelengthCalc3<ImagingMode, Channel1FW, Channel2FW>() {
 
             public PropertyDescriptor descriptor1() { return IMAGING_MODE_PROP; }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/InstNIFS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/InstNIFS.java
@@ -1,10 +1,3 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: InstNIFS.java 46996 2012-07-26 14:21:12Z swalker $
-//
 package edu.gemini.spModel.gemini.nifs;
 
 import edu.gemini.pot.sp.ISPObservation;
@@ -68,7 +61,7 @@ public final class InstNIFS extends SPInstObsComp implements PropertyProvider, G
     public static final SPComponentType SP_TYPE =
             SPComponentType.INSTRUMENT_NIFS;
 
-    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<String, PropertyDescriptor>();
+    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<>();
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     //Properties
@@ -475,8 +468,8 @@ public final class InstNIFS extends SPInstObsComp implements PropertyProvider, G
      * Return a list of InstConfigInfo objects describing the instrument's
      * queryable configuration parameters.
      */
-    public static List getInstConfigInfo() {
-        List<InstConfigInfo> configInfo = new LinkedList<InstConfigInfo>();
+    public static List<InstConfigInfo> getInstConfigInfo() {
+        final List<InstConfigInfo> configInfo = new LinkedList<>();
         configInfo.add(new InstConfigInfo(IMAGING_MIRROR_PROP));
         configInfo.add(new InstConfigInfo(DISPERSER_PROP));
         configInfo.add(new InstConfigInfo(MASK_PROP));
@@ -495,7 +488,7 @@ public final class InstNIFS extends SPInstObsComp implements PropertyProvider, G
         return GUIDE_PROBES;
     }
 
-    public static final ConfigInjector WAVELENGTH_INJECTOR = ConfigInjector.create(
+    public static final ConfigInjector<String> WAVELENGTH_INJECTOR = ConfigInjector.create(
         new ObsWavelengthCalc3<Disperser, Filter, Double>() {
             public PropertyDescriptor descriptor1() { return DISPERSER_PROP; }
             public PropertyDescriptor descriptor2() { return FILTER_PROP; }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/trecs/InstTReCS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/trecs/InstTReCS.java
@@ -59,7 +59,7 @@ public final class InstTReCS extends SPInstObsComp implements PropertyProvider, 
     public static final SPComponentType SP_TYPE =
             SPComponentType.INSTRUMENT_TRECS;
 
-    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<String, PropertyDescriptor>();
+    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<>();
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     public static final PropertyDescriptor DISPERSER_PROP;
@@ -859,8 +859,8 @@ public final class InstTReCS extends SPInstObsComp implements PropertyProvider, 
     /**
      * Return a list of InstConfigInfo objects describing the instrument's queryable configuration parameters.
      */
-    public static List getInstConfigInfo() {
-        List<InstConfigInfo> configInfo = new LinkedList<InstConfigInfo>();
+    public static List<InstConfigInfo> getInstConfigInfo() {
+        final List<InstConfigInfo> configInfo = new LinkedList<>();
         configInfo.add(new InstConfigInfo(DISPERSER_PROP));
         configInfo.add(new InstConfigInfo(MASK_PROP));
         configInfo.add(new InstConfigInfo(FILTER_PROP));
@@ -876,7 +876,7 @@ public final class InstTReCS extends SPInstObsComp implements PropertyProvider, 
         return PROPERTY_MAP;
     }
 
-    public static final ConfigInjector WAVELENGTH_INJECTOR = ConfigInjector.create(
+    public static final ConfigInjector<String> WAVELENGTH_INJECTOR = ConfigInjector.create(
         new ObsWavelengthCalc3<Disperser, Filter, Double>() {
             public PropertyDescriptor descriptor1() { return DISPERSER_PROP; }
             public PropertyDescriptor descriptor2() { return FILTER_PROP; }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.spModel.target.env;
 
 import edu.gemini.shared.util.immutable.*;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetUtil.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.spModel.target.offset;
 
 import edu.gemini.pot.sp.*;
@@ -14,6 +10,7 @@ import edu.gemini.spModel.guide.GuideOption;
 import edu.gemini.spModel.guide.GuideProbe;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A utility for converting between the old {@link OffsetPosList} and
@@ -27,7 +24,7 @@ public final class OffsetUtil {
     public static final Set<Offset> NO_OFFSETS = Collections.emptySet();
 
     /**
-     * A single {@ilnk Offset} at the base position.
+     * A single {@link Offset} at the base position.
      */
     public static final Set<Offset> BASE_POS_OFFSET =
             Collections.singleton(new Offset(new Angle(0, ARCSECS), new Angle(0, ARCSECS)));
@@ -38,19 +35,17 @@ public final class OffsetUtil {
      * given array of offset pos lists.  If there are none, then
      * {@link #NO_OFFSETS} are returned.
      */
-    public static Set<Offset> getOffsets(Option<OffsetPosList[]> posListAOpt) {
+    public static Set<Offset> getOffsets(Option<OffsetPosList<? extends OffsetPosBase>[]> posListAOpt) {
         if (posListAOpt.isEmpty()) return NO_OFFSETS;
         return getOffsets(posListAOpt.getValue());
     }
 
     // Get a set of all the offset positions in the given array of position
     // lists.
-    private static Collection<OffsetPosBase> extractOffsets(OffsetPosList[] posListA) {
-        Collection<OffsetPosBase> res = new ArrayList<OffsetPosBase>();
-        for (OffsetPosList opl : posListA) {
-            for (Object obj : opl.getAllPositions()) {
-                res.add((OffsetPosBase) obj);
-            }
+    private static Collection<OffsetPosBase> extractOffsets(OffsetPosList<? extends OffsetPosBase>[] posListA) {
+        Collection<OffsetPosBase> res = new ArrayList<>();
+        for (OffsetPosList<? extends OffsetPosBase> opl : posListA) {
+            res.addAll(opl.getAllPositions().stream().map(obj -> (OffsetPosBase) obj).collect(Collectors.toList()));
         }
         return res;
     }
@@ -59,7 +54,7 @@ public final class OffsetUtil {
     private static Set<Offset> convertOffsets(Collection<OffsetPosBase> col) {
         if (col.size() == 0) return NO_OFFSETS;
 
-        Set<Offset> res = new LinkedHashSet<Offset>();
+        Set<Offset> res = new LinkedHashSet<>();
         for (OffsetPosBase pos : col) {
             double x = pos.getXaxis();
             double y = pos.getYaxis();
@@ -105,7 +100,7 @@ public final class OffsetUtil {
      * Gets an unmodifiable Set of {@link Offset}s for all the positions in the
      * given array of offset pos lists.
      */
-    public static Set<Offset> getOffsets(OffsetPosList[] posListA) {
+    public static Set<Offset> getOffsets(OffsetPosList<? extends OffsetPosBase>[] posListA) {
         if ((posListA == null) || (posListA.length == 0)) return NO_OFFSETS;
         return convertOffsets(extractOffsets(posListA));
     }
@@ -115,7 +110,7 @@ public final class OffsetUtil {
      * If there are no explicit offset positions, then a single {@link Offset}
      * at the base position is returned.  See {@link #BASE_POS_OFFSET}.
      */
-    public static Set<Offset> getSciencePositions(Option<OffsetPosList[]> posListAOpt) {
+    public static Set<Offset> getSciencePositions(Option<OffsetPosList<? extends OffsetPosBase>[]> posListAOpt) {
         if (posListAOpt.isEmpty()) return BASE_POS_OFFSET;
         return getSciencePositions(posListAOpt.getValue());
     }
@@ -125,7 +120,7 @@ public final class OffsetUtil {
      * If there are no explicit offset positions, then a single {@link Offset}
      * at the base position is returned.  See {@link #BASE_POS_OFFSET}.
      */
-    public static Set<Offset> getSciencePositions(OffsetPosList[] posListA) {
+    public static Set<Offset> getSciencePositions(OffsetPosList<? extends OffsetPosBase>[] posListA) {
         if ((posListA == null) || (posListA.length == 0)) return BASE_POS_OFFSET;
 
         Set<Offset> res = convertOffsets(filterNonGuidedPositions(extractOffsets(posListA)));
@@ -139,7 +134,7 @@ public final class OffsetUtil {
 
     public static List<OffsetPosList<OffsetPosBase>> allOffsetPosLists(ISPNode node) {
         if (node == null) return Collections.emptyList();
-        final List<OffsetPosList<OffsetPosBase>> res = new ArrayList<OffsetPosList<OffsetPosBase>>();
+        final List<OffsetPosList<OffsetPosBase>> res = new ArrayList<>();
         addOffsetPosLists(node, res);
         return res;
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nici/test/InstNICITest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nici/test/InstNICITest.java
@@ -150,8 +150,7 @@ public class InstNICITest extends TestCase {
      * Test to see that simple set/get works, as well as serialization of the property,
      * persistence to/from a ParamSet.
      */
-    private void testProperty(InstNICI target, String propName, Class type, Collection values) throws Exception {
-
+    private void testProperty(InstNICI target, String propName, Class<?> type, Collection<?> values) throws Exception {
         String propertyName = Character.toUpperCase(propName.charAt(0)) + "";
         if (propName.length() > 1) {
             propertyName += propName.substring(1);
@@ -182,15 +181,15 @@ public class InstNICITest extends TestCase {
     }
 
     private void testProperty(InstNICI target, String propName, double[] values) throws Exception {
-        Collection<Double> vals = new ArrayList<Double>(values.length);
+        Collection<Double> vals = new ArrayList<>(values.length);
         for (double value : values) vals.add(value);
         testProperty(target, propName, Double.TYPE, vals);
     }
 
      private void testProperty(InstNICI target, String propName, Object[] values) throws Exception {
-        Collection<Object> vals = new ArrayList<Object>(values.length);
+        Collection<Object> vals = new ArrayList<>(values.length);
         if (values.length <= 0) throw new Exception("Collection has zero elements!");
-        Class type = values[0].getClass();
+        Class<?> type = values[0].getClass();
         vals.addAll(Arrays.asList(values));
 
          if (type.getSuperclass().isEnum()) {
@@ -201,7 +200,7 @@ public class InstNICITest extends TestCase {
     }
 
     private void testProperty(InstNICI target, String propName, int[] values) throws Exception {
-        Collection<Integer> vals = new ArrayList<Integer>(values.length);
+        Collection<Integer> vals = new ArrayList<>(values.length);
         for (int value : values) vals.add(value);
         testProperty(target, propName, Integer.TYPE, vals);
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/offset/OffsetUtilTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/offset/OffsetUtilTest.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.spModel.target.offset;
 
 import edu.gemini.skycalc.Angle;
@@ -40,9 +36,9 @@ public class OffsetUtilTest extends TestCase {
     }
 
     protected void setUp() {
-        emptyPosList  = new OffsetPosList<OffsetPos>(OffsetPos.FACTORY);
-        singlePosList = new OffsetPosList<OffsetPos>(OffsetPos.FACTORY);
-        twoPosList    = new OffsetPosList<OffsetPos>(OffsetPos.FACTORY);
+        emptyPosList  = new OffsetPosList<>(OffsetPos.FACTORY);
+        singlePosList = new OffsetPosList<>(OffsetPos.FACTORY);
+        twoPosList    = new OffsetPosList<>(OffsetPos.FACTORY);
 
         addPosition(singlePosList, 0);
         addPosition(twoPosList, 0);
@@ -53,68 +49,68 @@ public class OffsetUtilTest extends TestCase {
     }
 
     public void testGetOffsets() throws Exception {
-        Set<Offset> res = OffsetUtil.getOffsets((OffsetPosList[])null);
+        Set<Offset> res = OffsetUtil.getOffsets((OffsetPosList<?>[])null);
         assertEquals(0, res.size());
 
-        res = OffsetUtil.getOffsets(new OffsetPosList[] {});
+        res = OffsetUtil.getOffsets(new OffsetPosList<?>[] {});
         assertEquals(0, res.size());
 
-        res = OffsetUtil.getOffsets(new OffsetPosList[] {emptyPosList});
+        res = OffsetUtil.getOffsets(new OffsetPosList<?>[] {emptyPosList});
         assertEquals(0, res.size());
 
-        res = OffsetUtil.getOffsets(new OffsetPosList[] {emptyPosList, singlePosList});
+        res = OffsetUtil.getOffsets(new OffsetPosList<?>[] {emptyPosList, singlePosList});
         assertEquals(1, res.size());
         assertEquals(offset0, res.iterator().next());
 
-        res = OffsetUtil.getOffsets(new OffsetPosList[] {singlePosList, twoPosList});
+        res = OffsetUtil.getOffsets(new OffsetPosList<?>[] {singlePosList, twoPosList});
         assertEquals(2, res.size());
         assertTrue(res.contains(offset0));
         assertTrue(res.contains(offset1));
     }
 
     public void testOptionGetOffsets() throws Exception {
-        Option<OffsetPosList[]> none = None.instance();
+        Option<OffsetPosList<?>[]> none = None.instance();
         Set<Offset> res = OffsetUtil.getOffsets(none);
         assertEquals(0, res.size());
 
-        res = OffsetUtil.getOffsets(new Some<OffsetPosList[]>(new OffsetPosList[] {}));
+        res = OffsetUtil.getOffsets(new Some<>(new OffsetPosList<?>[] {}));
         assertEquals(0, res.size());
 
-        res = OffsetUtil.getOffsets(new Some<OffsetPosList[]>(new OffsetPosList[] {emptyPosList}));
+        res = OffsetUtil.getOffsets(new Some<>(new OffsetPosList<?>[] {emptyPosList}));
         assertEquals(0, res.size());
 
-        res = OffsetUtil.getOffsets(new Some<OffsetPosList[]>(new OffsetPosList[] {emptyPosList, singlePosList}));
+        res = OffsetUtil.getOffsets(new Some<>(new OffsetPosList<?>[] {emptyPosList, singlePosList}));
         assertEquals(1, res.size());
         assertEquals(offset0, res.iterator().next());
 
-        res = OffsetUtil.getOffsets(new Some<OffsetPosList[]>(new OffsetPosList[] {singlePosList, twoPosList}));
+        res = OffsetUtil.getOffsets(new Some<>(new OffsetPosList<?>[] {singlePosList, twoPosList}));
         assertEquals(2, res.size());
         assertTrue(res.contains(offset0));
         assertTrue(res.contains(offset1));
     }
 
     public void testGetScienceOffsets() throws Exception {
-        Set<Offset> res = OffsetUtil.getSciencePositions((OffsetPosList[])null);
+        Set<Offset> res = OffsetUtil.getSciencePositions((OffsetPosList<?>[])null);
         assertEquals(1, res.size());
         assertTrue(res.contains(offset0));
 
-        res = OffsetUtil.getSciencePositions(new OffsetPosList[] {});
+        res = OffsetUtil.getSciencePositions(new OffsetPosList<?>[] {});
         assertEquals(1, res.size());
         assertTrue(res.contains(offset0));
 
-        res = OffsetUtil.getSciencePositions(new OffsetPosList[] {emptyPosList});
+        res = OffsetUtil.getSciencePositions(new OffsetPosList<?>[] {emptyPosList});
         assertEquals(1, res.size());
         assertTrue(res.contains(offset0));
 
-        OffsetPosList<OffsetPos> pl = new OffsetPosList<OffsetPos>(OffsetPos.FACTORY);
+        OffsetPosList<OffsetPos> pl = new OffsetPosList<>(OffsetPos.FACTORY);
         addPosition(pl, 1);
-        res = OffsetUtil.getSciencePositions(new OffsetPosList[] {pl});
+        res = OffsetUtil.getSciencePositions(new OffsetPosList<?>[] {pl});
         assertEquals(1, res.size());
         assertTrue(res.contains(offset1));
     }
 
     public void testFilterSkyPositions() throws Exception {
-        OffsetPosList<OffsetPos> pl = new OffsetPosList<OffsetPos>(OffsetPos.FACTORY);
+        OffsetPosList<OffsetPos> pl = new OffsetPosList<>(OffsetPos.FACTORY);
         final OffsetPos pos0 = addPosition(pl, 0);
         final OffsetPos pos1 = addPosition(pl, 1);
         final OffsetPos pos2 = addPosition(pl, 2);
@@ -126,7 +122,7 @@ public class OffsetUtilTest extends TestCase {
         pos2.setLink(GUIDER1, inactive);
         pos2.setLink(GUIDER2, inactive);
 
-        Set<Offset> res = OffsetUtil.getSciencePositions(new OffsetPosList[] {pl});
+        Set<Offset> res = OffsetUtil.getSciencePositions(new OffsetPosList<?>[] {pl});
         assertEquals(2, res.size());
         assertTrue(res.contains(offset0));
         assertTrue(res.contains(offset1));
@@ -134,7 +130,7 @@ public class OffsetUtilTest extends TestCase {
 
     public void testFilterAllPositions() throws Exception {
 
-        OffsetPosList<OffsetPos> pl = new OffsetPosList<OffsetPos>(OffsetPos.FACTORY);
+        OffsetPosList<OffsetPos> pl = new OffsetPosList<>(OffsetPos.FACTORY);
         final OffsetPos pos1 = addPosition(pl, 1);
         final OffsetPos pos2 = addPosition(pl, 2);
 
@@ -146,7 +142,7 @@ public class OffsetUtilTest extends TestCase {
         pos2.setLink(GUIDER1, inactive);
         pos2.setLink(GUIDER2, inactive);
 
-        Set<Offset> res = OffsetUtil.getSciencePositions(new OffsetPosList[] {pl});
+        Set<Offset> res = OffsetUtil.getSciencePositions(new OffsetPosList<?>[] {pl});
         assertEquals(1, res.size());
         assertTrue(res.contains(offset0));
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1,6 +1,6 @@
 package jsky.app.ot.gemini.editor.targetComponent;
 
-import edu.gemini.catalog.ui.QueryResultsWindow;
+import edu.gemini.catalog.ui.QueryResultsFrame;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
@@ -69,8 +69,10 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.primaryButton  .addActionListener(primaryListener);
 
         _w.guidingControls.manualGuideStarButton().peer().addActionListener(manualGuideStarListener);
-        _w.guidingControls.newManualGuideStarButton().peer().addActionListener(evt ->
-                QueryResultsWindow.instance().showOn(getNode()));
+
+        _w.guidingControls.newManualGuideStarButton().peer().addActionListener(evt -> {
+            QueryResultsFrame.instance().showOn(getNode());
+        });
         _w.guidingControls.autoGuideStarGuiderSelector().addSelectionListener(strategy ->
                 AgsStrategyUtil.setSelection(getContextObservation(), strategy)
         );

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
@@ -75,15 +75,6 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
     final PropertyChangeListener updateParallacticAnglePCL;
     final PropertyChangeListener updateUnboundedAnglePCL;
 
-//    /**
-//     * Value assigned to WFS tags to indicate that the WFS is parked (inactive).
-//     */
-//    public static final String PARKED = "park";
-//
-//    /**
-//     * Value assigned to WFS tags to indicate that the WFS is frozen (not moving).
-//     */
-//    public static final String FROZEN = "freeze";
 
     @Override
     public void focusGained(FocusEvent focusEvent) {
@@ -206,7 +197,7 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
      * The constructor initializes the user interface.
      */
     public EdCompInstGMOS() {
-        _w = new GmosForm<T>();
+        _w = new GmosForm<>();
         _offsetTable = _w.offsetTable;
         _customROITable = _w.customROITable;
 
@@ -268,36 +259,30 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
         _w.removeButton.addActionListener(this);
 
         // initialize the combo boxes
-        initListBox(_w.disperserComboBox, getDisperserClass(), new ActionListener() {
-            public void actionPerformed(ActionEvent evt) {
-                getDataObject().setDisperser((Enum) _w.disperserComboBox.getSelectedItem());
-                _updateDisperser();
-                _checkDisperserValue();
-            }
+        initListBox(_w.disperserComboBox, getDisperserClass(), evt -> {
+            getDataObject().setDisperser((Enum) _w.disperserComboBox.getSelectedItem());
+            _updateDisperser();
+            _checkDisperserValue();
         });
 
 
-        initListBox(_w.filterComboBox, getFilterClass(), new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                getDataObject().setFilter((Enum) _w.filterComboBox.getSelectedItem());
-                _checkDisperserValue();
+        initListBox(_w.filterComboBox, getFilterClass(), e -> {
+            getDataObject().setFilter((Enum) _w.filterComboBox.getSelectedItem());
+            _checkDisperserValue();
 
-            }
         });
 
-        initListBox(_w.detectorManufacturerComboBox, getDetectorManufacturerClass(), new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                final DetectorManufacturer selectedDetectorManufacturer =
-                        (DetectorManufacturer) _w.detectorManufacturerComboBox.getSelectedItem();
-                if (selectedDetectorManufacturer != getDataObject().getDetectorManufacturer()) {
-                    getDataObject().setDetectorManufacturer((DetectorManufacturer) _w.detectorManufacturerComboBox.getSelectedItem());
+        initListBox(_w.detectorManufacturerComboBox, getDetectorManufacturerClass(), e -> {
+            final DetectorManufacturer selectedDetectorManufacturer =
+                    (DetectorManufacturer) _w.detectorManufacturerComboBox.getSelectedItem();
+            if (selectedDetectorManufacturer != getDataObject().getDetectorManufacturer()) {
+                getDataObject().setDetectorManufacturer((DetectorManufacturer) _w.detectorManufacturerComboBox.getSelectedItem());
 //                    _instGMOS.initializeDetectorManufacturerValues();
 
-                    _updateControlVisibility();
-                    _updateReadoutCharacteristics();
-                    _updateNodAndShuffle();
-                    _updateCCD();
-                }
+                _updateControlVisibility();
+                _updateReadoutCharacteristics();
+                _updateNodAndShuffle();
+                _updateCCD();
             }
         });
 
@@ -355,28 +340,15 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
         _clearWarning(_w.warningCustomROI);
 
         _w.detectorManufacturerComboBox.setEnabled(OTOptions.isStaffGlobally()); // REL-1194
-        StaffBean$.MODULE$.addPropertyChangeListener(new PropertyChangeListener() {
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                _w.detectorManufacturerComboBox.setEnabled(isEnabled() && OTOptions.isStaffGlobally()); // REL-1194
-            }
+        StaffBean$.MODULE$.addPropertyChangeListener(evt -> {
+            _w.detectorManufacturerComboBox.setEnabled(isEnabled() && OTOptions.isStaffGlobally()); // REL-1194
         });
 
         addCustomRoiPasteKeyBinding();
 
         // Create the property change listeners for the parallactic angle panel.
-        updateParallacticAnglePCL = new PropertyChangeListener() {
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                _w.posAnglePanel.updateParallacticControls();
-            }
-        };
-        updateUnboundedAnglePCL   = new PropertyChangeListener() {
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                _w.posAnglePanel.updateUnboundedControls();
-            }
-        };
+        updateParallacticAnglePCL = evt -> _w.posAnglePanel.updateParallacticControls();
+        updateUnboundedAnglePCL   = evt -> _w.posAnglePanel.updateUnboundedControls();
     }
 
     private Site getSite() {
@@ -399,8 +371,8 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
     //This method will initialize the DropDownListBox with the elements
     //indicated in Enum class, and will configure the widget to show all the
     //available options.
-    private <E extends Enum<E>> void initListBox(JComboBox widget, Class<E> c, ActionListener l) {
-        final SpTypeComboBoxModel<E> model = new SpTypeComboBoxModel<E>(c);
+    private <E extends Enum<E>> void initListBox(JComboBox<E> widget, Class<E> c, ActionListener l) {
+        final SpTypeComboBoxModel<E> model = new SpTypeComboBoxModel<>(c);
         widget.setModel(model);
         widget.setRenderer(new SpTypeComboBoxRenderer());
         widget.setMaximumRowCount(c.getEnumConstants().length);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
@@ -104,7 +104,7 @@ public class TpeBasePosFeature extends TpePositionFeature {
 
     /**
      */
-    public void drag(TpeMouseEvent tme) {
+    public void drag(final TpeMouseEvent tme) {
         if (_dragObject != null) {
             if (_dragObject.screenPos == null) {
                 _dragObject.screenPos = new Point2D.Double(tme.xWidget, tme.yWidget);
@@ -113,7 +113,7 @@ public class TpeBasePosFeature extends TpePositionFeature {
                 _dragObject.screenPos.y = tme.yWidget;
             }
 
-            SPTarget tp = (SPTarget) _dragObject.taggedPos;
+            final SPTarget tp = _dragObject.taggedPos;
             tp.setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
         }
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -489,12 +489,12 @@ public class TpeGuidePosFeature extends TpePositionFeature
 
     /**
      */
-    public void drag(TpeMouseEvent tme) {
+    public void drag(final TpeMouseEvent tme) {
         if (_dragObject != null && _dragObject.screenPos != null) {
             _dragObject.screenPos.x = tme.xWidget;
             _dragObject.screenPos.y = tme.yWidget;
 
-            SPTarget tp = (SPTarget) _dragObject.taggedPos;
+            final SPTarget tp = _dragObject.taggedPos;
             tp.setRaDecDegrees(tme.pos.getRaDeg(), tme.pos.getDecDeg());
         }
     }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
@@ -1,0 +1,50 @@
+package edu.gemini.catalog.ui
+
+import javax.swing.UIManager
+
+import edu.gemini.catalog.api._
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.obs.context.ObsContext
+
+import scala.swing.SwingApplication
+
+import scalaz._
+import Scalaz._
+
+/**
+ * Test Launcher for the Catalog navigator
+ */
+object CatalogQueryDemo extends SwingApplication {
+  import QueryResultsFrame.instance
+  import edu.gemini.shared.util.immutable.{None => JNone, Some => JSome}
+  import edu.gemini.spModel.gemini.niri.{InstNIRI, NiriOiwfsGuideProbe}
+  import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
+  import edu.gemini.spModel.guide.GuideProbe
+  import edu.gemini.spModel.target.SPTarget
+  import edu.gemini.spModel.target.env.TargetEnvironment
+  import edu.gemini.spModel.target.obsComp.PwfsGuideProbe
+  import jsky.util.gui.Theme
+
+  val query = CatalogQuery(Coordinates(RightAscension.fromAngle(Angle.fromDegrees(3.1261166666666895)),Declination.fromAngle(Angle.fromDegrees(337.93268333333333)).getOrElse(Declination.zero)),RadiusConstraint.between(Angle.zero,Angle.fromDegrees(0.16459874517619255)),List(MagnitudeConstraints(RBandsList,FaintnessConstraint(16.0),Some(SaturationConstraint(3.1999999999999993)))),UCAC4)
+
+  def startup(args: Array[String]) {
+    System.setProperty("apple.awt.antialiasing", "on")
+    System.setProperty("apple.awt.textantialiasing", "on")
+    Theme.install()
+
+    UIManager.put("Button.defaultButtonFollowsFocus", true)
+
+    val ra = Angle.fromHMS(0, 12, 30.286).getOrElse(Angle.zero)
+    val dec = Declination.fromAngle(Angle.zero - Angle.fromDMS(22, 4, 2.34).getOrElse(Angle.zero)).getOrElse(Declination.zero)
+    val guiders = Set[GuideProbe](NiriOiwfsGuideProbe.instance, PwfsGuideProbe.pwfs1, PwfsGuideProbe.pwfs2)
+    val target = new SPTarget(ra.toDegrees, dec.toDegrees) <| {_.setName("HIP 1000")}
+    val env = TargetEnvironment.create(target)
+    val inst = new InstNIRI <| {_.setPosAngle(0.0)}
+
+    val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
+    val ctx = ObsContext.create(env, inst, new JSome(Site.GN), conditions, null, null, JNone.instance())
+
+    instance.showOn(ctx)
+  }
+
+}

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/PreferredSizeFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/PreferredSizeFrame.scala
@@ -1,0 +1,23 @@
+package edu.gemini.catalog.ui
+
+import java.awt.Dimension
+
+import edu.gemini.shared.gui.SizePreference
+
+import scala.swing.Window
+
+/**
+ * Mixin with a Scala Swing Window to get an initial size according to the screen
+ */
+trait PreferredSizeFrame { this: Window =>
+  def adjustSize() {
+    size = SizePreference.getDimension(this.getClass).getOrElse {
+      // Set initial based on the desktop's size, the code below will work with multiple desktops
+      val screenSize = java.awt.GraphicsEnvironment
+        .getLocalGraphicsEnvironment
+        .getDefaultScreenDevice
+        .getDefaultConfiguration.getBounds
+      new Dimension(screenSize.getWidth.intValue() * 3 / 4, (2f / 3f * screenSize.getHeight).intValue())
+    }
+  }
+}

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -6,7 +6,7 @@ import javax.swing.border.Border
 import javax.swing.{UIManager, DefaultComboBoxModel}
 
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
-import edu.gemini.ags.api.AgsRegistrar
+import edu.gemini.ags.api.{AgsGuideQuality, AgsRegistrar}
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api._
 import edu.gemini.catalog.votable._
@@ -20,6 +20,7 @@ import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.core._
 import edu.gemini.ui.miglayout.MigPanel
 import edu.gemini.ui.miglayout.constraints._
+import jsky.app.ot.gemini.editor.targetComponent.GuidingIcon
 import jsky.app.ot.tpe.TpeContext
 import jsky.app.ot.util.Resources
 
@@ -36,11 +37,21 @@ import Scalaz._
  * Frame to display the Query controls and results
  */
 object QueryResultsFrame extends Frame with PreferredSizeFrame {
+
+  private class GuidingFeedbackRenderer extends Table.AbstractRenderer[AgsGuideQuality, Label](new Label) {
+    override def configure(t: Table, sel: Boolean, foc: Boolean, value: AgsGuideQuality, row: Int, col: Int): Unit = {
+      component.icon = GuidingIcon(value, enabled = true)
+      component.text = ""
+    }
+  }
+
   private lazy val resultsTable = new Table() with SortableTable with TableColumnsAdjuster {
 
     override def rendererComponent(isSelected: Boolean, focused: Boolean, row: Int, column: Int) =
       // Note that we need to use the same conversions as indicated on SortableTable to get the value
       (model, model.getValueAt(viewToModelRow(row), viewToModelColumn(column))) match {
+        case (m: TargetsModel, q:AgsGuideQuality) =>
+          new GuidingFeedbackRenderer().componentFor(this, isSelected, focused, q, row, column)
         case (m: TargetsModel, value) =>
           // Delegate rendering to the model
           m.rendererComponent(value ,isSelected, focused, row, column).getOrElse(super.rendererComponent(isSelected, focused, row, column))

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -7,7 +7,7 @@ import javax.swing.{UIManager, DefaultComboBoxModel, SwingConstants}
 import javax.swing.table._
 
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
-import edu.gemini.ags.api.{AgsStrategy, AgsRegistrar}
+import edu.gemini.ags.api.AgsRegistrar
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api._
 import edu.gemini.catalog.votable._
@@ -21,7 +21,6 @@ import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.core._
 import edu.gemini.ui.miglayout.MigPanel
 import edu.gemini.ui.miglayout.constraints._
-import jsky.app.ot.gemini.editor.targetComponent.GuidingFeedback.ProbeLimits
 import jsky.app.ot.tpe.TpeContext
 import jsky.app.ot.util.Resources
 
@@ -34,695 +33,494 @@ import scala.swing.event._
 import scalaz._
 import Scalaz._
 
-trait PreferredSizeFrame { this: Window =>
-  def adjustSize() {
-    size = SizePreference.getDimension(this.getClass).getOrElse {
-      // Set initial based on the desktop's size, the code below will work with multiple desktops
-      val screenSize = java.awt.GraphicsEnvironment
-        .getLocalGraphicsEnvironment
-        .getDefaultScreenDevice
-        .getDefaultConfiguration.getBounds
-      new Dimension(screenSize.getWidth.intValue() * 3 / 4, (2f / 3f * screenSize.getHeight).intValue())
+/**
+ * Frame to display the Query controls and results
+ */
+object QueryResultsFrame extends Frame with PreferredSizeFrame {
+  private lazy val resultsTable = new Table() with SortableTable with TableColumnsAdjuster {
+    private val m = TargetsModel(Coordinates.zero, Nil)
+    model = model
+    new TableRowSorter[TargetsModel](m) <| {
+      _.toggleSortOrder(0)
+    } <| {
+      peer.setRowSorter
+    }
+
+    // Align Right
+    peer.setDefaultRenderer(classOf[String], new DefaultTableCellRenderer() {
+      setHorizontalAlignment(SwingConstants.RIGHT)
+    })
+  }
+
+  private lazy val closeButton = new Button("Close") {
+    reactions += {
+      case ButtonClicked(_) => QueryResultsFrame.visible = false
     }
   }
-}
 
-/**
- * Locally describe an ags strategy including its limits and the query that would trigger
- */
-case class SupportedStrategy(strategy: AgsStrategy, limits: Option[ProbeLimits], query: List[CatalogQuery])
+  private lazy val scrollPane = new ScrollPane() {
+    contents = resultsTable
+  }
 
-/**
- * Describes the observation used to do a Guide Star Search
- */
-case class ObservationInfo(objectName: Option[String], instrumentName: Option[String], strategy: Option[AgsStrategy], validStrategies: List[SupportedStrategy], conditions: Option[Conditions], catalog: CatalogName) {
-  def catalogQuery:List[CatalogQuery] = validStrategies.collect {
-      case SupportedStrategy(s, _, query) if s == strategy => query
-    }.flatten
-}
+  private lazy val resultsLabel = new Label("Query") {
+    horizontalAlignment = Alignment.Center
 
-object ObservationInfo {
+    def updateCount(c: Int): Unit = {
+      text = s"Query results: $c"
+    }
+  }
+
+  private lazy val errorLabel = new Label("") {
+    horizontalAlignment = Alignment.Left
+    foreground = Color.red
+
+    def reset(): Unit = text = ""
+  }
+
+  title = "Query Results"
+  QueryForm.buildLayout(Nil)
+  contents = new MigPanel(LC().fill().insets(0).gridGap("0px", "0px").debug(0)) {
+    // Query Form
+    add(QueryForm, CC().alignY(TopAlign).minWidth(280.px))
+    // Results Table
+    add(new BorderPanel() {
+      border = titleBorder(title)
+      add(scrollPane, BorderPanel.Position.Center)
+    }, CC().grow().spanX(2).pushY().pushX())
+    // Labels and command buttons at the bottom
+    add(resultsLabel, CC().alignX(LeftAlign).alignY(BaselineAlign).newline().gap(10.px, 10.px, 10.px, 10.px))
+    add(errorLabel, CC().alignX(LeftAlign).alignY(BaselineAlign).gap(10.px, 10.px, 10.px, 10.px))
+    add(closeButton, CC().alignX(RightAlign).alignY(BaselineAlign).gap(10.px, 10.px, 10.px, 10.px))
+  }
+
+  // Set initial size
+  adjustSize()
+  // Update location according to the last save position
+  SizePreference.getPosition(this.getClass).foreach { p =>
+    location = p
+  }
+
+  // Save position and dimensions
+  listenTo(this)
+  reactions += {
+    case _: UIElementResized =>
+      SizePreference.setDimension(getClass, Some(this.size))
+    case _: UIElementMoved =>
+      SizePreference.setPosition(getClass, Some(this.location))
+  }
+
+
+  /** Create a titled border with inner and outer padding. */
+  def titleBorder(title: String): Border =
+    createCompoundBorder(
+      createEmptyBorder(2, 2, 2, 2),
+      createCompoundBorder(
+        createTitledBorder(title),
+        createEmptyBorder(2, 2, 2, 2)))
 
   /**
-   * Converts an AgsStrategy to a simpler description to be stored in the UI model
+   * Show error message at the bottom line
    */
-  private def toSupportedStrategy(obsCtx: ObsContext, strategy: AgsStrategy, mt: MagnitudeTable):SupportedStrategy = {
-    val pb = strategy.magnitudes(obsCtx, mt).map(k => ProbeLimits(strategy.probeBands, obsCtx, k._2)).headOption
-    val queries = strategy.catalogQueries(obsCtx, mt)
-    SupportedStrategy(strategy, pb.flatten, queries)
+  def displayError(error: String): Unit = {
+    errorLabel.text = error
   }
 
-  def apply(ctx: ObsContext, mt: MagnitudeTable):ObservationInfo = ObservationInfo(
-    Option(ctx.getTargets.getBase).map(_.getTarget.getName),
-    Option(ctx.getInstrument).map(_.getTitle),
-    AgsRegistrar.currentStrategy(ctx),
-    AgsRegistrar.validStrategies(ctx).map(toSupportedStrategy(ctx, _, mt)),
-    ctx.getConditions.some,
-    UCAC4)
+  /**
+   * Called after a name search completes
+   */
+  def updateName(search: String, targets: List[SiderealTarget]): Unit = {
+    QueryForm.updateName(targets.headOption)
+    targets.headOption.ifNone {
+      errorLabel.text = s"Target '$search' not found..."
+    }
+  }
 
-}
+  /**
+   * Called after  a query completes to update the UI according to the results
+   */
+  def updateResults(info: Option[ObservationInfo], queryResult: QueryResult): Unit = {
+    queryResult.query match {
+      case q: ConeSearchCatalogQuery =>
+        val model = TargetsModel(q.base, queryResult.result.targets.rows)
+        resultsTable.model = model
 
-/**
- * Support calculating column widths and can adjust them to the outer width
- */
-trait TableColumnsAdjuster { this: Table =>
-  autoResizeMode = Table.AutoResizeMode.Off
+        // The sorting logic may change if the list of magnitudes changes
+        new TableRowSorter[TargetsModel](model) <| {
+          _.toggleSortOrder(0)
+        } <| {
+          _.sort()
+        } <| {
+          resultsTable.peer.setRowSorter
+        }
 
-  val minSpacing: Int = 20
+        // Adjust the width of the columns
+        val insets = scrollPane.border.getBorderInsets(scrollPane.peer)
+        resultsTable.adjustColumns(scrollPane.bounds.width - insets.left - insets.right)
 
-  def adjustColumns(containerWidth: Int): Unit = {
-    import scala.math.max
+        // Update the count of rows
+        resultsLabel.updateCount(queryResult.result.targets.rows.length)
 
-    def updateTableColumn(column: TableColumn, width: Int):Unit = {
-      if (column.getResizable) {
-        this.peer.getTableHeader.setResizingColumn(column)
-        column <| {_.setPreferredWidth(width)} <| {_.setWidth(width)}
+        // Update the query form
+        QueryForm.updateQuery(info, q)
+      case _ =>
+    }
+  }
+
+  protected def revalidateFrame(): Unit = {
+    contents.headOption.foreach(_.revalidate())
+  }
+
+  /**
+   * Contains the data used to create the right-hand side form to do queries
+   */
+  private case object QueryForm extends MigPanel(LC().fill().insets(0.px).debug(0)) {
+
+    // Represents a magnitude filter containing the controls that make the row
+    case class MagnitudeFilterControls(addButton: Button, faintess: NumberField, separator: Label, saturation: NumberField, bandCB: ComboBox[MagnitudeBand], removeButton: Button)
+
+    border = titleBorder("Query Params")
+
+    lazy val queryButton = new Button("Query") {
+      reactions += {
+        case ButtonClicked(_) =>
+          // Hit the catalog with a new query
+          buildQuery.foreach(Function.tupled(reloadSearchData))
       }
     }
 
-    def calculateColumnWidth(column: TableColumn): Int = {
+    // Action to disable the query button if there are invalid fields
+    val queryButtonEnabling: Reaction = {
+      case ValueChanged(a) =>
+        queryButton.enabled = a match {
+          case f: AngleTextField[_] => f.valid
+          case f: NumberField       => f.valid
+          case _                    => true
+        }
+    }
 
-      def calculateColumnHeaderWidth: Int = {
-        val value = column.getHeaderValue
-        val renderer = Option(column.getHeaderRenderer).getOrElse(this.peer.getTableHeader.getDefaultRenderer)
-
-        renderer.getTableCellRendererComponent(this.peer, value, false, false, -1, column.getModelIndex).getPreferredSize.width
+    lazy val objectName = new TextField("") with SelectOnFocus {
+      val foregroundColor = UIManager.getColor("TextField.foreground")
+      listenTo(keys)
+      reactions += {
+        case KeyPressed(_, Key.Enter, _, _) if text.nonEmpty =>
+          doNameSearch(text)
+        case KeyTyped(_, _, _, _)                            =>
+          errorLabel.reset()
+          foreground = foregroundColor
       }
-
-      def cellDataWidth(row: Int, column: Int): Int = {
-        val cellRenderer = this.peer.getCellRenderer(row, column)
-        val c = this.peer.prepareRenderer(cellRenderer, row, column)
-        c.getPreferredSize.width + this.peer.getIntercellSpacing.width
+    }
+    lazy val searchByName = new Button("") {
+      icon = Resources.getIcon("eclipse/search.gif")
+      ButtonFlattener.flatten(peer)
+      reactions += {
+        case ButtonClicked(_) if objectName.text.nonEmpty =>
+          doNameSearch(objectName.text)
       }
+    }
+    lazy val instrumentName = new Label("")
+    lazy val catalogBox = new ComboBox(List[CatalogName](UCAC4, PPMXL)) with TextRenderer[CatalogName] {
+      override def text(a: CatalogName) = ~Option(a).map(_.displayName)
+    }
+    lazy val guider = new ComboBox(List.empty[SupportedStrategy]) with TextRenderer[SupportedStrategy] {
+      override def text(a: SupportedStrategy) = ~Option(a).map(_.strategy.key.displayName)
 
-      def calculateColumnDataWidth: Int = {
-        (0 until this.model.getRowCount).foldLeft(0) { (currMax, i) =>
-          max(currMax, cellDataWidth(i, column.getModelIndex))
+      listenTo(selection)
+      reactions += {
+        case SelectionChanged(_) =>
+          updateGuideSpeedText()
+      }
+    }
+    lazy val sbBox = new ComboBox(List(SPSiteQuality.SkyBackground.values(): _*)) with TextRenderer[SPSiteQuality.SkyBackground] {
+      override def text(a: SPSiteQuality.SkyBackground) = a.displayValue()
+    }
+    lazy val ccBox = new ComboBox(List(SPSiteQuality.CloudCover.values(): _*)) with TextRenderer[SPSiteQuality.CloudCover] {
+      override def text(a: SPSiteQuality.CloudCover) = a.displayValue()
+    }
+    lazy val iqBox = new ComboBox(List(SPSiteQuality.ImageQuality.values(): _*)) with TextRenderer[SPSiteQuality.ImageQuality] {
+      override def text(a: SPSiteQuality.ImageQuality) = a.displayValue()
+    }
+    lazy val limitsLabel = new Label() {
+      font = font.deriveFont(font.getSize2D * 0.8f)
+    }
+
+    lazy val ra = new RATextField(RightAscension.zero) {
+      reactions += queryButtonEnabling
+
+      def updateRa(ra: RightAscension): Unit = {
+        value = ra
+      }
+    }
+
+    lazy val dec = new DecTextField(Declination.zero) {
+      reactions += queryButtonEnabling
+
+      def updateDec(dec: Declination): Unit = {
+        value = dec
+      }
+    }
+
+    lazy val radiusStart, radiusEnd = new NumberField(None) {
+      reactions += queryButtonEnabling
+
+      def updateAngle(angle: Angle): Unit = {
+        text = f"${angle.toArcmins}%2.2f"
+      }
+    }
+
+    // Contains the list of controls on the UI to make magnitude filters
+    val magnitudeControls = mutable.ListBuffer.empty[MagnitudeFilterControls]
+
+    // Supported bands, remove R-Like duplicates
+    val bands = MagnitudeBand.all.collect {
+      case MagnitudeBand.R  => MagnitudeBand._r
+      case MagnitudeBand.UC => MagnitudeBand._r
+      case b                => b
+    }.distinct
+
+    /**
+     * Reconstructs the layout depending on the magnitude constraints
+     */
+    def buildLayout(filters: List[MagnitudeConstraints]): Unit = {
+      _contents.clear()
+
+      add(catalogBox, CC().spanX(7).alignX(CenterAlign))
+      add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
+      add(new Label("Object"), CC().spanX(2).newline())
+      add(objectName, CC().spanX(3).growX())
+      add(searchByName, CC().spanX(4))
+      add(new Label("RA"), CC().spanX(2).newline())
+      add(ra, CC().spanX(3).growX())
+      add(new Label("J2000") {
+        verticalAlignment = Alignment.Center
+      }, CC().spanY(2).spanX(2))
+      add(new Label("Dec"), CC().spanX(2).newline())
+      add(dec, CC().spanX(3).growX())
+      add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
+      add(new Label("Instrument"), CC().spanX(2).newline())
+      add(instrumentName, CC().spanX(3))
+      add(new Label("Guider"), CC().spanX(2).newline())
+      add(guider, CC().spanX(3).growX())
+      add(new Label("Sky Background"), CC().spanX(2).newline())
+      add(sbBox, CC().spanX(3).growX())
+      add(new Label("Cloud Cover"), CC().spanX(2).newline())
+      add(ccBox, CC().spanX(3).growX())
+      add(new Label("Image Quality"), CC().spanX(2).newline())
+      add(iqBox, CC().spanX(3).growX())
+      add(limitsLabel, CC().spanX(7).growX().newline())
+      add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
+      add(new Label("Radial Range"), CC().spanX(2).newline())
+      add(radiusStart, CC().minWidth(50.px).growX())
+      add(new Label("-"), CC())
+      add(radiusEnd, CC().minWidth(50.px).growX())
+      add(new Label("arcmin"), CC().spanX(3))
+      add(new Label("Magnitudes"), CC().spanX(2).newline())
+      add(new Label("Bright."), CC().spanX(2))
+      add(new Label("Faint."), CC())
+
+      if (filters.isEmpty) {
+        add(addMagnitudeRowButton(0), CC().spanX(2).alignX(RightAlign).newline())
+      } else {
+        // Replace current magnitude filters
+        magnitudeControls.clear()
+        magnitudeControls ++= filters.zipWithIndex.flatMap(Function.tupled(filterControls))
+
+        // Add magnitude filters list
+        magnitudeControls.foreach {
+          case MagnitudeFilterControls(addButton, faintness, separator, saturation, cb, removeButton) =>
+            add(addButton, CC().spanX(2).newline().alignX(RightAlign))
+            add(saturation, CC().minWidth(50.px).growX())
+            add(separator, CC())
+            add(faintness, CC().minWidth(50.px).growX())
+            add(cb, CC().grow())
+            add(removeButton, CC())
         }
       }
 
-      val columnHeaderWidth = calculateColumnHeaderWidth
-      val columnDataWidth = calculateColumnDataWidth
-
-      max(columnHeaderWidth, columnDataWidth)
-    }
-
-    val tcm = this.peer.getColumnModel
-
-    // Calculate the width
-    val cols = for {
-        i <- 0 until tcm.getColumnCount
-      } yield (tcm.getColumn(i), calculateColumnWidth(tcm.getColumn(i)))
-    val initialWidth = cols.map(_._2).sum
-
-    // Adjust space to fit on the outer width
-    val spacing = max(minSpacing, (containerWidth - initialWidth) / tcm.getColumnCount)
-    // Add the rounding error to the first col
-    val initialOffset = max(0, containerWidth - cols.map(_._2 + spacing).sum)
-    // Set width + spacing
-    cols.zipWithIndex.foreach {
-      case ((c, w), i) if i == 0 => updateTableColumn(c, w + spacing + initialOffset) // Add rounding error to the first col
-      case ((c, w), i)           => updateTableColumn(c, w + spacing)
-    }
-  }
-}
-
-object QueryResultsWindow {
-
-  private object table {
-
-    sealed trait TableColumn[T] {
-      val title: String
-
-      def lens: PLens[Target, T]
-
-      def displayValue(t: T): String = t.toString
-
-      def render(target: Target): String = ~lens.get(target).map(displayValue)
-    }
-
-    case class IdColumn(title: String) extends TableColumn[String] {
-      override val lens = Target.name
-    }
-
-    case class RAColumn(title: String) extends TableColumn[RightAscension] {
-      override val lens = Target.coords >=> Coordinates.ra.partial
-
-      override def displayValue(t: RightAscension) = t.toAngle.formatHMS
-    }
-
-    case class DECColumn(title: String) extends TableColumn[Declination] {
-      override val lens = Target.coords >=> Coordinates.dec.partial
-
-      override def displayValue(t: Declination) = t.formatDMS
-    }
-
-    case class DistanceColumn(base: Coordinates, title: String) extends TableColumn[Angle] {
-      val distance: Coordinates @> Angle = Lens(c => Store(r => c, Coordinates.difference(base, c).distance))
-
-      override val lens = Target.coords >=> distance.partial
-
-      override def displayValue(t: Angle) = f"${t.toArcmins}%.2f"
-    }
-
-    case class PMRAColumn(title: String) extends TableColumn[RightAscensionAngularVelocity] {
-      override val lens = Target.pm >=> ProperMotion.deltaRA.partial
-
-      override def displayValue(t: RightAscensionAngularVelocity): String = f"${t.velocity.masPerYear}%.2f"
-    }
-
-    case class PMDecColumn(title: String) extends TableColumn[DeclinationAngularVelocity] {
-      override val lens = Target.pm >=> ProperMotion.deltaDec.partial
-
-      override def displayValue(t: DeclinationAngularVelocity): String = f"${t.velocity.masPerYear}%.2f"
-    }
-
-    case class MagnitudeColumn(band: MagnitudeBand) extends TableColumn[Magnitude] {
-      override val title = band.name
-      // Lens from list of magnitudes to the band's magnitude if present
-      val bLens: List[Magnitude] @?> Magnitude = PLens(ml => ml.find(_.band === band).map(m => Store(b => sys.error("read-only lens"), m)))
-      override val lens = Target.magnitudes >=> bLens
-
-      override def displayValue(t: Magnitude): String = f"${t.value}%.2f"
-    }
-
-    def baseColumnNames(base: Coordinates): List[TableColumn[_]] = List(IdColumn("Id"), RAColumn("RA"), DECColumn("Dec"), DistanceColumn(base, "Dist. [arcmin]"))
-    val pmColumns: List[TableColumn[_]] = List(PMRAColumn("µ RA"), PMDecColumn("µ Dec"))
-    val magColumns = MagnitudeBand.all.map(MagnitudeColumn)
-
-    case class TargetsModel(base: Coordinates, targets: List[SiderealTarget]) extends AbstractTableModel {
-
-      // Available columns from the list of targets
-      val columns = {
-        val bandsInTargets = targets.flatMap(_.magnitudes).map(_.band).distinct
-        val hasPM = targets.exists(_.properMotion.isDefined)
-        val pmCols = if (hasPM) pmColumns else Nil
-        val magCols = magColumns.filter(m => bandsInTargets.contains(m.band))
-
-        baseColumnNames(base) ::: pmCols ::: magCols
-      }
-
-      override def getRowCount = targets.length
-
-      override def getColumnCount = columns.size
-
-      override def getColumnName(column: Int): String =
-        columns(column).title
-
-      override def getValueAt(rowIndex: Int, columnIndex: Int) = (targets.isDefinedAt(rowIndex) option {
-        val target = targets(rowIndex)
-        columns.zipWithIndex.find(_._2 == columnIndex).map { c =>
-          c._1.render(target)
-        }
-      }).flatten.orNull
-
+      add(queryButton, CC().newline().span(7).pushX().alignX(RightAlign).gapTop(10.px))
     }
 
     /**
-     * Frame to display the Query controls and results
+     * Updates the text containing the limits for the currently selected guider
      */
-    object QueryResultsFrame extends Frame with PreferredSizeFrame {
-      private lazy val resultsTable = new Table() with SortableTable with TableColumnsAdjuster {
-        private val m = TargetsModel(Coordinates.zero, Nil)
-        model = model
-        new TableRowSorter[TargetsModel](m) <| {_.toggleSortOrder(0)} <| {peer.setRowSorter}
+    def updateGuideSpeedText(): Unit =
+      for {
+        sel <- guider.selection.item.some
+        probeLimit <- sel.limits
+      } limitsLabel.text = probeLimit.detailRange
 
-        // Align Right
-        peer.setDefaultRenderer(classOf[String], new DefaultTableCellRenderer() {
-          setHorizontalAlignment(SwingConstants.RIGHT)
-        })
+    /**
+     * Update query form according to the passed values
+     */
+    def updateQuery(info: Option[ObservationInfo], query: ConeSearchCatalogQuery): Unit = {
+      info.foreach { i =>
+        objectName.text = ~i.objectName
+        instrumentName.text = ~i.instrumentName
+        // Update guiders box model
+        val guiderModel = new DefaultComboBoxModel[SupportedStrategy](new java.util.Vector((~info.map(_.validStrategies)).asJava))
+        val selected = for {
+          in <- info
+          s  <- in.strategy
+          it <- in.validStrategies.find(_.strategy == s)
+        } yield it
+        selected.foreach(guiderModel.setSelectedItem)
+        guider.peer.setModel(guiderModel)
+        // Update conditions
+        i.conditions.foreach { c =>
+          sbBox.selection.item = c.sb
+          ccBox.selection.item = c.cc
+          iqBox.selection.item = c.iq
+        }
+        updateGuideSpeedText()
+      }
+      // Update the RA
+      ra.updateRa(query.base.ra)
+      dec.updateDec(query.base.dec)
+
+      // Update radius constraint
+      radiusStart.updateAngle(query.radiusConstraint.minLimit)
+      radiusEnd.updateAngle(query.radiusConstraint.maxLimit)
+
+      buildLayout(query.filters.list.collect { case q: MagnitudeQueryFilter => q.mc })
+    }
+
+    def updateName(t: Option[SiderealTarget]): Unit = {
+      t.foreach { i =>
+        // Don't update the name, Simbad often has many names for the same target
+        ra.updateRa(i.coordinates.ra)
+        dec.updateDec(i.coordinates.dec)
+      }
+      t.ifNone {
+        objectName.foreground = Color.red
       }
 
-      private lazy val closeButton = new Button("Close") {
-        reactions += {
-          case ButtonClicked(_) => QueryResultsFrame.visible = false
-        }
+    }
+
+    // Makes a combo box out of the supported bands
+    private def bandsBoxes(bandsList: BandsList): List[ComboBox[MagnitudeBand]] = {
+      def bandComboBox(band: MagnitudeBand) = new ComboBox(bands) with TextRenderer[MagnitudeBand] {
+        selection.item = band
+
+        override def text(a: MagnitudeBand) = a.name
       }
 
-      private lazy val scrollPane = new ScrollPane() {
-        contents = resultsTable
-      }
-
-      private lazy val resultsLabel = new Label("Query") {
-        horizontalAlignment = Alignment.Center
-
-        def updateCount(c: Int):Unit = {
-          text = s"Query results: $c"
-        }
-      }
-
-      private lazy val errorLabel = new Label("") {
-        horizontalAlignment = Alignment.Left
-        foreground = Color.red
-
-        def reset(): Unit = text = ""
-      }
-
-      title = "Query Results"
-      QueryForm.buildLayout(Nil)
-      contents = new MigPanel(LC().fill().insets(0).gridGap("0px", "0px").debug(0)) {
-        // Query Form
-        add(QueryForm, CC().alignY(TopAlign).minWidth(280.px))
-        // Results Table
-        add(new BorderPanel() {
-          border = titleBorder(title)
-          add(scrollPane, BorderPanel.Position.Center)
-        }, CC().grow().spanX(2).pushY().pushX())
-        // Labels and command buttons at the bottom
-        add(resultsLabel, CC().alignX(LeftAlign).alignY(BaselineAlign).newline().gap(10.px, 10.px, 10.px, 10.px))
-        add(errorLabel, CC().alignX(LeftAlign).alignY(BaselineAlign).gap(10.px, 10.px, 10.px, 10.px))
-        add(closeButton, CC().alignX(RightAlign).alignY(BaselineAlign).gap(10.px, 10.px, 10.px, 10.px))
-      }
-
-      // Set initial size
-      adjustSize()
-      // Update location according to the last save position
-      SizePreference.getPosition(this.getClass).foreach { p =>
-        location = p
-      }
-
-      // Save position and dimensions
-      listenTo(this)
-      reactions += {
-        case _: UIElementResized =>
-          SizePreference.setDimension(getClass, Some(this.size))
-        case _: UIElementMoved =>
-          SizePreference.setPosition(getClass, Some(this.location))
-      }
-
-
-      /** Create a titled border with inner and outer padding. */
-      def titleBorder(title: String): Border =
-        createCompoundBorder(
-          createEmptyBorder(2,2,2,2),
-          createCompoundBorder(
-            createTitledBorder(title),
-            createEmptyBorder(2,2,2,2)))
-
-      /**
-       * Show error message at the bottom line
-       */
-      def displayError(error: String): Unit = {
-        errorLabel.text = error
-      }
-
-      /**
-       * Called after a name search completes
-       */
-      def updateName(search: String, targets: List[SiderealTarget]): Unit = {
-        QueryForm.updateName(targets.headOption)
-        targets.headOption.ifNone {
-          errorLabel.text = s"Target '$search' not found..."
-        }
-      }
-
-      /**
-       * Called after  a query completes to update the UI according to the results
-       */
-      def updateResults(info: Option[ObservationInfo], queryResult: QueryResult): Unit = {
-        queryResult.query match {
-          case q: ConeSearchCatalogQuery =>
-            val model = TargetsModel(q.base, queryResult.result.targets.rows)
-            resultsTable.model = model
-
-            // The sorting logic may change if the list of magnitudes changes
-            new TableRowSorter[TargetsModel](model) <| {_.toggleSortOrder(0)} <| {_.sort()} <| {resultsTable.peer.setRowSorter}
-
-            // Adjust the width of the columns
-            val insets = queryFrame.scrollPane.border.getBorderInsets(queryFrame.scrollPane.peer)
-            resultsTable.adjustColumns(queryFrame.scrollPane.bounds.width - insets.left - insets.right)
-
-            // Update the count of rows
-            resultsLabel.updateCount(queryResult.result.targets.rows.length)
-
-            // Update the query form
-            QueryForm.updateQuery(info, q)
-          case _ =>
-        }
-      }
-
-      protected def revalidateFrame(): Unit = {
-        contents.headOption.foreach(_.revalidate())
-      }
-
-      /**
-       * Contains the data used to create the right-hand side form to do queries
-       */
-      private case object QueryForm extends MigPanel(LC().fill().insets(0.px).debug(0)) {
-
-        // Represents a magnitude filter containing the controls that make the row
-        case class MagnitudeFilterControls(addButton: Button, faintess: NumberField, separator: Label, saturation: NumberField, bandCB: ComboBox[MagnitudeBand], removeButton: Button)
-
-        border = titleBorder("Query Params")
-
-        lazy val queryButton = new Button("Query") {
-          reactions += {
-            case ButtonClicked(_) =>
-              // Hit the catalog with a new query
-              buildQuery.foreach(Function.tupled(reloadSearchData))
-          }
-        }
-
-        // Action to disable the query button if there are invalid fields
-        val queryButtonEnabling:Reaction = {
-          case ValueChanged(a) =>
-            queryButton.enabled = a match {
-              case f: AngleTextField[_] => f.valid
-              case f: NumberField       => f.valid
-              case _                    => true
-            }
-        }
-
-        lazy val objectName = new TextField("") with SelectOnFocus {
-          val foregroundColor = UIManager.getColor("TextField.foreground")
-          listenTo(keys)
-          reactions += {
-            case KeyPressed(_, Key.Enter, _, _) if text.nonEmpty =>
-              doNameSearch(text)
-            case KeyTyped(_, _, _, _) =>
-              errorLabel.reset()
-              foreground = foregroundColor
-          }
-        }
-        lazy val searchByName = new Button("") {
-          icon = Resources.getIcon("eclipse/search.gif")
-          ButtonFlattener.flatten(peer)
-          reactions += {
-            case ButtonClicked(_) if objectName.text.nonEmpty =>
-              doNameSearch(objectName.text)
-          }
-        }
-        lazy val instrumentName = new Label("")
-        lazy val catalogBox = new ComboBox(List[CatalogName](UCAC4, PPMXL)) with TextRenderer[CatalogName] {
-          override def text(a: CatalogName) = ~Option(a).map(_.displayName)
-        }
-        lazy val guider = new ComboBox(List.empty[SupportedStrategy]) with TextRenderer[SupportedStrategy] {
-          override def text(a: SupportedStrategy) = ~Option(a).map(_.strategy.key.displayName)
-          listenTo(selection)
-          reactions += {
-            case SelectionChanged(_) =>
-              updateGuideSpeedText()
-          }
-        }
-        lazy val sbBox = new ComboBox(List(SPSiteQuality.SkyBackground.values(): _*)) with TextRenderer[SPSiteQuality.SkyBackground] {
-          override def text(a: SPSiteQuality.SkyBackground) = a.displayValue()
-        }
-        lazy val ccBox = new ComboBox(List(SPSiteQuality.CloudCover.values(): _*)) with TextRenderer[SPSiteQuality.CloudCover] {
-          override def text(a: SPSiteQuality.CloudCover) = a.displayValue()
-        }
-        lazy val iqBox = new ComboBox(List(SPSiteQuality.ImageQuality.values(): _*)) with TextRenderer[SPSiteQuality.ImageQuality] {
-          override def text(a: SPSiteQuality.ImageQuality) = a.displayValue()
-        }
-        lazy val limitsLabel = new Label() {
-          font = font.deriveFont(font.getSize2D * 0.8f)
-        }
-
-        lazy val ra = new RATextField(RightAscension.zero) {
-          reactions += queryButtonEnabling
-
-          def updateRa(ra: RightAscension): Unit = {
-            value = ra
-          }
-        }
-
-        lazy val dec = new DecTextField(Declination.zero) {
-          reactions += queryButtonEnabling
-
-          def updateDec(dec: Declination): Unit = {
-            value = dec
-          }
-        }
-
-        lazy val radiusStart, radiusEnd = new NumberField(None) {
-          reactions += queryButtonEnabling
-          def updateAngle(angle: Angle): Unit = {
-            text = f"${angle.toArcmins}%2.2f"
-          }
-        }
-
-        // Contains the list of controls on the UI to make magnitude filters
-        val magnitudeControls = mutable.ListBuffer.empty[MagnitudeFilterControls]
-
-        // Supported bands, remove R-Like duplicates
-        val bands = MagnitudeBand.all.collect {
-          case MagnitudeBand.R  => MagnitudeBand._r
-          case MagnitudeBand.UC => MagnitudeBand._r
-          case b                => b
-        }.distinct
-
-        /**
-         * Reconstructs the layout depending on the magnitude constraints
-         */
-        def buildLayout(filters: List[MagnitudeConstraints]): Unit = {
-          _contents.clear()
-
-          add(catalogBox, CC().spanX(7).alignX(CenterAlign))
-          add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
-          add(new Label("Object"), CC().spanX(2).newline())
-          add(objectName, CC().spanX(3).growX())
-          add(searchByName, CC().spanX(4))
-          add(new Label("RA"), CC().spanX(2).newline())
-          add(ra, CC().spanX(3).growX())
-          add(new Label("J2000") {
-            verticalAlignment = Alignment.Center
-          }, CC().spanY(2).spanX(2))
-          add(new Label("Dec"), CC().spanX(2).newline())
-          add(dec, CC().spanX(3).growX())
-          add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
-          add(new Label("Instrument"), CC().spanX(2).newline())
-          add(instrumentName, CC().spanX(3))
-          add(new Label("Guider"), CC().spanX(2).newline())
-          add(guider, CC().spanX(3).growX())
-          add(new Label("Sky Background"), CC().spanX(2).newline())
-          add(sbBox, CC().spanX(3).growX())
-          add(new Label("Cloud Cover"), CC().spanX(2).newline())
-          add(ccBox, CC().spanX(3).growX())
-          add(new Label("Image Quality"), CC().spanX(2).newline())
-          add(iqBox, CC().spanX(3).growX())
-          add(limitsLabel, CC().spanX(7).growX().newline())
-          add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
-          add(new Label("Radial Range"), CC().spanX(2).newline())
-          add(radiusStart, CC().minWidth(50.px).growX())
-          add(new Label("-"), CC())
-          add(radiusEnd, CC().minWidth(50.px).growX())
-          add(new Label("arcmin"), CC().spanX(3))
-          add(new Label("Magnitudes"), CC().spanX(2).newline())
-          add(new Label("Bright."), CC().spanX(2))
-          add(new Label("Faint."), CC())
-
-          if (filters.isEmpty) {
-            add(addMagnitudeRowButton(0), CC().spanX(2).alignX(RightAlign).newline())
-          } else {
-            // Replace current magnitude filters
-            magnitudeControls.clear()
-            magnitudeControls ++= filters.zipWithIndex.flatMap(Function.tupled(filterControls))
-
-            // Add magnitude filters list
-            magnitudeControls.foreach {
-              case MagnitudeFilterControls(addButton, faintness, separator, saturation, cb, removeButton) =>
-                add(addButton, CC().spanX(2).newline().alignX(RightAlign))
-                add(saturation, CC().minWidth(50.px).growX())
-                add(separator, CC())
-                add(faintness, CC().minWidth(50.px).growX())
-                add(cb, CC().grow())
-                add(removeButton, CC())
-            }
-          }
-
-          add(queryButton, CC().newline().span(7).pushX().alignX(RightAlign).gapTop(10.px))
-        }
-
-        /**
-         * Updates the text containing the limits for the currently selected guider
-         */
-        def updateGuideSpeedText():Unit =
-          for {
-            sel        <- guider.selection.item.some
-            probeLimit <- sel.limits
-          } limitsLabel.text = probeLimit.detailRange
-
-        /**
-         * Update query form according to the passed values
-         */
-        def updateQuery(info: Option[ObservationInfo], query: ConeSearchCatalogQuery): Unit = {
-          info.foreach { i =>
-            objectName.text = ~i.objectName
-            instrumentName.text = ~i.instrumentName
-            // Update guiders box model
-            val guiderModel = new DefaultComboBoxModel[SupportedStrategy](new java.util.Vector((~info.map(_.validStrategies)).asJava))
-            val selected = for {
-                in <- info
-                s  <- in.strategy
-                it <- in.validStrategies.find(_.strategy == s)
-              } yield it
-            selected.foreach(guiderModel.setSelectedItem)
-            guider.peer.setModel(guiderModel)
-            // Update conditions
-            i.conditions.foreach { c =>
-              sbBox.selection.item = c.sb
-              ccBox.selection.item = c.cc
-              iqBox.selection.item = c.iq
-            }
-            updateGuideSpeedText()
-          }
-          // Update the RA
-          ra.updateRa(query.base.ra)
-          dec.updateDec(query.base.dec)
-
-          // Update radius constraint
-          radiusStart.updateAngle(query.radiusConstraint.minLimit)
-          radiusEnd.updateAngle(query.radiusConstraint.maxLimit)
-
-          buildLayout(query.filters.list.collect {case q: MagnitudeQueryFilter => q.mc})
-        }
-
-        def updateName(t: Option[SiderealTarget]): Unit = {
-          t.foreach { i =>
-            // Don't update the name, Simbad often has many names for the same target
-            ra.updateRa(i.coordinates.ra)
-            dec.updateDec(i.coordinates.dec)
-          }
-          t.ifNone {
-            objectName.foreground = Color.red
-          }
-
-        }
-
-        // Makes a combo box out of the supported bands
-        private def bandsBoxes(bandsList: BandsList): List[ComboBox[MagnitudeBand]] = {
-          def bandComboBox(band: MagnitudeBand) = new ComboBox(bands) with TextRenderer[MagnitudeBand] {
-            selection.item = band
-            override def text(a: MagnitudeBand) = a.name
-          }
-
-          bandsList match {
-            case RBandsList       => List(bandComboBox(MagnitudeBand._r)) // TODO Should we represent the R-Family as a separate entry on the combo box?
-            case NiciBandsList    => List(bandComboBox(MagnitudeBand._r), bandComboBox(MagnitudeBand.V))
-            case SingleBand(band) => List(bandComboBox(band))
-          }
-        }
-
-        // Read the GUI values and constructs the constrains
-        private def currentFilters: List[MagnitudeConstraints] =
-          magnitudeControls.map {
-            case MagnitudeFilterControls(_, faintess, _, saturation, bandCB, _) =>
-              MagnitudeConstraints(BandsList.bandList(bandCB.selection.item), FaintnessConstraint(faintess.text.toDouble), SaturationConstraint(saturation.text.toDouble).some)
-          }.toList
-
-        // Make a query out of the form parameters
-        private def buildQuery: Option[(Option[ObservationInfo], CatalogQuery)] = {
-          queryButton.enabled option {
-            // No validation here, the Query button is disabled unless all the controls are valid
-            val coordinates = Coordinates(ra.value, dec.value)
-            val radiusConstraint = RadiusConstraint.between(Angle.fromArcmin(radiusStart.text.toDouble), Angle.fromArcmin(radiusEnd.text.toDouble))
-
-            val guiders = for {
-              i <- 0 until guider.peer.getModel.getSize
-            } yield guider.peer.getModel.getElementAt(i)
-
-            // TODO Change the search query for different conditions OCSADV-416
-            val conditions = Conditions.NOMINAL.sb(sbBox.selection.item).cc(ccBox.selection.item).iq(iqBox.selection.item)
-
-            val selectedCatalog = catalogBox.selection.item
-            val info = ObservationInfo(objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog)
-            val defaultQuery = CatalogQuery(coordinates, radiusConstraint, currentFilters, selectedCatalog)
-            // Start with the guider's query and update it with the values on the UI
-            val calculatedQuery = guider.selection.item.query.headOption.collect {
-              case c: ConeSearchCatalogQuery if currentFilters.nonEmpty => c.copy(base = coordinates, radiusConstraint = radiusConstraint, magnitudeConstraints = currentFilters, catalog = selectedCatalog)
-              case c: ConeSearchCatalogQuery                            => c.copy(base = coordinates, radiusConstraint = radiusConstraint, catalog = selectedCatalog) // Use the magnitude constraints from the guider
-            }
-            (info.some, calculatedQuery.getOrElse(defaultQuery))
-          }
-        }
-
-        // Plus button to add a new row of magnitude filter
-        private def addMagnitudeRowButton(index: Int) = new Button("+") {
-          reactions += {
-            case ButtonClicked(_) =>
-              // Make a copy of the current row
-              val mc = magnitudeControls.lift(index).map { mc =>
-                  List(mc.copy())
-                }.getOrElse {
-                  filterControls(MagnitudeConstraints(RBandsList, FaintnessConstraint(99), SaturationConstraint(-99).some), 0)
-                }
-              magnitudeControls.insertAll(index, mc)
-              buildLayout(currentFilters)
-              // Important to re-layout the parent
-              revalidateFrame()
-          }
-        }
-
-        // Minus button to remove a row of magnitude filters
-        private def removeMagnitudeRowButton(index: Int) = new Button("-") {
-          reactions += {
-            case ButtonClicked(s) =>
-              magnitudeControls.lift(index).foreach { _ =>
-                magnitudeControls.remove(index)
-                buildLayout(currentFilters)
-                // Important to re-layout the parent
-                revalidateFrame()
-              }
-          }
-        }
-
-        // Make GUI controls for a Magnitude Constraint
-        private def filterControls(mc: MagnitudeConstraints, index: Int): List[MagnitudeFilterControls] = {
-          val faint = new NumberField(mc.faintnessConstraint.brightness.some) {
-                        reactions += queryButtonEnabling
-                      }
-          val sat = new NumberField(mc.saturationConstraint.map(_.brightness)) {
-                      reactions += queryButtonEnabling
-                    }
-          bandsBoxes(mc.searchBands).map(MagnitudeFilterControls(addMagnitudeRowButton(index), faint, new Label("-"), sat, _, removeMagnitudeRowButton(index)))
-        }
-
+      bandsList match {
+        case RBandsList       => List(bandComboBox(MagnitudeBand._r)) // TODO Should we represent the R-Family as a separate entry on the combo box?
+        case NiciBandsList    => List(bandComboBox(MagnitudeBand._r), bandComboBox(MagnitudeBand.V))
+        case SingleBand(band) => List(bandComboBox(band))
       }
     }
 
-    val queryFrame = QueryResultsFrame
+    // Read the GUI values and constructs the constrains
+    private def currentFilters: List[MagnitudeConstraints] =
+      magnitudeControls.map {
+        case MagnitudeFilterControls(_, faintess, _, saturation, bandCB, _) =>
+          MagnitudeConstraints(BandsList.bandList(bandCB.selection.item), FaintnessConstraint(faintess.text.toDouble), SaturationConstraint(saturation.text.toDouble).some)
+      }.toList
+
+    // Make a query out of the form parameters
+    private def buildQuery: Option[(Option[ObservationInfo], CatalogQuery)] = {
+      queryButton.enabled option {
+        // No validation here, the Query button is disabled unless all the controls are valid
+        val coordinates = Coordinates(ra.value, dec.value)
+        val radiusConstraint = RadiusConstraint.between(Angle.fromArcmin(radiusStart.text.toDouble), Angle.fromArcmin(radiusEnd.text.toDouble))
+
+        val guiders = for {
+          i <- 0 until guider.peer.getModel.getSize
+        } yield guider.peer.getModel.getElementAt(i)
+
+        // TODO Change the search query for different conditions OCSADV-416
+        val conditions = Conditions.NOMINAL.sb(sbBox.selection.item).cc(ccBox.selection.item).iq(iqBox.selection.item)
+
+        val selectedCatalog = catalogBox.selection.item
+        val info = ObservationInfo(objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog)
+        val defaultQuery = CatalogQuery(coordinates, radiusConstraint, currentFilters, selectedCatalog)
+        // Start with the guider's query and update it with the values on the UI
+        val calculatedQuery = guider.selection.item.query.headOption.collect {
+          case c: ConeSearchCatalogQuery if currentFilters.nonEmpty => c.copy(base = coordinates, radiusConstraint = radiusConstraint, magnitudeConstraints = currentFilters, catalog = selectedCatalog)
+          case c: ConeSearchCatalogQuery                            => c.copy(base = coordinates, radiusConstraint = radiusConstraint, catalog = selectedCatalog) // Use the magnitude constraints from the guider
+        }
+        (info.some, calculatedQuery.getOrElse(defaultQuery))
+      }
+    }
+
+    // Plus button to add a new row of magnitude filter
+    private def addMagnitudeRowButton(index: Int) = new Button("+") {
+      reactions += {
+        case ButtonClicked(_) =>
+          // Make a copy of the current row
+          val mc = magnitudeControls.lift(index).map { mc =>
+            List(mc.copy())
+          }.getOrElse {
+            filterControls(MagnitudeConstraints(RBandsList, FaintnessConstraint(99), SaturationConstraint(-99).some), 0)
+          }
+          magnitudeControls.insertAll(index, mc)
+          buildLayout(currentFilters)
+          // Important to re-layout the parent
+          revalidateFrame()
+      }
+    }
+
+    // Minus button to remove a row of magnitude filters
+    private def removeMagnitudeRowButton(index: Int) = new Button("-") {
+      reactions += {
+        case ButtonClicked(s) =>
+          magnitudeControls.lift(index).foreach { _ =>
+            magnitudeControls.remove(index)
+            buildLayout(currentFilters)
+            // Important to re-layout the parent
+            revalidateFrame()
+          }
+      }
+    }
+
+    // Make GUI controls for a Magnitude Constraint
+    private def filterControls(mc: MagnitudeConstraints, index: Int): List[MagnitudeFilterControls] = {
+      val faint = new NumberField(mc.faintnessConstraint.brightness.some) {
+        reactions += queryButtonEnabling
+      }
+      val sat = new NumberField(mc.saturationConstraint.map(_.brightness)) {
+        reactions += queryButtonEnabling
+      }
+      bandsBoxes(mc.searchBands).map(MagnitudeFilterControls(addMagnitudeRowButton(index), faint, new Label("-"), sat, _, removeMagnitudeRowButton(index)))
+    }
+
   }
 
+  private def catalogSearch(query: CatalogQuery, backend: VoTableBackend, message: String, onSuccess: (QueryResult) => Unit): Unit = {
+    import scala.concurrent.ExecutionContext.Implicits.global
 
-  private def catalogSearch(query: CatalogQuery, backend: VoTableBackend, message: String, onSuccess: (QueryResult) => Unit) : Unit = {
-      import scala.concurrent.ExecutionContext.Implicits.global
-      import QueryResultsWindow.table._
-
-      GlassLabel.show(queryFrame.peer.getRootPane, message)
-      VoTableClient.catalog(query, backend).onComplete {
-        case scala.util.Failure(f) =>
-          GlassLabel.hide(queryFrame.peer.getRootPane)
-          queryFrame.displayError(s"Exception: ${f.getMessage}")
-        case scala.util.Success(x) if x.result.containsError =>
-          GlassLabel.hide(queryFrame.peer.getRootPane)
-          queryFrame.displayError(s"Error: ${x.result.problems.head.displayValue}")
-        case scala.util.Success(x) =>
-          Swing.onEDT {
-            GlassLabel.hide(queryFrame.peer.getRootPane)
-            onSuccess(x)
-          }
-      }
+    GlassLabel.show(peer.getRootPane, message)
+    VoTableClient.catalog(query, backend).onComplete {
+      case scala.util.Failure(f)                           =>
+        GlassLabel.hide(peer.getRootPane)
+        displayError(s"Exception: ${f.getMessage}")
+      case scala.util.Success(x) if x.result.containsError =>
+        GlassLabel.hide(peer.getRootPane)
+        displayError(s"Error: ${x.result.problems.head.displayValue}")
+      case scala.util.Success(x)                           =>
+        Swing.onEDT {
+          GlassLabel.hide(peer.getRootPane)
+          onSuccess(x)
+        }
     }
+  }
 
   private def doNameSearch(search: String): Unit = {
-    import QueryResultsWindow.table._
     catalogSearch(CatalogQuery(search), SimbadNameBackend, "Searching...", { x =>
-      queryFrame.updateName(search, x.result.targets.rows)
+      updateName(search, x.result.targets.rows)
     })
   }
 
   private def reloadSearchData(obsInfo: Option[ObservationInfo], query: CatalogQuery) {
-    import QueryResultsWindow.table._
     catalogSearch(query, ConeSearchBackend, "Searching...", { x =>
-      queryFrame.updateResults(obsInfo, x)
+      updateResults(obsInfo, x)
     })
   }
 
   // Shows the frame and loads the query
-  protected [ui] def showWithQuery(ctx: ObsContext, mt: MagnitudeTable, q: CatalogQuery):Unit = Swing.onEDT {
-    import QueryResultsWindow.table._
-
-    queryFrame.visible = true
-    queryFrame.peer.toFront()
+  protected[ui] def showWithQuery(ctx: ObsContext, mt: MagnitudeTable, q: CatalogQuery): Unit = Swing.onEDT {
+    visible = true
+    peer.toFront()
     reloadSearchData(ObservationInfo(ctx, mt).some, q)
   }
 
@@ -742,46 +540,9 @@ object QueryResultsWindow {
         case q: ConeSearchCatalogQuery =>
           // OCSADV-403 Display all the rows, removing the magnitude constraints
           showWithQuery(obsCtx, mt, q.copy(magnitudeConstraints = Nil))
-        case _                         =>
-          // Ignore named queries
+        case _ =>
+        // Ignore named queries
       }
     }
   }
-
-}
-
-object CatalogQueryDemo extends SwingApplication {
-  import QueryResultsWindow.instance
-  import jsky.util.gui.Theme
-  import edu.gemini.shared.util.immutable.{None => JNone, Some => JSome}
-  import edu.gemini.spModel.gemini.niri.InstNIRI
-  import edu.gemini.spModel.gemini.niri.NiriOiwfsGuideProbe
-  import edu.gemini.spModel.guide.GuideProbe
-  import edu.gemini.spModel.target.obsComp.PwfsGuideProbe
-  import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
-  import edu.gemini.spModel.target.SPTarget
-  import edu.gemini.spModel.target.env.TargetEnvironment
-
-  val query = CatalogQuery(Coordinates(RightAscension.fromAngle(Angle.fromDegrees(3.1261166666666895)),Declination.fromAngle(Angle.fromDegrees(337.93268333333333)).getOrElse(Declination.zero)),RadiusConstraint.between(Angle.zero,Angle.fromDegrees(0.16459874517619255)),List(MagnitudeConstraints(RBandsList,FaintnessConstraint(16.0),Some(SaturationConstraint(3.1999999999999993)))),UCAC4)
-
-  def startup(args: Array[String]) {
-    System.setProperty("apple.awt.antialiasing", "on")
-    System.setProperty("apple.awt.textantialiasing", "on")
-    Theme.install()
-
-    UIManager.put("Button.defaultButtonFollowsFocus", true)
-
-    val ra = Angle.fromHMS(0, 12, 30.286).getOrElse(Angle.zero)
-    val dec = Declination.fromAngle(Angle.zero - Angle.fromDMS(22, 4, 2.34).getOrElse(Angle.zero)).getOrElse(Declination.zero)
-    val guiders = Set[GuideProbe](NiriOiwfsGuideProbe.instance, PwfsGuideProbe.pwfs1, PwfsGuideProbe.pwfs2)
-    val target = new SPTarget(ra.toDegrees, dec.toDegrees) <| {_.setName("HIP 1000")}
-    val env = TargetEnvironment.create(target)
-    val inst = new InstNIRI <| {_.setPosAngle(0.0)}
-
-    val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-    val ctx = ObsContext.create(env, inst, new JSome(Site.GN), conditions, null, null, JNone.instance())
-
-    instance.showOn(ctx)
-  }
-
 }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -435,8 +435,10 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         val conditions = Conditions.NOMINAL.sb(sbBox.selection.item).cc(ccBox.selection.item).iq(iqBox.selection.item)
 
         val selectedCatalog = catalogBox.selection.item
-        // TODO Create a synthetic ObsContext out of the parameters
-        val info = ObservationInfo(None, objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog, ProbeLimitsTable.loadOrThrow())
+
+
+        val inst = ObservationInfo.toInstrument(instrumentName.text)
+        val info = ObservationInfo(None, objectName.text.some, coordinates.some, inst, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog, ProbeLimitsTable.loadOrThrow())
         val defaultQuery = CatalogQuery(coordinates, radiusConstraint, currentFilters, selectedCatalog)
         // Start with the guider's query and update it with the values on the UI
         val calculatedQuery = guider.selection.item.query.headOption.collect {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -136,7 +136,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
   def updateResults(info: Option[ObservationInfo], queryResult: QueryResult): Unit = {
     queryResult.query match {
       case q: ConeSearchCatalogQuery =>
-        val model = TargetsModel(q.base, queryResult.result.targets.rows)
+        val model = TargetsModel(info, q.base, queryResult.result.targets.rows)
         resultsTable.model = model
 
         // The sorting logic may change if the list of magnitudes changes
@@ -421,7 +421,8 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         val conditions = Conditions.NOMINAL.sb(sbBox.selection.item).cc(ccBox.selection.item).iq(iqBox.selection.item)
 
         val selectedCatalog = catalogBox.selection.item
-        val info = ObservationInfo(objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog)
+        // TODO Create a synthetic ObsContext out of the parameters
+        val info = ObservationInfo(None, objectName.text.some, instrumentName.text.some, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog, ProbeLimitsTable.loadOrThrow())
         val defaultQuery = CatalogQuery(coordinates, radiusConstraint, currentFilters, selectedCatalog)
         // Start with the guider's query and update it with the values on the UI
         val calculatedQuery = guider.selection.item.query.headOption.collect {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -42,6 +42,8 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     override def configure(t: Table, sel: Boolean, foc: Boolean, value: AgsGuideQuality, row: Int, col: Int): Unit = {
       component.icon = GuidingIcon(value, enabled = true)
       component.text = ""
+      component.preferredSize = new Dimension(GuidingIcon.sideLength + 2, GuidingIcon.sideLength + 2)
+      component.maximumSize = new Dimension(GuidingIcon.sideLength  + 2, GuidingIcon.sideLength + 2)
     }
   }
 
@@ -155,6 +157,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
         // Adjust the width of the columns
         val insets = scrollPane.border.getBorderInsets(scrollPane.peer)
+        resultsTable.peer.getColumnModel.getColumn(0).setResizable(false)
         resultsTable.adjustColumns(scrollPane.bounds.width - insets.left - insets.right)
 
         // Update the count of rows

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -38,18 +38,12 @@ import Scalaz._
  */
 object QueryResultsFrame extends Frame with PreferredSizeFrame {
   private lazy val resultsTable = new Table() with SortableTable with TableColumnsAdjuster {
-    private val m = TargetsModel(Coordinates.zero, Nil)
-    model = model
-    new TableRowSorter[TargetsModel](m) <| {
-      _.toggleSortOrder(0)
-    } <| {
-      peer.setRowSorter
-    }
-
-    // Align Right
-    peer.setDefaultRenderer(classOf[String], new DefaultTableCellRenderer() {
-      setHorizontalAlignment(SwingConstants.RIGHT)
-    })
+    override def rendererComponent(isSelected: Boolean, focused: Boolean, row: Int, column: Int) =
+      (model, model.getValueAt(row, column)) match {
+        case (m: TargetsModel, value) =>
+          // Delegate rendering to the model
+          m.rendererComponent(value ,isSelected, focused, row, column).getOrElse(super.rendererComponent(isSelected, focused, row, column))
+      }
   }
 
   private lazy val closeButton = new Button("Close") {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -3,8 +3,7 @@ package edu.gemini.catalog.ui
 import java.awt.Color
 import javax.swing.BorderFactory._
 import javax.swing.border.Border
-import javax.swing.{UIManager, DefaultComboBoxModel, SwingConstants}
-import javax.swing.table._
+import javax.swing.{UIManager, DefaultComboBoxModel}
 
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
 import edu.gemini.ags.api.AgsRegistrar
@@ -38,8 +37,10 @@ import Scalaz._
  */
 object QueryResultsFrame extends Frame with PreferredSizeFrame {
   private lazy val resultsTable = new Table() with SortableTable with TableColumnsAdjuster {
+
     override def rendererComponent(isSelected: Boolean, focused: Boolean, row: Int, column: Int) =
-      (model, model.getValueAt(row, column)) match {
+      // Note that we need to use the same conversions as indicated on SortableTable to get the value
+      (model, model.getValueAt(viewToModelRow(row), viewToModelColumn(column))) match {
         case (m: TargetsModel, value) =>
           // Delegate rendering to the model
           m.rendererComponent(value ,isSelected, focused, row, column).getOrElse(super.rendererComponent(isSelected, focused, row, column))
@@ -139,13 +140,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         resultsTable.model = model
 
         // The sorting logic may change if the list of magnitudes changes
-        new TableRowSorter[TargetsModel](model) <| {
-          _.toggleSortOrder(0)
-        } <| {
-          _.sort()
-        } <| {
-          resultsTable.peer.setRowSorter
-        }
+        resultsTable.peer.setRowSorter(model.sorter)
 
         // Adjust the width of the columns
         val insets = scrollPane.border.getBorderInsets(scrollPane.peer)

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -436,7 +436,6 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
         val selectedCatalog = catalogBox.selection.item
 
-
         val inst = ObservationInfo.toInstrument(instrumentName.text)
         val info = ObservationInfo(None, objectName.text.some, coordinates.some, inst, Option(guider.selection.item.strategy), guiders.toList, conditions.some, selectedCatalog, ProbeLimitsTable.loadOrThrow())
         val defaultQuery = CatalogQuery(coordinates, radiusConstraint, currentFilters, selectedCatalog)

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TableColumnsAdjuster.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TableColumnsAdjuster.scala
@@ -1,0 +1,72 @@
+package edu.gemini.catalog.ui
+
+import javax.swing.table.TableColumn
+import scala.swing.Table
+
+import scalaz._
+import Scalaz._
+
+/**
+ * Support calculating column widths and can adjust them to the outer width
+ */
+trait TableColumnsAdjuster { this: Table =>
+  autoResizeMode = Table.AutoResizeMode.Off
+
+  val minSpacing: Int = 20
+
+  def adjustColumns(containerWidth: Int): Unit = {
+    import scala.math.max
+
+    def updateTableColumn(column: TableColumn, width: Int):Unit = {
+      if (column.getResizable) {
+        this.peer.getTableHeader.setResizingColumn(column)
+        column <| {_.setPreferredWidth(width)} <| {_.setWidth(width)}
+      }
+    }
+
+    def calculateColumnWidth(column: TableColumn): Int = {
+
+      def calculateColumnHeaderWidth: Int = {
+        val value = column.getHeaderValue
+        val renderer = Option(column.getHeaderRenderer).getOrElse(this.peer.getTableHeader.getDefaultRenderer)
+
+        renderer.getTableCellRendererComponent(this.peer, value, false, false, -1, column.getModelIndex).getPreferredSize.width
+      }
+
+      def cellDataWidth(row: Int, column: Int): Int = {
+        val cellRenderer = this.peer.getCellRenderer(row, column)
+        val c = this.peer.prepareRenderer(cellRenderer, row, column)
+        c.getPreferredSize.width + this.peer.getIntercellSpacing.width
+      }
+
+      def calculateColumnDataWidth: Int = {
+        (0 until this.model.getRowCount).foldLeft(0) { (currMax, i) =>
+          max(currMax, cellDataWidth(i, column.getModelIndex))
+        }
+      }
+
+      val columnHeaderWidth = calculateColumnHeaderWidth
+      val columnDataWidth = calculateColumnDataWidth
+
+      max(columnHeaderWidth, columnDataWidth)
+    }
+
+    val tcm = this.peer.getColumnModel
+
+    // Calculate the width
+    val cols = for {
+        i <- 0 until tcm.getColumnCount
+      } yield (tcm.getColumn(i), calculateColumnWidth(tcm.getColumn(i)))
+    val initialWidth = cols.map(_._2).sum
+
+    // Adjust space to fit on the outer width
+    val spacing = max(minSpacing, (containerWidth - initialWidth) / tcm.getColumnCount)
+    // Add the rounding error to the first col
+    val initialOffset = max(0, containerWidth - cols.map(_._2 + spacing).sum)
+    // Set width + spacing
+    cols.zipWithIndex.foreach {
+      case ((c, w), i) if i == 0 => updateTableColumn(c, w + spacing + initialOffset) // Add rounding error to the first col
+      case ((c, w), i)           => updateTableColumn(c, w + spacing)
+    }
+  }
+}

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -1,0 +1,147 @@
+package edu.gemini.catalog
+
+import javax.swing.table.AbstractTableModel
+
+import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
+import edu.gemini.ags.api.{AgsRegistrar, AgsStrategy}
+import edu.gemini.catalog.api.{UCAC4, CatalogName, CatalogQuery}
+import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+import edu.gemini.spModel.obs.context.ObsContext
+import jsky.app.ot.gemini.editor.targetComponent.GuidingFeedback.ProbeLimits
+
+import scalaz._
+import Scalaz._
+
+/**
+ * contains the Catalog Navigator UI model classes
+ */
+package object ui {
+
+  /**
+   * Locally describe an ags strategy including its limits and the query that would trigger
+   */
+  case class SupportedStrategy(strategy: AgsStrategy, limits: Option[ProbeLimits], query: List[CatalogQuery])
+
+  /**
+   * Describes the observation used to do a Guide Star Search
+   */
+  case class ObservationInfo(objectName: Option[String], instrumentName: Option[String], strategy: Option[AgsStrategy], validStrategies: List[SupportedStrategy], conditions: Option[Conditions], catalog: CatalogName) {
+    def catalogQuery:List[CatalogQuery] = validStrategies.collect {
+        case SupportedStrategy(s, _, query) if s == strategy => query
+      }.flatten
+  }
+
+  object ObservationInfo {
+
+    /**
+     * Converts an AgsStrategy to a simpler description to be stored in the UI model
+     */
+    private def toSupportedStrategy(obsCtx: ObsContext, strategy: AgsStrategy, mt: MagnitudeTable):SupportedStrategy = {
+      val pb = strategy.magnitudes(obsCtx, mt).map(k => ProbeLimits(strategy.probeBands, obsCtx, k._2)).headOption
+      val queries = strategy.catalogQueries(obsCtx, mt)
+      SupportedStrategy(strategy, pb.flatten, queries)
+    }
+
+    def apply(ctx: ObsContext, mt: MagnitudeTable):ObservationInfo = ObservationInfo(
+      Option(ctx.getTargets.getBase).map(_.getTarget.getName),
+      Option(ctx.getInstrument).map(_.getTitle),
+      AgsRegistrar.currentStrategy(ctx),
+      AgsRegistrar.validStrategies(ctx).map(toSupportedStrategy(ctx, _, mt)),
+      ctx.getConditions.some,
+      UCAC4)
+
+  }
+
+  /**
+   * Represents a table column description
+   * @tparam T The type of the column
+   */
+  sealed trait CatalogNavigatorColumn[T] {
+    val title: String
+
+    def lens: PLens[Target, T]
+
+    def displayValue(t: T): String = t.toString
+
+    def render(target: Target): String = ~lens.get(target).map(displayValue)
+  }
+
+  case class IdColumn(title: String) extends CatalogNavigatorColumn[String] {
+    override val lens = Target.name
+  }
+
+  case class RAColumn(title: String) extends CatalogNavigatorColumn[RightAscension] {
+    override val lens = Target.coords >=> Coordinates.ra.partial
+
+    override def displayValue(t: RightAscension) = t.toAngle.formatHMS
+  }
+
+  case class DECColumn(title: String) extends CatalogNavigatorColumn[Declination] {
+    override val lens = Target.coords >=> Coordinates.dec.partial
+
+    override def displayValue(t: Declination) = t.formatDMS
+  }
+
+  case class DistanceColumn(base: Coordinates, title: String) extends CatalogNavigatorColumn[Angle] {
+    val distance: Coordinates @> Angle = Lens(c => Store(r => c, Coordinates.difference(base, c).distance))
+
+    override val lens = Target.coords >=> distance.partial
+
+    override def displayValue(t: Angle) = f"${t.toArcmins}%.2f"
+  }
+
+  case class PMRAColumn(title: String) extends CatalogNavigatorColumn[RightAscensionAngularVelocity] {
+    override val lens = Target.pm >=> ProperMotion.deltaRA.partial
+
+    override def displayValue(t: RightAscensionAngularVelocity): String = f"${t.velocity.masPerYear}%.2f"
+  }
+
+  case class PMDecColumn(title: String) extends CatalogNavigatorColumn[DeclinationAngularVelocity] {
+    override val lens = Target.pm >=> ProperMotion.deltaDec.partial
+
+    override def displayValue(t: DeclinationAngularVelocity): String = f"${t.velocity.masPerYear}%.2f"
+  }
+
+  case class MagnitudeColumn(band: MagnitudeBand) extends CatalogNavigatorColumn[Magnitude] {
+    override val title = band.name
+    // Lens from list of magnitudes to the band's magnitude if present
+    val bLens: List[Magnitude] @?> Magnitude = PLens(ml => ml.find(_.band === band).map(m => Store(b => sys.error("read-only lens"), m)))
+    override val lens = Target.magnitudes >=> bLens
+
+    override def displayValue(t: Magnitude): String = f"${t.value}%.2f"
+  }
+
+  def baseColumnNames(base: Coordinates): List[CatalogNavigatorColumn[_]] = List(IdColumn("Id"), RAColumn("RA"), DECColumn("Dec"), DistanceColumn(base, "Dist. [arcmin]"))
+  val pmColumns: List[CatalogNavigatorColumn[_]] = List(PMRAColumn("µ RA"), PMDecColumn("µ Dec"))
+  val magColumns = MagnitudeBand.all.map(MagnitudeColumn)
+
+  /**
+   * Data model for the main table of the catalog navigator
+   */
+  case class TargetsModel(base: Coordinates, targets: List[SiderealTarget]) extends AbstractTableModel {
+
+    // Available columns from the list of targets
+    val columns = {
+      val bandsInTargets = targets.flatMap(_.magnitudes).map(_.band).distinct
+      val hasPM = targets.exists(_.properMotion.isDefined)
+      val pmCols = if (hasPM) pmColumns else Nil
+      val magCols = magColumns.filter(m => bandsInTargets.contains(m.band))
+
+      baseColumnNames(base) ::: pmCols ::: magCols
+    }
+
+    override def getRowCount = targets.length
+
+    override def getColumnCount = columns.size
+
+    override def getColumnName(column: Int): String =
+      columns(column).title
+
+    override def getValueAt(rowIndex: Int, columnIndex: Int) = targets.lift(rowIndex).flatMap { t =>
+      columns.zipWithIndex.find(_._2 == columnIndex).map(_._1.render(t))
+    }.orNull
+
+  }
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingIcon.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingIcon.scala
@@ -16,6 +16,7 @@ import javax.swing.ImageIcon
  * enabled and disabled variations.
  */
 object GuidingIcon {
+  val sideLength = 16
 
   private val darkGreen = new Color(0, 153, 0)
 
@@ -31,7 +32,7 @@ object GuidingIcon {
   // See: http://en.wikipedia.org/wiki/Harvey_Balls
   private def makeIcon(q: AgsGuideQuality, enabled: Boolean): ImageIcon = {
     new ImageIcon({
-      val img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB)
+      val img = new BufferedImage(sideLength, sideLength, BufferedImage.TYPE_INT_ARGB)
       val g2  = img.createGraphics()
 
       Rendering.withQuality(g2) {


### PR DESCRIPTION
On this PR a column is added to the Catalog navigator displaying ax guiding quality indicator as below (By default targets are sorted by quality):

![screenshot 2015-10-06 15 12 19](https://cloud.githubusercontent.com/assets/3615303/10317895/04b92816-6c3d-11e5-8c53-b498823215ea.png)

This is a rather large code update, The Catalog Navigator was getting too big and had to be separated on a few files, additionally changes were made to support custom sorting and displaying of the drawn guiding quality icons.

Finally, for guiding quality calculations, we need to have a way to create an `ObsContext` from the information on the query form. I'm not completely happy with the way it is done in this PR but I have marked those to be reviewed later with @swalker2m 

For now I want to get these changes in to move forward with TPE integration

Several old java classes were updated with modern code while doing this PR