### PR TITLE
OCSADV-386: Spectroscopy ITC Peak counts = signal + background.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -100,6 +100,7 @@ trait ItcTable extends Table {
       case (ico: Icon, str: String)  => new Label(str,              ico,  Alignment.Left)
       case d: DisplayableSpType      => new Label(d.displayValue(), null, Alignment.Left)
       case Some(i: Int)              => new Label(i.toString,       null, Alignment.Right)
+      case Some(l: Long)             => new Label(l.toString,       null, Alignment.Right)
       case Some(d: Double)           => new Label(f"$d%.2f",        null, Alignment.Right)
       case Some(s: String)           => new Label(s,                null, Alignment.Left)
       case None | null               => new Label("")


### PR DESCRIPTION
Small bug fix that calculates the peak value for spectroscopy as the maximum value of the sum of the signal and background functions over wavelength.

**GNIRS**
![image](https://cloud.githubusercontent.com/assets/7856060/10355305/08a94b3a-6d06-11e5-87c5-a9c649184f12.png)

**GNIRS Cross Dispersed**
![image](https://cloud.githubusercontent.com/assets/7856060/10355298/f3c0f7f4-6d05-11e5-9a9c-2127d5f92833.png)


*As a side note:*
If you wonder about the structuring of the data: ITC calculation results contain several series of resulting data, e.g. `SignalData` and `BackgroundData` (available types depend on instrument and calculation modes). For each of these types there can be several arrays, e.g. for GNIRS in cross dispersion mode there is one of each data arrays (signal, background) for each order (6).

The modeling of those result values is a bit cryptic, but I have to work with what the underlying ITC code provides. However by now I also have a better feeling for how this data looks like for different instruments and potentially I'll restructure those result objects a bit at some point. For now it is what it is I am afraid..