### PR TITLE
OCSADV-430: Fixed issue where observations in groups were being ignored.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -120,7 +120,7 @@ object BagsManager {
       p.addCompositeChangeListener(propertyChangeListener)
 
       // Only queue up observations that do not have an auto guide star.
-      p.getObservations.asScala.foreach { obs =>
+      p.getAllObservations.asScala.foreach { obs =>
         val obsCtx = ObsContext.create(obs)
         obsCtx.asScalaOpt.foreach { ctx =>
           if (ctx.getTargets.getGuideEnvironment.getPrimaryReferencedGuiders.isEmpty ||
@@ -251,9 +251,14 @@ object BagsManager {
           if (!sameEnv)
             updateObservation(obsComp.getContextObservation)
 
-        case prog: ISPProgram => prog.getObservations.asScala.foreach(updateObservation)
-        case node: ISPNode    => updateObservation(node.getContextObservation)
-        case _                => // Ignore
+        case prog: ISPProgram =>
+          prog.getAllObservations.asScala.foreach(updateObservation)
+        case group: ISPGroup =>
+          group.getObservations.asScala.foreach(updateObservation)
+        case node: ISPNode    =>
+          updateObservation(node.getContextObservation)
+        case _                =>
+          // Ignore
       }
     }
   }


### PR DESCRIPTION
This was just a stupid lack of knowledge on my part: instead of iterating over ALL observations of a program, I was only iterating over the observations not contained in groups. By changing the method call from `getObservations` to `getAllObservations`, now observations in groups are handled.

Additionally, I added a case clause to handle changes to `ISPGroup`, since otherwise this would fall through to `ISPNode` and the `getContextObservation` method would not handle all observations in the group as should be done.