### PR TITLE
OCSADV-1852B: Display correct read noise for F2; use unicode characters.

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>Acquisition Camera ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+    <meta charset="UTF-8"/>
+    <title>Acquisition Camera ITC</title>
+    <base target="content_frame">
+    <link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -27,17 +28,16 @@
     <tr>
 
       <td><input type="radio" name="Profile" value="POINT" checked></td>
-      <td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal PSF</a>) with spatially integrated brightness <input type="text" name="psSourceNorm" size="8" value="20.0"> <select name="psSourceUnits" size="1">
-        <option selected value="MAG">mag</option>
-        <option value="ABMAG">AB mag</option>
-
-        <option value="JY">Jy</option>
-
-        <option value="WATTS">W/m^2/um</option>
-        <option value="ERGS_WAVELENGTH">ergs/s/cm^2/A</option>
-        <option value="ERGS_FREQUENCY">ergs/s/cm^2/Hz</option>
-      </select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
-
+      <td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal PSF</a>) with spatially integrated brightness <input type="text" name="psSourceNorm" size="8" value="20.0">
+          <select name="psSourceUnits" size="1">
+              <option selected value="MAG">mag</option>
+              <option value="ABMAG">AB mag</option>
+              <option value="JY">Jy</option>
+              <option value="WATTS">W/m²/µm</option>
+              <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+              <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+          </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+      </td>
     </tr>
     <tr>
 
@@ -48,54 +48,54 @@
       <td>&nbsp;</td>
 
       <td><img src="spacer.gif" width="40" height="1" style="opacity:0.0"/><input type="radio" name="Profile" value="GAUSSIAN"></td>
-      <td>Gaussian profile with full width half maximum of <input type="text" name="gaussFwhm" size="5" value="1.0"> arcsec and spatially integrated brightness of <input type="text" name="gaussSourceNorm" size="8" value="1.0e-3"> <select name="gaussSourceUnits" size="1">
-
-        <option value="MAG">mag</option>
-        <option value="ABMAG">AB mag</option>
-        <option selected value="JY">Jy</option>
-
-        <option value="WATTS">W/m^2/um</option>
-        <option value="ERGS_WAVELENGTH">ergs/s/cm^2/A</option>
-        <option value="ERGS_FREQUENCY">ergs/s/cm^2/Hz</option>
-
-      </select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+      <td>Gaussian profile with full width half maximum of <input type="text" name="gaussFwhm" size="5" value="1.0"> arcsec and spatially integrated brightness of <input type="text" name="gaussSourceNorm" size="8" value="1.0e-3">
+          <select name="gaussSourceUnits" size="1">
+              <option value="MAG">mag</option>
+              <option value="ABMAG">AB mag</option>
+              <option selected value="JY">Jy</option>
+              <option value="WATTS">W/m²/µm</option>
+              <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+              <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+          </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+      </td>
     </tr>
     <tr>
 
       <td>&nbsp;</td>
       <td><img src="spacer.gif" width="40" height="1" style="opacity:0.0"/><input type="radio" name="Profile" value="UNIFORM"></td>
-      <td>Uniform surface brightness <input type="text" name="usbSourceNorm" size="8" value="22.0"> <select name="usbSourceUnits" size="1">
-        <option selected value="MAG_PSA">mag / sq arcsec</option>
+      <td>Uniform surface brightness <input type="text" name="usbSourceNorm" size="8" value="22.0">
+          <select name="usbSourceUnits" size="1">
+              <option selected value="MAG_PSA">mag/arcsec²</option>
+              <option value="ABMAG_PSA">AB mag/arcsec²</option>
+              <option value="JY_PSA">Jy/arcsec²</option>
+              <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+              <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+              <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+          </select> (e.g. 21.6 mag/arcsec²)
 
-        <option value="ABMAG_PSA">AB mag / sq arcsec</option>
-        <option value="JY_PSA">Jy / sq arcsec</option>
-
-        <option value="WATTS_PSA">W/m^2/um / sq arcsec</option>
-        <option value="ERGS_WAVELENGTH_PSA">ergs/s/cm^2/A / sq arcsec</option>
-        <option value="ERGS_FREQUENCY_PSA">ergs/s/cm^2/Hz / sq arcsec</option>
-      </select> (e.g. 21.6 mag / sq arcsec) </td>
+      </td>
 
     </tr>
     <tr>
 
       <td colspan="3"><img src="spacer.gif" width="1" height="40" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-          <option value="U">U (0.36um)</option>
-          <option value="B">B (0.44um)</option>
-          <option value="g">g' (0.48um) </option>
-          <option value="V">V (0.55um)</option>
-          <option value="r">r' (0.62um) </option>
-          <option value="R" selected>R (0.67um)</option>
-          <option value="i">i' (0.77um) </option>
-          <option value="I">I (0.87um)</option>
-          <option value="z">z' (0.92um) </option>
-          <option value="J">J (1.25um)</option>
-          <option value="H">H (1.65um)</option>
-          <option value="K">K (2.2um)</option>
-          <option value="L">L' (3.76um)</option>
-          <option value="M">M' (4.77um)</option>
-          <option value="N">N (10.5um)</option>
-          <option value="Q">Q (20.1um)</option>
+          <option value="U">U (0.36µm)</option>
+          <option value="B">B (0.44µm)</option>
+          <option value="g">g' (0.48µm) </option>
+          <option value="V">V (0.55µm)</option>
+          <option value="r">r' (0.62µm) </option>
+          <option value="R" selected>R (0.67µm)</option>
+          <option value="i">i' (0.77µm) </option>
+          <option value="I">I (0.87µm)</option>
+          <option value="z">z' (0.92µm) </option>
+          <option value="J">J (1.25µm)</option>
+          <option value="H">H (1.65µm)</option>
+          <option value="K">K (2.2µm)</option>
+          <option value="L">L' (3.76µm)</option>
+          <option value="M">M' (4.77µm)</option>
+          <option value="N">N (10.5µm)</option>
+          <option value="Q">Q (20.1µm)</option>
 
       </select> band</td>
 
@@ -212,13 +212,13 @@
 
       <td colspan="2">Single emission line at wavelength <input type="text" name="lineWavelength" size="5" value="0.656"> micron with line flux <input type="text" name="lineFlux" size="8" value="5.0e-19"> <select name="lineFluxUnits" size="1">
 
-        <option selected value="watts_flux">W/m^2</option>
-        <option value="ergs_flux">ergs/s/cm^2</option>
+        <option selected value="watts_flux">W/m²</option>
+        <option value="ergs_flux">erg/s/cm²</option>
       </select> and line width <input type="text" name="lineWidth" size="7" value="100.0"> km/s on a flat (in wavelength) continuum of flux density <input type="text" name="lineContinuum" size="8" value="1.0e-16"> <select name="lineContinuumUnits" size="1">
 
-        <option selected value="watts_fd_wavelength">W/m^2/um</option>
+        <option selected value="watts_fd_wavelength">W/m²/µm</option>
 
-        <option value="ergs_fd_wavelength">ergs/s/cm^2/A</option>
+        <option value="ergs_fd_wavelength">erg/s/cm²/Å</option>
       </select></td>
     </tr>
     <tr>
@@ -261,10 +261,10 @@
 
       <td>Colour filter: </td>
       <td><select name="ColorFilter" size="1">
-        <option value="B_G0152">B (0.44um)</option>
-        <option value="V_G0153">V (0.55um)</option>
-        <option selected value="R_G0154">R (0.67um)</option>
-        <option value="I_G0155">I (0.87um)</option>
+        <option value="B_G0152">B (0.44µm)</option>
+        <option value="V_G0153">V (0.55µm)</option>
+        <option selected value="R_G0154">R (0.67µm)</option>
+        <option value="I_G0155">I (0.87µm)</option>
       </select></td>
       <td>Neutral density (ND) filter:</td>
       <td><select name="NDFilter" size="1">

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>Flamingos-2 ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+    <meta charset="UTF-8"/>
+    <title>Flamingos-2 ITC</title>
+    <base target="content_frame">
+    <link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -30,23 +31,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" /> <select name="psSourceUnits" size="1">
-
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
-
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" />
+                    <select name="psSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td valign="top"></td>
@@ -57,42 +51,30 @@
 				<td> </td>
 
 				<td><img src="/spacer.gif" height="1" width="40"  style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" /> <select name="gaussSourceUnits" size="1">
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" /> <select name="usbSourceUnits" size="1">
-
-				<option value="MAG_PSA">
-				mag / sq arcsec</option>
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 
 			</tr>		
 		
@@ -101,22 +83,22 @@
 				with the above <b>brightness normalisation</b> applied in filter
 				<select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R">R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K" selected>K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N">N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R">R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K" selected>K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N">N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
 
                 </select> band</td>
 
@@ -158,138 +140,69 @@
 			<tr>
 				<td><input value="LIBRARY_STAR" name="Distribution" checked="checked" type="radio" /></td>
 				<td colspan="2">Library spectrum of a star with spectral type <select name="stSpectrumType" size="1">
-				<option value="O5V">
-				O5V</option>
-				<option value="O8III">
-				O8III</option>
-
-				<option value="B0V">
-				B0V</option>
-				<option value="B5-7V">
-				B5-7V</option>
-				<option value="B5III">
-				B5III</option>
-				<option value="B5I">
-
-				B5I</option>
-				<option value="A0V" selected="selected">
-				A0V</option>
-				<option value="A0III">
-				A0III</option>
-				<option value="A0I">
-				A0I</option>
-
-				<option value="A5V">
-				A5V</option>
-				<option value="A5III">
-				A5III</option>
-				<option value="F0V">
-				F0V</option>
-				<option value="F0III">
-
-				F0III</option>
-				<option value="F0I">
-				F0I</option>
-				<option value="F5V">
-				F5V</option>
-				<option value="F5V-w">
-				F5V-w</option>
-
-				<option value="F6V-r">
-				F6V-r</option>
-				<option value="F5III">
-				F5III</option>
-				<option value="F5I">
-				F5I</option>
-				<option value="G0V">
-
-				G0V</option>
-				<option value="G0V-w">
-				G0V-w</option>
-				<option value="G0V-r">
-				G0V-r</option>
-				<option value="G0III">
-				G0III</option>
-
-				<option value="G0I">
-				G0I</option>
-				<option value="G2V">
-				G2V</option>
-				<option value="G5V">
-				G5V</option>
-				<option value="G5V-w">
-
-				G5V-w</option>
-				<option value="G5V-r">
-				G5V-r</option>
-				<option value="G5III">
-				G5III</option>
-				<option value="G5III-w">
-				G5III-w</option>
-
-				<option value="G5III-r">
-				G5III-r</option>
-				<option value="G5I">
-				G5I</option>
-				<option value="K0V">
-				K0V</option>
-				<option value="K0V-r">
-
-				K0V-r</option>
-				<option value="K0III">
-				K0III</option>
-				<option value="K0III-w">
-				K0III-w</option>
-				<option value="K0III-r">
-				K0III-r</option>
-
-				<option value="K0-1II">
-				K0-1II</option>
-				<option value="K4V">
-				K4V</option>
-				<option value="K4III">
-				K4III</option>
-				<option value="K4III-w">
-
-				K4III-w</option>
-				<option value="K4III-r">
-				K4III-r</option>
-				<option value="K4I">
-				K4I</option>
-				<option value="M0V">
-				M0V</option>
-
-				<option value="M0III">
-				M0III</option>
-				<option value="M3V">
-				M3V</option>
-				<option value="M3III">
-				M3III</option>
-				<option value="M6V">
-
-				M6V</option>
-				<option value="M6III">
-				M6III</option>
-				<option value="M9III">
-				M9III</option>
+				<option value="O5V">O5V</option>
+				<option value="O8III">O8III</option>
+				<option value="O8III">O8III</option>
+				<option value="B0V">B0V</option>
+				<option value="B5-7V">B5-7V</option>
+				<option value="B5III">B5III</option>
+				<option value="B5I">B5I</option>
+				<option value="A0V" selected="selected">A0V</option>
+				<option value="A0III">A0III</option>
+				<option value="A0I"> A0I</option>
+				<option value="A5V">A5V</option>
+				<option value="A5III">A5III</option>
+				<option value="F0V">F0V</option>
+				<option value="F0III">F0III</option>
+				<option value="F0I">F0I</option>
+				<option value="F5V">F5V</option>
+				<option value="F5V-w">F5V-w</option>
+				<option value="F6V-r">F6V-r</option>
+				<option value="F5III">F5III</option>
+				<option value="F5I">F5I</option>
+				<option value="G0V">G0V</option>
+				<option value="G0V-w">G0V-w</option>
+				<option value="G0V-r">G0V-r</option>
+				<option value="G0III">G0III</option>
+				<option value="G0I">G0I</option>
+				<option value="G2V">G2V</option>
+				<option value="G5V">G5V</option>
+				<option value="G5V-w">G5V-w</option>
+				<option value="G5V-r">G5V-r</option>
+				<option value="G5III">G5III</option>
+				<option value="G5III-w">G5III-w</option>
+				<option value="G5III-r">G5III-r</option>
+				<option value="G5I">G5I</option>
+				<option value="K0V">K0V</option>
+				<option value="K0V-r">K0V-r</option>
+				<option value="K0III">K0III</option>
+				<option value="K0III-w">K0III-w</option>
+				<option value="K0III-r">K0III-r</option>
+				<option value="K0-1II">K0-1II</option>
+				<option value="K4V">K4V</option>
+				<option value="K4III">K4III</option>
+				<option value="K4III-w">K4III-w</option>
+				<option value="K4III-r">K4III-r</option>
+				<option value="K4I">K4I</option>
+				<option value="M0V">M0V</option>
+				<option value="M0III">M0III</option>
+				<option value="M3V">M3V</option>
+				<option value="M3III">M3III</option>
+				<option value="M6V">M6V</option>
+				<option value="M6III">M6III</option>
+				<option value="M9III">M9III</option>
 				</select></td>
 			</tr>
 
 			<tr>
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
 				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="2.2" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
-				<option value="watts_flux">
-				W/m^2</option>
-				<option value="ergs_flux">
-
-				ergs/s/cm^2</option>
+				<option value="watts_flux">W/m²</option>
+				<option value="ergs_flux">erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="100.0" type="text" /> km/s
 				on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-16" type="text" /> <select name="lineContinuumUnits" size="1">
-				<option value="watts_fd_wavelength">
-				W/m^2/um</option>
-				<option value="ergs_fd_wavelength">
-
-				ergs/s/cm^2/A</option>
+				<option value="watts_fd_wavelength">W/m²/µm</option>
+				<option value="ergs_fd_wavelength">erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -350,11 +263,11 @@
 				<td>
 				<select name="Filter" size="1">
 					<option value="OPEN">Open</option>
-					<option value="Y">Y (1.02 um)</option>
-					<option value="J_LOW">J-low (1.15 um)</option>
-					<option value="J">J (1.25 um)</option>
-					<option value="H">H (1.65 um)</option>
-					<option value="K_SHORT" selected> Ks (2.15 um)</option>
+					<option value="Y">Y (1.02 µm)</option>
+					<option value="J_LOW">J-low (1.15 µm)</option>
+					<option value="J">J (1.25 µm)</option>
+					<option value="H">H (1.65 µm)</option>
+					<option value="K_SHORT" selected> Ks (2.15 µm)</option>
 					<option value="JH">JH</option>
 					<option value="HK">HK</option>
 				</select>
@@ -386,13 +299,13 @@
 			<tr>
 				<td colspan="4" style="padding-left:30">
 				<input value="BRIGHT_OBJECT_SPEC" name="ReadMode" type="radio"/>
-				Bright object: CDS and readnoise = 12 e-
+				Bright object: CDS and readnoise = 11.7 e-
 				<br>
 				<input value="MEDIUM_OBJECT_SPEC" name="ReadMode" checked="checked" type="radio"/>
-				Medium object: 4 reads and readnoise = 6 e-
+				Medium object: 4 reads and readnoise = 6.0 e-
 				<br>
 				<input value="FAINT_OBJECT_SPEC" name="ReadMode" type="radio"/>
-				Faint object: 8 reads and readnoise < 5 e-				
+				Faint object: 8 reads and readnoise < 5.0 e-
 
 			</tr>
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>GMOS-N ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+    <meta charset="UTF-8"/>
+    <title>GMOS-N ITC</title>
+	<base target="content_frame">
+	<link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -30,22 +31,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" /> <select name="psSourceUnits" size="1">
-
-				<option selected="selected" value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" />
+                    <select name="psSourceUnits" size="1">
+                        <option selected value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 
 			</tr>
 			<tr>
@@ -57,63 +52,51 @@
 				<td> </td>
 
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="20" type="text" /> <select name="gaussSourceUnits" size="1">
-				<option value="MAG" selected="selected">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="20" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option selected value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" /> <select name="usbSourceUnits" size="1">
-
-				<option selected="selected" value="MAG_PSA">
-				mag / sq arcsec</option>
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option selected value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-				<option value="U">U (0.36um)</option>
-				<option value="B">B (0.44um)</option>
-                <option value="g">g' (0.48um) </option>
-                <option value="V">V (0.55um)</option>
-                <option value="r">r' (0.62um) </option>
-				<option value="R" selected>R (0.67um)</option>
-                <option value="i">i' (0.77um) </option>
-                <option value="I">I (0.87um)</option>
-                <option value="z">z' (0.92um) </option>
-                <option value="J">J (1.25um)</option>
-				<option value="H">H (1.65um)</option>
-				<option value="K">K (2.2um)</option>
-				<option value="L">L' (3.76um)</option>
-				<option value="M">M' (4.77um)</option>
-				<option value="N">N (10.5um)</option>
-				<option value="Q">Q (20.1um)</option>
+				<option value="U">U (0.36µm)</option>
+				<option value="B">B (0.44µm)</option>
+                <option value="g">g' (0.48µm) </option>
+                <option value="V">V (0.55µm)</option>
+                <option value="r">r' (0.62µm) </option>
+				<option value="R" selected>R (0.67µm)</option>
+                <option value="i">i' (0.77µm) </option>
+                <option value="I">I (0.87µm)</option>
+                <option value="z">z' (0.92µm) </option>
+                <option value="J">J (1.25µm)</option>
+				<option value="H">H (1.65µm)</option>
+				<option value="K">K (2.2µm)</option>
+				<option value="L">L' (3.76µm)</option>
+				<option value="M">M' (4.77µm)</option>
+				<option value="N">N (10.5µm)</option>
+				<option value="Q">Q (20.1µm)</option>
 
 				</select> band</td>
 
@@ -278,19 +261,19 @@
 			</tr>
 			<tr>
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
-				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="0.656" type="text" /> um with line flux <input name="lineFlux" size="8" value="5.0e-17" type="text" /> <select name="lineFluxUnits" size="1">
+				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="0.656" type="text" /> µm with line flux <input name="lineFlux" size="8" value="5.0e-17" type="text" /> <select name="lineFluxUnits" size="1">
 				<option value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 
 				<option selected="selected" value="ergs_flux">
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="500.0" type="text" /> km/s
 				on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-17" type="text" /> <select name="lineContinuumUnits" size="1">
 				<option value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 
 				<option selected="selected" value="ergs_fd_wavelength">
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -614,7 +597,7 @@
 			</tr>
 			<tr>
 				<td colspan="3">For spectroscopy, <input value="AUTO" name="PlotLimits" checked="checked" type="radio" /> autoscale or <input value="USER" name="PlotLimits" type="radio" /> specify
-				limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="0.500" type="text" /> um and upper wavelength <input name="plotWavelengthU" size="6" value="0.900" type="text" /> um) </td>
+				limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="0.500" type="text" /> µm and upper wavelength <input name="plotWavelengthU" size="6" value="0.900" type="text" /> µm) </td>
 
 			</tr>
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>GMOS SOUTH ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+	<meta charset="UTF-8"/>
+	<title>GMOS SOUTH ITC</title>
+    <base target="content_frame">
+    <link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -31,22 +32,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" /> <select name="psSourceUnits" size="1">
-				<option selected="selected" value="MAG">
-				mag</option>
-
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" />
+                    <select name="psSourceUnits" size="1">
+                        <option selected value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td valign="top"></td>
@@ -57,63 +52,51 @@
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="20" type="text" /> <select name="gaussSourceUnits" size="1">
-
-				<option value="MAG" selected="selected">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="20" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option selected value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" /> <select name="usbSourceUnits" size="1">
-				<option selected="selected" value="MAG_PSA">
-				mag / sq arcsec</option>
-
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option selected value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R" selected>R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K">K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N">N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R" selected>R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K">K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N">N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
 
                 </select> band</td>
 
@@ -278,19 +261,19 @@
 			</tr>
 			<tr>
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
-				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="0.656" type="text" /> um with line flux <input name="lineFlux" size="8" value="5.0e-17" type="text" /> <select name="lineFluxUnits" size="1">
+				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="0.656" type="text" /> µm with line flux <input name="lineFlux" size="8" value="5.0e-17" type="text" /> <select name="lineFluxUnits" size="1">
 				<option value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 
 				<option selected="selected" value="ergs_flux">
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="500.0" type="text" /> km/s
 				on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-17" type="text" /> <select name="lineContinuumUnits" size="1">
 				<option value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 
 				<option selected="selected" value="ergs_fd_wavelength">
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -617,7 +600,7 @@
 			</tr>
 			<tr>
 				<td colspan="2">For spectroscopy, <input value="AUTO" name="PlotLimits" checked="checked" type="radio" /> autoscale or <input value="USER" name="PlotLimits" type="radio" /> specify
-				limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="0.500" type="text" /> um and upper wavelength <input name="plotWavelengthU" size="6" value="0.900" type="text" /> um) </td>
+				limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="0.500" type="text" /> µm and upper wavelength <input name="plotWavelengthU" size="6" value="0.900" type="text" /> µm) </td>
 
 			</tr>
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>GNIRS ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+	<meta charset="UTF-8"/>
+	<title>GNIRS ITC</title>
+	<base target="content_frame">
+	<link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -31,22 +32,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="17.0" type="text" /> <select name="psSourceUnits" size="1">
-				<option selected="selected" value="MAG">
-				mag</option>
-
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="17.0" type="text" />
+					<select name="psSourceUnits" size="1">
+						<option selected value="MAG">mag</option>
+						<option value="ABMAG">AB mag</option>
+						<option value="JY">Jy</option>
+						<option value="WATTS">W/m²/µm</option>
+						<option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+						<option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+					</select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+				</td>
 			</tr>
 			<tr>
 				<td valign="top"></td>
@@ -57,63 +52,51 @@
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" /> <select name="gaussSourceUnits" size="1">
-
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option selected="selected" value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option selected value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" /> <select name="usbSourceUnits" size="1">
-				<option selected="selected" value="MAG_PSA">
-				mag / sq arcsec</option>
-
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option selected value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R">R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K" selected>K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N">N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R">R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K" selected>K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N">N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
 
 				</select> band</td>
 
@@ -280,17 +263,17 @@
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
 				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="2.2" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
 				<option selected="selected" value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 
 				<option value="ergs_flux">
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="500.0" type="text" /> km/s
 				on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-16" type="text" /> <select name="lineContinuumUnits" size="1">
 				<option selected="selected" value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 
 				<option value="ergs_fd_wavelength">
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -377,7 +360,7 @@
 				</select></td>
 
 				<td height="25">Spectrum central wavelength: </td>
-				<td height="25"><input name="instrumentCentralWavelength" size="5" value=" 2.15" type="text" /> um</td>
+				<td height="25"><input name="instrumentCentralWavelength" size="5" value=" 2.15" type="text" /> µm</td>
 			</tr>
 			<tr>
 				<td height="25">Cross dispersion:</td>
@@ -406,24 +389,24 @@
 			<tr>
 				<td align="right" height="21"><input value="BRIGHT" name="ReadMode" type="radio" />  </td>
 				<td height="21">medium background / bright objects  [shallow well; typically
-				for 1-2.5um, standard stars] </td>
+				for 1-2.5µm, standard stars] </td>
 			</tr>
 			<tr>
 				<td align="right" height="21"><input value="FAINT" name="ReadMode" checked="checked" type="radio" />  </td>
 
 				<td height="21">low background / faint objects [shallow well; typically
-				for 1-2.5um, science targets] </td>
+				for 1-2.5µm, science targets] </td>
 			</tr>
 			<tr>
 				<td align="right" height="21"><input value="VERY_FAINT" name="ReadMode" type="radio" />  </td>
 				<td height="21">very low background / faintest objects [shallow well; typically for
-				1-2.5um v. faint science targets] </td>
+				1-2.5µm v. faint science targets] </td>
 			</tr>
 			<tr>
 
 				<td align="right" height="21"><input value="VERY_BRIGHT" name="ReadMode" type="radio" />  </td>
 				<td height="21">high background (i.e. thermal IR) [deep well; typically for
-				3-5um targets] </td>
+				3-5µm targets] </td>
 			</tr>
 			<tr>
 				<td colspan="2" height="21">Dark current of 0.1 e-/s </td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>GSAOI ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+	<meta charset="UTF-8"/>
+	<title>GSAOI ITC</title>
+	<base target="content_frame">
+	<link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -30,22 +31,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" /> <select name="psSourceUnits" size="1">
-
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" />
+                    <select name="psSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 
 			</tr>
 			<tr>
@@ -57,63 +52,51 @@
 				<td> </td>
 
 				<td><img src="/spacer.gif" height="1" width="40" border="0" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" /> <select name="gaussSourceUnits" size="1">
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" border="0" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" /> <select name="usbSourceUnits" size="1">
-
-				<option value="MAG_PSA">
-				mag / sq arcsec</option>
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" border="0" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R">R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K" selected>K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N">N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R">R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K" selected>K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N">N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
 
 				</select> band</td>
 
@@ -276,17 +259,17 @@
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
 				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="2.2" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
 				<option value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 				<option value="ergs_flux">
 
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="100.0" type="text" /> km/s
 				on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-16" type="text" /> <select name="lineContinuumUnits" size="1">
 				<option value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 				<option value="ergs_fd_wavelength">
 
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -341,28 +324,28 @@
                     <tr>
                         <td>Filter:</td>
                             <td colspan="3"><select name="Filter" size="1">
-                                <option value="Z">Z (1.015 um)</option>
-                                <option value="J">J (1.250 um)</option>
-                                <option value="H">H (1.650 um)</option>
-                                <option value="K_PRIME">K(prime) (2.120 um)</option>
-                                <option value="K_SHORT">K(short) (2.150 um)</option>
-                                <option value="K">K (2.200 um)</option>
-                                <option value="J_CONTINUUM">J-continuum(1.207 um)</option>
-                                <option value="H_CONTINUUM">H-continuum(1.570 um)</option>
-                                <option value="CH4_SHORT">CH4(short) (1.580 um)</option>
-                                <option value="CH4_LONG">CH4(long) (1.690 um)</option>
-                                <option value="K_CONTINUUM1">Ks-continuum (2.093 um)</option>
-                                <option value="K_CONTINUUM2">Kl-continuum (2.270 um)</option>
-                                <option value="HEI">HeI(1.083 um)</option>
-                                <option value="PA_GAMMA">Pa(gamma)(1.094 um)</option>
-                                <option value="PA_BETA">Pa(beta)(1.282 um)</option>
-                                <option value="FE_II">[FeII] (1.644 um)</option>
-                                <option value="H20_ICE">H2O ice (2.000 um)</option>
-                                <option value="HEI_2P2S">HeI (2p2s) (2.058 um)</option>
-                                <option value="H2_1_0_S_1">H2 1-0 S(1) (2.122 um)</option>
-                                <option value="BR_GAMMA">Br(gamma) (2.166 um)</option>
-                                <option value="H2_2_1_S_1">H2 2-1 S(1) (2.248 um)</option>
-                                <option value="CO">CO (2.360 um)</OPTION>
+                                <option value="Z">Z (1.015 µm)</option>
+                                <option value="J">J (1.250 µm)</option>
+                                <option value="H">H (1.650 µm)</option>
+                                <option value="K_PRIME">K(prime) (2.120 µm)</option>
+                                <option value="K_SHORT">K(short) (2.150 µm)</option>
+                                <option value="K">K (2.200 µm)</option>
+                                <option value="J_CONTINUUM">J-continuum(1.207 µm)</option>
+                                <option value="H_CONTINUUM">H-continuum(1.570 µm)</option>
+                                <option value="CH4_SHORT">CH4(short) (1.580 µm)</option>
+                                <option value="CH4_LONG">CH4(long) (1.690 µm)</option>
+                                <option value="K_CONTINUUM1">Ks-continuum (2.093 µm)</option>
+                                <option value="K_CONTINUUM2">Kl-continuum (2.270 µm)</option>
+                                <option value="HEI">HeI(1.083 µm)</option>
+                                <option value="PA_GAMMA">Pa(gamma)(1.094 µm)</option>
+                                <option value="PA_BETA">Pa(beta)(1.282 µm)</option>
+                                <option value="FE_II">[FeII] (1.644 µm)</option>
+                                <option value="H20_ICE">H2O ice (2.000 µm)</option>
+                                <option value="HEI_2P2S">HeI (2p2s) (2.058 µm)</option>
+                                <option value="H2_1_0_S_1">H2 1-0 S(1) (2.122 µm)</option>
+                                <option value="BR_GAMMA">Br(gamma) (2.166 µm)</option>
+                                <option value="H2_2_1_S_1">H2 2-1 S(1) (2.248 µm)</option>
+                                <option value="CO">CO (2.360 µm)</OPTION>
                         </select></td>
                     </tr>
                     </tbody>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>Michelle ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+	<meta charset="UTF-8"/>
+	<title>Michelle ITC</title>
+	<base target="content_frame">
+	<link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -29,22 +30,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="0.001" type="text" /> <select name="psSourceUnits" size="1">
-
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="0.001" type="text" />
+                    <select name="psSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 
 			</tr>
 			<tr>
@@ -55,63 +50,51 @@
 				<td> </td>
 
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="0.005" type="text" /> <select name="gaussSourceUnits" size="1">
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="0.005" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="12.0" type="text" /> <select name="usbSourceUnits" size="1">
-
-				<option value="MAG_PSA">
-				mag / sq arcsec</option>
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="12.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R">R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K">K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N">N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R">R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K">K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N">N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
 
 				</select> band</td>
 
@@ -195,16 +178,16 @@
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
 				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="12.8" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
 				<option value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 
 				<option value="ergs_flux">
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="500.0" type="text" /> km/s on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-16" type="text" /> <select name="lineContinuumUnits" size="1">
 				<option value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 
 				<option value="ergs_fd_wavelength">
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -253,14 +236,14 @@
 			<tr>
 				<td>Filter:</td>
 				<td><select name="Filter" size="1">
-				<option value="N_PRIME">N' (10.1um - 12.5um)</option>
-				<option value="QA">Qa (18.1um)</option>
-				<option value="SI_1">Si-1 (7.9um)</option>
-				<option value="SI_2">Si-2 (8.7um)</option>
-				<option value="SI_3">Si-3 (9.7um)</option>
-				<option value="SI_4">Si-4 (10.4um)</option>
-				<option value="SI_5">Si-5 (11.7um)</option>
-				<option value="SI_6">Si-6 (12.3um)</option>
+				<option value="N_PRIME">N' (10.1µm - 12.5µm)</option>
+				<option value="QA">Qa (18.1µm)</option>
+				<option value="SI_1">Si-1 (7.9µm)</option>
+				<option value="SI_2">Si-2 (8.7µm)</option>
+				<option value="SI_3">Si-3 (9.7µm)</option>
+				<option value="SI_4">Si-4 (10.4µm)</option>
+				<option value="SI_5">Si-5 (11.7µm)</option>
+				<option value="SI_6">Si-6 (12.3µm)</option>
 				<option value="NONE">No Filter(LowN LowQ Spectroscopy)</option>
 				</select></td>
 
@@ -288,7 +271,7 @@
 				</select></td>
 
 				<td>Spectrum central wavelength: </td>
-				<td><input name="instrumentCentralWavelength" size="8" value=" " type="text" /> um</td>
+				<td><input name="instrumentCentralWavelength" size="8" value=" " type="text" /> µm</td>
 
 			</tr>
 			<tr>
@@ -445,7 +428,7 @@
 				<td colspan="2" height="50" valign="bottom"><b>Output:</b> </td>
 			</tr>
 			<tr>
-				<td colspan="2">For spectroscopy, <input value="AUTO" name="PlotLimits" checked="checked" type="radio" /> autoscale or <input value="USER" name="PlotLimits" type="radio" /> specify limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="0.500" type="text" /> um and upper wavelength <input name="plotWavelengthU" size="6" value="0.900" type="text" /> um) </td>
+				<td colspan="2">For spectroscopy, <input value="AUTO" name="PlotLimits" checked="checked" type="radio" /> autoscale or <input value="USER" name="PlotLimits" type="radio" /> specify limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="0.500" type="text" /> µm and upper wavelength <input name="plotWavelengthU" size="6" value="0.900" type="text" /> µm) </td>
 
 			</tr>
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>NIFS ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+	<meta charset="UTF-8"/>
+	<title>NIFS ITC</title>
+	<base target="content_frame">
+	<link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -29,22 +30,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="17.0" type="text" /> <select name="psSourceUnits" size="1">
-
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="17.0" type="text" />
+                    <select name="psSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 
 			</tr>
 			<tr>
@@ -55,63 +50,51 @@
 				<td> </td>
 
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" /> <select name="gaussSourceUnits" size="1">
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" /> <select name="usbSourceUnits" size="1">
-
-				<option value="MAG_PSA">
-				mag / sq arcsec</option>
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R">R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K" selected>K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N">N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R">R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K" selected>K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N">N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
                 </select> band</td>
 
 			</tr>
@@ -273,15 +256,15 @@
 				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="2.2" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
 
 				<option value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 				<option value="ergs_flux">
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="500.0" type="text" /> km/s on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-16" type="text" /> <select name="lineContinuumUnits" size="1">
 
 				<option value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 				<option value="ergs_fd_wavelength">
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -354,7 +337,7 @@
 
 				</select></td>
 				<td height="25">Spectrum central wavelength: </td>
-				<td height="25"><input name="instrumentCentralWavelength" size="5" value="2.20" type="text" /> um</td>
+				<td height="25"><input name="instrumentCentralWavelength" size="5" value="2.20" type="text" /> µm</td>
 			</tr>
 			<!---->
 			<tr>
@@ -368,16 +351,16 @@
             <!-- REL-481 Update NIFS read noise estimates -->
 			<tr>
 				<td align="right" height="21"><input value="BRIGHT_OBJECT_SPEC" name="ReadMode" type="radio" />  </td>
-				<td colspan="3" height="21">medium background / bright objects  [shallow well; typically for 1-2.5um, standard stars, 15.4 e-] </td>
+				<td colspan="3" height="21">medium background / bright objects  [shallow well; typically for 1-2.5µm, standard stars, 15.4 e-] </td>
 			</tr>
 			<tr>
 				<td align="right" height="21"><input value="MEDIUM_OBJECT_SPEC" name="ReadMode" checked="checked" type="radio" />  </td>
 
-				<td colspan="3" height="21">low background / faint objects [shallow well; typically for 1-2.5um, science targets, 8.1 e-] </td>
+				<td colspan="3" height="21">low background / faint objects [shallow well; typically for 1-2.5µm, science targets, 8.1 e-] </td>
 			</tr>
 			<tr>
 				<td align="right" height="21"><input value="FAINT_OBJECT_SPEC" name="ReadMode" type="radio" />  </td>
-				<td colspan="3" height="21">very low background / faintest objects [shallow well; typically for 1-2.5um v. faint science targets, 4.6 e-] </td>
+				<td colspan="3" height="21">very low background / faintest objects [shallow well; typically for 1-2.5µm v. faint science targets, 4.6 e-] </td>
 			</tr>
 			<tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>NIRI ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+	<meta charset="UTF-8"/>
+	<title>NIRI ITC</title>
+	<base target="content_frame">
+	<link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -30,22 +31,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" /> <select name="psSourceUnits" size="1">
-
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="20.0" type="text" />
+					<select name="psSourceUnits" size="1">
+						<option value="MAG">mag</option>
+						<option value="ABMAG">AB mag</option>
+						<option value="JY">Jy</option>
+						<option value="WATTS">W/m²/µm</option>
+						<option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+						<option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+					</select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+				</td>
 
 			</tr>
 			<tr>
@@ -57,63 +52,51 @@
 				<td> </td>
 
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" /> <select name="gaussSourceUnits" size="1">
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-
-				<option value="JY">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="1.0e-3" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" /> <select name="usbSourceUnits" size="1">
-
-				<option value="MAG_PSA">
-				mag / sq arcsec</option>
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="22.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R">R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K" selected>K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N">N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R">R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K" selected>K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N">N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
                 </select> band</td>
 
 			</tr>
@@ -274,17 +257,17 @@
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
 				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="2.2" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
 				<option value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 				<option value="ergs_flux">
 
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="100.0" type="text" /> km/s
 				on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-16" type="text" /> <select name="lineContinuumUnits" size="1">
 				<option value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 				<option value="ergs_fd_wavelength">
 
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -351,14 +334,14 @@
 				<td><select name="Filter" size="1">
 				<option value="none" disabled>Broad band...</option>
 
-				<option value="BBF_Y">Y (1.02 um)</option>
-				<option value="BBF_J">J (1.25 um)</option>
-				<option value="BBF_H">H (1.65 um)</option>
-				<option value="BBF_KPRIME">K' (2.12 um)</option>
-				<option value="BBF_KSHORT">K(short) (2.15 um)</option>
-				<option value="BBF_K" selected="selected">K (2.20 um)</option>
-				<option value="BBF_LPRIME">L' (3.78 um)</option>
-				<option value="BBF_MPRIME">M' (4.68 um)</option>
+				<option value="BBF_Y">Y (1.02 µm)</option>
+				<option value="BBF_J">J (1.25 µm)</option>
+				<option value="BBF_H">H (1.65 µm)</option>
+				<option value="BBF_KPRIME">K' (2.12 µm)</option>
+				<option value="BBF_KSHORT">K(short) (2.15 µm)</option>
+				<option value="BBF_K" selected="selected">K (2.20 µm)</option>
+				<option value="BBF_LPRIME">L' (3.78 µm)</option>
+				<option value="BBF_MPRIME">M' (4.68 µm)</option>
 
 				<option value="none" disabled></option>
 				<option value="none" disabled>Grism order sorting...</option>
@@ -372,28 +355,28 @@
 				<option value="none" disabled></option>
 				<option value="none" disabled>Narrow band...</option>
 
-				<option value="NBF_HEI">HeI (2p2s triplet) (1.083 um)</option>
-				<option value="NBF_PAGAMMA">Pa-gamma (1.094 um)</option>
-				<option value="NBF_H">J-continuum (1.207 um)</option>
-				<option value="NBF_PABETA">Pa-beta (1.282 um)</option>
-				<option value="NBF_CH4SHORT">CH4(short) (1.580 um)</option>
-				<option value="NBF_CH4LONG">CH4(long) (1.690 um)</option>
-				<option value="NBF_HCONT">H-continuum (1.570 um)</option>
-				<option value="NBF_FEII">[FeII] (1.644 um)</option>
-				<option value="NBF_H2O_2045">H20 ice (2.045 um)</option>
-				<option value="NBF_HE12P2S">HeI (2p2s singlet) (2.059 um)</option>
-				<option value="NBF_KCONT1">K-continuum (2.090 um)</option>
-				<option value="NBF_H210">H2 1-0S(1) (2.122 um)</option>
-				<option value="NBF_BRGAMMA">Br-gamma (2.166 um)</option>
-				<option value="NBF_H221">H2 2-1S(1) (2.248 um)</option>
-				<option value="NBF_KCONT2">K-continuum (2.270 um)</option>
-				<option value="NBF_CH4ICE">CH4 ice (2.275 um)</option>
-				<option value="NBF_CO20">CO 2-0(bh) (2.294 um)</option>
-				<option value="NBF_CO31">CO 3-1(bh) (2.323 um)</option>
-				<option value="NBF_H2O">H2O ice (3.050 um)</option>
-				<option value="NBF_HC">hydrocarbon (3.295 um)</option>
-				<option value="NBF_BRACONT">Br-alpha continuum (3.990 um)</option>
-				<option value="NBF_BRA">Br-alpha (4.052 um)</option>
+				<option value="NBF_HEI">HeI (2p2s triplet) (1.083 µm)</option>
+				<option value="NBF_PAGAMMA">Pa-gamma (1.094 µm)</option>
+				<option value="NBF_H">J-continuum (1.207 µm)</option>
+				<option value="NBF_PABETA">Pa-beta (1.282 µm)</option>
+				<option value="NBF_CH4SHORT">CH4(short) (1.580 µm)</option>
+				<option value="NBF_CH4LONG">CH4(long) (1.690 µm)</option>
+				<option value="NBF_HCONT">H-continuum (1.570 µm)</option>
+				<option value="NBF_FEII">[FeII] (1.644 µm)</option>
+				<option value="NBF_H2O_2045">H20 ice (2.045 µm)</option>
+				<option value="NBF_HE12P2S">HeI (2p2s singlet) (2.059 µm)</option>
+				<option value="NBF_KCONT1">K-continuum (2.090 µm)</option>
+				<option value="NBF_H210">H2 1-0S(1) (2.122 µm)</option>
+				<option value="NBF_BRGAMMA">Br-gamma (2.166 µm)</option>
+				<option value="NBF_H221">H2 2-1S(1) (2.248 µm)</option>
+				<option value="NBF_KCONT2">K-continuum (2.270 µm)</option>
+				<option value="NBF_CH4ICE">CH4 ice (2.275 µm)</option>
+				<option value="NBF_CO20">CO 2-0(bh) (2.294 µm)</option>
+				<option value="NBF_CO31">CO 3-1(bh) (2.323 µm)</option>
+				<option value="NBF_H2O">H2O ice (3.050 µm)</option>
+				<option value="NBF_HC">hydrocarbon (3.295 µm)</option>
+				<option value="NBF_BRACONT">Br-alpha continuum (3.990 µm)</option>
+				<option value="NBF_BRA">Br-alpha (4.052 µm)</option>
 				</select></td>
 
 				<td>Focal plane mask:</td>
@@ -413,11 +396,11 @@
 
 			</tr>
 			<tr>
-				<td colspan="4">Detector bias (i.e. well depth) set for <input value="SHALLOW" name="WellDepth" checked="checked" type="radio" /> low or <input value="DEEP" name="WellDepth" type="radio" />high flux mode (typically &lt;2.5um and &gt;2.5um respectively) </td>
+				<td colspan="4">Detector bias (i.e. well depth) set for <input value="SHALLOW" name="WellDepth" checked="checked" type="radio" /> low or <input value="DEEP" name="WellDepth" type="radio" />high flux mode (typically &lt;2.5µm and &gt;2.5µm respectively) </td>
 			</tr>
 			<tr>
 				<td colspan="4">Read noise set for <input value="IMAG_SPEC_NB" name="ReadMode" checked="checked" type="radio" /> low noise, <input value="IMAG_1TO25" name="ReadMode" type="radio" />medium noise, or <input value="IMAG_SPEC_3TO5" name="ReadMode" type="radio" />high noise
-				mode (typically narrow band faint object 1-2.5um imaging/spectroscopy, JHK imaging and bright object 1-2.5um spectroscopy, and 3-5um imaging and spectroscopy, respectively) </td>
+				mode (typically narrow band faint object 1-2.5µm imaging/spectroscopy, JHK imaging and bright object 1-2.5µm spectroscopy, and 3-5µm imaging and spectroscopy, respectively) </td>
 
 			</tr>
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -1,9 +1,10 @@
 <html>
 
 <head>
-<title>T-ReCS ITC</title>
-<base target="content_frame">
-<link rel="stylesheet" type="text/css" href="itc_test.css" />
+	<meta charset="UTF-8"/>
+	<title>T-ReCS ITC</title>
+	<base target="content_frame">
+	<link rel="stylesheet" type="text/css" href="itc_test.css" />
 </head>
 
 <body link="#0000FF" vlink="#8B0000" text="#000000" bgcolor="#ffffff">
@@ -32,22 +33,16 @@
 			<tr>
 				<td><input name="Profile" value="POINT" checked="checked" type="radio" /></td>
 				<td colspan="2"><b>Point source</b> (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10257#spatial','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">nominal
-				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="0.001" type="text" /> <select name="psSourceUnits" size="1">
-				<option value="MAG">
-				mag</option>
-
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY" selected="selected">
-				Jy</option>
-				<option value="WATTS">
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				PSF</a>) with spatially integrated brightness <input name="psSourceNorm" size="8" value="0.001" type="text" />
+                    <select name="psSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option selected value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 			</tr>
 			<tr>
 				<td valign="top"></td>
@@ -58,63 +53,51 @@
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="GAUSSIAN" type="radio" /></td>
-				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="0.005" type="text" /> <select name="gaussSourceUnits" size="1">
-
-				<option value="MAG">
-				mag</option>
-				<option value="ABMAG">
-				AB mag</option>
-				<option value="JY" selected="selected">
-				Jy</option>
-				<option value="WATTS">
-
-				W/m^2/um</option>
-				<option value="ERGS_WAVELENGTH">
-				ergs/s/cm^2/A</option>
-				<option value="ERGS_FREQUENCY">
-				ergs/s/cm^2/Hz</option>
-				</select> (e.g. 19.3 mag or 2e-17 W/m^2/um) </td>
+				<td>Gaussian profile with full width half maximum (including seeing) of <input name="gaussFwhm" size="5" value="1.0" type="text" /> arcsec and spatially integrated brightness of <input name="gaussSourceNorm" size="8" value="0.005" type="text" />
+                    <select name="gaussSourceUnits" size="1">
+                        <option value="MAG">mag</option>
+                        <option value="ABMAG">AB mag</option>
+                        <option selected value="JY">Jy</option>
+                        <option value="WATTS">W/m²/µm</option>
+                        <option value="ERGS_WAVELENGTH">erg/s/cm²/Å</option>
+                        <option value="ERGS_FREQUENCY">erg/s/cm²/Hz</option>
+                    </select> (e.g. 19.3 mag or 2e-17 W/m²/µm)
+                </td>
 
 			</tr>
 			<tr>
 				<td> </td>
 				<td><img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input name="Profile" value="UNIFORM" type="radio" /></td>
-				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="12.0" type="text" /> <select name="usbSourceUnits" size="1">
-				<option selected="selected" value="MAG_PSA">
-				mag / sq arcsec</option>
-
-				<option value="ABMAG_PSA">
-				AB mag / sq arcsec</option>
-				<option value="JY_PSA">
-				Jy / sq arcsec</option>
-				<option value="WATTS_PSA">
-				W/m^2/um / sq arcsec</option>
-				<option value="ERGS_WAVELENGTH_PSA">
-
-				ergs/s/cm^2/A / sq arcsec</option>
-				<option value="ERGS_FREQUENCY_PSA">
-				ergs/s/cm^2/Hz / sq arcsec</option>
-				</select> (e.g. 21.6 mag / sq arcsec) </td>
+				<td>Uniform surface brightness <input name="usbSourceNorm" size="8" value="12.0" type="text" />
+                    <select name="usbSourceUnits" size="1">
+                        <option selected value="MAG_PSA">mag/arcsec²</option>
+                        <option value="ABMAG_PSA">AB mag/arcsec²</option>
+                        <option value="JY_PSA">Jy/arcsec²</option>
+                        <option value="WATTS_PSA">W/m²/µm/arcsec²</option>
+                        <option value="ERGS_WAVELENGTH_PSA">erg/s/cm²/Å/arcsec²</option>
+                        <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
+                    </select> (e.g. 21.6 mag/arcsec²)
+                </td>
 			</tr>
 			<tr>
 				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
 
-                    <option value="U">U (0.36um)</option>
-                    <option value="B">B (0.44um)</option>
-                    <option value="g">g' (0.48um) </option>
-                    <option value="V">V (0.55um)</option>
-                    <option value="r">r' (0.62um) </option>
-                    <option value="R">R (0.67um)</option>
-                    <option value="i">i' (0.77um) </option>
-                    <option value="I">I (0.87um)</option>
-                    <option value="z">z' (0.92um) </option>
-                    <option value="J">J (1.25um)</option>
-                    <option value="H">H (1.65um)</option>
-                    <option value="K">K (2.2um)</option>
-                    <option value="L">L' (3.76um)</option>
-                    <option value="M">M' (4.77um)</option>
-                    <option value="N" selected>N (10.5um)</option>
-                    <option value="Q">Q (20.1um)</option>
+                    <option value="U">U (0.36µm)</option>
+                    <option value="B">B (0.44µm)</option>
+                    <option value="g">g' (0.48µm) </option>
+                    <option value="V">V (0.55µm)</option>
+                    <option value="r">r' (0.62µm) </option>
+                    <option value="R">R (0.67µm)</option>
+                    <option value="i">i' (0.77µm) </option>
+                    <option value="I">I (0.87µm)</option>
+                    <option value="z">z' (0.92µm) </option>
+                    <option value="J">J (1.25µm)</option>
+                    <option value="H">H (1.65µm)</option>
+                    <option value="K">K (2.2µm)</option>
+                    <option value="L">L' (3.76µm)</option>
+                    <option value="M">M' (4.77µm)</option>
+                    <option value="N" selected>N (10.5µm)</option>
+                    <option value="Q">Q (20.1µm)</option>
                 </select> band</td>
 
 			</tr>
@@ -197,17 +180,17 @@
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
 				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="12.8" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
 				<option selected="selected" value="watts_flux">
-				W/m^2</option>
+				W/m²</option>
 
 				<option value="ergs_flux">
-				ergs/s/cm^2</option>
+				erg/s/cm²</option>
 				</select> and line width <input name="lineWidth" size="7" value="500.0" type="text" /> km/s
 				on a flat (in wavelength) continuum of flux density <input name="lineContinuum" size="8" value="1.0e-16" type="text" /> <select name="lineContinuumUnits" size="1">
 				<option selected="selected" value="watts_fd_wavelength">
-				W/m^2/um</option>
+				W/m²/µm</option>
 
 				<option value="ergs_fd_wavelength">
-				ergs/s/cm^2/A</option>
+				erg/s/cm²/Å</option>
 				</select></td>
 			</tr>
 			<tr>
@@ -269,23 +252,23 @@
 				<td>Filter:</td>
 				<td><select name="Filter" size="1">
 
-				<option selected="selected" value="N">N (broad 10um)</option>
-				<option value="SI_1">Si-1 (7.7um)</option>
-				<option value="SI_2">Si-2 (8.7um)</option>
-				<option value="SI_3">Si-3 (9.7um)</option>
-				<option value="SI_4">Si-4 (10.4um)</option>
-				<option value="SI_5">Si-5 (11.7um)</option>
-				<option value="SI_6">Si-6 (12.3um)</option>
+				<option selected="selected" value="N">N (broad 10µm)</option>
+				<option value="SI_1">Si-1 (7.7µm)</option>
+				<option value="SI_2">Si-2 (8.7µm)</option>
+				<option value="SI_3">Si-3 (9.7µm)</option>
+				<option value="SI_4">Si-4 (10.4µm)</option>
+				<option value="SI_5">Si-5 (11.7µm)</option>
+				<option value="SI_6">Si-6 (12.3µm)</option>
 				<option value="AR_III">[Ar III]</option>
 				<option value="S_IV">[S IV]</option>
 				<option value="NE_II">[Ne II]</option>
 				<option value="NE_II_CONT">[Ne II] cont</option>
-				<option value="PAH_8_6">PAH 8.6um</option>
-				<option value="PAH_11_3">PAH 11.3um</option>
+				<option value="PAH_8_6">PAH 8.6µm</option>
+				<option value="PAH_11_3">PAH 11.3µm</option>
 				<option value="Q_SHORT">Q short</option>
 				<option value="QA">Qa</option>
 				<option value="QB">Qb</option>
-				<option value="Q">Q (broad 20.8um)</option>
+				<option value="Q">Q (broad 20.8µm)</option>
 				<option value="K">K</option>
 				<option value="L">L</option>
 				<option value="M">M</option>
@@ -313,7 +296,7 @@
 				<option value="LOW_RES_20">LoRes-20 grating</option>
 				</select></td>
 				<td>Spectrum central wavelength: </td>
-				<td><input name="instrumentCentralWavelength" size="8" value=" " type="text" /> um</td>
+				<td><input name="instrumentCentralWavelength" size="8" value=" " type="text" /> µm</td>
 			</tr>
 			<tr>
 
@@ -464,7 +447,7 @@
 			</tr>
 			<tr>
 				<td colspan="2">For spectroscopy, <input value="AUTO" name="PlotLimits" checked="checked" type="radio" /> autoscale or <input value="USER" name="PlotLimits" type="radio" /> specify
-				limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="8.0" type="text" /> um and upper wavelength <input name="plotWavelengthU" size="6" value="13.000" type="text" /> um) </td>
+				limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="8.0" type="text" /> µm and upper wavelength <input name="plotWavelengthU" size="6" value="13.000" type="text" /> µm) </td>
 
 			</tr>
 			<tr>


### PR DESCRIPTION
A quick correction of a read noise value for F2 on the HTML page.

![image](https://cloud.githubusercontent.com/assets/7856060/10328054/54d5e600-6c4b-11e5-9100-18eeba1dc43f.png)

Under cover of this change I also decided to introduce unicode characters where appropriate to display units.

![image](https://cloud.githubusercontent.com/assets/7856060/10328017/ddab20b8-6c4a-11e5-9481-10fb4e86acfc.png)
 