### PR TITLE
OCSADV-437: BAGS threading and lookups

### DIFF
--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -37,7 +37,7 @@ class VoTableClientSpec extends SpecificationWithJUnit with VoTableClient with N
       ConeSearchBackend.queryParams(query) should beEqualTo(Array(new NameValuePair("CATALOG", "ucac4"), new NameValuePair("RA", "10.000"), new NameValuePair("DEC", "20.000"), new NameValuePair("SR", "0.100")))
     }
     "make a query to a bad site" in {
-      Await.result(doQuery(query, new URL("http://unknown site"), ConeSearchBackend), 2.seconds) should throwA[UnknownHostException]
+      Await.result(doQuery(query, new URL("http://unknown site"), ConeSearchBackend), 10.seconds) should throwA[UnknownHostException]
     }
     "be able to select the first successful of several futures" in {
       def f1 = Future { Thread.sleep(1000); throw new RuntimeException("oops") }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -143,7 +143,7 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
                     // If we timed out, we don't want to delay.
                     case Failure(ex: TimeoutException) =>
                       LOG.warning(s"$bagsIdMsg failed: ${ex.getMessage}")
-                      enqueue(obs, 5000L)
+                      enqueue(obs, 0L)
 
                     // For all other exceptions, print the full stack trace.
                     case Failure(ex) =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -97,8 +97,10 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
       synchronized {
         val key = obs.getNodeKey
         state += key
-        executor.schedule(new Runnable {
-          def run(): Unit =
+        executor.schedule(new Thread {
+          setPriority(Thread.NORM_PRIORITY - 1)
+
+          override def run(): Unit =
 
           // If dequeue is false this means that (a) another task scheduled *after* me ended up
           // running before me, so their result is as good as mine would have been and we're done;


### PR DESCRIPTION
This fixes three minor things:

1. Thread priority of BAGS threads. (May speed things up?)

2. Initial check for whether or not observations should be queued for BAGS lookup had accidentally been moved to always, causing obs changes to fail to queue obs for BAGS, so there is a fix for this with the addition of an `initialEnqueue` parameter to `BagsManager.enqueue` to only perform the check when programs are first watched. This will go away with the upcoming feedback changes, so this should be considered a temporary fix to a temporary problem.

3. Unrelated: timeout increased for `VoTableClientSpec` since the small value for timeout was causing this test case to frequently fail.