### PR TITLE
OCSADV-334: Use Redshift from core model in ITC code.

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -1,6 +1,6 @@
 package edu.gemini.itc.shared
 
-import edu.gemini.spModel.core.{BrightnessUnit, MagnitudeBand}
+import edu.gemini.spModel.core.{Redshift, BrightnessUnit, MagnitudeBand}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{WaterVapor, CloudCover, SkyBackground, ImageQuality}
 import edu.gemini.spModel.target.{UniformSource, SpectralDistribution, SpatialProfile}
 
@@ -20,7 +20,7 @@ final case class SourceDefinition(
                      norm: Double,
                      units: BrightnessUnit,
                      normBand: MagnitudeBand,
-                     redshift: Double) {
+                     redshift: Redshift) {
 
   val isUniform = profile match {
     case UniformSource => true

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
@@ -21,7 +21,7 @@ public final class HtmlPrinter {
 
         sb.append("Source spatial profile, brightness, and spectral distribution: \n");
         sb.append("  The z = ");
-        sb.append(sdp.redshift().redshift());
+        sb.append(sdp.redshift().z());
         sb.append(" ");
         sb.append(HtmlUtil.sourceProfileString(sdp.profile()));
         sb.append(" is a");

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
@@ -21,7 +21,7 @@ public final class HtmlPrinter {
 
         sb.append("Source spatial profile, brightness, and spectral distribution: \n");
         sb.append("  The z = ");
-        sb.append(sdp.redshift());
+        sb.append(sdp.redshift().redshift());
         sb.append(" ");
         sb.append(HtmlUtil.sourceProfileString(sdp.profile()));
         sb.append(" is a");

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -2,7 +2,6 @@ package edu.gemini.itc.web
 
 import javax.servlet.http.HttpServletRequest
 
-import edu.gemini.itc.base._
 import edu.gemini.itc.shared._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.core.WavelengthConversions._
@@ -24,6 +23,7 @@ import edu.gemini.spModel.gemini.trecs.TReCSParams
 import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.target._
 import edu.gemini.spModel.telescope.IssPort
+import squants.motion.KilometersPerSecond
 import squants.motion.VelocityConversions._
 import squants.radio.IrradianceConversions._
 import squants.radio.SpectralIrradianceConversions._
@@ -343,7 +343,7 @@ object ITCRequest {
     val redshiftName = r.parameter("Recession")
     val redshift = redshiftName match {
       case "REDSHIFT" => Redshift(r.doubleParameter("z"))
-      case "VELOCITY" => Redshift(r.doubleParameter("v") / ITCConstants.C)
+      case "VELOCITY" => Redshift.fromApparentRadialVelocity(KilometersPerSecond(r.doubleParameter("v")))
       case _          => throw new NoSuchElementException(s"Unknown Recession $redshiftName")
     }
 

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -342,8 +342,8 @@ object ITCRequest {
     //Get Redshift
     val redshiftName = r.parameter("Recession")
     val redshift = redshiftName match {
-      case "REDSHIFT" => r.doubleParameter("z")
-      case "VELOCITY" => r.doubleParameter("v") / ITCConstants.C
+      case "REDSHIFT" => Redshift(r.doubleParameter("z"))
+      case "VELOCITY" => Redshift(r.doubleParameter("v") / ITCConstants.C)
       case _          => throw new NoSuchElementException(s"Unknown Recession $redshiftName")
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
@@ -25,7 +25,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
                                 final SpectralIrradiance continuum, final Redshift redshift, final double interval) {
 
         //shift start and end depending on redshift
-        final double z     = redshift.redshift();
+        final double z     = redshift.z();
         final double start = 300 / (1 + z);
         final double end = 30000 / (1 + z);
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
@@ -1,5 +1,6 @@
 package edu.gemini.itc.base;
 
+import edu.gemini.spModel.core.Redshift;
 import edu.gemini.spModel.core.Wavelength;
 import squants.motion.Velocity;
 import squants.radio.Irradiance;
@@ -21,11 +22,12 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
     }
 
     public EmissionLineSpectrum(final Wavelength wavelength, final Velocity width, final Irradiance flux,
-                                final SpectralIrradiance continuum, final double z, final double interval) {
+                                final SpectralIrradiance continuum, final Redshift redshift, final double interval) {
 
         //shift start and end depending on redshift
-        final double start = 300 / (1 + z); //ancient, potentially obsolete comment for start value: 0.2*_wavelength;//.8
-        final double end = 30000 / (1 + z); //ancient, potentially obsolete comment for end value  : 1.8*_wavelength;//1.2
+        final double z     = redshift.redshift();
+        final double start = 300 / (1 + z);
+        final double end = 30000 / (1 + z);
 
         final int n = (int) ((end - start) / interval + 1);
         final double[] fluxArray = new double[n];

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
@@ -20,7 +20,7 @@ public class PowerLawSpectrum extends DefaultSampledSpectrum {
         double _end = 1.8 * end;//1.2
 
         //shift start and end depending on redshift
-        final double z = redshift.redshift();
+        final double z = redshift.z();
         _start /= (1 + z);
         _end /= (1 + z);
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
@@ -1,14 +1,6 @@
-// This software is Copyright(c) 2010 Association of Universities for
-// Research in Astronomy, Inc.  This software was prepared by the
-// Association of Universities for Research in Astronomy, Inc. (AURA)
-// acting as operator of the Gemini Observatory under a cooperative
-// agreement with the National Science Foundation. This software may 
-// only be used or copied as described in the license set out in the 
-// file LICENSE included with the distribution package.
-
-// $Id: PowerLawSpectrum.java,v 1.2 2003/11/21 14:31:02 shane Exp $
-//
 package edu.gemini.itc.base;
+
+import edu.gemini.spModel.core.Redshift;
 
 /**
  * This class creates a PowerLaw spectrum over the interval defined by the
@@ -18,32 +10,22 @@ package edu.gemini.itc.base;
 
 public class PowerLawSpectrum extends DefaultSampledSpectrum {
 
-    // Private c'tor to support clone()
-//    private PowerLawSpectrum(DefaultSampledSpectrum spectrum)
-//    {
-//       _spectrum = spectrum;
-//    }
+    public PowerLawSpectrum(final double powerLawIndex, final double start, final double end, final double interval, final Redshift redshift) {
 
-
-    public PowerLawSpectrum(double powerLawIndex, double start, double end,
-                            double interval, double z) {
         super(new double[1], 0.0, 1.0);  // create a dummy Default Spectrum.  Will be
-        //  will be overwritten later.
-        double _flux;
 
-        double _sampling = interval;
-        double lambda;  // var to be used to construct sed
+        final double _sampling = interval;
 
         double _start = 0.2 * start;//.8
         double _end = 1.8 * end;//1.2
-        //System.out.println("Start: "+ start +"End: " +end);
+
         //shift start and end depending on redshift
+        final double z = redshift.redshift();
         _start /= (1 + z);
         _end /= (1 + z);
 
-        int n = (int) ((_end - _start) / _sampling + 1);
+        final int n = (int) ((_end - _start) / _sampling + 1);
         double[] fluxArray = new double[n];
-//System.out.println("Array: " + (n+40) + " sample "+ _sampling);
 
 
         int i = 0;
@@ -55,8 +37,6 @@ public class PowerLawSpectrum extends DefaultSampledSpectrum {
         }
 
         reset(fluxArray, _start, _sampling);
-
-        //_spectrum.print();
 
     }
 
@@ -72,14 +52,5 @@ public class PowerLawSpectrum extends DefaultSampledSpectrum {
         returnFlux = Math.pow(lambda, powerLawIndex);
         return returnFlux;
     }
-
-
-    //Implements the clonable interface
-//    public Object clone()
-//    {
-//       DefaultSampledSpectrum spectrum =
-//                          (DefaultSampledSpectrum)_spectrum.clone();
-//       return new PowerLawSpectrum(spectrum);
-//    }
 
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/RedshiftVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/RedshiftVisitor.java
@@ -1,17 +1,8 @@
-// This software is Copyright(c) 2010 Association of Universities for
-// Research in Astronomy, Inc.  This software was prepared by the
-// Association of Universities for Research in Astronomy, Inc. (AURA)
-// acting as operator of the Gemini Observatory under a cooperative
-// agreement with the National Science Foundation. This software may 
-// only be used or copied as described in the license set out in the 
-// file LICENSE included with the distribution package.
-//
-// $Id: RedshiftVisitor.java,v 1.3 2003/11/21 14:31:02 shane Exp $
-//
 package edu.gemini.itc.operation;
 
 import edu.gemini.itc.base.SampledSpectrum;
 import edu.gemini.itc.base.SampledSpectrumVisitor;
+import edu.gemini.spModel.core.Redshift;
 
 /**
  * This visitor performs a redshift on the spectrum.
@@ -23,24 +14,22 @@ public class RedshiftVisitor implements SampledSpectrumVisitor {
      */
     public static final double MIN_SHIFT = 0.0001;
 
-    private double _z = 0;  // z = v / c
+    private final double _z;  // z = v / c
 
     /**
      * @param z redshift = velocity / c
      */
-    public RedshiftVisitor(double z) {
-        _z = z;
+    public RedshiftVisitor(final Redshift redshift) {
+        _z = redshift.redshift();
     }
 
     /**
      * Performs the redshift on specified spectrum.
      */
-    public void visit(SampledSpectrum sed) {
-        // only shift if greater than MIN_SHIFT
-        if (getShift() <= MIN_SHIFT) return;  // No scaling to be done.
-
-        sed.rescaleX(1.0 + getShift());
-        return;
+    public void visit(final SampledSpectrum sed) {
+        if (getShift() > MIN_SHIFT) {
+            sed.rescaleX(1.0 + getShift());
+        }
     }
 
     /**
@@ -50,14 +39,4 @@ public class RedshiftVisitor implements SampledSpectrumVisitor {
         return _z;
     }
 
-    /**
-     * Sets the redshift.
-     */
-    public void setShift(double z) {
-        _z = z;
-    }
-
-    public String toString() {
-        return "Redshift z = " + getShift();
-    }
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/RedshiftVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/RedshiftVisitor.java
@@ -20,7 +20,7 @@ public class RedshiftVisitor implements SampledSpectrumVisitor {
      * @param z redshift = velocity / c
      */
     public RedshiftVisitor(final Redshift redshift) {
-        _z = redshift.redshift();
+        _z = redshift.z();
     }
 
     /**

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/operation/BlackBodySpectrum.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/operation/BlackBodySpectrum.scala
@@ -185,7 +185,7 @@ object BlackBodySpectrum {
   def apply(temp: Double, interval: Double, flux: Double, units: BrightnessUnit, band: MagnitudeBand, redshift: Redshift) = {
 
     //rescale the start and end depending on the redshift
-    val z         = redshift.redshift
+    val z         = redshift.z
     val start     =   300 / (1 + z)
     val end       = 30000 / (1 + z)
     val n         = ((end - start) / interval + 1).toInt

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/operation/BlackBodySpectrum.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/operation/BlackBodySpectrum.scala
@@ -1,7 +1,7 @@
 package edu.gemini.itc.operation
 
 import edu.gemini.itc.base.{SampledSpectrumVisitor, ZeroMagnitudeStar, VisitableSampledSpectrum, DefaultSampledSpectrum}
-import edu.gemini.spModel.core.{SurfaceBrightness, MagnitudeSystem, BrightnessUnit, MagnitudeBand}
+import edu.gemini.spModel.core._
 
 /**
  * This class creates a black body spectrum over the interval defined by the
@@ -182,20 +182,20 @@ final class BlackBodySpectrum(spectrum: DefaultSampledSpectrum) extends Visitabl
 
 object BlackBodySpectrum {
 
-  def apply(temp: Double, interval: Double, flux: Double, units: BrightnessUnit, band: MagnitudeBand, z: Double) = {
+  def apply(temp: Double, interval: Double, flux: Double, units: BrightnessUnit, band: MagnitudeBand, redshift: Redshift) = {
 
     //rescale the start and end depending on the redshift
-    val start: Double = 300 / (1 + z)
-    val end: Double = 30000 / (1 + z)
-
-    val n: Int = ((end - start) / interval + 1).toInt
-    val fluxArray: Array[Double] = new Array[Double](n + 40)
+    val z         = redshift.redshift
+    val start     =   300 / (1 + z)
+    val end       = 30000 / (1 + z)
+    val n         = ((end - start) / interval + 1).toInt
+    val fluxArray = new Array[Double](n + 40)
 
     //if units need to be converted do it.
     val magFlux = convertToMag(flux, units, band)
 
-    var i: Int = 0
-    var wavelength: Double = start
+    var i = 0
+    var wavelength = start
     while (wavelength <= end) {
       fluxArray(i) = blackbodyFlux(wavelength, temp)
       i = i + 1
@@ -205,12 +205,12 @@ object BlackBodySpectrum {
     val spectrum = new DefaultSampledSpectrum(fluxArray, start, interval)
 
     //with blackbody convert W m^2 um^-1 to phot....
-    val zeropoint: Double = ZeroMagnitudeStar.getAverageFlux(band)
-    val phot_norm: Double = zeropoint * Math.pow(10.0, -0.4 * magFlux)
-    val average: Double = spectrum.getAverage(band.start.toNanometers / (1 + z), band.end.toNanometers / (1 + z))
+    val zeropoint = ZeroMagnitudeStar.getAverageFlux(band)
+    val phot_norm = zeropoint * Math.pow(10.0, -0.4 * magFlux)
+    val average   = spectrum.getAverage(band.start.toNanometers / (1 + z), band.end.toNanometers / (1 + z))
 
     // Calculate multiplier.
-    val multiplier: Double = phot_norm / average
+    val multiplier = phot_norm / average
     spectrum.rescaleY(multiplier)
     
     new BlackBodySpectrum(spectrum)

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
@@ -2,7 +2,7 @@ package edu.gemini.itc.baseline.util
 
 import edu.gemini.itc.shared.TelescopeDetails.Coating
 import edu.gemini.itc.shared._
-import edu.gemini.spModel.core.{SurfaceBrightness, MagnitudeSystem, MagnitudeBand}
+import edu.gemini.spModel.core.{Redshift, SurfaceBrightness, MagnitudeSystem, MagnitudeBand}
 import edu.gemini.spModel.core.WavelengthConversions._
 import edu.gemini.spModel.gemini.altair.AltairParams.{FieldLens, GuideStarType}
 import edu.gemini.spModel.guide.GuideProbe
@@ -92,13 +92,13 @@ object Fixture {
       GaussianSource(1.0),
       BlackBody(10000),
       1.0e-3, MagnitudeSystem.Vega, MagnitudeBand.U,
-      0.0
+      Redshift(0.0)
     ),
     new SourceDefinition(
       GaussianSource(1.0),
       PowerLaw(-1.0),
       1.0e-3, MagnitudeSystem.Vega, MagnitudeBand.U,
-      0.5
+      Redshift(0.5)
     )
   )
 
@@ -108,13 +108,15 @@ object Fixture {
       PointSource,
       LibraryStar.A0V,
       20.0, MagnitudeSystem.Vega, MagnitudeBand.R,
-      0.0
+      Redshift(0.0)
+
     ),
     new SourceDefinition(
       GaussianSource(1.0),
       BlackBody(8000),
       1.0e-3, MagnitudeSystem.Jy, MagnitudeBand.R,
-      0.75
+      Redshift(0.75)
+
     )
   )
 
@@ -124,13 +126,15 @@ object Fixture {
       PointSource,
       LibraryStar.A0V,
       12.0, MagnitudeSystem.Vega, MagnitudeBand.K,
-      0.0
+      Redshift(0.0)
+
     ),
     new SourceDefinition(
       UniformSource,
       EmissionLine(2.2.microns, 250.0.kps, 5.0e-19.wattsPerSquareMeter, 1.0e-16.wattsPerSquareMeterPerMicron),
       22.0, SurfaceBrightness.Vega, MagnitudeBand.K,
-      0.75
+      Redshift(0.75)
+
     )
   )
 
@@ -140,13 +144,15 @@ object Fixture {
       PointSource,
       LibraryNonStar.NGC1068,
       9.0, MagnitudeSystem.AB, MagnitudeBand.N,
-      0.0
+      Redshift(0.0)
+
     ),
     new SourceDefinition(
       UniformSource,
       EmissionLine(12.8.microns, 500.kps, 5.0e-19.wattsPerSquareMeter, 1.0e-16.wattsPerSquareMeterPerMicron),
       12.0, SurfaceBrightness.Vega, MagnitudeBand.N,
-      1.5
+      Redshift(1.5)
+
     )
   )
 
@@ -156,13 +162,15 @@ object Fixture {
       GaussianSource(1.0),
       BlackBody(10000),
       1.0e-3, MagnitudeSystem.Vega, MagnitudeBand.Q,
-      0.0
+      Redshift(0.0)
+
     ),
     new SourceDefinition(
       UniformSource,
       PowerLaw(-1.0),
       11.0, SurfaceBrightness.Vega, MagnitudeBand.Q,
-      2.0
+      Redshift(2.0)
+
     )
   )
 

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
@@ -122,7 +122,7 @@ object Hash {
       src.distribution,
       src.norm,               // this is the magnitude value
       src.normBand.name,      // this is the magnitude band name
-      src.redshift.redshift
+      src.redshift.z
     )
 
   def calc(tp: TelescopeDetails): Int =

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Hash.scala
@@ -1,8 +1,6 @@
 package edu.gemini.itc.baseline.util
 
 import edu.gemini.itc.shared._
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover
-import edu.gemini.spModel.target._
 
 // TEMPORARY helper
 // All input objects will become immutable data only objects (probably Scala case classes).
@@ -124,7 +122,7 @@ object Hash {
       src.distribution,
       src.norm,               // this is the magnitude value
       src.normBand.name,      // this is the magnitude band name
-      src.redshift
+      src.redshift.redshift
     )
 
   def calc(tp: TelescopeDetails): Int =

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -94,7 +94,7 @@ public class SPTargetPio {
             paramSet.addParam(t.getPM1().getParam(factory, _PM1));
             paramSet.addParam(t.getPM2().getParam(factory, _PM2));
             paramSet.addParam(t.getParallax().getParam(factory, _PARALLAX));
-            Pio.addParam(factory, paramSet, _Z, Double.toString(t.getRedshift().redshift()));
+            Pio.addParam(factory, paramSet, _Z, Double.toString(t.getRedshift().z()));
         } else if (target instanceof NonSiderealTarget) {
             final NonSiderealTarget nst = (NonSiderealTarget) target;
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Redshift.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Redshift.scala
@@ -7,11 +7,11 @@ import scalaz.{Monoid, Order}
 /**
  * Specification of Radial velocity
  * TODO Cannot be a value class as it breaks java compatibility, convert to value class when the legacy target model disappears
- * @param redshift dimensionless measurement of redshift
+ * @param z dimensionless measurement of redshift
  */
-case class Redshift(redshift: Double) extends Serializable {
-  def toRadialVelocity: Velocity = Redshift.C * (((redshift + 1)*(redshift + 1) - 1)/((redshift + 1)*(redshift + 1) + 1))
-  def toApparentRadialVelocity: Velocity = Redshift.C * redshift
+case class Redshift(z: Double) extends Serializable {
+  def toRadialVelocity: Velocity = Redshift.C * (((z + 1)*(z + 1) - 1)/((z + 1)*(z + 1) + 1))
+  def toApparentRadialVelocity: Velocity = Redshift.C * z
 }
 
 object Redshift {
@@ -43,11 +43,11 @@ object Redshift {
 
   /** @group Typeclass Instances */
   implicit val order: Order[Redshift] =
-    Order.orderBy(_.redshift)
+    Order.orderBy(_.z)
 
   /** @group Typeclass Instances */
   implicit val ordering: scala.Ordering[Redshift] =
-    scala.Ordering.by(_.redshift)
+    scala.Ordering.by(_.z)
 
   /**
    * Additive monoid for `Redshift`
@@ -56,7 +56,7 @@ object Redshift {
   implicit val monoid: Monoid[Redshift] =
     new Monoid[Redshift] {
       val zero = Redshift.zero
-      def append(a: Redshift, b: => Redshift): Redshift = Redshift(a.redshift + b.redshift)
+      def append(a: Redshift, b: => Redshift): Redshift = Redshift(a.z + b.z)
     }
 
 }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -76,6 +76,6 @@ object AlmostEqual {
   implicit val RedshiftAlmostEqual =
     new AlmostEqual[Redshift] {
       def almostEqual(a: Redshift, b: Redshift) =
-        a.redshift ~= b.redshift
+        a.z ~= b.z
     }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
@@ -5,6 +5,7 @@ import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
 import edu.gemini.spModel.config2.ConfigSequence
+import edu.gemini.spModel.core.Redshift
 import edu.gemini.spModel.obscomp.SPInstObsComp
 import edu.gemini.spModel.target.env.TargetEnvironment
 import edu.gemini.spModel.target.system.HmsDegTarget
@@ -27,7 +28,7 @@ trait ItcParametersProvider {
   def targetEnvironment: String \/ TargetEnvironment
   def spectralDistribution: String \/ SpectralDistribution
   def spatialProfile: String \/ SpatialProfile
-  def redshift: String \/ Double
+  def redshift: String \/ Redshift
 }
 
 object ItcParametersProvider {
@@ -65,13 +66,13 @@ object ItcParametersProvider {
     def targetEnvironment: String \/ TargetEnvironment =
       Option(owner.getContextTargetEnv).fold("No target environment available".left[TargetEnvironment])(_.right)
 
-    def redshift: String \/ Double =
+    def redshift: String \/ Redshift =
       for {
         tEnv <- targetEnvironment
       } yield {
         tEnv.getBase.getTarget match {
-          case t: HmsDegTarget  => t.getRedshift.redshift // turn radial velocity into z-shift
-          case _                => 0.0                    // non-sidereal targets are assumed to have z-shift 0
+          case t: HmsDegTarget  => t.getRedshift // get z-shift for this target
+          case _                => Redshift(0.0) // non-sidereal targets are assumed to have z-shift 0
         }
       }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
@@ -60,7 +60,7 @@ final class SiderealDetailEditor extends TargetDetailEditor(ITarget.Tag.SIDEREAL
       case RadialVelocity         =>
         t.getRedshift.toRadialVelocity.toKilometersPerSecond
       case RedshiftZ              =>
-        t.getRedshift.redshift
+        t.getRedshift.z
       case ApparentRadialVelocity =>
         t.getRedshift.toApparentRadialVelocity.toKilometersPerSecond
     }


### PR DESCRIPTION
Use `Redshift` value from core model instead of a double in ITC code.

@cquiroz Maybe we should rename the value from `redshift` to `value` or `z`? As it is now we end up with many places like `.. = redshift.redshift` in the code. Not really a big issue, just wondering if renaming would make the code more readable.