### PR TITLE
Typeclass-based PIO and impl for new target model

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamCodecs.scala
@@ -12,19 +12,16 @@ import scalaz._, Scalaz._
 object TargetParamCodecs {
 
   implicit val RedshiftParamCodec: ParamCodec[Redshift] =
-    ParamCodec[Double].xmap(Redshift(_), _.redshift)
+    ParamCodec[Double].xmap(Redshift(_), _.z)
 
   implicit val AngleParamCodec: ParamCodec[Angle] =
     ParamCodec[Double].xmap(Angle.fromDegrees, _.toDegrees)
 
   implicit val ParallaxParamCodec: ParamCodec[Parallax] =
-    ParamCodec[Angle].xmap(Parallax(_), _.angle)
+    ParamCodec[Double].xmap(Parallax(_), _.mas)
 
   implicit val VelocityParamCodec: ParamCodec[Velocity] =
     ParamCodec[Double].xmap(KilometersPerSecond(_), _.toKilometersPerSecond)
-
-  implicit val RadialVelocityParamCodec: ParamCodec[RadialVelocity] =
-    ParamCodec[Velocity].xmap(RadialVelocity(_), _.velocity)
 
   implicit val RaParamCodec: ParamCodec[RA] =
     ParamCodec[Angle].xmap(RA.fromAngle, _.toAngle)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamCodecs.scala
@@ -1,0 +1,60 @@
+package edu.gemini.spModel.target
+
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.Target._
+import edu.gemini.spModel.pio.Param
+import edu.gemini.spModel.pio.codec._
+
+import squants.motion.{ Velocity, KilometersPerSecond }
+
+import scalaz._, Scalaz._
+
+object TargetParamCodecs {
+
+  implicit val RedshiftParamCodec: ParamCodec[Redshift] =
+    ParamCodec[Double].xmap(Redshift(_), _.redshift)
+
+  implicit val AngleParamCodec: ParamCodec[Angle] =
+    ParamCodec[Double].xmap(Angle.fromDegrees, _.toDegrees)
+
+  implicit val ParallaxParamCodec: ParamCodec[Parallax] =
+    ParamCodec[Angle].xmap(Parallax(_), _.angle)
+
+  implicit val VelocityParamCodec: ParamCodec[Velocity] =
+    ParamCodec[Double].xmap(KilometersPerSecond(_), _.toKilometersPerSecond)
+
+  implicit val RadialVelocityParamCodec: ParamCodec[RadialVelocity] =
+    ParamCodec[Velocity].xmap(RadialVelocity(_), _.velocity)
+
+  implicit val RaParamCodec: ParamCodec[RA] =
+    ParamCodec[Angle].xmap(RA.fromAngle, _.toAngle)
+
+  implicit val MagnitudeBParamCodec: ParamCodec[MagnitudeBand] =
+    ParamCodec[String].xmap(MagnitudeBand.unsafeFromString, _.name)
+
+  implicit val MagnitudeSysParamCodec: ParamCodec[MagnitudeSystem] =
+    ParamCodec[String].xmap(MagnitudeSystem.unsafeFromString, _.name)
+
+  implicit val AngularVelocParamCodec: ParamCodec[AngularVelocity] =
+    ParamCodec[Double].xmap(AngularVelocity(_), _.masPerYear)
+
+  implicit val RightAscensionAngularVelocParamCodec: ParamCodec[RightAscensionAngularVelocity] =
+    ParamCodec[AngularVelocity].xmap(RightAscensionAngularVelocity(_), _.velocity)
+
+  implicit val DeclinationAngularVelocParamCodec: ParamCodec[DeclinationAngularVelocity] =
+    ParamCodec[AngularVelocity].xmap(DeclinationAngularVelocity(_), _.velocity)
+
+  implicit val EpochParamCodec: ParamCodec[Epoch] = 
+    ParamCodec[Double].xmap(Epoch(_), _.year)
+
+  implicit val DecParamCodec: ParamCodec[Dec] =
+    new ParamCodec[Dec] {
+      def encode(key: String, a: Dec): Param = AngleParamCodec.encode(key, a.toAngle)
+      def decode(p: Param): PioError \/ Dec =
+        AngleParamCodec.decode(p).flatMap { a =>
+          Dec.fromAngle(a) \/> ParseError(p.getName, a.toString, "Dec")
+        }
+    }
+
+}
+

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
@@ -1,0 +1,124 @@
+package edu.gemini.spModel.target
+
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.Target._
+import edu.gemini.spModel.pio.{ Pio, ParamSet }
+import edu.gemini.spModel.pio.codec._
+import edu.gemini.spModel.pio.xml.PioXmlFactory
+import edu.gemini.spModel.target.TargetParamCodecs._
+
+import scalaz._, Scalaz._
+
+object TargetParamSetCodecs {
+
+  implicit val CoordinatesParamSetCodec: ParamSetCodec[Coordinates] =
+    ParamSetCodec.initial(Coordinates.zero)
+      .withParam("ra",  Coordinates.ra)
+      .withParam("dec", Coordinates.dec)
+
+  implicit val ProperMotionParamSetCodec: ParamSetCodec[ProperMotion] =
+    ParamSetCodec.initial(ProperMotion.zero)
+      .withParam("delta-ra",  ProperMotion.deltaRA)
+      .withParam("delta-dec", ProperMotion.deltaDec)
+      .withParam("epoch",     ProperMotion.epoch)
+
+  implicit val MagnitudeParamSetCodec: ParamSetCodec[Magnitude] =
+    ParamSetCodec.initial(Magnitude(Double.NaN, MagnitudeBand.R, None, MagnitudeSystem.VEGA))
+      .withParam("value",         Magnitude.value)
+      .withParam("band",          Magnitude.band)
+      .withParam("system",        Magnitude.system)
+      .withOptionalParam("error", Magnitude.error)
+
+  implicit val EphemerisElementParamSetCodec: ParamSetCodec[(Long, Coordinates)] =
+    ParamSetCodec.initial((0L, Coordinates.zero))
+      .withParam("time",           Lens.firstLens[Long, Coordinates])
+      .withParamSet("coordinates", Lens.secondLens[Long, Coordinates])
+
+  implicit val SiderealTargetParamSetCodec: ParamSetCodec[SiderealTarget] = 
+    ParamSetCodec.initial(SiderealTarget.empty)
+      .withParam("name",                     SiderealTarget.name)
+      .withOptionalParam("radial-velocity",  SiderealTarget.radialVelocity)
+      .withOptionalParam("redshift",         SiderealTarget.redshift)
+      .withOptionalParam("parallax",         SiderealTarget.parallax)
+      .withManyParamSet("magnitude",         SiderealTarget.magnitudes)
+      .withParamSet("coordinates",           SiderealTarget.coordinates)
+      .withOptionalParamSet("proper-motion", SiderealTarget.properMotion)
+
+  implicit val TooTargetParamSetCodec: ParamSetCodec[TooTarget] =
+    ParamSetCodec.initial(TooTarget.empty)
+      .withParam("name", TooTarget.name)
+
+  implicit val CometParamSetCodec: ParamSetCodec[HorizonsDesignation.Comet] =
+    ParamSetCodec.initial(HorizonsDesignation.Comet(""))
+      .withParam("des", HorizonsDesignation.Comet.des)
+      
+  implicit val AsteroidParamSetCodec: ParamSetCodec[HorizonsDesignation.Asteroid] =
+    ParamSetCodec.initial(HorizonsDesignation.Asteroid(""))
+      .withParam("des", HorizonsDesignation.Asteroid.des)
+      
+  implicit val AsteroidOldStyleParamSetCodec: ParamSetCodec[HorizonsDesignation.AsteroidOldStyle] =
+    ParamSetCodec.initial(HorizonsDesignation.AsteroidOldStyle(0))
+      .withParam("num", HorizonsDesignation.AsteroidOldStyle.num)
+      
+  implicit val MajorBodyParamSetCodec: ParamSetCodec[HorizonsDesignation.MajorBody] =
+    ParamSetCodec.initial(HorizonsDesignation.MajorBody(0))
+      .withParam("num", HorizonsDesignation.MajorBody.num)
+      
+  implicit val HorizonsDesignationParamSetCodec: ParamSetCodec[HorizonsDesignation] =
+    new ParamSetCodec[HorizonsDesignation] {
+      val pf = new PioXmlFactory
+      def encode(key: String, a: HorizonsDesignation): ParamSet = {
+        val (tag, ps) = a match {
+          case d: HorizonsDesignation.Comet            => ("comet", CometParamSetCodec.encode(key, d))
+          case d: HorizonsDesignation.Asteroid         => ("asteroid", AsteroidParamSetCodec.encode(key, d))
+          case d: HorizonsDesignation.AsteroidOldStyle => ("asteroid-old-style", AsteroidOldStyleParamSetCodec.encode(key, d))
+          case d: HorizonsDesignation.MajorBody        => ("major-body", MajorBodyParamSetCodec.encode(key, d))
+        }
+        Pio.addParam(pf, ps, "tag", tag)
+        ps
+      }    
+      def decode(ps: ParamSet): PioError \/ HorizonsDesignation = {
+        (Option(ps.getParam("tag")).map(_.getValue) \/> MissingKey("tag")) flatMap {
+          case "comet"              => CometParamSetCodec.decode(ps)
+          case "asteroid"           => AsteroidParamSetCodec.decode(ps)
+          case "asteroid-old-style" => AsteroidOldStyleParamSetCodec.decode(ps)
+          case "major-body"         => MajorBodyParamSetCodec.decode(ps)
+          case hmm                  => UnknownTag(hmm, "HorizonsDesignation").left
+        }
+      }
+    }
+
+  implicit val NonSiderealTargetParamSetCodec: ParamSetCodec[NonSiderealTarget] =
+    ParamSetCodec.initial(NonSiderealTarget.empty)
+      .withParam("name",                     NonSiderealTarget.name)
+      .withOptionalParamSet("horizons-designation",  NonSiderealTarget.horizonsDesignation)
+      .withManyParamSet("ephemeris-element", NonSiderealTarget.ephemerisElements)
+      .withManyParamSet("magnitude",         NonSiderealTarget.magnitudes)
+
+  implicit val TargetParamSetCodec: ParamSetCodec[Target] =
+    new ParamSetCodec[Target] {
+      val pf = new PioXmlFactory
+      def encode(key: String, a: Target): ParamSet = {
+        val (tag, ps) = a match {
+          case t: SiderealTarget    => ("sidereal",    SiderealTargetParamSetCodec.encode(key, t))
+          case t: TooTarget         => ("too",         TooTargetParamSetCodec.encode(key, t))
+          case t: NonSiderealTarget => ("nonsidereal", NonSiderealTargetParamSetCodec.encode(key, t))
+        }
+        Pio.addParam(pf, ps, "tag", tag)
+        ps
+      }    
+      def decode(ps: ParamSet): PioError \/ Target = {
+        (Option(ps.getParam("tag")).map(_.getValue) \/> MissingKey("tag")) flatMap {
+          case "sidereal"    => SiderealTargetParamSetCodec.decode(ps)
+          case "too"         => TooTargetParamSetCodec.decode(ps)
+          case "nonsidereal" => NonSiderealTargetParamSetCodec.decode(ps)
+          case hmm           => UnknownTag(hmm, "Target").left
+        }
+      }
+    }
+
+}
+
+
+
+

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
@@ -23,7 +23,7 @@ object TargetParamSetCodecs {
       .withParam("epoch",     ProperMotion.epoch)
 
   implicit val MagnitudeParamSetCodec: ParamSetCodec[Magnitude] =
-    ParamSetCodec.initial(Magnitude(Double.NaN, MagnitudeBand.R, None, MagnitudeSystem.VEGA))
+    ParamSetCodec.initial(Magnitude(Double.NaN, MagnitudeBand.R, None, MagnitudeSystem.Vega))
       .withParam("value",         Magnitude.value)
       .withParam("band",          Magnitude.band)
       .withParam("system",        Magnitude.system)
@@ -37,7 +37,6 @@ object TargetParamSetCodecs {
   implicit val SiderealTargetParamSetCodec: ParamSetCodec[SiderealTarget] = 
     ParamSetCodec.initial(SiderealTarget.empty)
       .withParam("name",                     SiderealTarget.name)
-      .withOptionalParam("radial-velocity",  SiderealTarget.radialVelocity)
       .withOptionalParam("redshift",         SiderealTarget.redshift)
       .withOptionalParam("parallax",         SiderealTarget.parallax)
       .withManyParamSet("magnitude",         SiderealTarget.magnitudes)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamCodecSpec.scala
@@ -1,0 +1,53 @@
+package edu.gemini.spModel.target
+
+import edu.gemini.spModel.core.Arbitraries
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.Target._
+import edu.gemini.spModel.pio.codec._
+
+import scalaz._
+import Scalaz._
+
+import org.scalacheck.{ Properties, Gen, Arbitrary }
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop._
+import org.scalacheck.Gen
+
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import AlmostEqual.AlmostEqualOps
+
+object TargetParamCodecsSpec extends Specification with ScalaCheck with Arbitraries {
+  import TargetParamCodecs._
+
+  def close[A: ParamCodec: Arbitrary: AlmostEqual](implicit mf: Manifest[A]) = 
+    mf.runtimeClass.getName ! forAll { (key: String, value: A) =>
+      val c = ParamCodec[A]
+      c.decode(c.encode(key, value)).map(_ ~= value) must_== \/-(true)
+    }
+
+  def exact[A: ParamCodec: Arbitrary](implicit mf: Manifest[A]) = 
+    mf.runtimeClass.getName ! forAll { (key: String, value: A) =>
+      val c = ParamCodec[A]
+      c.decode(c.encode(key, value)) must_== \/-(value)
+    }
+
+  "Target Param Codecs" >> {
+    close[Redshift]
+    close[Angle]
+    close[Parallax]
+    close[RadialVelocity]
+    close[RA]
+    exact[MagnitudeBand]
+    exact[MagnitudeSystem]
+    close[Epoch] 
+    close[Dec]
+    close[RightAscensionAngularVelocity]
+    close[DeclinationAngularVelocity]
+  }
+
+}
+
+
+

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamCodecSpec.scala
@@ -37,7 +37,6 @@ object TargetParamCodecsSpec extends Specification with ScalaCheck with Arbitrar
     close[Redshift]
     close[Angle]
     close[Parallax]
-    close[RadialVelocity]
     close[RA]
     exact[MagnitudeBand]
     exact[MagnitudeSystem]

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamSetCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamSetCodecSpec.scala
@@ -1,0 +1,50 @@
+package edu.gemini.spModel.target
+
+import edu.gemini.spModel.core.Arbitraries
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.Target._
+import edu.gemini.spModel.pio.codec._
+
+import scalaz._
+import Scalaz._
+
+import org.scalacheck.{ Properties, Gen, Arbitrary }
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop._
+import org.scalacheck.Gen
+
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import AlmostEqual.AlmostEqualOps
+
+object TargetParamSetCodecsSpec extends Specification with ScalaCheck with Arbitraries {
+  import TargetParamSetCodecs._
+
+  def close[A: ParamSetCodec: Arbitrary: AlmostEqual](implicit mf: Manifest[A]) = 
+    mf.runtimeClass.getName ! forAll { (key: String, value: A) =>
+      val c = ParamSetCodec[A]
+      c.decode(c.encode(key, value)).map(_ ~= value) must_== \/-(true)
+    }
+
+  def exact[A: ParamSetCodec: Arbitrary](implicit mf: Manifest[A]) = 
+    mf.runtimeClass.getName ! forAll { (key: String, value: A) =>
+      val c = ParamSetCodec[A]
+      c.decode(c.encode(key, value)) must_== \/-(value)
+    }
+
+  "Target ParamSet Codecs" >> {
+    close[Coordinates]
+    close[ProperMotion]
+    close[Magnitude]
+    close[(Long, Coordinates)]
+    close[SiderealTarget]
+    exact[TooTarget]
+    close[NonSiderealTarget]
+    close[Target]
+  }
+
+}
+
+
+

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Epoch.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Epoch.scala
@@ -1,10 +1,17 @@
 package edu.gemini.spModel.core
 
-/** Epoch in Julian years. */
-final case class Epoch(value: Double)
+import scalaz._, Scalaz._
+
+/** Epoch in Gregorian (?) years. */
+final case class Epoch(year: Double)
+
 
 object Epoch {
+
+  val year: Epoch @> Double = Lens.lensu((a, b) => a.copy(year = b), _.year)
+
   val J2000 = Epoch(2000.0)
+
 }
 
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/HorizonsDesignation.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/HorizonsDesignation.scala
@@ -17,23 +17,35 @@ object HorizonsDesignation {
    * the query string `DES=C/1973 E1;CAP`.
    */
   final case class Comet(des: String) extends HorizonsDesignation(s"DES=$des;CAP")
+  object Comet {
+    val des: Comet @> String = Lens.lensu((a, b) => a.copy(des = b), _.des)
+  }
 
   /**
    * Designation for an asteroid under modern naming conventions. Example: `1971 UC1` for
    * 1896 Beer, yielding a query string `DES=1971 UC1`.
    */
   final case class Asteroid(des: String) extends HorizonsDesignation(s"DES=$des")
+  object Asteroid {
+    val des: Asteroid @> String = Lens.lensu((a, b) => a.copy(des = b), _.des)
+  }
 
   /**
    * Designation for an asteroid under "old" naming conventions. These are small numbers. Example:
    * `4` for Vesta, yielding a query string `4;`
    */
   final case class AsteroidOldStyle(num: Int) extends HorizonsDesignation(s"$num;")
+  object AsteroidOldStyle {
+    val num: AsteroidOldStyle @> Int = Lens.lensu((a, b) => a.copy(num = b), _.num)
+  }
 
   /**
    * Designation for a major body (planet or satellite thereof). These have small numbers. Example:
    * `606` for Titan, yielding a query string `606`.
    */
   final case class MajorBody(num: Int) extends HorizonsDesignation(s"$num")
+  object MajorBody {
+    val num: MajorBody @> Int = Lens.lensu((a, b) => a.copy(num = b), _.num)
+  }
 
 }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Magnitude.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Magnitude.scala
@@ -27,6 +27,12 @@ case class Magnitude(value: Double, band: MagnitudeBand, error: Option[Double], 
 
 object Magnitude {
 
+  // Lenses
+  val value: Magnitude  @> Double          = Lens.lensu((a, b) => a.copy(value = b), _.value)
+  val band:  Magnitude  @> MagnitudeBand   = Lens.lensu((a, b) => a.copy(band = b), _.band)
+  val error: Magnitude  @> Option[Double]  = Lens.lensu((a, b) => a.copy(error = b), _.error)
+  val system: Magnitude @> MagnitudeSystem = Lens.lensu((a, b) => a.copy(system = b), _.system)
+
   // by system name, band name, value and error (in that order)
   implicit val MagnitudeOrdering: scala.math.Ordering[Magnitude] =
     scala.math.Ordering.by(m => (m.system.name, m.band.name, m.value, m.error))

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
@@ -51,6 +51,12 @@ object MagnitudeBand {
   lazy val all: List[MagnitudeBand] =
     List(_u, _g, _r, _i, _z, U, B, V, UC, R, I, Y, J, H, K, L, M, N, Q, AP)
 
+  def fromString(s: String): Option[MagnitudeBand] =
+    all.find(_.name == s)
+
+  def unsafeFromString(s: String): MagnitudeBand =
+    fromString(s).getOrElse(sys.error("Unknown magnitude band: " + s))
+
   // order by central wavelength; make sure that AP always shows up last because it's sort of a special case
   implicit val MagnitudeBandOrder: scalaz.Order[MagnitudeBand] =
     scalaz.Order.orderBy {

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeSystem.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeSystem.scala
@@ -39,6 +39,12 @@ object MagnitudeSystem {
   val allForOT: List[MagnitudeSystem] =
     List(Vega, AB, Jy)
 
+  def fromString(s: String): Option[MagnitudeSystem] =
+    all.find(_.name == s)
+
+  def unsafeFromString(s: String): MagnitudeSystem =
+    fromString(s).getOrElse(sys.error("Unknown magnitude system: " + s))
+
   implicit val MagnitudeSystemEqual: Equal[MagnitudeSystem] =
     Equal.equalA
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProperMotion.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProperMotion.scala
@@ -18,4 +18,6 @@ object ProperMotion {
 
   val deltaRA : ProperMotion @> RightAscensionAngularVelocity = Lens(t => Store(s => t.copy(deltaRA = s), t.deltaRA))
   val deltaDec: ProperMotion @> DeclinationAngularVelocity    = Lens(t => Store(s => t.copy(deltaDec = s), t.deltaDec))
+  val epoch:    ProperMotion @> Epoch                         = Lens(t => Store(s => t.copy(epoch = s), t.epoch))
+
 }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
@@ -117,7 +117,6 @@ object Target {
     val name:           SiderealTarget @> String          = Lens(t => Store(s => t.copy(name = s), t.name))
     val coordinates:    SiderealTarget @> Coordinates     = Lens(t => Store(c => t.copy(coordinates = c), t.coordinates))
     val properMotion:   SiderealTarget @> Option[ProperMotion]   = Lens(t => Store(c => t.copy(properMotion = c), t.properMotion))
-    val radialVelocity: SiderealTarget @> Option[RadialVelocity] = Lens(t => Store(s => t.copy(radialVelocity = s), t.radialVelocity))
     val redshift:       SiderealTarget @> Option[Redshift] = Lens(t => Store(s => t.copy(redshift = s), t.redshift))
     val parallax:       SiderealTarget @> Option[Parallax] = Lens(t => Store(s => t.copy(parallax = s), t.parallax))
     val magnitudes:     SiderealTarget @> List[Magnitude] = Lens(t => Store(c => t.copy(magnitudes = c), t.magnitudes))

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -2,21 +2,34 @@ package edu.gemini.spModel.core
 
 import scalaz._, Scalaz._
 
-trait AlmostEqual[A] {
+trait AlmostEqual[A] { outer =>
   def almostEqual(a: A, b: A): Boolean
+  def contramap[B](f: B => A): AlmostEqual[B] =
+    new AlmostEqual[B] {
+      def almostEqual(a: B, b: B) =
+        outer.almostEqual(f(a), f(b))
+    }
 }
 
 object AlmostEqual {
+
+  def by[A, B](f: B => A)(implicit ev: AlmostEqual[A]): AlmostEqual[B] =
+    ev.contramap(f)
 
   implicit class AlmostEqualOps[A](a: A)(implicit A: AlmostEqual[A]) {
     def ~=(b: A): Boolean = A.almostEqual(a, b)
   }
 
-  // almost equal if both None, or both Some and values are almost equal
   implicit def AlmostEqualOption[A: AlmostEqual]: AlmostEqual[Option[A]] =
     new AlmostEqual[Option[A]] {
       def almostEqual(a: Option[A], b: Option[A]) =
         (a |@| b)(_ ~= _).getOrElse(true)
+    }
+
+  implicit def AlmostEqualList[A: AlmostEqual]: AlmostEqual[List[A]] =
+    new AlmostEqual[List[A]] {
+      def almostEqual(a: List[A], b: List[A]) =
+        a.corresponds(b)(_ ~= _)
     }
 
   implicit val DoubleAlmostEqual =
@@ -25,22 +38,21 @@ object AlmostEqual {
         (a - b).abs < 0.00001
     }
 
-  implicit val AngleAlmostEqual =
-    new AlmostEqual[Angle] {
-      def almostEqual(a: Angle, b: Angle) =
-        a.toDegrees ~= b.toDegrees
-    }
+  implicit val AngleAlmostEqual = by((_: Angle).toDegrees)
+  implicit val RightAscensionAngularVelocityAlmostEqual = by((_: RightAscensionAngularVelocity).velocity.masPerYear)
+  implicit val DeclinationAngularVelocityAlmostEqual = by((_: DeclinationAngularVelocity).velocity.masPerYear)
+  implicit val RightAscensionAlmostEqual = by((_: RightAscension).toAngle)
+  implicit val DeclinationAlmostEqual = by((_: Declination).toAngle)
+  implicit val WavelengthAlmostEqual = by((_: Wavelength).toNanometers)
+  implicit val RedshiftAlmostEqual = by((_: Redshift).redshift)
+  implicit val ParallaxAlmostEqual = by((_: Parallax).angle)
+  implicit val RadialVelocityAlmostEqual = by((_: RadialVelocity).velocity.toKilometersPerSecond)
+  implicit val EpochAlmostEqual = by((_: Epoch).year)
 
-  implicit val RightAscensionAngularVelocityAlmostEqual =
-    new AlmostEqual[RightAscensionAngularVelocity] {
-      def almostEqual(a: RightAscensionAngularVelocity, b: RightAscensionAngularVelocity) =
-        a.velocity.masPerYear ~= b.velocity.masPerYear
-    }
-
-  implicit val DeclinationAngularVelocityAlmostEqual =
-    new AlmostEqual[DeclinationAngularVelocity] {
-      def almostEqual(a: DeclinationAngularVelocity, b: DeclinationAngularVelocity) =
-        a.velocity.masPerYear ~= b.velocity.masPerYear
+  implicit val CoordinatesAlmostEqual =
+    new AlmostEqual[Coordinates] {
+      def almostEqual(a: Coordinates, b: Coordinates) =
+        (a.ra ~= b.ra) && (a.dec ~= b.dec)
     }
 
   implicit val ProperMotionAlmostEqual =
@@ -49,33 +61,51 @@ object AlmostEqual {
         (a.deltaRA ~=  b.deltaRA) && (a.deltaDec ~= b.deltaDec)
     }
 
-  implicit val RightAscensionAlmostEqual =
-    new AlmostEqual[RightAscension] {
-      def almostEqual(a: RightAscension, b: RightAscension) =
-        a.toAngle ~= b.toAngle
+  implicit val MagnitudeAlmostEqual = 
+    new AlmostEqual[Magnitude] {
+      def almostEqual(a: Magnitude, b: Magnitude) =
+        (a.band   == b.band)   && 
+        (a.system == b.system) &&
+        (a.value  ~= b.value)  &&
+        (a.error  ~= b.error)
     }
 
-  implicit val DeclinationAlmostEqual =
-    new AlmostEqual[Declination] {
-      def almostEqual(a: Declination, b: Declination) =
-        a.toAngle ~= b.toAngle
+  implicit val EphemerisElementAlmostEqual =
+    new AlmostEqual[(Long, Coordinates)] {
+      def almostEqual(a: (Long, Coordinates), b: (Long, Coordinates)) =
+        (a._1 == b._1) && (a._2 ~= b._2)
     }
 
-  implicit val CoordinatesAlmostEqual =
-    new AlmostEqual[Coordinates] {
-      def almostEqual(a: Coordinates, b: Coordinates) =
-        (a.ra ~= b.ra) && (a.dec ~= b.dec)
+  implicit val SiderealTargetAlmostEqual =
+    new AlmostEqual[Target.SiderealTarget] {
+      def almostEqual(a: Target.SiderealTarget, b: Target.SiderealTarget) =
+        (a.name           == b.name)           &&
+        (a.coordinates    ~= b.coordinates)    &&
+        (a.properMotion   ~= b.properMotion)   &&
+        (a.radialVelocity ~= b.radialVelocity) &&
+        (a.redshift       ~= b.redshift)       &&
+        (a.parallax       ~= b.parallax)       &&
+        (a.magnitudes     ~= b.magnitudes)
     }
 
-  implicit val WavelengthAlmostEqual =
-    new AlmostEqual[Wavelength] {
-      def almostEqual(a: Wavelength, b: Wavelength) =
-        a.toNanometers ~= b.toNanometers
+  implicit val NonSiderealTargetAlmostEqual =
+    new AlmostEqual[Target.NonSiderealTarget] {
+      def almostEqual(a: Target.NonSiderealTarget, b: Target.NonSiderealTarget) =
+        (a.name == b.name) &&
+        (a.ephemeris.toList ~= b.ephemeris.toList) &&
+        (a.horizonsDesignation == b.horizonsDesignation) &&
+        (a.magnitudes ~= b.magnitudes)
     }
 
-  implicit val RedshiftAlmostEqual =
-    new AlmostEqual[Redshift] {
-      def almostEqual(a: Redshift, b: Redshift) =
-        a.z ~= b.z
+  implicit val TargetAlmostEqual =
+    new AlmostEqual[Target] {
+      def almostEqual(a: Target, b: Target) =
+        (a, b) match {
+          case (a: Target.TooTarget, b: Target.TooTarget) => a == b
+          case (a: Target.SiderealTarget, b: Target.SiderealTarget) => a ~= b
+          case (a: Target.NonSiderealTarget, b: Target.NonSiderealTarget) => a ~= b
+          case _ => false
+        }
     }
+
 }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -44,9 +44,8 @@ object AlmostEqual {
   implicit val RightAscensionAlmostEqual = by((_: RightAscension).toAngle)
   implicit val DeclinationAlmostEqual = by((_: Declination).toAngle)
   implicit val WavelengthAlmostEqual = by((_: Wavelength).toNanometers)
-  implicit val RedshiftAlmostEqual = by((_: Redshift).redshift)
-  implicit val ParallaxAlmostEqual = by((_: Parallax).angle)
-  implicit val RadialVelocityAlmostEqual = by((_: RadialVelocity).velocity.toKilometersPerSecond)
+  implicit val RedshiftAlmostEqual = by((_: Redshift).z)
+  implicit val ParallaxAlmostEqual = by((_: Parallax).mas)
   implicit val EpochAlmostEqual = by((_: Epoch).year)
 
   implicit val CoordinatesAlmostEqual =
@@ -82,7 +81,6 @@ object AlmostEqual {
         (a.name           == b.name)           &&
         (a.coordinates    ~= b.coordinates)    &&
         (a.properMotion   ~= b.properMotion)   &&
-        (a.radialVelocity ~= b.radialVelocity) &&
         (a.redshift       ~= b.redshift)       &&
         (a.parallax       ~= b.parallax)       &&
         (a.magnitudes     ~= b.magnitudes)

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/CodecSyntax.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/CodecSyntax.scala
@@ -1,0 +1,19 @@
+package edu.gemini.spModel.pio.codec
+
+import scalaz._, Scalaz._
+
+import scala.collection.JavaConverters._
+import edu.gemini.spModel.pio._
+import edu.gemini.spModel.pio.xml.PioXmlFactory
+
+object CodecSyntax {
+
+  class ParamSetCodecOps[A](a: A)(implicit ev: ParamSetCodec[A]) {
+    def encode(key: String): ParamSet = ev.encode(key, a)
+  }
+
+  class ParamSetOps(ps: ParamSet) {
+    def decode[A](implicit ev: ParamSetCodec[A]): PioError \/ A = ev.decode(ps)
+  }
+
+}

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamCodec.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamCodec.scala
@@ -1,0 +1,59 @@
+package edu.gemini.spModel.pio.codec
+
+import scalaz._, Scalaz._
+
+import edu.gemini.spModel.pio._
+import edu.gemini.spModel.pio.xml.{ PioXmlUtil, PioXmlFactory }
+
+trait ParamCodec[A] { outer =>
+  def encode(key: String, a: A): Param
+  def decode(p: Param): PioError \/ A
+  def xmap[B](f: A => B, g: B => A): ParamCodec[B] =
+    new ParamCodec[B] {
+      def encode(key: String, a: B): Param = outer.encode(key, g(a))
+      def decode(p: Param): PioError \/ B = outer.decode(p).map(f)
+    }
+}
+
+object ParamCodec {
+  
+  private val pf = new PioXmlFactory
+
+  def apply[A](implicit ev: ParamCodec[A]) = ev
+
+  implicit val StringParamCodec: ParamCodec[String] =
+    new ParamCodec[String] {
+      def encode(key: String, a: String): Param = pf.createParam(key) <| (_.setValue(a))
+      def decode(p: Param): PioError \/ String = Option(p.getValue) \/> NullValue(p.getName)
+    }
+
+  implicit val DoubleParamCodec: ParamCodec[Double] =
+    new ParamCodec[Double] {
+      def encode(key: String, a: Double): Param = StringParamCodec.encode(key, a.toString)
+      def decode(p: Param): PioError \/ Double = StringParamCodec.decode(p) match {
+        case \/-(s) => s.parseDouble.disjunction.leftMap(_ => ParseError(p.getName, s, "Double"))
+        case -\/(e) => -\/(e)
+      }          
+    }
+
+  implicit val IntParamCodec: ParamCodec[Int] =
+    new ParamCodec[Int] {
+      def encode(key: String, a: Int): Param = StringParamCodec.encode(key, a.toString)
+      def decode(p: Param): PioError \/ Int = StringParamCodec.decode(p) match {
+        case \/-(s) => s.parseInt.disjunction.leftMap(_ => ParseError(p.getName, s, "Int"))
+        case -\/(e) => -\/(e)
+      }          
+    }
+
+  implicit val LongParamCodec: ParamCodec[Long] =
+    new ParamCodec[Long] {
+      def encode(key: String, a: Long): Param = StringParamCodec.encode(key, a.toString)
+      def decode(p: Param): PioError \/ Long = StringParamCodec.decode(p) match {
+        case \/-(s) => s.parseLong.disjunction.leftMap(_ => ParseError(p.getName, s, "Long"))
+        case -\/(e) => -\/(e)
+      }          
+    }
+
+}
+
+

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamSetCodec.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamSetCodec.scala
@@ -1,0 +1,113 @@
+package edu.gemini.spModel.pio.codec
+
+import scalaz._, Scalaz._
+
+import scala.collection.JavaConverters._
+import edu.gemini.spModel.pio._
+import edu.gemini.spModel.pio.xml.PioXmlFactory
+
+trait ParamSetCodec[A] { outer =>
+  
+  def encode(key: String, a: A): ParamSet
+  
+  def decode(ps: ParamSet): PioError \/ A
+
+  def withParam[B](key: String, lens: A @> B)(implicit pc: ParamCodec[B]): ParamSetCodec[A] =
+    new ParamSetCodec[A] {
+      def encode(key0: String, a: A): ParamSet = {
+        val ps = outer.encode(key0, a)
+        val p  = pc.encode(key, lens.get(a))
+        ps.addParam(p)
+        ps
+      }
+      def decode(ps: ParamSet): PioError \/ A =
+        for {
+          a <- outer.decode(ps)
+          p <- Option(ps.getParam(key)) \/> MissingKey("withParam: " + key)
+          b <- pc.decode(p)
+        } yield lens.set(a, b)
+    }
+
+  def withOptionalParam[B](key: String, lens: A @> Option[B])(implicit pc: ParamCodec[B]): ParamSetCodec[A] =
+    new ParamSetCodec[A] {
+      def encode(key0: String, a: A): ParamSet = {
+        val ps = outer.encode(key0, a)
+        lens.get(a).foreach { a =>
+          val p  = pc.encode(key, a)
+          ps.addParam(p)
+        }
+        ps
+      }
+      def decode(ps: ParamSet): PioError \/ A =
+        outer.decode(ps) flatMap { a =>
+          Option(ps.getParam(key)) match {
+            case None     => \/-(lens.set(a, none))
+            case Some(ps) => pc.decode(ps).map(b => lens.set(a, some(b)))
+          }
+        }
+    }
+
+  def withParamSet[B](key: String, lens: A @> B)(implicit psc: ParamSetCodec[B]): ParamSetCodec[A] =
+    new ParamSetCodec[A] {
+      def encode(key0: String, a: A): ParamSet = {
+        val ps0 = outer.encode(key0, a)
+        val ps1 = psc.encode(key, lens.get(a))
+        ps0.addParamSet(ps1)
+        ps0
+      }
+      def decode(ps: ParamSet): PioError \/ A =
+        for {
+          a <- outer.decode(ps)
+          p <- Option(ps.getParamSet(key)) \/> MissingKey("withParamSet: " + key)
+          b <- psc.decode(p)
+        } yield lens.set(a, b)
+    }
+
+  def withOptionalParamSet[B](key: String, lens: A @> Option[B])(implicit psc: ParamSetCodec[B]): ParamSetCodec[A] =
+    new ParamSetCodec[A] {
+      def encode(key0: String, a: A): ParamSet =
+        outer.encode(key0, a) <| { ps => 
+          lens.get(a).foreach { b =>
+            psc.encode(key, b) <| ps.addParamSet
+          }
+        }
+      def decode(ps: ParamSet): PioError \/ A =
+        outer.decode(ps).flatMap { a =>
+          Option(ps.getParamSet(key)) match {
+            case None     => \/-(lens.set(a, none))
+            case Some(ps) => psc.decode(ps).map(b => lens.set(a, some(b)))
+          }
+        }
+    }
+
+  def withManyParamSet[B](key: String, lens: A @> List[B])(implicit psc: ParamSetCodec[B]): ParamSetCodec[A] =
+    new ParamSetCodec[A] {
+      def encode(key0: String, a: A): ParamSet = {
+        val ps0 = outer.encode(key0, a)
+        lens.get(a).foreach { b =>
+          val ps1 = psc.encode(key, b)
+          ps0.addParamSet(ps1)
+        }
+        ps0
+      }
+      def decode(ps: ParamSet): PioError \/ A =
+        outer.decode(ps).flatMap { a =>
+          ps.getParamSets(key).asScala.toList.traverseU(psc.decode).map(lens.set(a, _))
+        }
+    }
+
+}
+
+object ParamSetCodec {
+
+  val pf = new PioXmlFactory
+
+  def apply[A](implicit ev: ParamSetCodec[A]): ParamSetCodec[A] = ev
+
+  def initial[A](empty: A): ParamSetCodec[A] =
+    new ParamSetCodec[A] {
+      def encode(key: String, a: A): ParamSet = pf.createParamSet(key)
+      def decode(ps: ParamSet): PioError \/ A = empty.right
+    }
+
+}

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/PioError.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/PioError.scala
@@ -1,0 +1,8 @@
+package edu.gemini.spModel.pio.codec
+
+sealed trait PioError
+case class MissingKey(name: String) extends PioError
+case class NullValue(name: String) extends PioError
+case class ParseError(name: String, value: String, dataType: String) extends PioError
+case class UnknownTag(tag: String, dataType: String) extends PioError
+

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/package.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/package.scala
@@ -1,0 +1,11 @@
+package edu.gemini.spModel.pio
+
+package object codec {
+
+  implicit def toParamSetCodecOps[A: ParamSetCodec](a: A): CodecSyntax.ParamSetCodecOps[A] = 
+    new CodecSyntax.ParamSetCodecOps(a)
+
+  implicit def toParamSetOps(ps: ParamSet): CodecSyntax.ParamSetOps = 
+    new CodecSyntax.ParamSetOps(ps)
+
+}


### PR DESCRIPTION
This PR does three things:
- It adds `PioParamCodec` and `PioParamSetCodec` typeclasses for PIO encoding. The main advantage of this approach is that encoding and decoding are defined together via lensing and cannot get out of sync.
- It adds instances for the atomic and composite types in `spModel.core` to allow serialization of the new target model. Tests are included.
- It straightens out the `Lens` situation for the new `Target` model.

:-1: need Jira issue, rebase