### PR TITLE
OCSADV-426: Added checks for executed observations.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -12,7 +12,6 @@ import edu.gemini.spModel.obs.ObservationStatus
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.env.TargetEnvironment
-import edu.gemini.spModel.target.obsComp.TargetObsComp
 import edu.gemini.shared.util.immutable.{Option => GOption}
 import jsky.app.ot.OT
 import jsky.app.ot.tpe._
@@ -60,12 +59,12 @@ object BagsManager {
           // This is reported only as a GenericError in a CatalogException, unfortunately.
           case Failure(CatalogException((e: GenericError) :: _)) =>
             LOG.warning(s"BAGS lookup for observation=${observation.getObservationID} failed: ${e.msg}")
-            taskComplete (this, success = false)
+            taskComplete(this, success = false)
 
           // For all other exceptions, print the full stack trace.
           case Failure(ex) =>
             LOG.log(Level.WARNING, s"BAGS lookup for observation=${observation.getObservationID} failed.", ex)
-            taskComplete (this, success = false)
+            taskComplete(this, success = false)
         }
       }
 


### PR DESCRIPTION
Previously, BAGS was selecting guide stars for observations marked as "executed".
We now leave these observations alone.

@swalker2m, as per your suggestion due to the computation-heavy nature of calls to `ObservationStatus.computeFor`, I tried to push this call as far as possible into the BAGS process, but I am not sure if this is the best place to put it (i.e. after AGS is called but before results are applied), and the calls to AGS are redundant in this case.

I would greatly appreciate any feedback or suggestions as to if you think there is a preferable place to put this, as the calls to AGS are unnecessary with the results thrown away as things currently stand.