### PR TITLE
OCSADV-396-A: Draw selected targets on the TPE

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/Catalog.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/Catalog.java
@@ -1,18 +1,9 @@
-// Copyright 2002
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: Catalog.java 38103 2011-10-19 19:47:32Z fnussber $
-
-
 package jsky.catalog;
-
 
 import jsky.coords.CoordinateRadius;
 
 import java.net.URL;
 import java.io.IOException;
-
 
 /**
  * This interface defines the common interface to all catalogs.
@@ -20,62 +11,62 @@ import java.io.IOException;
  * @version $Revision: 38103 $
  * @author Allan Brighton
  */
-public abstract interface Catalog extends QueryResult, Cloneable {
+public interface Catalog extends QueryResult, Cloneable {
 
     /** Value returned by getType() for servers that return a table */
-    public static final String CATALOG = "catalog";
+    String CATALOG = "catalog";
 
     /** Value returned by getType() for servers that return a table containing pointers to
      images and other data */
-    public static final String ARCHIVE = "archive";
+    String ARCHIVE = "archive";
 
     /** Value returned by getType() for servers that return an image */
-    public static final String IMAGE_SERVER = "imagesvr";
+    String IMAGE_SERVER = "imagesvr";
 
     /** Value returned by getType() for servers that return the RA,Dec coordinates for an object name */
-    public static final String NAME_SERVER = "namesvr";
+    String NAME_SERVER = "namesvr";
 
     /** Value returned by getType() for catalogs that return a list of other catalogs */
-    public static final String DIRECTORY = "directory";
+    String DIRECTORY = "directory";
 
     /** Value returned by getType() for local catalog files. */
-    public static final String LOCAL = "local";
+    String LOCAL = "local";
 
     /** Propery to store user preferences prefences */
-    public static final String SKY_USER_CATALOG = "jsky.catalog.sky";
+    String SKY_USER_CATALOG = "jsky.catalog.sky";
 
     /** Implementation of the clone method (makes a shallow copy). */
     @SuppressWarnings({"CloneDoesntDeclareCloneNotSupportedException"})
-    public Object clone();
+    Object clone();
 
 
     /** Return the name of the catalog */
-    public String getName();
+    String getName();
 
     /** Set the catalog's name */
-    public void setName(String name);
+    void setName(String name);
 
 
     /** Return the Id or short name of the catalog */
-    public String getId();
+    String getId();
 
     /** Return a string to display as a title for the catalog in a user interface */
-    public String getTitle();
+    String getTitle();
 
     /** Return a description of the catalog, or null if not available */
-    public String getDescription();
+    String getDescription();
 
     /** Return a URL pointing to documentation for the catalog, or null if not available */
-    public URL getDocURL();
+    URL getDocURL();
 
     /** If this catalog can be querried, return the number of query parameters that it accepts */
-    public int getNumParams();
+    int getNumParams();
 
     /** Return a description of the ith query parameter */
-    public FieldDesc getParamDesc(int i);
+    FieldDesc getParamDesc(int i);
 
     /** Return a description of the named query parameter */
-    public FieldDesc getParamDesc(String name);
+    FieldDesc getParamDesc(String name);
 
 
     /**
@@ -86,7 +77,7 @@ public abstract interface Catalog extends QueryResult, Cloneable {
      * @param queryArgs (in/out) describes the query arguments
      * @param region (in) describes the query region (center and radius range)
      */
-    public void setRegionArgs(QueryArgs queryArgs, CoordinateRadius region);
+    void setRegionArgs(QueryArgs queryArgs, CoordinateRadius region);
 
     /**
      * Return true if this is a local catalog, and false if it requires
@@ -94,28 +85,28 @@ public abstract interface Catalog extends QueryResult, Cloneable {
      * run in the event dispatching thread, while others are done in a
      * separate thread.
      */
-    public boolean isLocal();
+    boolean isLocal();
 
     /** Return true if this object represents an image server. */
-    public boolean isImageServer();
+    boolean isImageServer();
 
     /** Return the catalog type (one of the constants: CATALOG, ARCHIVE, DIRECTORY, LOCAL, IMAGE_SERVER) */
-    public String getType();
+    String getType();
 
     /** Set the parent catalog directory */
-    public void setParent(CatalogDirectory catDir);
+    void setParent(CatalogDirectory catDir);
 
     /** Return a reference to the parent catalog directory, or null if not known. */
-    public CatalogDirectory getParent();
+    CatalogDirectory getParent();
 
     /**
      * Return an array of Catalog or CatalogDirectory objects representing the
      * path from the root catalog directory to this catalog.
      */
-    public Catalog[] getPath();
+    Catalog[] getPath();
 
     /** Provides a query argument object that can be used with this catalog. */
-    public QueryArgs getQueryArgs();
+    QueryArgs getQueryArgs();
 
     /**
      * Query the catalog using the given arguments and return the result.
@@ -128,7 +119,7 @@ public abstract interface Catalog extends QueryResult, Cloneable {
      * @return An object describing the result of the query.
      */
     @Deprecated
-    public QueryResult query(QueryArgs queryArgs) throws CatalogException, IOException;
+    QueryResult query(QueryArgs queryArgs) throws CatalogException, IOException;
 }
 
 

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/MemoryCatalog.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/MemoryCatalog.java
@@ -1,10 +1,3 @@
-// Copyright 2002
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: MemoryCatalog.java 47333 2012-08-07 16:36:02Z swalker $
-
-
 package jsky.catalog;
 
 import edu.gemini.catalog.skycat.DefaultOutputAdapter;
@@ -23,10 +16,7 @@ import jsky.util.StringTokenizerUtil;
 import javax.swing.table.DefaultTableModel;
 import java.io.*;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Properties;
-import java.util.Vector;
+import java.util.*;
 
 /**
  * Used to manage tabular catalog data in memory, such as the
@@ -56,13 +46,10 @@ public class MemoryCatalog extends DefaultTableModel
         implements TableQueryResult, Saveable, SaveableAsHTML {
 
     // Table property names
-    public static final String EQUINOX = "equinox";
     public static final String SYMBOL = "symbol";
     public static final String ID_COL = "id_col";
     public static final String RA_COL = "ra_col";
     public static final String DEC_COL = "dec_col";
-    public static final String X_COL = "x_col";
-    public static final String Y_COL = "y_col";
 
     /** The catalog corresponding to this table. */
     private Catalog _catalog;
@@ -157,7 +144,7 @@ public class MemoryCatalog extends DefaultTableModel
      * @param in the stream to read the catalog data from
      */
     public MemoryCatalog(Catalog catalog, InputStream in) throws IOException {
-        this(catalog, in, None.INSTANCE, -1);
+        this(catalog, in, None.instance(), -1);
     }
 
     /**
@@ -169,7 +156,7 @@ public class MemoryCatalog extends DefaultTableModel
      * @param queryArgs represents the arguments to the query that resulted in this table
      */
     public MemoryCatalog(Catalog catalog, InputStream in, QueryArgs queryArgs) throws IOException {
-        this(catalog, in, None.INSTANCE, queryArgs.getMaxRows());
+        this(catalog, in, None.instance(), queryArgs.getMaxRows());
         _queryArgs = queryArgs;
     }
 
@@ -813,9 +800,7 @@ public class MemoryCatalog extends DefaultTableModel
     /** Set the data types for column values. */
     public void setColumnClasses(Class<?>[] ar) {
         _columnClasses = new Vector<>(ar.length);
-        for (Class<?> anAr : ar) {
-            _columnClasses.add(anAr);
-        }
+        Collections.addAll(_columnClasses, ar);
     }
 
 

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/PlotableCatalog.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/PlotableCatalog.java
@@ -1,18 +1,4 @@
-// Copyright 2002
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: PlotableCatalog.java 4726 2004-05-14 16:50:12Z brighton $
-
-
 package jsky.catalog;
-
-
-import jsky.coords.CoordinateRadius;
-
-import java.net.URL;
-import java.io.IOException;
-
 
 /**
  * Defines the interface for catalogs whose tabular query results
@@ -21,28 +7,25 @@ import java.io.IOException;
  * @version $Revision: 4726 $
  * @author Allan Brighton
  */
-public abstract interface PlotableCatalog extends Catalog {
+public interface PlotableCatalog extends Catalog {
 
     /** Return the number of plot symbol definitions associated with this catalog. */
-    public int getNumSymbols();
+    int getNumSymbols();
 
     /** Return the ith plot symbol description */
-    public TablePlotSymbol getSymbolDesc(int i);
+    TablePlotSymbol getSymbolDesc(int i);
 
     /** Return an array of symbol descriptions, or null if none are defined. */
-    public TablePlotSymbol[] getSymbols();
+    TablePlotSymbol[] getSymbols();
 
     /** Set the plot symbol descriptions to use to plot tables returned from this catalog */
-    public void setSymbols(TablePlotSymbol[] symbols);
+    void setSymbols(TablePlotSymbol[] symbols);
 
     /** Set to true if the user edited the plot symbol definitions (default: false) */
-    public void setSymbolsEdited(boolean edited);
+    void setSymbolsEdited(boolean edited);
 
     /** Return true if the user edited the plot symbol definitions otherwise false */
-    public boolean isSymbolsEdited();
-
-    /** Save the catalogs's symbol definitions to disk with the user's changes */
-    public void saveSymbolConfig();
+    boolean isSymbolsEdited();
 
 }
 

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/RowCoordinates.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/RowCoordinates.java
@@ -1,15 +1,4 @@
-/*
- * ESO Archive
- *
- * $Id: RowCoordinates.java 4414 2004-02-03 16:21:36Z brighton $
- *
- * who             when        what
- * --------------  ----------  ----------------------------------------
- * Allan Brighton  1999/05/10  Created
- */
-
 package jsky.catalog;
-
 
 import java.util.*;
 
@@ -123,7 +112,7 @@ public class RowCoordinates {
                     } else if (ra instanceof Double && dec instanceof Double) {
                         return new WorldCoords((Double) ra, (Double) dec, equinox);
                     } else if (ra instanceof Float && dec instanceof Float) {
-                        return new WorldCoords(((Float) ra).floatValue(), ((Float) dec).floatValue(), equinox);
+                        return new WorldCoords((Float) ra, (Float) dec, equinox);
                     }
                 }
             } else if (isPix) {
@@ -132,7 +121,7 @@ public class RowCoordinates {
                     if (x instanceof Double && y instanceof Double)
                         return new ImageCoords((Double) x, (Double) y);
                     else if (x instanceof Float && y instanceof Float)
-                        return new ImageCoords(((Float) x).floatValue(), ((Float) y).floatValue());
+                        return new ImageCoords((Float) x, (Float) y);
                 }
             }
         } catch (NumberFormatException e) {

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/TablePlotSymbol.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/TablePlotSymbol.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: TablePlotSymbol.java 8038 2007-08-07 20:19:41Z swalker $
- */
-
 package jsky.catalog;
 
 import gnu.jel.DVMap;

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/TableQueryResult.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/TableQueryResult.java
@@ -1,13 +1,3 @@
-/*
- * ESO Archive
- *
- * $Id: TableQueryResult.java 37429 2011-09-15 07:56:53Z abrighton $
- *
- * who             when        what
- * --------------  ----------  ----------------------------------------
- * Allan Brighton  1999/05/10  Created
- */
-
 package jsky.catalog;
 
 import java.util.Vector;
@@ -17,7 +7,6 @@ import javax.swing.table.TableModel;
 import jsky.coords.Coordinates;
 import jsky.coords.WorldCoordinates;
 
-
 /**
  * This interface defines the methods required to access tabular query results.
  * It extends QueryResult, since it represents the result of a catalog query.
@@ -25,63 +14,63 @@ import jsky.coords.WorldCoordinates;
  * It also extends Catalog, so that it is possible to search again in the result
  * of a previous query.
  */
-public abstract interface TableQueryResult extends Catalog, TableModel {
+public interface TableQueryResult extends Catalog, TableModel {
 
     /**
      * Returns the Vector of Vectors that contains the table's data values.
      * The vectors contained in the outer vector are each a single row of values.
      */
-    public Vector<Vector<Object>> getDataVector();
+     Vector<Vector<Object>> getDataVector();
 
     /** Return a description of the ith table column field */
-    public FieldDesc getColumnDesc(int i);
+     FieldDesc getColumnDesc(int i);
 
     /** Return the table column index for the given column name */
-    public int getColumnIndex(String name);
+     int getColumnIndex(String name);
 
     /** Return a vector of column headings for this table. */
-    public Vector<String> getColumnIdentifiers();
+     Vector<String> getColumnIdentifiers();
 
     /** Return true if the table has coordinate columns, such as (ra, dec) */
-    public boolean hasCoordinates();
+     boolean hasCoordinates();
 
     /**
      * Return a Coordinates object based on the appropriate columns in the given row,
      * or null if there are no coordinates available for the row.
      */
-    public Coordinates getCoordinates(int rowIndex);
+     Coordinates getCoordinates(int rowIndex);
 
     /**
      * Return an object describing the columns that can be used to search
      * this catalog.
      */
-    public RowCoordinates getRowCoordinates();
+     RowCoordinates getRowCoordinates();
 
     /**
      * Return the center coordinates for this table from the query arguments,
      * if known, otherwise return the coordinates of the first row, or null
      * if there are no world coordinates available.
      */
-    public WorldCoordinates getWCSCenter();
+     WorldCoordinates getWCSCenter();
 
     /**
      * Return the object representing the arguments to the query that resulted in this table,
      * if known, otherwise null.
      */
-    public QueryArgs getQueryArgs();
+     QueryArgs getQueryArgs();
 
     /**
      * Set the object representing the arguments to the query that resulted in this table.
      */
-    public void setQueryArgs(QueryArgs queryArgs);
+     void setQueryArgs(QueryArgs queryArgs);
 
     /** Return true if the result was truncated and more data would have been available */
-    public boolean isMore();
+     boolean isMore();
 
     /**
      * Return the catalog used to create this table,
      * or a dummy, generated catalog object, if not known.
      */
-    public Catalog getCatalog();
+     Catalog getCatalog();
 
 }

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/astrocat/AstroCatConfig.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/astrocat/AstroCatConfig.java
@@ -1,11 +1,3 @@
-/*
- * Copyright 2002 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: AstroCatConfig.java 23553 2010-01-22 19:24:12Z swalker $
- */
-
-
 package jsky.catalog.astrocat;
 
 import jsky.catalog.*;
@@ -283,6 +275,7 @@ public class AstroCatConfig extends AbstractCatalogDirectory {
     /**
      * Save the catalog list in the default location (~/.jsky/AstroCat.xml)
      */
+    @Deprecated
     public void save() {
         String home = System.getProperty("user.home");
         String sep = System.getProperty("file.separator");

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/astrocat/AstroCatalog.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/astrocat/AstroCatalog.java
@@ -1,9 +1,3 @@
-// Copyright 2002
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: AstroCatalog.java 39360 2011-11-25 13:02:23Z swalker $
-
 package jsky.catalog.astrocat;
 
 import jsky.catalog.*;
@@ -285,11 +279,6 @@ public class AstroCatalog implements PlotableCatalog {
     /** Return true if the user edited the plot symbol definitions otherwise false */
     public boolean isSymbolsEdited() {
         return _symbolsEdited;
-    }
-
-    /** Save the catalog symbol information to disk with the user's changes */
-    public void saveSymbolConfig() {
-        AstroCatConfig.getConfigFile().save();
     }
 
     /**
@@ -601,7 +590,7 @@ public class AstroCatalog implements PlotableCatalog {
 
 
     // Return the URL to use to query the catalog with the current parameter values
-    private URL _getQueryUrl(QueryArgs queryArgs) throws MalformedURLException, IOException, CatalogException {
+    private URL _getQueryUrl(QueryArgs queryArgs) throws IOException, CatalogException {
         // determine the query region and max rows settings
         String urlStr = _getBaseUrl();
         SearchCondition[] sc = queryArgs.getConditions();

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/skycat/SkycatCatalog.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/skycat/SkycatCatalog.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: SkycatCatalog.java 47126 2012-08-01 15:40:43Z swalker $
- */
-
 package jsky.catalog.skycat;
 
 import jsky.catalog.*;
@@ -248,13 +241,6 @@ public class SkycatCatalog implements PlotableCatalog {
      */
     public boolean isSymbolsEdited() {
         return _entry.isSymbolsEdited();
-    }
-
-    /**
-     * Save the catalog symbol information to disk with the user's changes
-     */
-    public void saveSymbolConfig() {
-        SkycatConfigFile.getConfigFile().save();
     }
 
     /**

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/skycat/SkycatConfigFile.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/skycat/SkycatConfigFile.java
@@ -431,6 +431,7 @@ public class SkycatConfigFile extends AbstractCatalogDirectory {
      * (~/.jsky/skycat.cfg) to make it permanent. The information is saved in the
      * same format used by the skycat application.
      */
+    @Deprecated
     public void save() {
         String home = System.getProperty("user.home");
         String sep = System.getProperty("file.separator");

--- a/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/skycat/SkycatPlotSymbol.java
+++ b/bundle/edu.gemini.catalog/src/main/java/jsky/catalog/skycat/SkycatPlotSymbol.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: SkycatPlotSymbol.java 4414 2004-02-03 16:21:36Z brighton $
- */
-
 package jsky.catalog.skycat;
 
 import jsky.catalog.RowCoordinates;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPNode.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPNode.java
@@ -1,10 +1,3 @@
-// Copyright 1999 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: ISPNode.java 46997 2012-07-26 15:51:35Z swalker $
-//
-
 package edu.gemini.pot.sp;
 
 import edu.gemini.pot.sp.version.LifespanId;
@@ -14,7 +7,6 @@ import edu.gemini.spModel.data.ISPDataObject;
 
 import java.beans.PropertyChangeListener;
 import java.util.Set;
-
 
 /**
  * This is the base interface for all the Science Program nodes.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.spModel.obs.context;
 
 import edu.gemini.pot.sp.*;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.spModel.target.env;
 
 import edu.gemini.shared.util.immutable.*;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -1,14 +1,6 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: TargetObsComp.java 45277 2012-05-15 22:53:11Z swalker $
-//
 package edu.gemini.spModel.target.obsComp;
 
 import edu.gemini.pot.sp.SPComponentType;
-import edu.gemini.shared.util.immutable.ApplyOp;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
@@ -24,7 +16,6 @@ import edu.gemini.spModel.target.system.ITarget;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.Collection;
-
 
 /**
  * A class for telescope observation component items.  Maintains a
@@ -74,9 +65,7 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
         final TargetObsComp toc = (TargetObsComp) super.clone();
         toc.targetEnv = targetEnv.cloneTargets();
         toc.prop      = toc.new PcePropagator();
-        toc.targetEnv.getTargets().foreach(new ApplyOp<SPTarget>() {
-            @Override public void apply(SPTarget target) { target.addWatcher(toc.prop); }
-        });
+        toc.targetEnv.getTargets().foreach(target -> target.addWatcher(toc.prop));
         return toc;
     }
 
@@ -132,12 +121,9 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
     }
 
     private void watchTargets() {
-        targetEnv.getTargets().foreach(new ApplyOp<SPTarget>() {
-            @Override
-            public void apply(SPTarget target) {
-                target.deleteWatcher(prop);
-                target.addWatcher(prop);
-            }
+        targetEnv.getTargets().foreach(target -> {
+            target.deleteWatcher(prop);
+            target.addWatcher(prop);
         });
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetPos.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetPos.java
@@ -1,11 +1,3 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: OffsetPos.java 8574 2008-05-18 20:47:17Z swalker $
-//
-
 package edu.gemini.spModel.target.offset;
 
 /**
@@ -13,7 +5,7 @@ package edu.gemini.spModel.target.offset;
  * for extracting positions.
  */
 public final class OffsetPos extends OffsetPosBase {
-;
+
     public static final Factory<OffsetPos> FACTORY = new Factory<OffsetPos>() {
         public OffsetPos create(String tag) {
             return new OffsetPos(tag);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetPosBase.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetPosBase.java
@@ -164,7 +164,7 @@ public abstract class OffsetPosBase extends WatchablePos {
 
         // Update the current value
 
-        Map<GuideProbe, GuideOption> m = new TreeMap<GuideProbe, GuideOption>(GuideProbe.KeyComparator.instance);
+        Map<GuideProbe, GuideOption> m = new TreeMap<>(GuideProbe.KeyComparator.instance);
         m.putAll(_linkMap);
         m.put(guider, option);
         _linkMap = Collections.unmodifiableMap(m);
@@ -207,11 +207,11 @@ public abstract class OffsetPosBase extends WatchablePos {
     }
 
     public Set<GuideProbe> getGuideProbes() {
-        return new HashSet<GuideProbe>(_linkMap.keySet());
+        return new HashSet<>(_linkMap.keySet());
     }
 
     public Set<GuideProbe> getGuideProbes(GuideProbe.Type type) {
-        Set<GuideProbe> res = new HashSet<GuideProbe>();
+        Set<GuideProbe> res = new HashSet<>();
         for (GuideProbe probe : _linkMap.keySet()) {
             if (probe.getType() == type) res.add(probe);
         }
@@ -240,7 +240,7 @@ public abstract class OffsetPosBase extends WatchablePos {
         if (_linkMap.size() == 1) {
             _linkMap = Collections.emptyMap();
         } else {
-            Map<GuideProbe, GuideOption> newLinks = new TreeMap<GuideProbe, GuideOption>(GuideProbe.KeyComparator.instance);
+            Map<GuideProbe, GuideOption> newLinks = new TreeMap<>(GuideProbe.KeyComparator.instance);
             newLinks.putAll(_linkMap);
             newLinks.remove(probe);
             _linkMap = Collections.unmodifiableMap(newLinks);
@@ -402,7 +402,7 @@ public abstract class OffsetPosBase extends WatchablePos {
 
         defaultGuideOption = Pio.getEnumValue(paramSet, DEFAULT_GUIDE_OPTION_PARAM, DefaultGuideOptions.Value.on);
 
-        Map<GuideProbe, GuideOption> links = new TreeMap<GuideProbe, GuideOption>(GuideProbe.KeyComparator.instance);
+        Map<GuideProbe, GuideOption> links = new TreeMap<>(GuideProbe.KeyComparator.instance);
         setLinkParameters(links, LINK_PREFIX, paramSet);
         if (links.size() == 0) {
             _linkMap = Collections.emptyMap();
@@ -463,7 +463,7 @@ public abstract class OffsetPosBase extends WatchablePos {
             return None.instance();
         }
 
-        return new Some<Offset>(new Offset(new Angle(p, ARCSECS), new Angle(q, ARCSECS)));
+        return new Some<>(new Offset(new Angle(p, ARCSECS), new Angle(q, ARCSECS)));
     }
 
     public static final ItemKey TEL_P_KEY       = new ItemKey("telescope:p");
@@ -482,7 +482,7 @@ public abstract class OffsetPosBase extends WatchablePos {
         Object q = config.getItemValue(TEL_Q_KEY);
         if ((p == null) || (q == null)) return None.instance();
 
-        Double pd, qd = null;
+        Double pd, qd;
         try {
             pd = parsePqVal(p);
             qd = parsePqVal(q);
@@ -492,7 +492,7 @@ public abstract class OffsetPosBase extends WatchablePos {
             return None.instance();
         }
 
-        return new Some<Offset>(new Offset(new Angle(pd, ARCSECS), new Angle(qd, ARCSECS)));
+        return new Some<>(new Offset(new Angle(pd, ARCSECS), new Angle(qd, ARCSECS)));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetPosList.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/offset/OffsetPosList.java
@@ -34,7 +34,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
     private transient List<OffsetPosListWatcher<P>> _watchers;
 
     /** The implementation of the list. */
-    private List<P> _posList = new ArrayList<P>();
+    private List<P> _posList = new ArrayList<>();
 
     private final OffsetPosBase.Factory<P> _factory;
 
@@ -63,7 +63,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
             //noinspection unchecked
             ol = (OffsetPosList<P>) super.clone();
             ol._watchers    = null;
-            ol._posList     = new ArrayList<P>();
+            ol._posList     = new ArrayList<>();
         } catch (CloneNotSupportedException ex) {
             // Should not happen
             throw new UnsupportedOperationException();
@@ -98,7 +98,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
      */
     public synchronized List<P> getAllPositions() {
         if (_posList == null) return Collections.emptyList();
-        return new ArrayList<P>(_posList);
+        return new ArrayList<>(_posList);
     }
 
     /**
@@ -265,7 +265,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
         // list.
         Set<GuideProbe> rmProbes = op.getGuideProbes();
         rmProbes.removeAll(advancedGuiding);
-        for (GuideProbe gp : rmProbes) op.removeLink(gp);
+        rmProbes.forEach(op::removeLink);
 
         // Add any that are missing.
         for (GuideProbe gp : advancedGuiding) {
@@ -292,7 +292,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
 
     public void addAdvancedGuiding(GuideProbe gp) {
         if (advancedGuiding.contains(gp)) return;
-        final Set<GuideProbe> a = new TreeSet<GuideProbe>(GuideProbe.KeyComparator.instance);
+        final Set<GuideProbe> a = new TreeSet<>(GuideProbe.KeyComparator.instance);
         a.addAll(advancedGuiding);
         a.add(gp);
         updateAdvancedGuiding(Collections.unmodifiableSet(a));
@@ -305,7 +305,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
         if (advancedGuiding.size() == 1) {
             newValue = Collections.emptySet();
         } else {
-            Set<GuideProbe> a = new TreeSet<GuideProbe>(GuideProbe.KeyComparator.instance);
+            Set<GuideProbe> a = new TreeSet<>(GuideProbe.KeyComparator.instance);
             a.addAll(advancedGuiding);
             a.remove(gp);
             newValue = Collections.unmodifiableSet(a);
@@ -325,7 +325,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
         if (guiders.isEmpty()) {
             newValue = Collections.emptySet();
         } else {
-            Set<GuideProbe> a = new TreeSet<GuideProbe>(GuideProbe.KeyComparator.instance);
+            Set<GuideProbe> a = new TreeSet<>(GuideProbe.KeyComparator.instance);
             a.addAll(guiders);
             newValue = Collections.unmodifiableSet(a);
         }
@@ -490,7 +490,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
         ParamSet paramSet = factory.createParamSet(name);
 
         if (advancedGuiding.size() > 0) {
-            List<String> keys = new ArrayList<String>(advancedGuiding.size());
+            List<String> keys = new ArrayList<>(advancedGuiding.size());
             for (GuideProbe gp : advancedGuiding) keys.add(gp.getKey());
             Pio.addListParam(factory, paramSet, ADVANCED_GUIDING_PROP, keys);
         }
@@ -513,7 +513,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
         if (paramSet == null) return;
 
         boolean migrate = false;
-        final List<P> positions = new ArrayList<P>(paramSet.getParamSetCount());
+        final List<P> positions = new ArrayList<>(paramSet.getParamSetCount());
         for (ParamSet ps : paramSet.getParamSets()) {
             final P op = _factory.create(ps.getName());
             op.setParamSet(ps);
@@ -525,7 +525,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
             }
         }
 
-        final Set<GuideProbe> advanced = new TreeSet<GuideProbe>(GuideProbe.KeyComparator.instance);
+        final Set<GuideProbe> advanced = new TreeSet<>(GuideProbe.KeyComparator.instance);
         if (migrate) {
             OffsetPosMigration.apply(positions);
             if (positions.size() > 0) {
@@ -575,7 +575,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
      */
     public synchronized void addWatcher(OffsetPosListWatcher<P> w) {
         if (_watchers == null) {
-            _watchers = new ArrayList<OffsetPosListWatcher<P>>();
+            _watchers = new ArrayList<>();
         } else if (_watchers.contains(w)) {
             return;
         }
@@ -595,7 +595,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
      */
     protected final synchronized List<OffsetPosListWatcher<P>> _getWatchers() {
         if (_watchers == null) return null;
-        return new ArrayList<OffsetPosListWatcher<P>>(_watchers);
+        return new ArrayList<>(_watchers);
     }
 
     /**
@@ -626,7 +626,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
         int n = v.size();
         for (int i = 0; i < n; i++) {
             OffsetPosListWatcher<P> w = v.get(i);
-            w.posListAddedPosition(this, new ArrayList<P>(tp));
+            w.posListAddedPosition(this, new ArrayList<>(tp));
         }
     }
 
@@ -643,7 +643,7 @@ public final class OffsetPosList<P extends OffsetPosBase> implements Cloneable, 
         int n = v.size();
         for (int i = 0; i < n; i++) {
             OffsetPosListWatcher<P> w = v.get(i);
-            w.posListRemovedPosition(this, new ArrayList<P>(tp));
+            w.posListRemovedPosition(this, new ArrayList<>(tp));
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/jskycat/JSkyCat.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/jskycat/JSkyCat.java
@@ -7,11 +7,8 @@ import jsky.navigator.NavigatorImageDisplayInternalFrame;
 import jsky.navigator.NavigatorInternalFrame;
 import jsky.util.I18N;
 import jsky.util.Preferences;
-import jsky.util.Resources;
 import jsky.util.gui.*;
 
-import javax.media.jai.JAI;
-import javax.media.jai.TileCache;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.WindowAdapter;
@@ -362,97 +359,5 @@ public class JSkyCat extends JFrame {
         }
     }
 
-
-    /**
-     * The main class of the JSkyCat application.
-     * <p>
-     * Usage: java [-Djsky.catalog.skycat.config=$SKYCAT_CONFIG]
-     *             JSkyCat [-[no]internalframes]
-     *             [-shownavigator]
-     *             [-port portNumber]
-     *             [imageFileOrUrl]
-     * <p>
-     * The <em>jsky.catalog.skycat.config</em> property defines the Skycat style catalog config file to use.
-     * (The default uses the ESO Skycat config file).
-     * <p>
-     * If -internalframes is specified, internal frames are used.
-     * The -nointernalframes option has the opposite effect.
-     * (The default is to use internal frames under Windows only).
-     * <p>
-     * If -shownavigator is specified, the catalog navigator window is displayed on startup.
-     * <p>
-     * The -port option causes the main image window to listen on a socket for client connections.
-     * This can be used to remote control the application.
-     * <p>
-     * The imageFileOrUrl argument may be an image file or URL to load.
-     */
-    public static void main(String args[]) {
-        String imageFileOrUrl = null;
-        //boolean internalFrames = (File.separatorChar == '\\');
-        boolean internalFrames = false;
-        boolean showNavigator = false;
-        int portNum = 0;
-        boolean ok = true;
-        int tilecache = 64;
-
-        label:
-        for (int i = 0; i < args.length; i++) {
-            if (args[i].charAt(0) == '-') {
-                String opt = args[i];
-                switch (opt) {
-                    case "-internalframes":
-                        internalFrames = true;
-                        break;
-                    case "-nointernalframes":
-                        internalFrames = false;
-                        break;
-                    case "-shownavigator":
-                        showNavigator = true;
-                        break;
-                    case "-port":
-                        String arg = args[++i];
-                        portNum = Integer.parseInt(arg);
-                        break;
-                    case "-tilecache":
-                        try {
-                            tilecache = Integer.parseInt(args[++i]);
-                        } catch (NumberFormatException e) {
-                            System.out.println("Warning: bad value for -tilecache option: " + args[i]);
-                        }
-                        break;
-                    default:
-                        System.out.println(_I18N.getString("unknownOption") + ": " + opt);
-                        ok = false;
-                        break label;
-                }
-            } else {
-                if (imageFileOrUrl != null) {
-                    System.out.println(_I18N.getString("specifyOneImageOrURL") + ": " + imageFileOrUrl);
-                    ok = false;
-                    break;
-                }
-                imageFileOrUrl = args[i];
-            }
-        }
-
-        if (!ok) {
-            System.out.println("Usage: java JSkyCat [-[no]internalframes] [-shownavigator] [-port portNum] [imageFileOrUrl]");
-            System.exit(1);
-        }
-
-        // Set default log properties
-        if (System.getProperty("log4j.configuration") == null)
-            System.setProperty("log4j.configuration", Resources.getResource("logConfig.prop").toString());
-
-
-        TileCache cache = JAI.getDefaultInstance().getTileCache();
-        cache.setMemoryCapacity(tilecache * 1024 * 1024);
-        // For testing
-        // new tilecachetool.TCTool();
-
-        Theme.install();
-
-        new JSkyCat(imageFileOrUrl, internalFrames, showNavigator, portNum);
-    }
 }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/jskycat/JSkyCat.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/jskycat/JSkyCat.java
@@ -1,13 +1,3 @@
-/*
- * ESO Archive
- *
- * $Id: JSkyCat.java 7729 2007-04-27 21:09:07Z gillies $
- *
- * who             when        what
- * --------------  ----------  ----------------------------------------
- * Allan Brighton  1999/05/03  Created
- */
-
 package jsky.app.jskycat;
 
 import jsky.image.gui.MainImageDisplay;
@@ -142,7 +132,7 @@ public class JSkyCat extends JFrame {
             setContentPane(desktop);
         }
 
-        NavigatorInternalFrame navigatorFrame = null;
+        NavigatorInternalFrame navigatorFrame;
         NavigatorImageDisplayInternalFrame imageFrame = null;
         if (imageFileOrUrl != null || !showNavigator) {
             imageFrame = makeNavigatorImageDisplayInternalFrame(desktop, imageFileOrUrl);
@@ -190,7 +180,7 @@ public class JSkyCat extends JFrame {
      * @param imageFileOrUrl an image file or URL to display
      */
     protected void makeFrameLayout(boolean showNavigator, String imageFileOrUrl) {
-        NavigatorFrame navigatorFrame = null;
+        NavigatorFrame navigatorFrame;
         NavigatorImageDisplayFrame imageFrame = null;
 
         if (imageFileOrUrl != null || !showNavigator) {
@@ -405,28 +395,35 @@ public class JSkyCat extends JFrame {
         boolean ok = true;
         int tilecache = 64;
 
+        label:
         for (int i = 0; i < args.length; i++) {
             if (args[i].charAt(0) == '-') {
                 String opt = args[i];
-                if (opt.equals("-internalframes")) {
-                    internalFrames = true;
-                } else if (opt.equals("-nointernalframes")) {
-                    internalFrames = false;
-                } else if (opt.equals("-shownavigator")) {
-                    showNavigator = true;
-                } else if (opt.equals("-port")) {
-                    String arg = args[++i];
-                    portNum = Integer.parseInt(arg);
-                } else if (opt.equals("-tilecache")) {
-                    try {
-                        tilecache = Integer.parseInt(args[++i]);
-                    } catch (NumberFormatException e) {
-                        System.out.println("Warning: bad value for -tilecache option: " + args[i]);
-                    }
-                } else {
-                    System.out.println(_I18N.getString("unknownOption") + ": " + opt);
-                    ok = false;
-                    break;
+                switch (opt) {
+                    case "-internalframes":
+                        internalFrames = true;
+                        break;
+                    case "-nointernalframes":
+                        internalFrames = false;
+                        break;
+                    case "-shownavigator":
+                        showNavigator = true;
+                        break;
+                    case "-port":
+                        String arg = args[++i];
+                        portNum = Integer.parseInt(arg);
+                        break;
+                    case "-tilecache":
+                        try {
+                            tilecache = Integer.parseInt(args[++i]);
+                        } catch (NumberFormatException e) {
+                            System.out.println("Warning: bad value for -tilecache option: " + args[i]);
+                        }
+                        break;
+                    default:
+                        System.out.println(_I18N.getString("unknownOption") + ": " + opt);
+                        ok = false;
+                        break label;
                 }
             } else {
                 if (imageFileOrUrl != null) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/tpe/OffsetPosMap.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/tpe/OffsetPosMap.java
@@ -37,7 +37,7 @@ public final class OffsetPosMap extends PosMap<String, OffsetPosBase> implements
     }
 
     public boolean exists(String key) {
-        return (iterator.posList() == null) ? false : iterator.posList().exists(key);
+        return iterator.posList() != null && iterator.posList().exists(key);
     }
 
     protected boolean posListAvailable() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -1,6 +1,7 @@
 package jsky.app.ot.tpe;
 
 import edu.gemini.pot.sp.*;
+import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.gemini.nici.SeqRepeatNiciOffset;
@@ -12,7 +13,6 @@ import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
 import edu.gemini.spModel.target.offset.OffsetPosSelection;
-import edu.gemini.spModel.target.system.CoordinateParam.Units;
 import edu.gemini.spModel.target.system.ITarget;
 import jsky.app.jskycat.JSkyCat;
 import jsky.app.ot.OT;
@@ -60,7 +60,7 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
     /**
      * List of all features
      */
-    private Vector<TpeImageFeature> _allFeatures = new Vector<>();
+    private final Vector<TpeImageFeature> _allFeatures;
 
     private TpeContext _ctx = TpeContext.empty();
 
@@ -72,22 +72,22 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
     /**
      * Tool button helper
      */
-    private TpeEditorTools _editorTools;
+    private final TpeEditorTools _editorTools;
 
     /**
      * Object managing the image features
      */
-    private TpeFeatureManager _featureMan;
+    private final TpeFeatureManager _featureMan;
 
     /**
      * Toolbar (on the side with toggle buttons)
      */
-    private TpeToolBar _tpeToolBar;
+    private final TpeToolBar _tpeToolBar;
 
     /**
      * Menu bar
      */
-    private TpeImageDisplayMenuBar _tpeMenuBar;
+    private final TpeImageDisplayMenuBar _tpeMenuBar;
 
     private final AgsContextPublisher _agsPub = new AgsContextPublisher();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeFeatureManager.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeFeatureManager.java
@@ -9,6 +9,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * This is a helper object used to manage the various TpeImageFeatures.
@@ -89,7 +90,7 @@ final class TpeFeatureManager {
             Preferences.set(prefName, selected);
         });
 
-        final Option<Component> keyPanel = tif.getKey().isEmpty() ? None.<Component>instance() :
+        final Option<Component> keyPanel = tif.getKey().isEmpty() ? None.instance() :
                                              new Some<>(TpeToolBar.createKeyPanel(tif.getKey().getValue()));
 
         _featureMap.put(name, new TpeFeatureData(tif, btn, keyPanel));
@@ -102,17 +103,12 @@ final class TpeFeatureManager {
         }
     }
 
-    public void updateAvailableOptions(Collection<TpeImageFeature> feats, TpeContext ctx) {
+    public void updateAvailableOptions(final Collection<TpeImageFeature> feats, final TpeContext ctx) {
 
         // TpeImageFeatures are clearly meant to each have a unique name as
         // nothing in this class would work otherwise.  Here we remember those
         // that are supposed to be available.
-        final Set<String> available = new HashSet<>();
-        for (final TpeImageFeature tif : feats) {
-            if (tif.isEnabled(ctx)) {
-                available.add(tif.getName());
-            }
-        }
+        final Set<String> available = feats.stream().filter(tif -> tif.isEnabled(ctx)).map(TpeImageFeature::getName).collect(Collectors.toSet());
 
         // Walk through all the features and make them visible or not as
         // appropriate.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageFeature.java
@@ -16,7 +16,6 @@ import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Point2D;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -54,10 +53,10 @@ public abstract class TpeImageFeature implements TelescopePosWatcher {
     protected boolean _isVisible;
 
     /** The feature's name. */
-    protected String _name;
+    protected final String _name;
 
     /** The feature's description. */
-    protected String _description;
+    protected final String _description;
 
     /**
      * Instantiate a TpeImageFeature from a fully qualified class name.
@@ -265,9 +264,6 @@ public abstract class TpeImageFeature implements TelescopePosWatcher {
      * move the area to the current screen position that represents (0,0) of the instrument's coordinate system.
      * Note: This method implicitly includes the correction needed for images in the TPE with coordinate systems
      * that are flipped along the x-Axis (flipRA).
-     * @param rotation
-     * @param scaleFactor
-     * @param translation
      */
     protected void setTransformationToScreen(Angle rotation, double scaleFactor, Point2D.Double translation) {
         double radians = rotation.convertTo(Angle.Unit.RADIANS).getMagnitude();
@@ -280,7 +276,6 @@ public abstract class TpeImageFeature implements TelescopePosWatcher {
 
     /**
      * Gets the current transformation for mapping a geometry to the screen.
-     * @return
      */
     protected AffineTransform getTransformationToScreen() {
         return toScreenTransform;
@@ -289,8 +284,6 @@ public abstract class TpeImageFeature implements TelescopePosWatcher {
     /**
      * Transforms a geometry to screen coordinates according to the parameter set with
      * {@see setTransformationFlipXY} and {@see setTransformationToScreen}.
-     * @param area
-     * @return
      */
     protected Area transformToScreen(Area area) {
         area.transform(toScreenTransform);
@@ -333,7 +326,7 @@ public abstract class TpeImageFeature implements TelescopePosWatcher {
         }
     }
     // List of Figures to draw.
-    protected LinkedList<Figure> _figureList = new LinkedList<>();
+    protected final LinkedList<Figure> _figureList = new LinkedList<>();
     protected void clearFigures() {
         _figureList.clear();
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -1,6 +1,5 @@
 package jsky.app.ot.tpe;
 
-import edu.gemini.ags.api.AgsStrategy;
 import edu.gemini.catalog.api.MagnitudeConstraints;
 import edu.gemini.catalog.ui.QueryResultsFrame;
 import edu.gemini.shared.cat.CatalogSearchParameters;
@@ -8,17 +7,14 @@ import edu.gemini.shared.cat.ICatalogAlgorithm;
 import edu.gemini.catalog.api.MagnitudeLimits;
 import edu.gemini.catalog.api.RadiusLimits;
 import edu.gemini.shared.util.immutable.*;
-import edu.gemini.spModel.ags.AgsStrategyKey;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.*;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
-import edu.gemini.spModel.target.system.CoordinateParam.Units;
 import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.util.Angle;
-import jsky.app.ot.ags.AgsStrategyUtil;
 import jsky.app.ot.tpe.gems.GemsGuideStarSearchDialog;
 import jsky.app.ot.util.OtColor;
 import jsky.app.ot.util.PolygonD;

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/BasicTablePlotter.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/BasicTablePlotter.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2002 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: BasicTablePlotter.java 38445 2011-11-08 05:25:34Z abrighton $
- */
-
 package jsky.catalog.gui;
 
 import diva.canvas.CanvasLayer;
@@ -168,8 +161,7 @@ public class BasicTablePlotter
 
         // The symbol objects need a reference to the table being plotted
         // to evaluate expressions based on column values
-        for (int i = 0; i < symbols.length; i++)
-            symbols[i].setTable(table);
+        for (TablePlotSymbol symbol : symbols) symbol.setTable(table);
 
         // holds the plot symbols for this table
         _symbolAr = new SymbolListItem[symbols.length];
@@ -986,9 +978,9 @@ public class BasicTablePlotter
     private static Tuple2<CatalogHeader, CatalogRow> wrap(Collection<String> header, Collection<Object> row) {
         ImList<Tuple2<String,Class<?>>> colLst = DefaultImList.create();
         for (String col : header) {
-            colLst = colLst.append(new Pair<String,Class<?>>(col, String.class));
+            colLst = colLst.append(new Pair<>(col, String.class));
         }
-        return new Pair<CatalogHeader,  CatalogRow>(
+        return new Pair<>(
                 new DefaultCatalogHeader(colLst),
                 new DefaultCatalogRow(DefaultImList.create(row)));
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/CatalogQueryTool.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/CatalogQueryTool.java
@@ -157,11 +157,9 @@ public class CatalogQueryTool extends JPanel
         if (_catalog != null && _catalog.isImageServer()) {
             final JButton store = new JButton();
 
-            store.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    if (_catalogQueryPanel != null) {
-                        _catalogQueryPanel.storeUserSelection();
-                    }
+            store.addActionListener(e -> {
+                if (_catalogQueryPanel != null) {
+                    _catalogQueryPanel.storeUserSelection();
                 }
             });
             store.setAction(StoreImageServerAction.getAction(_catalog));

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TableDisplayTool.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TableDisplayTool.java
@@ -1,34 +1,18 @@
-/*
- * ESO Archive
- *
- * $Id: TableDisplayTool.java 37930 2011-10-07 23:17:24Z lobrien $
- *
- * who             when        what
- * --------------  ----------  ----------------------------------------
- * Allan Brighton  1999/06/02  Created
- */
-
 package jsky.catalog.gui;
 
 import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.print.PrinterException;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.OptionalDataException;
-import java.lang.ClassNotFoundException;
 import java.util.Vector;
 import java.util.logging.Logger;
 
 import javax.swing.JButton;
 import javax.swing.JDesktopPane;
 import javax.swing.JFileChooser;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JLayeredPane;
 import javax.swing.JOptionPane;
@@ -38,7 +22,6 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.table.DefaultTableModel;
 
 import jsky.catalog.MemoryCatalog;
 import jsky.catalog.QueryResult;
@@ -57,7 +40,6 @@ import jsky.util.gui.SwingUtil;
 import jsky.util.gui.TabbedPanel;
 import jsky.util.gui.TabbedPanelFrame;
 import jsky.util.gui.TabbedPanelInternalFrame;
-
 
 /**
  * Combines a TableDisplay component for displaying query results in
@@ -175,12 +157,7 @@ public class TableDisplayTool extends JPanel
         makeLayout(queryResultDisplay);
 
         // try to plot the table after it is displayed (make sure its the event thread)
-        SwingUtilities.invokeLater(new Runnable() {
-
-            public void run() {
-                plot();
-            }
-        });
+        SwingUtilities.invokeLater(TableDisplayTool.this::plot);
     }
 
 
@@ -233,39 +210,25 @@ public class TableDisplayTool extends JPanel
         _plotButton = new JButton(_I18N.getString("plot"));
         _plotButton.setToolTipText(_I18N.getString("plotTip"));
         panel.add(_plotButton);
-        _plotButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                unplot();
-                plot();
-            }
+        _plotButton.addActionListener(ev -> {
+            unplot();
+            plot();
         });
 
         _unplotButton = new JButton(_I18N.getString("unplot"));
         _unplotButton.setToolTipText(_I18N.getString("unplotTip"));
         panel.add(_unplotButton);
-        _unplotButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                unplot();
-            }
-        });
+        _unplotButton.addActionListener(ev -> unplot());
 
         _unplotAllButton = new JButton(_I18N.getString("unplotAll"));
         _unplotAllButton.setToolTipText(_I18N.getString("unplotTip"));
         panel.add(_unplotAllButton);
-        _unplotAllButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                unplotAll();
-            }
-        });
+        _unplotAllButton.addActionListener(ev -> unplotAll());
 
         _configButton = new JButton(_I18N.getString("configure"));
         _configButton.setToolTipText(_I18N.getString("configureTip"));
         panel.add(_configButton);
-        _configButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                configure();
-            }
-        });
+        _configButton.addActionListener(ev -> configure());
 
         return panel;
     }
@@ -393,16 +356,8 @@ public class TableDisplayTool extends JPanel
         final IApplyCancel symbolConfig = (IApplyCancel) getPlotter().getConfigPanel(getTable());
         tabbedPane.add((JPanel) symbolConfig, _I18N.getString("plotSymbols"));
 
-        ActionListener applyListener = new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                symbolConfig.apply();
-            }
-        };
-        ActionListener cancelListener = new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                symbolConfig.cancel();
-            }
-        };
+        ActionListener applyListener = e -> symbolConfig.apply();
+        ActionListener cancelListener = e -> symbolConfig.cancel();
         _configPanel.getApplyButton().addActionListener(applyListener);
         _configPanel.getOKButton().addActionListener(applyListener);
         _configPanel.getCancelButton().addActionListener(cancelListener);
@@ -415,16 +370,8 @@ public class TableDisplayTool extends JPanel
         _tableConfig = new TableColumnConfigPanel(_tableDisplay);
         tabbedPane.add(_tableConfig, _I18N.getString("showTableCols"));
 
-        ActionListener applyListener = new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                _tableConfig.apply();
-            }
-        };
-        ActionListener cancelListener = new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                _tableConfig.cancel();
-            }
-        };
+        ActionListener applyListener = e -> _tableConfig.apply();
+        ActionListener cancelListener = e -> _tableConfig.cancel();
         _configPanel.getApplyButton().addActionListener(applyListener);
         _configPanel.getOKButton().addActionListener(applyListener);
         _configPanel.getCancelButton().addActionListener(cancelListener);
@@ -494,8 +441,7 @@ public class TableDisplayTool extends JPanel
      * to open.
      */
     protected JFileChooser makeFileChooser() {
-        JFileChooser _fileChooser = new JFileChooser(new File("."));
-        return _fileChooser;
+        return new JFileChooser(new File("."));
     }
 
 
@@ -590,7 +536,7 @@ public class TableDisplayTool extends JPanel
     /**
      * Add a row to the table.
      */
-    public void addRow(Vector v) {
+    public void addRow(Vector<Object> v) {
         _tableDisplay.getTable().addRow(v);
         _tableDisplay.update();
         updateTitle();
@@ -601,20 +547,12 @@ public class TableDisplayTool extends JPanel
      * An exception will be thrown if the row index is
      * out of range or the vector has the wrong size.
      */
-    public void updateRow(int rowIndex, Vector v) {
+    public void updateRow(int rowIndex, Vector<Object> v) {
         TableQueryResult table = _tableDisplay.getTableQueryResult();
         for (int colIndex = 0; colIndex < v.size(); colIndex++) {
             table.setValueAt(v.get(colIndex), rowIndex, colIndex);
         }
         _tableDisplay.update();
-    }
-
-    /**
-     * Return the vector for the given row.
-     */
-    public Vector getRow(int rowIndex) {
-        DefaultTableModel model = (DefaultTableModel) _tableDisplay.getTableQueryResult();
-        return (Vector) model.getDataVector().get(rowIndex);
     }
 
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TablePlotter.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TablePlotter.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: TablePlotter.java 4414 2004-02-03 16:21:36Z brighton $
- */
-
 package jsky.catalog.gui;
 
 import java.awt.Graphics2D;
@@ -25,32 +18,32 @@ import jsky.graphics.CanvasGraphics;
  * @version $Revision: 4414 $
  * @author Allan Brighton
  */
-public abstract interface TablePlotter {
+public interface TablePlotter {
 
     /** Plot the given table data */
-    public void plot(TableQueryResult table);
+    void plot(TableQueryResult table);
 
     /** Erase the plot of the given table data */
-    public void unplot(TableQueryResult table);
+    void unplot(TableQueryResult table);
 
     /** Erase all plot symbols */
-    public void unplotAll();
+    void unplotAll();
 
     /** Recalculate the coordinates and replot all symbols after a change in the coordinate system. */
-    public void replotAll();
+    void replotAll();
 
     /** Return an array containing the tables managed by this object. */
-    public TableQueryResult[] getTables();
+    TableQueryResult[] getTables();
 
     /** Select the symbol corresponding to the given table row */
-    public void selectSymbol(TableQueryResult table, int tableRow);
+    void selectSymbol(TableQueryResult table, int tableRow);
 
     /** Deselect the symbol corresponding to the given table row */
-    public void deselectSymbol(TableQueryResult table, int tableRow);
+    void deselectSymbol(TableQueryResult table, int tableRow);
 
 
     /** Set the plot symbol info for the given table */
-    public void setPlotSymbolInfo(TableQueryResult table, TablePlotSymbol[] symbols);
+    void setPlotSymbolInfo(TableQueryResult table, TablePlotSymbol[] symbols);
 
     /**
      * Return the plot symbol info for the given table.
@@ -58,52 +51,52 @@ public abstract interface TablePlotter {
      * @param table object representing the catalog table
      * @return an array of PlotSymbol objects, one for each plot symbol defined.
      */
-    public TablePlotSymbol[] getPlotSymbolInfo(TableQueryResult table);
+    TablePlotSymbol[] getPlotSymbolInfo(TableQueryResult table);
 
 
     /**
      * If the given argument is false, hide all plot symbols managed by this object,
      * otherwise show them again.
      */
-    public void setVisible(boolean isVisible);
+    void setVisible(boolean isVisible);
 
     /** Set the object to use to draw catalog symbols */
-    public void setCanvasGraphics(CanvasGraphics canvasGraphics);
+    void setCanvasGraphics(CanvasGraphics canvasGraphics);
 
     /** Return the object to use to draw catalog symbols */
-    public CanvasGraphics getCanvasGraphics();
+    CanvasGraphics getCanvasGraphics();
 
     /** Set the object used to convert to screen coordinates for drawing */
-    public void setCoordinateConverter(CoordinateConverter c);
+    void setCoordinateConverter(CoordinateConverter c);
 
     /**
      * If the given screen coordinates point is within a displayed catalog symbol, set it to
      * point to the center of the symbol and return the name and coordinates
      * from the catalog table row. Otherwise, return null and do nothing.
      */
-    public NamedCoordinates getCatalogPosition(Point2D.Double p);
+    NamedCoordinates getCatalogPosition(Point2D.Double p);
 
     /** Return the object used to convert to screen coordinates for drawing */
-    public CoordinateConverter getCoordinateConverter();
+    CoordinateConverter getCoordinateConverter();
 
     /** Add a listener for selection events on symbols */
-    public void addSymbolSelectionListener(SymbolSelectionListener listener);
+    void addSymbolSelectionListener(SymbolSelectionListener listener);
 
     /** Remove a listener for selection events on symbols */
-    public void removeSymbolSelectionListener(SymbolSelectionListener listener);
+    void removeSymbolSelectionListener(SymbolSelectionListener listener);
 
     /** Add a listener for selection events on tables */
-    public void addTableSelectionListener(TableSelectionListener listener);
+    void addTableSelectionListener(TableSelectionListener listener);
 
     /** Remove a listener for selection events on tables */
-    public void removeTableSelectionListener(TableSelectionListener listener);
+    void removeTableSelectionListener(TableSelectionListener listener);
 
     /**
      * Return a panel to use to configure the plot symbols for the given table.
      *
      * @param table the result of a query
      */
-    public JPanel getConfigPanel(TableQueryResult table);
+    JPanel getConfigPanel(TableQueryResult table);
 
     /**
      * Paint the catalog symbols using the given graphics object.
@@ -111,11 +104,11 @@ public abstract interface TablePlotter {
      * @param g the graphics context
      * @param region if not null, the region to paint
      */
-    public void paintSymbols(Graphics2D g, Rectangle2D region);
+    void paintSymbols(Graphics2D g, Rectangle2D region);
 
     /**
      * Transform the plot symbols using the given AffineTransform
      * (called when the image is transformed, to keep the plot symbols up to date).
      */
-    public void transformGraphics(AffineTransform trans);
+    void transformGraphics(AffineTransform trans);
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TableSymbolConfig.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TableSymbolConfig.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2002 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: TableSymbolConfig.java 8331 2007-12-05 19:16:40Z anunez $
- */
-
 package jsky.catalog.gui;
 
 import java.awt.event.ActionEvent;
@@ -104,19 +97,17 @@ public class TableSymbolConfig extends TableSymbolConfigGUI implements IApplyCan
         _plotter = plotter;
 
         symbolTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        symbolTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-            public void valueChanged(ListSelectionEvent e) {
-                if (e.getValueIsAdjusting())
-                    return;
-                int first = e.getFirstIndex();
-                int last = e.getLastIndex();
-                ListSelectionModel model = symbolTable.getSelectionModel();
-                for (int i = first; i <= last; i++) {
-                    if (model.isSelectedIndex(i) && i >= 0 && i < _symbols.length) {
-                        _selectedSymbolRow = i;
-                        editSymbol(_symbols[i]);
-                        break;
-                    }
+        symbolTable.getSelectionModel().addListSelectionListener(e -> {
+            if (e.getValueIsAdjusting())
+                return;
+            int first = e.getFirstIndex();
+            int last = e.getLastIndex();
+            ListSelectionModel model = symbolTable.getSelectionModel();
+            for (int i = first; i <= last; i++) {
+                if (model.isSelectedIndex(i) && i >= 0 && i < _symbols.length) {
+                    _selectedSymbolRow = i;
+                    editSymbol(_symbols[i]);
+                    break;
                 }
             }
         });
@@ -247,8 +238,7 @@ public class TableSymbolConfig extends TableSymbolConfigGUI implements IApplyCan
         DefaultListModel model = (DefaultListModel) list.getModel();
         model.removeAllElements();
         if (ar != null) {
-            for (int i = 0; i < ar.length; i++)
-                model.addElement(ar[i]);
+            for (String anAr : ar) model.addElement(anAr);
         }
     }
 
@@ -258,8 +248,7 @@ public class TableSymbolConfig extends TableSymbolConfigGUI implements IApplyCan
         model.removeAllElements();
         if (v != null) {
             int n = v.size();
-            for (int i = 0; i < n; i++)
-                model.addElement(v.get(i));
+            for (Object aV : v) model.addElement(aV);
         }
     }
 
@@ -271,16 +260,15 @@ public class TableSymbolConfig extends TableSymbolConfigGUI implements IApplyCan
         setListData(useList, used);
 
         // List of column variables not used
-        Vector v = _table.getColumnIdentifiers();
+        Vector<String> v = _table.getColumnIdentifiers();
         int size = v.size();
-        Vector ignore = new Vector(size);
-        for (int i = 0; i < size; i++) {
-            String s = (String) v.get(i);
+        Vector<String> ignore = new Vector<>(size);
+        for (String s : v) {
             if (used == null) {
                 ignore.add(s);
             } else {
-                for (int j = 0; j < used.length; j++) {
-                    if (s.equals(used[j]))
+                for (String anUsed : used) {
+                    if (s.equals(anUsed))
                         continue;
                     ignore.add(s);
                 }
@@ -301,9 +289,9 @@ public class TableSymbolConfig extends TableSymbolConfigGUI implements IApplyCan
         // Select the correct color
         String colorName = symb.getColorName(symb.getFg());
         ar = TablePlotSymbol.COLOR_NAMES;
-        for (int i = 0; i < ar.length; i++) {
-            if (colorName.equals(ar[i])) {
-                colorComboBox.getModel().setSelectedItem(ar[i]);
+        for (String anAr : ar) {
+            if (colorName.equals(anAr)) {
+                colorComboBox.getModel().setSelectedItem(anAr);
                 break;
             }
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorFrame.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorFrame.java
@@ -1,13 +1,3 @@
-/*
- * ESO Archive
- *
- * $Id: NavigatorFrame.java 39360 2011-11-25 13:02:23Z swalker $
- *
- * who             when        what
- * --------------  ----------  ----------------------------------------
- * Allan Brighton  1999/06/02  Created
- */
-
 package jsky.navigator;
 
 import jsky.catalog.CatalogDirectory;
@@ -17,13 +7,9 @@ import jsky.catalog.gui.CatalogTree;
 import jsky.catalog.gui.TablePlotter;
 import jsky.image.gui.MainImageDisplay;
 import jsky.util.Preferences;
-import jsky.util.gui.DialogUtil;
 
 import javax.swing.*;
-import javax.swing.event.TreeSelectionEvent;
-import javax.swing.event.TreeSelectionListener;
 import java.awt.*;
-
 
 /**
  * Provides a top level window and menubar for the Navigator class.
@@ -57,11 +43,7 @@ public class NavigatorFrame extends JFrame {
 
         // Selecting a catalog from the menu turns autoQuery on, but selecting one from the tree should
         // turn it off again
-        catalogTree.getTree().addTreeSelectionListener(new TreeSelectionListener() {
-            public void valueChanged(TreeSelectionEvent e) {
-                navigator.setAutoQuery(false);
-            }
-        });
+        catalogTree.getTree().addTreeSelectionListener(e -> navigator.setAutoQuery(false));
 
 
         NavigatorToolBar toolbar = new NavigatorToolBar(navigator);

--- a/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorImageDisplayManager.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorImageDisplayManager.java
@@ -1,8 +1,3 @@
-// Copyright 2003 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: NavigatorImageDisplayManager.java 4726 2004-05-14 16:50:12Z brighton $
-//
 package jsky.navigator;
 
 import java.awt.Component;
@@ -12,12 +7,12 @@ import java.awt.Component;
  * An interface for classes that manage the creation of and a reference to
  * an image display window and its frame.
  */
-public abstract interface NavigatorImageDisplayManager {
+public interface NavigatorImageDisplayManager {
 
     /** Return the image display widget */
-    public NavigatorImageDisplay getImageDisplay();
+    NavigatorImageDisplay getImageDisplay();
 
     /** Return the image display frame, creating it if needed */
-    public Component getImageDisplayControlFrame();
+    Component getImageDisplayControlFrame();
 }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorQueryTool.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/navigator/NavigatorQueryTool.java
@@ -1,22 +1,11 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: NavigatorQueryTool.java 47126 2012-08-01 15:40:43Z swalker $
- */
-
 package jsky.navigator;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 
 import edu.gemini.catalog.api.MagnitudeLimits;
 import edu.gemini.catalog.api.RadiusLimits;
@@ -68,18 +57,16 @@ public class NavigatorQueryTool extends CatalogQueryTool implements SelectedArea
         setImageDisplay(imageDisplay);
 
         // update the RA,Dec display if a different equinox is chosen
-        getCatalogQueryPanel().addChangeListener(new ChangeListener() {
-            public void stateChanged(ChangeEvent e) {
-                JComboBox cb = (JComboBox) e.getSource();
-                String s = getCatalogQueryPanel().getLabelForComponent(cb);
-                if (s == null)
-                    return;
-                if (s.equalsIgnoreCase("equinox")) {
-                    if (_selectedArea != null)
-                        setSelectedArea(_selectedArea);
-                    else
-                        setFromImage(false, false);
-                }
+        getCatalogQueryPanel().addChangeListener(e -> {
+            JComboBox cb = (JComboBox) e.getSource();
+            String s = getCatalogQueryPanel().getLabelForComponent(cb);
+            if (s == null)
+                return;
+            if (s.equalsIgnoreCase("equinox")) {
+                if (_selectedArea != null)
+                    setSelectedArea(_selectedArea);
+                else
+                    setFromImage(false, false);
             }
         });
     }
@@ -130,21 +117,12 @@ public class NavigatorQueryTool extends CatalogQueryTool implements SelectedArea
 
         _selectAreaButton = new JButton("Select Area...");
         _selectAreaButton.setToolTipText("Drag out an area of the image to use for the query");
-        _selectAreaButton.addActionListener(new ActionListener() {
-
-            public void actionPerformed(ActionEvent e) {
-                selectArea();
-            }
-        });
+        _selectAreaButton.addActionListener(e -> selectArea());
         buttonPanel.add(_selectAreaButton);
 
         _setFromImageButton = new JButton("Set From Image");
         _setFromImageButton.setToolTipText("Set the query parameters from the currently displayed image");
-        _setFromImageButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                setFromImage(false, true);
-            }
-        });
+        _setFromImageButton.addActionListener(e -> setFromImage(false, true));
         buttonPanel.add(_setFromImageButton);
 
         return buttonPanel;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -2,7 +2,7 @@ package jsky.app.ot.tpe
 
 import edu.gemini.pot.sp._
 
-import edu.gemini.shared.util.immutable.{None => JNone, Option => JOption, Some => JSome}
+import edu.gemini.shared.util.immutable.{None => JNone, Option => JOption}
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.data.{ISPDataObject, IOffsetPosListProvider}
@@ -35,8 +35,6 @@ object TpeContext {
     c <- Option(f(o))
   } yield c
 
-  private[tpe] def toJOption[T](o: Option[T]): JOption[T] =
-    o.map(t => new JSome[T](t)).getOrElse(JNone.instance())
 }
 
 import TpeContext._
@@ -191,7 +189,7 @@ case class TpeContext(node: Option[ISPNode]) {
 
   def obsContext: Option[ObsContext] = siteQuality.dataObject.flatMap(sq => obsContextWithConditions(sq.conditions))
 
-  def obsContextJava: JOption[ObsContext] = toJOption(obsContext)
+  def obsContextJava: JOption[ObsContext] = obsContext.asGeminiOpt
 
   def obsContextWithConditions(c: Conditions): Option[ObsContext] = for {
     s <- obsShell
@@ -202,7 +200,7 @@ case class TpeContext(node: Option[ISPNode]) {
   } yield ObsContext.create(obs.getAgsStrategyOverride, t, i, site, c, offsets.scienceOffsetsJava, ao, obs.getSchedulingBlock)
 
   def obsContextJavaWithConditions(c: Conditions): JOption[ObsContext] =
-    toJOption(obsContextWithConditions(c))
+    obsContextWithConditions(c).asGeminiOpt
 
   def schedulingBlock: Option[SchedulingBlock] =
     obsShell.flatMap(_.getDataObject.asInstanceOf[SPObservation].getSchedulingBlock.asScalaOpt)

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/TablePanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/TablePanel.java
@@ -1,11 +1,4 @@
-// Copyright 2003
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: TablePanel.java 7983 2007-07-31 15:20:11Z swalker $
-
 package jsky.plot;
-
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -24,8 +17,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTable;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
@@ -41,7 +32,6 @@ import jsky.util.PrintableWithDialog;
 import jsky.util.SaveableWithDialog;
 import jsky.util.gui.DialogUtil;
 import jsky.util.gui.SortedJTable;
-
 
 /**
  * A panel for displaying elevation plot data in tabular form.
@@ -122,11 +112,7 @@ public class TablePanel extends JPanel implements PrintableWithDialog, SaveableW
     public void setModel(ElevationPlotModel model) {
         _model = model;
         _update();
-        _model.addChangeListener(new ChangeListener() {
-            public void stateChanged(ChangeEvent e) {
-                _update();
-            }
-        });
+        _model.addChangeListener(e -> _update());
     }
 
     /**
@@ -166,8 +152,7 @@ public class TablePanel extends JPanel implements PrintableWithDialog, SaveableW
 
     // Create and return a new file chooser
     private JFileChooser _makeFileChooser() {
-        JFileChooser _fileChooser = new JFileChooser();
-        return _fileChooser;
+        return new JFileChooser();
     }
 
     /**
@@ -210,9 +195,9 @@ public class TablePanel extends JPanel implements PrintableWithDialog, SaveableW
         };
         int numRows = model.getRowCount();
         int numCols = model.getColumnCount();
-        Vector dataVector = new Vector(numRows);
+        Vector<Vector<Object>> dataVector = new Vector<>(numRows);
         for (int i = 0; i < numRows; i++) {
-            Vector row = new Vector(numCols);
+            Vector<Object> row = new Vector<>(numCols);
             for (int j = 0; j < numCols; j++) {
                 row.add(model.getValueAt(i, j));
             }

--- a/bundle/jsky.util/src/main/java/jsky/util/Resources.java
+++ b/bundle/jsky.util/src/main/java/jsky/util/Resources.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: Resources.java 4414 2004-02-03 16:21:36Z brighton $
- */
-
 package jsky.util;
 
 import java.io.BufferedInputStream;
@@ -17,7 +10,6 @@ import java.util.Properties;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
-
 
 /**
  * Resources provides a central class with methods for accessing
@@ -41,7 +33,7 @@ public final class Resources {
     public static final String CONFIG_PATH = RESOURCE_PATH + "/" + CONFIG_SUBPATH + "/";
 
     // ImageCache provides a cache of already present icons.
-    private static Map<String, Icon> _rmap = new HashMap<String, Icon>();
+    private static Map<String, Icon> _rmap = new HashMap<>();
 
     // Disallow instances
     private Resources() {
@@ -56,9 +48,8 @@ public final class Resources {
         return getResource(resource, Resources.class);
     }
 
-    public static URL getResource(String resource, Class c) {
+    public static URL getResource(String resource, Class<?> c) {
         String path = RESOURCE_PATH + '/' + resource;
-        //System.out.println("getResource: " + path);
         return c.getResource(path);
     }
 
@@ -69,7 +60,6 @@ public final class Resources {
      */
     public static InputStream getResourceAsStream(String resource) {
         String path = RESOURCE_PATH + '/' + resource;
-        //System.out.println("getResource: " + path);
         return Resources.class.getResourceAsStream(path);
     }
 
@@ -91,7 +81,7 @@ public final class Resources {
         return getIcon(iconFileName, Resources.class);
     }
 
-    public static Icon getIcon(String iconFileName, Class clazz) {
+    public static Icon getIcon(String iconFileName, Class<?> clazz) {
         // First check the map under the iconFileName
         Icon icon = _rmap.get(iconFileName);
         if (icon != null) {


### PR DESCRIPTION
This PR is the first step to integrate the TPE with the Catalog Navigator. It supports the following actions:

* When opening the navigator the TPE is opened too
* If a query is done on the navigator, the TPE is updated to be centered on the searched coordinates

I'm not totally happy with this code but given time constraints I'm pressing ahead. The main difficulty is that TPE is designed around the current tree of nodes (`ISPNode` and children) via the `TpeContext` class. However, that tree does not exist on the context of the Catalog Navigator so we need to produce an alternative of `TpeContext` that extracts target information from an `ObsContext`. As `ObsContext` is quite unrelated to the nodes trees, adapters are built to let the TPE work against it in a read-only mode.

In this PR most of the code deals with updated legacy code, but the relevant changes are concentrated in [`TpeContext`](ocs/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala)
