### PR TITLE
OCSADV-421: Convert non-gems ManualGS to use VoTable

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1,6 +1,5 @@
 package jsky.app.ot.gemini.editor.targetComponent;
 
-import edu.gemini.catalog.ui.QueryResultsFrame;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
@@ -70,9 +69,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         _w.guidingControls.manualGuideStarButton().peer().addActionListener(manualGuideStarListener);
 
-        _w.guidingControls.newManualGuideStarButton().peer().addActionListener(evt -> {
-            QueryResultsFrame.instance().showOn(getNode());
-        });
         _w.guidingControls.autoGuideStarGuiderSelector().addSelectionListener(strategy ->
                 AgsStrategyUtil.setSelection(getContextObservation(), strategy)
         );

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -2,6 +2,7 @@ package jsky.app.ot.tpe;
 
 import edu.gemini.ags.api.AgsStrategy;
 import edu.gemini.catalog.api.MagnitudeConstraints;
+import edu.gemini.catalog.ui.QueryResultsFrame;
 import edu.gemini.shared.cat.CatalogSearchParameters;
 import edu.gemini.shared.cat.ICatalogAlgorithm;
 import edu.gemini.catalog.api.MagnitudeLimits;
@@ -1079,7 +1080,7 @@ public class TpeImageWidget extends NavigatorImageDisplay implements MouseInputL
         if (GuideStarSupport.hasGemsComponent(_ctx)) {
             showGemsGuideStarSearchDialog();
         } else {
-            TpeGuideStarDialog.showDialog(TpeManager.open().getImageWidget());
+            QueryResultsFrame.instance().showOn(_ctx.obsContext());
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/QueryResultDisplay.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/QueryResultDisplay.java
@@ -1,13 +1,3 @@
-/*
- * ESO Archive
- *
- * $Id: QueryResultDisplay.java 4414 2004-02-03 16:21:36Z brighton $
- *
- * who             when        what
- * --------------  ----------  ----------------------------------------
- * Allan Brighton  2000/01/05  Created
- */
-
 package jsky.catalog.gui;
 
 import jsky.catalog.*;
@@ -17,10 +7,11 @@ import jsky.catalog.*;
  * Classes defining this interface should know how to display the contents of
  * classes implementing the QueryResult interface.
  */
-public abstract interface QueryResultDisplay {
+@Deprecated
+public interface QueryResultDisplay {
 
     /**
      * Display the given query result.
      */
-    public void setQueryResult(QueryResult queryResult);
+    void setQueryResult(QueryResult queryResult);
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorImageDisplay.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorImageDisplay.java
@@ -11,6 +11,7 @@ import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
 import javax.swing.JLayeredPane;
 
+import edu.gemini.catalog.ui.QueryResultsFrame;
 import jsky.catalog.Catalog;
 import jsky.catalog.CatalogDirectory;
 import jsky.catalog.TableQueryResult;

--- a/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorImageDisplayToolBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorImageDisplayToolBar.java
@@ -16,7 +16,6 @@ public class NavigatorImageDisplayToolBar extends ImageDisplayToolBar {
 
     // toolbar buttons
     protected JButton catalogButton;
-    protected JButton newCatalogButton;
 
     /**
      * Create the toolbar for the given window
@@ -32,7 +31,6 @@ public class NavigatorImageDisplayToolBar extends ImageDisplayToolBar {
         super.addToolBarItems();
         addSeparator();
         add(makeCatalogButton());
-        add(makeNewCatalogButton());
     }
 
     /**
@@ -53,31 +51,12 @@ public class NavigatorImageDisplayToolBar extends ImageDisplayToolBar {
     }
 
     /**
-     * Make the new catalog button, if it does not yet exists. Otherwise update the display
-     * using the current options for displaying text or icons.
-     *
-     * @return the catalog button
-     */
-    protected JButton makeNewCatalogButton() {
-        if (newCatalogButton == null)
-            newCatalogButton = makeButton(_I18N.getString("showCatalogWindow"),
-                                       ((NavigatorImageDisplay) imageDisplay).getCatalogBrowseAction());
-
-        updateButton(newCatalogButton,
-                     "New Catalog",
-                     Resources.getIcon("Catalog24.gif", this.getClass()));
-        return newCatalogButton;
-    }
-
-
-    /**
      * Update the toolbar display using the current text/pictures options.
      * (redefined from the parent class).
      */
     public void update() {
         super.update();
         makeCatalogButton();
-        makeNewCatalogButton();
     }
 }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorManager.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorManager.java
@@ -1,8 +1,3 @@
-// Copyright 2003 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: NavigatorManager.java 4726 2004-05-14 16:50:12Z brighton $
-//
 package jsky.navigator;
 
 import javax.swing.JDesktopPane;
@@ -49,7 +44,7 @@ public final class NavigatorManager {
      */
     public static Navigator create() {
         if (_navigator == null) {
-            CatalogDirectory dir = null;
+            CatalogDirectory dir;
             try {
                 dir = CatalogNavigator.getCatalogDirectory();
             } catch (Exception e) {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -536,6 +536,11 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     TpeContext.apply(n).obsContext.foreach(showOn)
   }
 
+  def showOn(obsCtx: Option[ObsContext]): Unit = {
+    // TODO Support launching without a context
+    obsCtx.foreach(showOn)
+  }
+
   def showOn(obsCtx: ObsContext) {
     // TODO The user should be able to select the strategy OCSADV-403
     AgsRegistrar.currentStrategy(obsCtx).foreach { strategy =>

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TableColumnsAdjuster.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TableColumnsAdjuster.scala
@@ -70,7 +70,7 @@ trait TableColumnsAdjuster { this: Table =>
     // Adjust space to fit on the outer width
     val spacing = max(minSpacing, (containerWidth - initialWidth - nonResizableWidth) / resizableColumnsLength)
     // Add the rounding error to the first col
-    val initialOffset = containerWidth - cols.map(_._2 + spacing).sum - nonResizableWidth
+    val initialOffset = max(0, containerWidth - cols.map(_._2 + spacing).sum - nonResizableWidth)
     // Set width + spacing
     cols.zipWithIndex.foreach {
       case ((c, w), i) if i == 0 => updateTableColumn(c, w + spacing + initialOffset) // Add rounding error to the first col

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
@@ -31,15 +31,9 @@ class GuidingControls extends GridBagPanel {
   }
 
   val manualGuideStarButton = new Button("Manual GS")
-  // Temporary button to go to the new manual search
-  val newManualGuideStarButton = new Button("New Manual GS")
-  newManualGuideStarButton.visible = false
 
   layout(manualGuideStarButton) = new Constraints {
     gridx  = 2
-  }
-  layout(newManualGuideStarButton) = new Constraints {
-    gridx  = 3
   }
 
   def update(ctxOpt: edu.gemini.shared.util.immutable.Option[ObsContext]): Unit = {
@@ -56,6 +50,6 @@ class GuidingControls extends GridBagPanel {
   }
 
   def supportsNewManualGS(supports: Boolean) {
-    newManualGuideStarButton.visible = supports
+    manualGuideStarButton.visible = supports
   }
 }


### PR DESCRIPTION
Small PR that integrates the New Catalog Navigator instead of the old one. The old one is still accessible from the TPE
The PR also includes a couple of small bug fixes
With this PR in we should be able to make a release to let science staff check the new navigator