### PR TITLE
OCSADV-431: Removed BAGS label from type tag.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -188,7 +188,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             BagsTargetRow(final boolean isActiveGuideProbe, final Option<AgsGuideQuality> quality, final boolean enabled,
                           final GuideProbe probe, final SPTarget target, final Option<WorldCoords> baseCoords,
                           final Option<Long> when) {
-                super(enabled, String.format("%s (BAGS)", probe.getKey()), target, baseCoords, when);
+                super(enabled, probe.getKey(), target, baseCoords, when);
                 this.isActiveGuideProbe = isActiveGuideProbe;
                 this.quality = quality;
             }


### PR DESCRIPTION
Since we have an icon indicating BAGS guide stars, having the type tag include `(BAGS)` is redundant, as pointed out by Andy. Thus, we are simply removing it.