### PR TITLE
OCSADV-??? Target Cleanup

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -3,7 +3,7 @@ package edu.gemini.ags.api
 import edu.gemini.ags.api.AgsGuideQuality.Unusable
 import edu.gemini.ags.api.AgsMagnitude._
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.core.{BandsList, Magnitude}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.ImageQuality
 import edu.gemini.spModel.guide.{GuideStarValidation, ValidatableGuideProbe, GuideProbe, GuideProbeGroup, GuideSpeed}

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -6,7 +6,7 @@ import edu.gemini.catalog.api.CatalogQuery
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.core.{BandsList, Angle}
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.guide.{GuideStarValidation, ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
@@ -2,7 +2,6 @@ package edu.gemini.ags.gems
 
 import edu.gemini.catalog.api.{MagnitudeConstraints, RadiusConstraint}
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.shared.skyobject

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -5,7 +5,6 @@ import java.util.logging.Logger
 import edu.gemini.ags.gems.mascot.{MascotCat, MascotProgress, Strehl}
 import edu.gemini.catalog.api.MagnitudeConstraints
 import edu.gemini.spModel.core._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.gemini.gsaoi.{GsaoiOdgw, Gsaoi}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
@@ -20,7 +20,7 @@ object GemsUtils4Java {
   /**
    * Returns a list of unique targets in the given search results.
    */
-  def uniqueTargets(list: java.util.List[GemsCatalogSearchResults]): java.util.List[Target.SiderealTarget] = {
+  def uniqueTargets(list: java.util.List[GemsCatalogSearchResults]): java.util.List[SiderealTarget] = {
     import collection.breakOut
     new java.util.ArrayList(list.asScala.flatMap(_.results).groupBy(_.name).map(_._2.head)(breakOut).asJava)
   }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
@@ -2,7 +2,7 @@ package edu.gemini.ags.gems
 
 import edu.gemini.catalog.api._
 import edu.gemini.catalog.votable._
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.core.{Angle, MagnitudeBand, Coordinates}
 import edu.gemini.spModel.gemini.gems.GemsInstrument
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
@@ -4,7 +4,7 @@ import java.util.logging.Logger
 
 import edu.gemini.ags.gems.mascot.Mascot.ProgressFunction
 import edu.gemini.spModel.core.{BandsList, MagnitudeBand}
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import java.util.concurrent.CancellationException
 
 /**

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotGuideStar.scala
@@ -4,7 +4,7 @@ import java.util.logging.Logger
 
 import edu.gemini.ags.gems.mascot.Mascot.ProgressFunction
 import edu.gemini.spModel.core.Coordinates
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.shared.util.immutable.ScalaConverters._

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Star.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Star.scala
@@ -3,7 +3,6 @@ package edu.gemini.ags.gems.mascot
 import MascotConf._
 
 import edu.gemini.spModel.core._
-import edu.gemini.spModel.core.Target.SiderealTarget
 
 /**
  * An object in a Mascot starlist, extracted from the results of a query to a suitable catalog.

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/CandidateValidator.scala
@@ -2,7 +2,7 @@ package edu.gemini.ags.impl
 
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
 import edu.gemini.spModel.core.Coordinates
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.guide.GuideStarValidation
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -8,7 +8,7 @@ import edu.gemini.catalog.api._
 import edu.gemini.catalog.votable._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 
 import edu.gemini.spModel.ags.AgsStrategyKey.GemsKey
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2OiwfsGuideProbe

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -5,7 +5,7 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.ags.api.{AgsAnalysis, AgsStrategy}
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.core.BandsList
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -8,7 +8,7 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.skycalc
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.core.{Coordinates, Angle}
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, VignettingGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.system.CoordinateParam.Units

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
@@ -4,7 +4,6 @@ import edu.gemini.ags.api.AgsMagnitude
 import edu.gemini.ags.api.AgsMagnitude.{MagnitudeCalc, MagnitudeTable}
 import edu.gemini.catalog.api._
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.altair.AltairAowfsGuider
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2OiwfsGuideProbe

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/TargetsHelper.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/TargetsHelper.scala
@@ -1,6 +1,6 @@
 package edu.gemini.ags
 
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.core.{Magnitude, Coordinates}
 
 trait TargetsHelper {

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/CatalogSearchCriterionSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/CatalogSearchCriterionSpec.scala
@@ -2,7 +2,6 @@ package edu.gemini.ags.gems
 
 import edu.gemini.ags.TargetsHelper
 import edu.gemini.catalog.api._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -10,7 +10,6 @@ import edu.gemini.shared.util.immutable.{None => JNone}
 import edu.gemini.skycalc.Coordinates
 import edu.gemini.skycalc.Offset
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core.Magnitude
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
@@ -4,7 +4,7 @@ import edu.gemini.ags.gems.mascot.Star
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.shared.util.immutable.{Some => JSome, None => JNone }
 import edu.gemini.spModel.core.AlmostEqual._
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.core.{Angle, MagnitudeBand, Site}
 import edu.gemini.spModel.gemini.gems.Gems
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3RegressionSpec1.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3RegressionSpec1.scala
@@ -5,7 +5,6 @@ import edu.gemini.catalog.api._
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.shared.util.immutable.{None => JNone}
 import edu.gemini.spModel.core.AngleSyntax._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3RegressionSpec2.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3RegressionSpec2.scala
@@ -5,7 +5,6 @@ import edu.gemini.catalog.api._
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.shared.util.immutable.{None => JNone}
 import edu.gemini.spModel.core.AngleSyntax._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3RegressionSpec3.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3RegressionSpec3.scala
@@ -6,7 +6,6 @@ import edu.gemini.catalog.api._
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.shared.util.immutable.{None => JNone}
 import edu.gemini.spModel.core.AngleSyntax._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
@@ -3,7 +3,6 @@ package edu.gemini.ags.gems.mascot
 import edu.gemini.ags.gems.UCAC3Regression
 import edu.gemini.catalog.api.{PPMXL, RadiusConstraint, CatalogQuery}
 import edu.gemini.catalog.votable.{TestVoTableBackend, VoTableClient}
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.TargetEnvironment

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotTest.scala
@@ -1,6 +1,5 @@
 package edu.gemini.ags.gems.mascot
 
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import org.junit.Test
 import org.junit.Assert._

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
@@ -8,7 +8,6 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.shared.util.immutable.{ None => JNone }
 import edu.gemini.skycalc.{Offset, DDMMSS, HHMMSS}
 import edu.gemini.spModel.core._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.gemini.altair.{InstAltair, AltairParams}
 import edu.gemini.spModel.gemini.inst.InstRegistry
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -8,7 +8,6 @@ import edu.gemini.catalog.votable.{CannedBackend, TestVoTableBackend}
 import edu.gemini.pot.ModelConverters.NewAngle2Old
 import edu.gemini.skycalc.{Angle => SkycalcAngle, Offset => SkycalcOffset}
 import edu.gemini.spModel.ags.AgsStrategyKey._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core.MagnitudeBand.{_r, R, UC}
 import edu.gemini.spModel.core.MagnitudeSystem.Vega
 import edu.gemini.spModel.core._

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -7,7 +7,6 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.ags.AgsStrategyKey.GmosNorthOiwfsKey
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.MagnitudeBand.{_r, R, UC}
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.gemini.gmos.{InstGmosNorth, GmosOiwfsGuideProbe}
 import edu.gemini.spModel.inst.VignettingArbitraries
 import edu.gemini.spModel.obs.context.ObsContext

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -6,7 +6,6 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.{ None => JNone }
 import edu.gemini.skycalc.{DDMMSS, HHMMSS}
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.spModel.gemini.flamingos2.{Flamingos2OiwfsGuideProbe, Flamingos2}

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -1,7 +1,7 @@
 package edu.gemini.catalog.api
 
 import edu.gemini.spModel.core.Coordinates
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 
 import scalaz._
 import Scalaz._

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/MagnitudeConstraints.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/MagnitudeConstraints.scala
@@ -1,7 +1,7 @@
 package edu.gemini.catalog.api
 
 import edu.gemini.catalog.api.MagnitudeLimits.{SaturationLimit, FaintnessLimit}
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.core.{SingleBand, BandsList, MagnitudeBand, Magnitude}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/RadiusConstraint.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/RadiusConstraint.scala
@@ -1,6 +1,5 @@
 package edu.gemini.catalog.api
 
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 
 import scalaz._

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/skycat/binding/skyobj/Votable2SkyCatalogServlet.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/skycat/binding/skyobj/Votable2SkyCatalogServlet.scala
@@ -4,7 +4,6 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse, HttpServlet}
 import edu.gemini.catalog.api._
 import edu.gemini.catalog.votable.VoTableClient
 import edu.gemini.shared.skyobject.Magnitude.Band
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.pot.ModelConverters._
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTable.scala
@@ -1,7 +1,7 @@
 package edu.gemini.catalog.votable
 
 import edu.gemini.catalog.api.{CatalogName, CatalogQuery}
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 
 import scala.util.matching.Regex
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -6,7 +6,7 @@ import java.util.logging.Logger
 
 import edu.gemini.catalog.api.{NameCatalogQuery, ConeSearchCatalogQuery, CatalogQuery}
 import edu.gemini.spModel.core.Angle
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import org.apache.commons.httpclient.{NameValuePair, HttpClient}
 import org.apache.commons.httpclient.methods.GetMethod
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -4,7 +4,6 @@ import java.io.{ByteArrayInputStream, InputStream}
 
 import edu.gemini.catalog.api.CatalogName
 import edu.gemini.spModel.core._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import squants.motion.KilometersPerSecond
 
 import scala.io.Source

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/api/MagnitudeConstraintsSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/api/MagnitudeConstraintsSpec.scala
@@ -1,7 +1,6 @@
 package edu.gemini.catalog.api
 
 import edu.gemini.catalog.api.MagnitudeLimits.{SaturationLimit, FaintnessLimit}
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import org.specs2.mutable.SpecificationWithJUnit
 

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/api/RadiusConstraintSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/api/RadiusConstraintSpec.scala
@@ -1,6 +1,5 @@
 package edu.gemini.catalog.api
 
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import org.specs2.ScalaCheck
 import org.scalacheck.Prop._

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -4,7 +4,6 @@ import java.net.URL
 
 import edu.gemini.catalog.api.{SIMBAD, PPMXL, UCAC4}
 import edu.gemini.spModel.core._
-import edu.gemini.spModel.core.Target.SiderealTarget
 import org.specs2.mutable.SpecificationWithJUnit
 import squants.motion.KilometersPerSecond
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -2,7 +2,6 @@ package edu.gemini.pot
 
 import edu.gemini.shared.skyobject
 import edu.gemini.skycalc
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.spModel.rich.shared.immutable._

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/ModelConversionsSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/ModelConversionsSpec.scala
@@ -3,7 +3,6 @@ package edu.gemini.pot
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.shared.skyobject
 import edu.gemini.skycalc
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.HmsDegTarget

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/BandsList.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/BandsList.scala
@@ -1,6 +1,6 @@
 package edu.gemini.spModel.core
 
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 
 import scalaz._
 import Scalaz._

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -76,8 +76,8 @@ object AlmostEqual {
     }
 
   implicit val SiderealTargetAlmostEqual =
-    new AlmostEqual[Target.SiderealTarget] {
-      def almostEqual(a: Target.SiderealTarget, b: Target.SiderealTarget) =
+    new AlmostEqual[SiderealTarget] {
+      def almostEqual(a: SiderealTarget, b: SiderealTarget) =
         (a.name           == b.name)           &&
         (a.coordinates    ~= b.coordinates)    &&
         (a.properMotion   ~= b.properMotion)   &&
@@ -87,8 +87,8 @@ object AlmostEqual {
     }
 
   implicit val NonSiderealTargetAlmostEqual =
-    new AlmostEqual[Target.NonSiderealTarget] {
-      def almostEqual(a: Target.NonSiderealTarget, b: Target.NonSiderealTarget) =
+    new AlmostEqual[NonSiderealTarget] {
+      def almostEqual(a: NonSiderealTarget, b: NonSiderealTarget) =
         (a.name == b.name) &&
         (a.ephemeris.toList ~= b.ephemeris.toList) &&
         (a.horizonsDesignation == b.horizonsDesignation) &&
@@ -99,9 +99,9 @@ object AlmostEqual {
     new AlmostEqual[Target] {
       def almostEqual(a: Target, b: Target) =
         (a, b) match {
-          case (a: Target.TooTarget, b: Target.TooTarget) => a == b
-          case (a: Target.SiderealTarget, b: Target.SiderealTarget) => a ~= b
-          case (a: Target.NonSiderealTarget, b: Target.NonSiderealTarget) => a ~= b
+          case (a: TooTarget, b: TooTarget) => a == b
+          case (a: SiderealTarget, b: SiderealTarget) => a ~= b
+          case (a: NonSiderealTarget, b: NonSiderealTarget) => a ~= b
           case _ => false
         }
     }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
@@ -83,8 +83,8 @@ trait Arbitraries {
       } yield Magnitude(value, band, error, system)
     }
 
-  implicit val arbTooTarget: Arbitrary[Target.TooTarget] =
-    Arbitrary(arbitrary[String].map(Target.TooTarget))
+  implicit val arbTooTarget: Arbitrary[TooTarget] =
+    Arbitrary(arbitrary[String].map(TooTarget(_)))
 
   implicit val arbHorizonsDesignation: Arbitrary[HorizonsDesignation] =
     Arbitrary {
@@ -99,7 +99,7 @@ trait Arbitraries {
       } yield des
     }
 
-  implicit val arbSiderealTarget: Arbitrary[Target.SiderealTarget] =
+  implicit val arbSiderealTarget: Arbitrary[SiderealTarget] =
     Arbitrary {
       for {
           name           <- arbitrary[String]
@@ -108,24 +108,24 @@ trait Arbitraries {
           redshift       <- arbitrary[Option[Redshift]]
           parallax       <- arbitrary[Option[Parallax]]
           magnitudes     <- arbitrary[List[Magnitude]]
-      } yield Target.SiderealTarget(name, coordinates, properMotion, redshift, parallax, magnitudes)
+      } yield SiderealTarget(name, coordinates, properMotion, redshift, parallax, magnitudes)
     }
 
-  implicit val arbNonSiderealTarget: Arbitrary[Target.NonSiderealTarget] =
+  implicit val arbNonSiderealTarget: Arbitrary[NonSiderealTarget] =
     Arbitrary {
       for {
          name         <- arbitrary[String]
          ephemeris    <- arbitrary[List[(Long, Coordinates)]]
          horizonsDesignation <- arbitrary[Option[HorizonsDesignation]]
          magnitudes   <- arbitrary[List[Magnitude]]
-      } yield Target.NonSiderealTarget(name, ==>>.fromList(ephemeris), horizonsDesignation, magnitudes)
+      } yield NonSiderealTarget(name, ==>>.fromList(ephemeris), horizonsDesignation, magnitudes)
     }
 
   implicit val arbTarget: Arbitrary[Target] =
     Arbitrary(oneOf(
-      arbitrary[Target.TooTarget],
-      arbitrary[Target.SiderealTarget],
-      arbitrary[Target.NonSiderealTarget]))
+      arbitrary[TooTarget],
+      arbitrary[SiderealTarget],
+      arbitrary[NonSiderealTarget]))
 
   implicit val arbWavelength: Arbitrary[Wavelength] =
     Arbitrary(arbitrary[Short].map(n => Math.abs(n).nm))

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -1,7 +1,7 @@
 package jsky.app.ot.tpe.gems;
 
 import edu.gemini.ags.gems.GemsUtils4Java;
-import edu.gemini.spModel.core.Target;
+import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.catalog.api.UCAC4$;
 import jsky.catalog.Catalog;
 import jsky.catalog.FieldDesc;
@@ -43,7 +43,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     private Vector<String> _columnNames;
 
     // SkyObjects corresponding to the table rows
-    private List<Target.SiderealTarget> _siderealTargets;
+    private List<SiderealTarget> _siderealTargets;
 
     public CandidateGuideStarsTableModel(GemsGuideStarSearchModel model) {
         _model = model;
@@ -90,7 +90,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     private Vector<Vector<Object>> makeDataVector() {
         _siderealTargets = GemsUtils4Java.uniqueTargets(_model.getGemsCatalogSearchResults());
         Vector<Vector<Object>> rows = new Vector<>();
-        for (Target.SiderealTarget siderealTarget : _siderealTargets) {
+        for (SiderealTarget siderealTarget : _siderealTargets) {
             if (_isUCAC4) {
                 rows.add(CatalogUtils4Java.makeUCAC4Row(siderealTarget, _nirBand, _unusedBands));
             } else {
@@ -172,8 +172,8 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
      * Returns a list of SkyObjects corresponding to the checked (or unchecked) rows in the table
      * @param checked if true, return the checked rows (candidates), otherwise the unchecked (non-candidates)
      */
-    public List<Target.SiderealTarget> getCandidates(boolean checked) {
-        List<Target.SiderealTarget> result = new ArrayList<>();
+    public List<SiderealTarget> getCandidates(boolean checked) {
+        List<SiderealTarget> result = new ArrayList<>();
         int numRows = getRowCount();
         int col = Cols.CHECK.ordinal();
         for(int row = 0; row < numRows; row++) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
@@ -3,7 +3,7 @@ package jsky.app.ot.tpe.gems;
 import edu.gemini.pot.ModelConverters;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.spModel.core.MagnitudeBand;
-import edu.gemini.spModel.core.Target;
+import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.spModel.gems.GemsTipTiltMode;
 import edu.gemini.ags.gems.GemsCatalogSearchResults;
 import edu.gemini.ags.gems.GemsGuideStars;
@@ -88,7 +88,7 @@ class GemsGuideStarSearchController {
      * @param excludeCandidates list of SkyObjects to exclude
      */
     // Called from the TPE
-    public void analyze(List<Target.SiderealTarget> excludeCandidates) throws Exception {
+    public void analyze(List<SiderealTarget> excludeCandidates) throws Exception {
         TpeImageWidget tpe = TpeManager.create().getImageWidget();
         WorldCoords basePos = tpe.getBasePos();
         ObsContext obsContext = _worker.getObsContext(basePos.getRaDeg(), basePos.getDecDeg());
@@ -99,11 +99,11 @@ class GemsGuideStarSearchController {
 
     // Returns a list of the given gemsCatalogSearchResults, with any SkyObjects removed that are not
     // in the candidates list.
-    private List<GemsCatalogSearchResults> filter(List<Target.SiderealTarget> excludeCandidates,
+    private List<GemsCatalogSearchResults> filter(List<SiderealTarget> excludeCandidates,
                                                   List<GemsCatalogSearchResults> gemsCatalogSearchResults) {
         List<GemsCatalogSearchResults> results = new ArrayList<>();
         for (GemsCatalogSearchResults in : gemsCatalogSearchResults) {
-            List<Target.SiderealTarget> siderealTargets = new ArrayList<>(in.results().size());
+            List<SiderealTarget> siderealTargets = new ArrayList<>(in.results().size());
             siderealTargets.addAll(in.resultsAsJava());
             siderealTargets = removeAll(siderealTargets, excludeCandidates);
             if (!siderealTargets.isEmpty()) {
@@ -115,15 +115,15 @@ class GemsGuideStarSearchController {
     }
 
     // Removes all the objects in the targets list that are also in the excludeCandidates list by comparing names
-    private List<Target.SiderealTarget> removeAll(List<Target.SiderealTarget> targets, List<Target.SiderealTarget> excludeCandidates) {
+    private List<SiderealTarget> removeAll(List<SiderealTarget> targets, List<SiderealTarget> excludeCandidates) {
         return targets.stream().filter(siderealTarget -> !contains(excludeCandidates, siderealTarget)).collect(Collectors.toList());
     }
 
     // Returns true if a SkyObject with the same name is in the list
-    private boolean contains(List<Target.SiderealTarget> targets, Target.SiderealTarget target) {
+    private boolean contains(List<SiderealTarget> targets, SiderealTarget target) {
         String name = target.name();
         if (name != null) {
-            for (Target.SiderealTarget s : targets) {
+            for (SiderealTarget s : targets) {
                 if (name.equals(s.name())) return true;
             }
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -4,7 +4,7 @@ import edu.gemini.ags.gems.GemsGuideStarSearchOptions.*;
 import edu.gemini.ags.gems.GemsGuideStars;
 import edu.gemini.pot.ModelConverters;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.core.Target;
+import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import jsky.app.ot.tpe.GemsGuideStarWorker;
@@ -558,7 +558,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         _model.setAnalyseChoice((AnalyseChoice) _analyseComboBox.getSelectedItem());
         _model.setAllowPosAngleAdjustments(_allowPosAngleChangesCheckBox.isSelected());
 
-        final List<Target.SiderealTarget> excludeCandidates = _candidateGuideStarsTable.getTableModel().getCandidates(false);
+        final List<SiderealTarget> excludeCandidates = _candidateGuideStarsTable.getTableModel().getCandidates(false);
 
         new SwingWorker() {
 

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -13,7 +13,7 @@ import edu.gemini.catalog.votable._
 import edu.gemini.pot.sp.{SPComponentType, ISPNode}
 import edu.gemini.shared.gui.textComponent.{SelectOnFocus, TextRenderer, NumberField}
 import edu.gemini.shared.gui.{ButtonFlattener, GlassLabel, SizePreference, SortableTable}
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
 import edu.gemini.spModel.obs.context.ObsContext

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -8,7 +8,6 @@ import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api.{UCAC4, CatalogName, CatalogQuery}
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.{None => JNone, Some => JSome}
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gmos.{InstGmosSouth, InstGmosNorth}
@@ -160,7 +159,7 @@ abstract class CatalogNavigatorColumn[T >: Null: Manifest] {
 }
 
 case class IdColumn(title: String) extends CatalogNavigatorColumn[String] {
-  override val lens = Target.name
+  override val lens = Target.name.partial
 
   def ordering = implicitly[scala.math.Ordering[String]]
 }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/mascot/gui/contour/StrehlContourPlotTest.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/mascot/gui/contour/StrehlContourPlotTest.scala
@@ -5,7 +5,6 @@ import java.awt.geom.AffineTransform
 import edu.gemini.ags.gems.mascot.{Strehl, Mascot, Star}
 import javax.swing.JOptionPane
 
-import edu.gemini.spModel.core.Target.SiderealTarget
 import edu.gemini.spModel.core._
 
 /**

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
@@ -9,7 +9,7 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.shared.gui.GlassLabel
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.shared.util.immutable.{ Option => GOption }
-import edu.gemini.spModel.core.Target.SiderealTarget
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.CoordinateTypes.Parallax

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/gems/CatalogUtils4Java.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/gems/CatalogUtils4Java.scala
@@ -1,6 +1,6 @@
 package jsky.app.ot.tpe.gems
 
-import edu.gemini.spModel.core.{MagnitudeBand, Target}
+import edu.gemini.spModel.core.{MagnitudeBand, SiderealTarget}
 import jsky.coords.{DMS, HMS}
 import scala.collection.JavaConverters._
 
@@ -11,7 +11,7 @@ object CatalogUtils4Java {
   /**
    * Build a row of data items from a Sidereal Target from UCAC4 (Containing r' and UC)
    */
-  def makeUCAC4Row(siderealTarget: Target.SiderealTarget, nirBand: String, unusedBands: Array[String]): java.util.Vector[AnyRef] = {
+  def makeUCAC4Row(siderealTarget: SiderealTarget, nirBand: String, unusedBands: Array[String]): java.util.Vector[AnyRef] = {
     new java.util.Vector[AnyRef](Vector[AnyRef](
       Boolean.box(x = true),
       siderealTarget.name,
@@ -26,7 +26,7 @@ object CatalogUtils4Java {
   /**
    * Build a row of data items from a Sidereal Target
    */
-  def makeRow(siderealTarget: Target.SiderealTarget, nirBand: String, unusedBands: Array[String]): java.util.Vector[AnyRef] = {
+  def makeRow(siderealTarget: SiderealTarget, nirBand: String, unusedBands: Array[String]): java.util.Vector[AnyRef] = {
     new java.util.Vector[AnyRef](Vector[AnyRef](
       Boolean.box(x = true),
       siderealTarget.name,


### PR DESCRIPTION
This PR cleans up `Target` a bit, makes the subtypes top-level, introduces a `DefinedTarget` intermediate trait, and moves the lenses into separate traits. This is just mechanical cleanup.