### PR TITLE
OCSADV-436: Instrument selection

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -38,7 +38,6 @@ import scala.collection.JavaConverters._
 import scalaz._
 import Scalaz._
 
-
 /**
  * Locally describe an ags strategy including its limits and the query that would trigger
  */
@@ -103,7 +102,7 @@ object ObservationInfo {
     InstGmosNorth.INSTRUMENT_NAME_PROP     -> SPComponentType.INSTRUMENT_GMOS,
     InstGmosSouth.INSTRUMENT_NAME_PROP     -> SPComponentType.INSTRUMENT_GMOSSOUTH,
     GNIRSConstants.INSTRUMENT_NAME_PROP    -> SPComponentType.INSTRUMENT_GNIRS,
-    Gpi.INSTRUMENT_NAME_PROP               -> SPComponentType.INSTRUMENT_GPI ,
+    //Gpi.INSTRUMENT_NAME_PROP               -> SPComponentType.INSTRUMENT_GPI, GPI Doesn't have AGS Strategies defined
     InstMichelle.INSTRUMENT_NAME_PROP      -> SPComponentType.INSTRUMENT_MICHELLE,
     InstNICI.INSTRUMENT_NAME_PROP          -> SPComponentType.INSTRUMENT_NICI,
     InstNIFS.INSTRUMENT_NAME_PROP          -> SPComponentType.INSTRUMENT_NIFS,

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -119,7 +119,7 @@ object ObservationInfo {
   /**
    * Converts an AgsStrategy to a simpler description to be stored in the UI model
    */
-  private def toSupportedStrategy(obsCtx: ObsContext, strategy: AgsStrategy, mt: MagnitudeTable):SupportedStrategy = {
+  def toSupportedStrategy(obsCtx: ObsContext, strategy: AgsStrategy, mt: MagnitudeTable):SupportedStrategy = {
     val pb = strategy.magnitudes(obsCtx, mt).map(k => ProbeLimits(strategy.probeBands, obsCtx, k._2)).headOption
     val queries = strategy.catalogQueries(obsCtx, mt)
     SupportedStrategy(strategy, pb.flatten, queries)

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -92,7 +92,7 @@ case class ObservationInfo(ctx: Option[ObsContext], objectName: Option[String], 
 }
 
 object ObservationInfo {
-  val DefaultInstrument = SPComponentType.INSTRUMENT_GMOSSOUTH
+  val DefaultInstrument = SPComponentType.INSTRUMENT_VISITOR
 
   // Observation context loaded initially with default parameters
   val zero = new ObservationInfo(None, "".some, Coordinates.zero.some, DefaultInstrument.some, None, Nil, SPSiteQuality.Conditions.BEST.some, UCAC4, ProbeLimitsTable.loadOrThrow())


### PR DESCRIPTION
This PR adds a control to let the user select an instrument, thus updating the guiders and search criteria. It was agreed to make `Visitor` the default instrument and not to support the option of `No` instrument for the time being.
The control is indicated below:
![screenshot 2015-10-16 18 20 23](https://cloud.githubusercontent.com/assets/3615303/10553605/9963fc8c-7432-11e5-978e-ef452f643051.png)
