### PR TITLE
OCSADV-437: BAGS synchronization and threading

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
@@ -24,6 +24,7 @@ import edu.gemini.spModel.util.SPTreeUtil;
 import jsky.app.ot.OT;
 import jsky.app.ot.OTOptions;
 import jsky.app.ot.ags.BagsManager;
+import jsky.app.ot.ags.BagsManager$;
 import jsky.app.ot.editor.EdObsGroup;
 import jsky.app.ot.editor.OtItemEditor;
 import jsky.app.ot.editor.eng.EngEditor;
@@ -674,7 +675,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
 
             // If there was an old root, clean up
             if (getRoot() != null) {
-                BagsManager.unregisterProgram(getRoot());
+                BagsManager$.MODULE$.instance().watch(getRoot());
                 getDatabase().checkpoint();
                 getRoot().removePropertyChangeListener(ISPProgram.DATA_OBJECT_KEY, authListener);
                 updateEngToolWindow(null);
@@ -719,7 +720,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
                     _checker.check(getRoot(), getTree(), OT.getMagnitudeTable());
                 }
 
-                BagsManager.registerProgram(root);
+                BagsManager$.MODULE$.instance().watch(root);
             }
 
             // Finally, update title and actions
@@ -884,7 +885,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
             return;
         }
         if (p != null) {
-            BagsManager.unregisterProgram(p);
+            BagsManager$.MODULE$.instance().unwatch(p);
             treeSnapshots.remove(p.getNodeKey());
         }
         tryNavigate(_history.delete());
@@ -892,7 +893,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
 
     public void closeProgram(ISPProgram node) {
         if (node != null) {
-            BagsManager.unregisterProgram(node);
+            BagsManager$.MODULE$.instance().unwatch(node);
             treeSnapshots.remove(node.getNodeKey());
         }
         tryNavigate(_history.delete(node));
@@ -902,7 +903,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
     private void closeViewer() {
         // TODO: Do not know if we need to do this?
         if (getRoot() != null)
-            BagsManager.unregisterProgram(getRoot());
+            BagsManager$.MODULE$.instance().unwatch(getRoot());
 
         tryNavigate(_history.empty());
         treeSnapshots.clear();

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -102,6 +102,7 @@ object BagsManager {
       // Get the next task to run. This blocks on the queue.
       val task = nextTask()
 
+      // Execute the task.
       task.foreach(_.performLookup(this))
 
       // Resubmit self for execution.

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -1,300 +1,238 @@
 package jsky.app.ot.ags
 
 import java.beans.{PropertyChangeEvent, PropertyChangeListener}
-import java.util.concurrent.{TimeoutException, LinkedBlockingQueue, Executors}
+import java.util.concurrent.{TimeoutException, TimeUnit, ScheduledThreadPoolExecutor}
 import java.util.logging.{Level, Logger}
 
 import edu.gemini.ags.api.{AgsRegistrar, AgsStrategy}
 import edu.gemini.ags.gems.GemsGuideStars
-import edu.gemini.catalog.votable.{GenericError, CatalogException}
-import edu.gemini.pot.sp._
+import edu.gemini.catalog.votable.{CatalogException, GenericError}
+import edu.gemini.pot.sp.{ISPObservationContainer, ISPNode, ISPProgram, ISPObservation, SPNodeKey}
+import edu.gemini.shared.util.immutable.{Option => GOption, DefaultImList}
+import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.obs.ObservationStatus
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
-import edu.gemini.spModel.target.env.TargetEnvironment
-import edu.gemini.shared.util.immutable.{Option => GOption}
+import edu.gemini.spModel.target.env.{OptionsList, GuideProbeTargets, TargetEnvironment}
 import jsky.app.ot.OT
-import jsky.app.ot.tpe._
+import jsky.app.ot.tpe.{TpeContext, GuideStarSupport, GemsGuideStarWorker, GuideStarWorker}
+
 import scala.collection.JavaConverters._
-import scala.collection.immutable.HashMap
 import scala.concurrent.Await
 import scala.swing.Swing
-import scala.util.{Try, Failure, Success}
+import scala.util.{Success, Failure, Try}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import scalaz._, Scalaz._
 
 
-object BagsManager {
+final class BagsManager(executor: ScheduledThreadPoolExecutor) {
   private val LOG: Logger = Logger.getLogger(getClass.getName)
 
-  private case class BagsTask(observation: ISPObservation, curCtx: Option[ObsContext], nextCtx: Option[ObsContext]) {
-    def obsKey: SPNodeKey =
-      observation.getNodeKey
+  /** Syntax for ObsContext. */
+  implicit class ObsContextOps(ctx: ObsContext) {
+    def isEligibleForBags: Boolean = {
+      val targets = ctx.getTargets
+      val prgs    = targets.getGuideEnvironment.getPrimaryReferencedGuiders
+      prgs.isEmpty || prgs.asScala.exists { gp =>
+        targets.getPrimaryGuideProbeTargets(gp).asScalaOpt.forall(_.getBagsTarget.isEmpty)
+      }
+    }
+  }
 
-    // The state to move to when processing the task.
-    def nextTask: Option[BagsTask] =
-      nextCtx.map(_ => BagsTask(observation, nextCtx, None))
+  /** Our state is just a set of programs to watch, and a set of pending keys. */
+  case class BagsState(programs: Set[SPProgramID], keys: Set[SPNodeKey]) {
+    def +(key: SPNodeKey): BagsState = copy(keys = keys + key)
+    def -(key: SPNodeKey): BagsState = copy(keys = keys - key)
+    def +(pid: SPProgramID): BagsState = copy(programs = programs + pid)
+    def -(pid: SPProgramID): BagsState = copy(programs = programs - pid)
+  }
 
-    def isDone: Boolean =
-      nextCtx.isEmpty
+  /** Our state. Modifications must be synchronized on `this`. */
+  @volatile private var state: BagsState = BagsState(Set.empty, Set.empty)
 
-    def newContext(ctxOpt: Option[ObsContext]): BagsTask =
-      BagsTask(observation, curCtx, ctxOpt)
+  /**
+   * Atomically add a program to our watch list and attach listeners. Enqueue all observations for
+   * consideration for a BAGS lookup.
+   */
+  def watch(prog: ISPProgram): Unit = {
+    synchronized {
+      state += prog.getProgramID
+      prog.addStructureChangeListener(StructurePropertyChangeListener)
+      prog.addCompositeChangeListener(CompositePropertyChangeListener)
+    }
+    prog.getAllObservations.asScala.foreach(enqueue(_, 0L))
+  }
 
-    def performLookup(bagsThread: BagsThread): Unit = {
-      val bagsIdMsg = s"BAGS lookup on thread=${bagsThread.id} for observation=${observation.getObservationID}"
+  /**
+   * Atomically remove a program from our watch list and remove listeners. Any queued observations
+   * will be discarded as they come up for consideration.
+   */
+  def unwatch(prog: ISPProgram): Unit =
+    synchronized {
+      state -= prog.getProgramID
+      prog.removeStructureChangeListener(StructurePropertyChangeListener)
+      prog.removeCompositeChangeListener(CompositePropertyChangeListener)
+    }
 
-      def lookup[S,T](optExtract: S => Option[T])(worker: (TpeContext, S) => Unit)(results: Try[S]): Unit = {
-        results match {
-          case Success(selOpt) =>
-            LOG.info(s"$bagsIdMsg successful. Results=${optExtract(selOpt) ? "Yes" | "No"}.")
-            if (ObservationStatus.computeFor(observation) != ObservationStatus.OBSERVED) {
-              Swing.onEDT {
-                muteObservation(observation)
-                worker(TpeContext(observation), selOpt)
-                unmuteObservation(observation)
+  /**
+   * Remove the specified key from the task queue, if present. Return true if the key was present
+   * *and* the specified program is still on the watch list.
+   */
+  private def dequeue(key: SPNodeKey, pid: SPProgramID): Boolean =
+    synchronized {
+      if (state.keys(key)) {
+        state -= key
+        state.programs(pid)
+      } else false
+    }
+
+  /**
+   * Atomically enqueue a task that will consider the specified observation for BAGS lookup, after
+   * a delay of at least `delay` milliseconds.
+   */
+  def enqueue(observation: ISPObservation, delay: Long): Unit =
+    Option(observation).foreach { obs =>
+      synchronized {
+        val key = obs.getNodeKey
+        state += key
+        executor.schedule(new Runnable {
+          def run(): Unit =
+
+          // If dequeue is false this means that (a) another task scheduled *after* me ended up
+          // running before me, so their result is as good as mine would have been and we're done;
+          // or (b) we don't care about that program anymore, so we're done.
+            if (dequeue(key, obs.getProgramID)) {
+              // Otherwise construct an obs context, verify that it's bagworthy, and go
+              ObsContext.create(obs).asScalaOpt.filter(_.isEligibleForBags).foreach { ctx =>
+
+                //   do the lookup
+                //   on success {
+                //      if we're in the queue again, it means something changed while this task was
+                //      running, so discard this result and do nothing,
+                //      otherwise update the model
+                //   }
+                //   on failure enqueue again, maybe with a delay depending on the failure
+                val bagsIdMsg = s"BAGS lookup on thread=${Thread.currentThread.getId} for observation=${obs.getObservationID}"
+
+                def lookup[S, T](optExtract: S => Option[T])(worker: (TpeContext, S) => Unit)(results: Try[S]): Unit = {
+                  results match {
+                    case Success(selOpt) =>
+                      // If this observation is once again in the queue, then something changed while this task
+                      // was running, so discard the result.
+                      if (!state.keys(key)) {
+                        LOG.info(s"$bagsIdMsg successful. Results=${optExtract(selOpt) ? "Yes" | "No"}.")
+                        if (ObservationStatus.computeFor(obs) != ObservationStatus.OBSERVED) {
+                          Swing.onEDT {
+                            obs.getProgram.removeCompositeChangeListener(CompositePropertyChangeListener)
+                            obs.getProgram.removeStructureChangeListener(StructurePropertyChangeListener)
+                            worker(TpeContext(obs), selOpt)
+                            obs.getProgram.addStructureChangeListener(StructurePropertyChangeListener)
+                            obs.getProgram.addCompositeChangeListener(CompositePropertyChangeListener)
+                          }
+                        }
+                      }
+
+                    // We don't want to print the stack trace if the host is simply unreachable.
+                    // This is reported only as a GenericError in a CatalogException, unfortunately.
+                    case Failure(CatalogException((e: GenericError) :: _)) =>
+                      LOG.warning(s"$bagsIdMsg failed: ${e.msg}")
+                      enqueue(obs, 5000L)
+
+                    // If we timed out, we don't want to delay.
+                    case Failure(ex: TimeoutException) =>
+                      LOG.warning(s"$bagsIdMsg failed: ${ex.getMessage}")
+                      enqueue(obs, 5000L)
+
+                    // For all other exceptions, print the full stack trace.
+                    case Failure(ex) =>
+                      LOG.log(Level.WARNING, s"$bagsIdMsg} failed.", ex)
+                      enqueue(obs, 5000L)
+                  }
+                }
+
+
+                LOG.info(s"Performing $bagsIdMsg.")
+                AgsRegistrar.currentStrategy(ctx).foreach { strategy =>
+                  if (GuideStarSupport.hasGemsComponent(obs)) {
+                    lookup((x: GOption[GemsGuideStars]) => x.asScalaOpt)(GemsGuideStarWorker.applyResults(_, _, true))(Try(GemsGuideStarWorker.findGuideStars(ctx)))
+                  } else {
+                    val fut = strategy.select(ctx, OT.getMagnitudeTable)
+
+                    // This is a hideous abuse of Futures, but I don't see a way around it when combining AGS lookups
+                    // with GeMS lookups. We do not want the thread to spawn a Future and return immediately, because
+                    // then a huge number of tasks will be delegated to a single thread instead of being evenly
+                    // dispersed amongst the available threads, which will cause serious slowdown later.
+                    if (Try {
+                      val futDone = Await.ready(fut, 30.seconds)
+                      futDone.onComplete(lookup(identity[Option[AgsStrategy.Selection]])(GuideStarWorker.applyResults))
+                    }.isFailure) enqueue(obs, 5000L)
+                  }
+                }
               }
             }
-            taskSuccess(this)
-
-          // We don't want to print the stack trace if the host is simply unreachable.
-          // This is reported only as a GenericError in a CatalogException, unfortunately.
-          case Failure(CatalogException((e: GenericError) :: _)) =>
-            LOG.warning(s"$bagsIdMsg failed: ${e.msg}")
-            taskFail(this)
-
-          // If we timed out, we don't want to delay.
-          case Failure(ex: TimeoutException) =>
-            LOG.warning(s"$bagsIdMsg failed: ${ex.getMessage}")
-            taskFail(this, timedOut = true)
-
-          // For all other exceptions, print the full stack trace.
-          case Failure(ex) =>
-            LOG.log(Level.WARNING, s"$bagsIdMsg} failed.", ex)
-            taskFail(this)
-        }
-      }
-
-
-      LOG.info(s"Performing $bagsIdMsg.")
-      curCtx.foreach { obsCtx =>
-        AgsRegistrar.currentStrategy(obsCtx).foreach { strategy =>
-          if (GuideStarSupport.hasGemsComponent(observation)) {
-            lookup((x: GOption[GemsGuideStars]) => x.asScalaOpt)(GemsGuideStarWorker.applyResults(_, _, true))(Try(GemsGuideStarWorker.findGuideStars(obsCtx)))
-          } else {
-            // This future always completes, either with results or timeout of 30s, so we wait for it with a long timeout
-            // to let it do its thing.
-            val fut = strategy.select(obsCtx, OT.getMagnitudeTable)
-            val futDone = Await.ready(fut, LookupTimeout)
-            futDone.onComplete(lookup(identity[Option[AgsStrategy.Selection]])(GuideStarWorker.applyResults))
-          }
-        }
-      }
-    }
-  }
-
-  private case class BagsThread(id: Int) extends Thread {
-    setPriority(Thread.NORM_PRIORITY - 1)
-
-    override def run() {
-      // Get the next task to run. This blocks on the queue.
-      val task = nextTask()
-
-      // Execute the task.
-      task.foreach(_.performLookup(this))
-
-      // Resubmit self for execution.
-      executor.submit(this)
-    }
-  }
-
-  // A timeout for catalog searches that guarantees they will complete.
-  private val LookupTimeout = 1.hour
-
-  // If a task fails due to timeout, a thread takes a brief sleep before requeueing to allow sanity to restore. In ms.
-  private val RequeueDelay = 5000
-
-  // We use an executor to allow for a certain number of threads to run, which are created and fixed as per below.
-  private val NumThreads = math.max(1, Runtime.getRuntime.availableProcessors()-1)
-  private val executor = Executors.newFixedThreadPool(NumThreads)
-
-  // Tasks to lookup are managed in two forms: a blocking FIFO queue contains a list of observations by node key
-  // waiting for threads to perform lookups for them, and these node keys are mapped to acutal tasks to perform
-  // via the map.
-  private val taskQueue = new LinkedBlockingQueue[SPNodeKey]
-  private var taskMap = new HashMap[SPNodeKey, BagsTask]
-
-  // The programs we are actively managing. This is to prevent threads who fail from adding their observations
-  // back into the queue when the program is no longer active.
-  private var activePrograms = Set[SPNodeKey]()
-
-  // Create all of the threads and submit for execution.
-  List.tabulate(NumThreads)(i => new BagsThread(i)).foreach(executor.submit)
-
-
-  // Initial registration of program.
-  def registerProgram(prog: ISPProgram) = {
-    Option(prog).foreach { p =>
-      activePrograms.synchronized(activePrograms += p.getNodeKey)
-      p.addStructureChangeListener(structurePropertyChangeListener)
-      p.addCompositeChangeListener(compositePropertyChangeListener)
-
-      // Only queue up observations that do not have an auto guide star.
-      p.getAllObservations.asScala.foreach { obs =>
-        val obsCtx = ObsContext.create(obs)
-        obsCtx.asScalaOpt.foreach { ctx =>
-          if (ctx.getTargets.getGuideEnvironment.getPrimaryReferencedGuiders.isEmpty ||
-            ctx.getTargets.getGuideEnvironment.getPrimaryReferencedGuiders.asScala.exists(gp => {
-              ctx.getTargets.getPrimaryGuideProbeTargets(gp).asScalaOpt.forall(_.getBagsTarget.isEmpty)})) {
-            updateObservation(obs)
-          }
-        }
-      }
-    }
-  }
-
-  // Unregister a program.
-  def unregisterProgram(prog: ISPProgram) = {
-    Option(prog).foreach { p =>
-      p.getAllObservations.asScala.foreach(removeObservation)
-      p.removeCompositeChangeListener(compositePropertyChangeListener)
-      p.removeStructureChangeListener(structurePropertyChangeListener)
-      activePrograms.synchronized(activePrograms -= p.getNodeKey)
-    }
-  }
-
-  // Mute an observation from firing PropertyChangeEvents to BAGS while updating BAGS guide stars.
-  private def muteObservation(obs: ISPObservation) = {
-    obs.getProgram.removeCompositeChangeListener(compositePropertyChangeListener)
-    obs.getProgram.removeStructureChangeListener(structurePropertyChangeListener)
-  }
-
-  // Unmute an observation from firing PropertyChangeEvents to BAGS while updating BAGS guide stars.
-  private def unmuteObservation(obs: ISPObservation) = {
-    obs.getProgram.addStructureChangeListener(structurePropertyChangeListener)
-    obs.getProgram.addCompositeChangeListener(compositePropertyChangeListener)
-  }
-
-  // Retrieve the next task to perform and set it up, moving it into the processing phase by assigning
-  // curCtx to nextCtx.
-  private def nextTask(): Option[BagsTask] = {
-    val obsKey = taskQueue.take()
-    taskMap.synchronized {
-      val currTask = taskMap.get(obsKey)
-      val tmpTask = currTask.flatMap(_.nextTask)
-      tmpTask.foreach(t => taskMap += ((t.obsKey, t)))
-      tmpTask
-    }
-  }
-
-  // If a BAGS task succeeded, process it accordingly. This can comprise one of two things:
-  // 1. If the task is marked as done, remove it from the map.
-  // 2. If the task is marked as not done, requeue it.
-  private def taskSuccess(task: BagsTask): Unit = {
-    val obsKey = task.obsKey
-    // Check to see if the task is marked as done, and if so, remove.
-    val doneWithTask = taskMap.synchronized {
-      taskMap.get(obsKey).fold(true) { t =>
-        val done = t.isDone
-        if (done) taskMap -= obsKey
-        done
+        }, delay, TimeUnit.MILLISECONDS)
       }
     }
 
-    // If a task is not complete and the program is still active, we add it back.
-    if (!doneWithTask) {
-      val isActiveProgram = activePrograms.synchronized(activePrograms.contains(task.observation.getProgramKey))
-      if (isActiveProgram) {
-        taskQueue.synchronized {
-          if (!taskQueue.contains(obsKey))
-            taskQueue.add(obsKey)
-        }
+  object CompositePropertyChangeListener extends PropertyChangeListener {
+    override def propertyChange(evt: PropertyChangeEvent): Unit =
+      evt.getSource match {
+        case node: ISPNode => enqueue(node.getContextObservation, 0L)
+        case _             => // Ignore
       }
-    }
   }
 
-  // Called when a BAGS task failed to be processed properly, in which case, we must requeue it.
-  private def taskFail(task: BagsTask, timedOut: Boolean = false): Unit = {
-    val obsKey = task.obsKey
-
-    val isActiveProgram = activePrograms.synchronized(activePrograms.contains(task.observation.getProgramKey))
-    if (isActiveProgram) {
-      // We only need to do something if the task is not already in the queue.
-      // Check to see if the taskQueue contains the key.
-      // If the key is added to the taskQueue in the interim, this is fine.
-      // It will force another lookup, but that should not be problematic.
-      val containsKey = taskQueue.synchronized(taskQueue.contains(obsKey))
-
-      if (!containsKey) {
-        // If the task has no next context, revert it back to the unprocessed state.
-        // Otherwise, simply process it as is.
-        val newTask = task match {
-          case BagsTask(obs, Some(ctx), None) => BagsTask(obs, None, Some(ctx))
-          case t => t
-        }
-        taskMap.synchronized(taskMap += ((obsKey, newTask)))
-        taskQueue.synchronized(taskQueue.add(obsKey))
+  object StructurePropertyChangeListener extends PropertyChangeListener {
+    override def propertyChange(evt: PropertyChangeEvent): Unit =
+      evt.getSource match {
+        case cont: ISPObservationContainer => cont.getAllObservations.asScala.foreach(enqueue(_, 0L))
+        case _                             => // Ignore
       }
-
-      // Pause to give things a chance to right themselves.
-      if (!timedOut)
-        Thread.sleep(RequeueDelay)
-    }
   }
+}
 
-  // Given an observation, either insert it in all data structures or update the existing entry for it.
-  private def updateObservation(obs: ISPObservation) =
-    Option(obs).foreach { ispObs =>
-      val obsKey = ispObs.getNodeKey
-      val ctxOpt = ObsContext.create(ispObs).asScalaOpt
+object BagsManager {
+  private val NumThreads = math.max(1, Runtime.getRuntime.availableProcessors - 1)
+  val instance = new BagsManager(new ScheduledThreadPoolExecutor(NumThreads))
 
-      // Update the task map and the task queue.
-      taskMap.synchronized {
-        val task = taskMap.get(obsKey) match {
-          case Some(t) => t.newContext(ctxOpt)
-          case None    => BagsTask(ispObs, None, ctxOpt)
-        }
-        taskMap += ((obsKey, task))
-      }
-      taskQueue.synchronized {
-        if (!taskQueue.contains(obsKey))
-          taskQueue.add(obsKey)
-      }
-    }
-
-  // Remove a given observation from all data structures.
-  private def removeObservation(obs: ISPObservation) = {
-    Option(obs).foreach { ispObs =>
-      val obsKey = ispObs.getNodeKey
-      taskQueue.synchronized(taskQueue.remove(obsKey))
-      taskMap.synchronized(taskMap -= obsKey)
-    }
-  }
 
   // Check two target environments to see if the BAGS targets match exactly between them.
-  def bagsTargetsMatch(oldEnv: TargetEnvironment, newEnv: TargetEnvironment): Boolean =
-    oldEnv.getGuideEnvironment.getPrimaryReferencedGuiders.equals(newEnv.getGuideEnvironment.getPrimaryReferencedGuiders) &&
-      oldEnv.getGuideEnvironment.getPrimaryReferencedGuiders.asScala.forall { gp =>
-        oldEnv.getPrimaryGuideProbeTargets(gp).asScalaOpt.forall { oldGpt =>
-          val oldBags = oldGpt.getBagsTarget.asScalaOpt
-          val newBags = newEnv.getPrimaryGuideProbeTargets(gp).asScalaOpt.flatMap(_.getBagsTarget.asScalaOpt)
-          (oldBags.isEmpty && newBags.isEmpty) || oldBags.exists(oldTarget => newBags.exists(_.getTarget.equals(oldTarget.getTarget)))
-        }
-      }
+  def bagsTargetsMatch(oldEnv: TargetEnvironment, newEnv: TargetEnvironment): Boolean = {
+    // Find a group with a BAGS target in it in the old and new envs.
+    val oldGroup = oldEnv.getGroups.asScala.find(gg => gg.getAll.asScala.exists(_.getBagsTarget.isDefined))
+    val newGroup = newEnv.getGroups.asScala.find(gg => gg.getAll.asScala.exists(_.getBagsTarget.isDefined))
 
-  private val compositePropertyChangeListener = new PropertyChangeListener {
-    override def propertyChange(evt: PropertyChangeEvent): Unit = evt.getSource match {
-      case node: ISPNode => updateObservation(node.getContextObservation)
-      case _             => // Ignore
-    }
+    // Now compare the two groups to see if they have the same BAGS targets.
+    // Filter the GuideProbeTargets of the oldGroup to make sure that we are only looking at GPTs with BAGS.
+    val oldGpt = oldGroup.toList.flatMap(gg => gg.getAll.asScala.filter(_.getBagsTarget.isDefined))
+    val newGpt = newGroup.toList.flatMap(gg => gg.getAll.asScala.filter(_.getBagsTarget.isDefined))
+
+    // Now compare the two lists to make sure they have the same BAGS targets.
+    (oldGpt.size == newGpt.size) &&
+      oldGpt.forall(ogpt => newGpt.exists(ngpt => ngpt.getGuider == ogpt.getGuider &&
+        ngpt.getBagsTarget.getValue.getTarget.equals(ogpt.getBagsTarget.getValue.getTarget)))
   }
 
-  private val structurePropertyChangeListener = new PropertyChangeListener {
-    override def propertyChange(evt: PropertyChangeEvent): Unit = evt.getSource match {
-      case cont: ISPObservationContainer => cont.getAllObservations.asScala.foreach(updateObservation)
-      case _                             => // Ignore
+  // Given a target environment, clear all of the BAGS targets from it.
+  def clearBagsTargets(oldEnv: TargetEnvironment): TargetEnvironment = {
+    val oldGuideEnv = oldEnv.getGuideEnvironment
+    val newGuideEnv = oldGuideEnv.getOptions.asScala.foldLeft(oldGuideEnv) { (ge, gg) =>
+      // For this guide group, iterate over all GuideProbeTargets and eliminate the BAGS targets. Filter out any
+      // GuideProbeTargets that are left empty as a result as we no longer need them.
+      val bagslessGpts = gg.getAll.asScala.map(_.withBagsTarget(GuideProbeTargets.NO_TARGET)).filter(_.containsTargets)
+
+      // If there are still any targets left, replace gg in the guide environment with a new guide group.
+      // If there are no targets left, remove gg from the guide environment.
+      if (bagslessGpts.nonEmpty) {
+        val newGG = gg.setAll(DefaultImList.create(bagslessGpts.asJavaCollection))
+        val idx = ge.getOptions.indexOf(gg)
+        ge.setOptions(ge.getOptions.updated(idx, newGG))
+      } else {
+        ge.update(OptionsList.UpdateOps.remove(gg))
+      }
     }
+    oldEnv.setGuideEnvironment(newGuideEnv)
   }
 }


### PR DESCRIPTION
This PR is to address several things, notably:

1. During refactoring, I found an issue in the way that I was using scala `Future`s inside of a `Thread`, which we have to do to work with the thread pool and GeMS as well as single probes due to the differences in the way these function. This has been fixed with `Await` to wait for the `Future` to complete, whereas previously the thread just merrily kept on letting the `Futures` run and completed, restarting to make more of them, which is exactly what we do not want.

2. Minor refactoring of methods and check for `TimeoutException` during lookups to handle it differently.

3. Synchronization. @tpolecat and @cquiroz both stated some concerns with the way I was using synchronization before, namely due to a nested synchronization. I have managed to work out the kinks and avoid this now so as to avoid possible deadlocking risks. I have also added some comments to the code to provide more detail about how the two data structures used to manage the observation IDs / associated tasks are handled.

I hope that this is sufficient documentation, but I can provide more if there is still any concern.