### PR TITLE
OCSADV-443: Data model change for BAGS feedback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 3, 1)
+ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 3, 1)
 
 pitVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 0)
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -196,20 +196,10 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
             // Map all the old GuideTargets in the old target environment, keyed
             // by their guider.  This will include all guiders in use, not just
             // GsaoiOdgw.
-//            boolean enabled = true;
             final TargetEnvironment env = ctx.getTargets();
-            final Map<GuideProbe, GuideProbeTargets> gtMap = new HashMap<>();
-
             final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
-            for (final GuideProbeTargets gt : grp) {
-                gtMap.put(gt.getGuider(), gt);
-
-                // All ODGW should be disabled if any are disabled.
-                // TODO: GuideProbeTargets.isEnabled
-//                if (enabled && (gt.getGuider() instanceof GsaoiOdgw)) {
-//                    enabled = gt.isEnabled();
-//                }
-            }
+            final Map<GuideProbe, GuideProbeTargets> gtMap = new HashMap<>();
+            grp.getAll().foreach(gt -> gtMap.put(gt.getGuider(), gt));
 
             // Create the optimized target environment.
             boolean updated = false;
@@ -231,11 +221,12 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
                     final GuideProbeTargets gptOld = gtMap.get(odgw);
                     final boolean primaryIsBags = gptOld != null && gptOld.getBagsTarget().exists(primary::equals);
-                    final BagsStatus bagsStatus = primaryIsBags ? BagsSuccessWithTarget$.MODULE$.apply(primary) : BagsLookupPending$.MODULE$;
-                    final GuideProbeTargets gptNew = GuideProbeTargets.create(odgw, bagsStatus, new Some<>(primary), imLst);
+                    final GuideProbeTargets gptTmp = GuideProbeTargets.create(odgw, imLst).withExistingPrimary(primary);
+                    final GuideProbeTargets gptNew = primaryIsBags ? gptTmp.withBagsTarget(primary) : gptTmp;
                     gtMap.put(odgw, gptNew);
 
-                    if (!updated && (gptOld == null || targetsUpdated(imLst, gptOld.getTargets()) || !gptOld.getBagsTarget().equals(bagsStatus.bagsStarAsJava()))) {
+                    if (!updated && (gptOld == null || targetsUpdated(imLst, gptOld.getTargets())
+                            || !gptOld.getBagsTarget().equals(gptNew.getBagsStatus().bagsStarAsJava()))) {
                         updated = true;
                     }
                 }
@@ -252,8 +243,8 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
         }
 
         private boolean targetsUpdated(ImList<SPTarget> lst1, ImList<SPTarget> lst2) {
-            Set<SPTarget> targets1 = new HashSet<SPTarget>(lst1.toList());
-            Set<SPTarget> targets2 = new HashSet<SPTarget>(lst2.toList());
+            Set<SPTarget> targets1 = new HashSet<>(lst1.toList());
+            Set<SPTarget> targets2 = new HashSet<>(lst2.toList());
             return !targets1.equals(targets2);
         }
 
@@ -265,7 +256,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
     private final GsaoiDetectorArray.Id id;
 
-    private GsaoiOdgw(GsaoiDetectorArray.Id id) {
+    GsaoiOdgw(GsaoiDetectorArray.Id id) {
         this.id = id;
     }
 
@@ -304,7 +295,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
     }
 
     public Option<GuideProbeGroup> getGroup() {
-        return new Some<GuideProbeGroup>(Group.instance);
+        return new Some<>(Group.instance);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -8,9 +8,7 @@ import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
-import edu.gemini.spModel.target.env.GuideGroup;
-import edu.gemini.spModel.target.env.GuideProbeTargets;
-import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.*;
 
 import java.awt.geom.Area;
 import java.util.*;
@@ -233,11 +231,11 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
                     final GuideProbeTargets gptOld = gtMap.get(odgw);
                     final boolean primaryIsBags = gptOld != null && gptOld.getBagsTarget().exists(primary::equals);
-                    final Option<SPTarget> bagsTarget = primaryIsBags ? new Some<>(primary) : GuideProbeTargets.NO_TARGET;
-                    final GuideProbeTargets gptNew = GuideProbeTargets.create(odgw, bagsTarget, new Some<>(primary), imLst);
+                    final BagsStatus bagsStatus = primaryIsBags ? BagsSuccessWithTarget$.MODULE$.apply(primary) : BagsLookupPending$.MODULE$;
+                    final GuideProbeTargets gptNew = GuideProbeTargets.create(odgw, bagsStatus, new Some<>(primary), imLst);
                     gtMap.put(odgw, gptNew);
 
-                    if (!updated && (gptOld == null || targetsUpdated(imLst, gptOld.getTargets()) || !gptOld.getBagsTarget().equals(bagsTarget))) {
+                    if (!updated && (gptOld == null || targetsUpdated(imLst, gptOld.getTargets()) || !gptOld.getBagsTarget().equals(bagsStatus.bagsStarAsJava()))) {
                         updated = true;
                     }
                 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/BagsStatus.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/BagsStatus.scala
@@ -56,13 +56,22 @@ object BagsStatus {
   val BagsTargetParamSetName: String = "bagsTarget"
 
 
+//  def fromParamSet(parent: ParamSet): BagsStatus = {
+//    Option(parent.getParamSet(BagsStatusParamSetName)).map { ps =>
+//      Option(ps.getParam(BagsStatusParamName).getValue) match {
+//        case Some(BagsSuccessNoTargets.id)  => BagsSuccessNoTargets
+//        case Some(BagsSuccessWithTarget.id) =>
+//          Option(ps.getParamSet(BagsTargetParamSetName)).map(bps => BagsSuccessWithTarget(SPTarget.fromParamSet(bps))).getOrElse(BagsLookupPending)
+//        case _ => BagsLookupPending
+//      }
+//    }.getOrElse(BagsLookupPending)
+//  }
   def fromParamSet(parent: ParamSet): BagsStatus = {
-    Option(parent.getParamSet(BagsStatusParamSetName)).map { ps =>
-      Option(ps.getParam(BagsStatusParamName).getValue) match {
-        case Some(BagsSuccessNoTargets.id)  => BagsSuccessNoTargets
-        case Some(BagsSuccessWithTarget.id) =>
+    Option(parent.getParamSet(BagsStatusParamSetName)).flatMap { ps =>
+      Option(ps.getParam(BagsStatusParamName).getValue).collect {
+        case BagsSuccessNoTargets.id  => BagsSuccessNoTargets
+        case BagsSuccessWithTarget.id =>
           Option(ps.getParamSet(BagsTargetParamSetName)).map(bps => BagsSuccessWithTarget(SPTarget.fromParamSet(bps))).getOrElse(BagsLookupPending)
-        case _ => BagsLookupPending
       }
     }.getOrElse(BagsLookupPending)
   }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/BagsStatus.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/BagsStatus.scala
@@ -1,0 +1,69 @@
+package edu.gemini.spModel.target.env
+
+import edu.gemini.shared.util.immutable.{Option => GOption}
+import edu.gemini.spModel.pio.{ParamSet, Pio, PioFactory}
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.rich.shared.immutable._
+
+// Possible BAGS statuses used by GuideProbeTargets to indicate the state of BAGS targets and lookups.
+sealed trait BagsStatus extends Cloneable {
+  val bagsStar: Option[SPTarget] = None
+  def bagsStarAsJava: GOption[SPTarget] = bagsStar.asGeminiOpt
+  override def clone: BagsStatus = this
+
+  def getParamSet(factory: PioFactory): ParamSet = {
+    val paramSet = factory.createParamSet(BagsStatus.BagsStatusParamSetName)
+    Pio.addParam(factory, paramSet, BagsStatus.BagsStatusParamName, id)
+    bagsStar.foreach { t =>
+      val bagsParamSet = factory.createParamSet(BagsStatus.BagsTargetParamSetName)
+      bagsParamSet.addParamSet(t.getParamSet(factory))
+    }
+    paramSet
+  }
+
+  def id: String
+}
+
+// TODO: For objects, we want to just return this.
+// TODO: For case class, we want to return an instance.
+
+// Note that we use BagsLookupPending as a default state when BAGS hasn't run or should be rerun, and the BagsManager
+// determines based on the observation if BAGS actually should be run.
+case object BagsLookupPending extends BagsStatus {
+  override val id = "BagsLookupPending"
+}
+case object BagsLookupRunning extends BagsStatus {
+  override val id = "BagsLookupRunning"
+}
+
+case class BagsSuccessWithTarget(target: SPTarget) extends BagsStatus with Cloneable {
+  override val bagsStar = Option(target)
+  override def clone = BagsSuccessWithTarget(target.clone())
+  override val id = BagsSuccessWithTarget.id
+}
+object BagsSuccessWithTarget {
+  val id = "BagsSuccessWithTarget"
+}
+
+case object BagsSuccessNoTargets extends BagsStatus {
+  override val id = "BagsSuccessNoTargets"
+}
+
+
+object BagsStatus {
+  val BagsStatusParamSetName: String = "bagsStatus"
+  val BagsStatusParamName:    String = "bagsStatusType"
+  val BagsTargetParamSetName: String = "bagsTarget"
+
+
+  def fromParamSet(parent: ParamSet): BagsStatus = {
+    Option(parent.getParamSet(BagsStatusParamSetName)).map { ps =>
+      Option(ps.getParam(BagsStatusParamName).getValue) match {
+        case Some(BagsSuccessNoTargets.id)  => BagsSuccessNoTargets
+        case Some(BagsSuccessWithTarget.id) =>
+          Option(ps.getParamSet(BagsTargetParamSetName)).map(bps => BagsSuccessWithTarget(SPTarget.fromParamSet(bps))).getOrElse(BagsLookupPending)
+        case _ => BagsLookupPending
+      }
+    }.getOrElse(BagsLookupPending)
+  }
+}

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
@@ -32,8 +32,8 @@ final class Fixture {
         tl_pwfs2 = DefaultImList.create(t_pwfs2);
         tl_gmos  = DefaultImList.create();
 
-        gpt_pwfs1 = GuideProbeTargets.create(pwfs1, GuideProbeTargets.NO_TARGET, new Some<>(t_pwfs1_2), tl_pwfs1);
-        gpt_pwfs2 = GuideProbeTargets.create(pwfs2, GuideProbeTargets.NO_TARGET, GuideProbeTargets.NO_TARGET, tl_pwfs2);
+        gpt_pwfs1 = GuideProbeTargets.create(pwfs1, tl_pwfs1).withExistingPrimary(t_pwfs1_2);
+        gpt_pwfs2 = GuideProbeTargets.create(pwfs2, tl_pwfs2);
         gpt_gmos  = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance);
 
         grp_all  = GuideGroup.create("All", gpt_gmos, gpt_pwfs1, gpt_pwfs2);

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
@@ -76,8 +76,7 @@ enum SPTargetPosListParser {
         public void addTarget(SPTarget target, Targets targets) {
             GuideProbeTargets gt = targets.guideMap.get(guider);
             if (gt == null) {
-                gt = GuideProbeTargets.create(guider, GuideProbeTargets.NO_TARGET,
-                        GuideProbeTargets.NO_TARGET, ImCollections.singletonList(target));
+                gt = GuideProbeTargets.create(guider, ImCollections.singletonList(target));
             } else {
                 gt = gt.addManualTarget(target);
             }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -92,9 +92,7 @@ public final class TargetGroupTest extends TestBase {
             targetList = targetList.cons(targets[i]);
         }
 
-        final Option<SPTarget> primaryTarget = targetList.headOption();
-        GuideProbeTargets gt = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, GuideProbeTargets.NO_TARGET, primaryTarget, targetList);
-
+        GuideProbeTargets gt = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, targetList).withExistingPrimary(targetList.headOption());
         ImList<GuideProbeTargets> gtCollection = DefaultImList.create(gt);
         ImList<SPTarget> userTargets = ImCollections.emptyList();
 
@@ -149,10 +147,8 @@ public final class TargetGroupTest extends TestBase {
         ImList<SPTarget> targetList;
         targetList = ImCollections.singletonList(guide2).cons(guide1);
 
-        GuideProbeTargets gt = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance, GuideProbeTargets.NO_TARGET,
-                GuideProbeTargets.NO_TARGET, targetList).withPrimaryByIndex(1);
+        GuideProbeTargets gt = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance, targetList).withPrimaryByIndex(1);
         nameMap.putGuiderName(GmosOiwfsGuideProbe.instance, "OIWFS");
-
         ImList<GuideProbeTargets> gtCollection = DefaultImList.create(gt);
         ImList<SPTarget> userTargets = ImCollections.emptyList();
 
@@ -166,12 +162,10 @@ public final class TargetGroupTest extends TestBase {
 
         // Create the target environment with multiple guiders.
         final ImList<SPTarget> targetList1 = ImCollections.singletonList(pwfs1_2).cons(pwfs1_1);
-        final GuideProbeTargets pwfs1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, GuideProbeTargets.NO_TARGET,
-                new Some<>(pwfs1_1), targetList1);
+        final GuideProbeTargets pwfs1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, targetList1).withExistingPrimary(new Some<>(pwfs1_1));
 
         final ImList<SPTarget> targetList2 = ImCollections.singletonList(pwfs2_2).cons(pwfs2_1);
-        GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, GuideProbeTargets.NO_TARGET,
-                new Some<>(pwfs2_1), targetList2);
+        GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, targetList2).withExistingPrimary(new Some<>(pwfs2_1));
 
         final TargetEnvironment env = TargetEnvironment.create(base).
             putPrimaryGuideProbeTargets(pwfs1).putPrimaryGuideProbeTargets(pwfs2);
@@ -183,12 +177,10 @@ public final class TargetGroupTest extends TestBase {
 
         // Create the target environment with multiple guiders.
         final ImList<SPTarget> targetList1 = ImCollections.singletonList(pwfs1_2).cons(pwfs1_1);
-        final GuideProbeTargets pwfs1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, GuideProbeTargets.NO_TARGET,
-                new Some<>(pwfs1_1), targetList1);
+        final GuideProbeTargets pwfs1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, targetList1).withExistingPrimary(new Some<>(pwfs1_1));
 
         final ImList<SPTarget> targetList2 = ImCollections.singletonList(pwfs2_2).cons(pwfs2_1);
-        GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, GuideProbeTargets.NO_TARGET,
-                new Some<>(pwfs2_1), targetList2).withPrimaryByIndex(None.INTEGER);
+        GuideProbeTargets pwfs2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, targetList2).withExistingPrimary(new Some<>(pwfs2_1)).withPrimaryByIndex(None.INTEGER);
 
         final TargetEnvironment env = TargetEnvironment.create(base).
                 putPrimaryGuideProbeTargets(pwfs1).putPrimaryGuideProbeTargets(pwfs2);
@@ -201,8 +193,7 @@ public final class TargetGroupTest extends TestBase {
         final SPTarget oiwfsTarget = new SPTarget();
 
         final ImList<SPTarget> targetList = ImCollections.singletonList(oiwfsTarget);
-        GuideProbeTargets gt = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance, GuideProbeTargets.NO_TARGET,
-                new Some<>(oiwfsTarget), targetList);
+        GuideProbeTargets gt = GuideProbeTargets.create(GmosOiwfsGuideProbe.instance, targetList).withExistingPrimary(new Some<>(oiwfsTarget));
 
         final TargetEnvironment env = TargetEnvironment.create(base).putPrimaryGuideProbeTargets(gt);
 
@@ -223,8 +214,7 @@ public final class TargetGroupTest extends TestBase {
         final SPTarget odgwTarget = new SPTarget();
 
         final ImList<SPTarget> targetList = ImCollections.singletonList(odgwTarget);
-        final GuideProbeTargets gt = GuideProbeTargets.create(GsaoiOdgw.odgw1, GuideProbeTargets.NO_TARGET,
-                new Some<>(odgwTarget), targetList);
+        final GuideProbeTargets gt = GuideProbeTargets.create(GsaoiOdgw.odgw1, targetList).withExistingPrimary(new Some<>(odgwTarget));
 
         final TargetEnvironment env = TargetEnvironment.create(base).putPrimaryGuideProbeTargets(gt);
 
@@ -245,8 +235,7 @@ public final class TargetGroupTest extends TestBase {
         final SPTarget aowfsTarget = new SPTarget();
 
         final ImList<SPTarget> targetList = ImCollections.singletonList(aowfsTarget);
-        final GuideProbeTargets gt = GuideProbeTargets.create(AltairAowfsGuider.instance, GuideProbeTargets.NO_TARGET,
-                new Some<>(aowfsTarget), targetList);
+        final GuideProbeTargets gt = GuideProbeTargets.create(AltairAowfsGuider.instance, targetList).withExistingPrimary(new Some<>(aowfsTarget));
 
         final TargetEnvironment env = TargetEnvironment.create(base).putPrimaryGuideProbeTargets(gt);
 
@@ -267,8 +256,7 @@ public final class TargetGroupTest extends TestBase {
         final SPTarget cwfsTarget = new SPTarget();
 
         final ImList<SPTarget> targetList = ImCollections.singletonList(cwfsTarget);
-        final GuideProbeTargets gt = GuideProbeTargets.create(Canopus.Wfs.cwfs1, GuideProbeTargets.NO_TARGET,
-                new Some<>(cwfsTarget), targetList);
+        final GuideProbeTargets gt = GuideProbeTargets.create(Canopus.Wfs.cwfs1, targetList).withExistingPrimary(new Some<>(cwfsTarget));
 
         final TargetEnvironment env = TargetEnvironment.create(base).putPrimaryGuideProbeTargets(gt);
 
@@ -287,13 +275,11 @@ public final class TargetGroupTest extends TestBase {
 
     public void testDefaultGroupName() throws Exception {
         final ImList<SPTarget> targetList1 = ImCollections.singletonList(pwfs1_1);
-        final GuideProbeTargets gpt_pwfs1_1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, GuideProbeTargets.NO_TARGET,
-                new Some<>(pwfs1_1), targetList1);
+        final GuideProbeTargets gpt_pwfs1_1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, targetList1).withExistingPrimary(new Some<>(pwfs1_1));
         final ImList<GuideProbeTargets> gpt1 = ImCollections.singletonList(gpt_pwfs1_1);
 
         final ImList<SPTarget> targetList2 = ImCollections.singletonList(pwfs1_2);
-        final GuideProbeTargets gpt_pwfs1_2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, GuideProbeTargets.NO_TARGET,
-                new Some<>(pwfs1_2), targetList2);
+        final GuideProbeTargets gpt_pwfs1_2 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, targetList2).withExistingPrimary(new Some<>(pwfs1_2));
         final ImList<GuideProbeTargets> gpt2 = ImCollections.singletonList(gpt_pwfs1_2);
 
         // grp1 -> "Explict Name"


### PR DESCRIPTION
Previously, we maintained an `Option<SPTarget>` in `GuideProbeTargets` to store a possible BAGS target; however, due to the new requirement to provide feedback for BAGS, the decision was made to instead replace this with a `BagsStatus` which comprises a number of possible statuses that can be used and represented by BAGS.

This is the initial change to the data model to accommodate this feature. The actual feedback itself and changes to `BagsManager` will be forthcoming, but the previous functionality has been maintained through this change.