### PR TITLE
REL-2369 demote Pluto

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -46,7 +46,7 @@ public class SPTargetPio {
     private static final String _PERIHELION = "perihelion";
     private static final String _EPOCH_OF_PERIHELION = "epochOfPeri";
 
-    private static final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.FULL);
+    public static final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.FULL);
     static {
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/NamedTarget.java
@@ -28,8 +28,7 @@ public final class NamedTarget extends NonSiderealTarget {
         JUPITER("Jupiter", 599),
         SATURN ("Saturn",  699),
         URANUS ("Uranus",  799),
-        NEPTUNE("Neptune", 899),
-        PLUTO  ("Pluto",   999);
+        NEPTUNE("Neptune", 899);
 
         private final String _displayValue;
         public final int queryId; // search for this

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
@@ -3,7 +3,11 @@ package edu.gemini.spModel.io.impl.migration.to2016A
 import edu.gemini.spModel.io.impl.SpIOTags
 import edu.gemini.spModel.io.impl.migration.Migration
 import edu.gemini.spModel.io.impl.migration.PioSyntax._
-import edu.gemini.spModel.pio.{Container, Document, ParamSet, Version}
+import edu.gemini.spModel.pio.{Container, Document, Param, Version}
+import edu.gemini.spModel.pio.xml.{PioXmlUtil}
+
+import scala.collection.JavaConverters._
+
 import squants.motion.KilometersPerSecond
 import squants.radio.{WattsPerSquareMeter, WattsPerSquareMeterPerMicron}
 
@@ -27,7 +31,7 @@ object To2016A extends Migration {
 
   // These will be applied in the given order
   private val conversions: List[Document => Unit] = List(
-    addUnitsToELine
+    addUnitsToELine, demotePluto
   )
 
   // Starting 2016A we store squants quantities with their units, older programs need to have units added
@@ -40,5 +44,46 @@ object To2016A extends Migration {
       p.getParam("continuum").setUnits(WattsPerSquareMeterPerMicron.symbol)
     })
   }
+
+  // Turn Pluto into an asteroid by removing its system and object id, replacing them with system
+  // and orbital elements from the properly resolved value below. Coordinates and valid-at date
+  // are preserved.
+  private def demotePluto(d: Document): Unit =
+    for {
+      ps  <- allTargets(d)
+      sys <- Option(ps.getParam("system")).toList if sys.getValue == "Solar system object"
+      obj <- Option(ps.getParam("object")).toList if obj.getValue == "PLUTO"
+    } {
+      ps.removeChild(obj)
+      ps.removeChild(sys)
+      plutoParams.foreach(ps.addParam)
+    }
+
+  // Params taken from a program with a properly resolved Pluto (now an asteroid). This includes
+  // only the system and orbital elements.
+  lazy val plutoParams: List[Param] = {
+    PioXmlUtil.read(
+      <document>
+        <container>
+          <paramset name="pluto">
+            <param name="system" value="MPC minor planet"/>
+            <param name="epoch" value="2457217.5" units="JD"/>
+            <param name="anode" value="110.2100007229519" units="degrees"/>
+            <param name="aq" value="39.74409337717218" units="au"/>
+            <param name="e" value="0.2543036816945946"/>
+            <param name="inclination" value="17.36609399010031" units="degrees"/>
+            <param name="lm" value="0.0" units="degrees"/>
+            <param name="n" value="0.0" units="degrees/day"/>
+            <param name="perihelion" value="114.2248220688449" units="degrees"/>
+            <param name="epochOfPeri" value="2447885.60548777" units="JD"/>
+          </paramset>
+        </container>
+      </document>.toString
+    ).asInstanceOf[Document]
+      .getContainers.get(0).asInstanceOf[Container]
+      .getParamSet("pluto").getParams.asInstanceOf[java.util.List[Param]]
+      .asScala.toList
+  }
+
 
 }

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016A/pluto.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016A/pluto.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2015B-1" subtype="basic" key="cfec9a86-d48c-445f-a852-6cf98fb9a0b7" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="be9d40e2-9f9b-4915-8fc8-ae3845f3b8c6" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GMOS-N Observation"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="4fa2f93e-f2b4-4112-8389-f1f3c726f474" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e7237a60-3996-4153-a751-87998a55864e" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="Pluto"/>
+              <param name="c1" value="15:41:38.380"/>
+              <param name="c2" value="-15:52:28.70"/>
+              <param name="validAt" value="10/28/15 7:39:58 PM UTC"/>
+              <param name="system" value="Solar system object"/>
+              <param name="object" value="PLUTO"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="11ec9898-ee95-491e-a29f-e6f2f3047a51" name="GMOS-N">
+        <paramset name="GMOS-N" kind="dataObj">
+          <param name="exposureTime" value="300.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <paramset name="parallacticAngleDuration">
+            <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
+            <param name="explicitDuration" value="0"/>
+          </paramset>
+          <param name="adc" value="NONE"/>
+          <param name="ampCount" value="SIX"/>
+          <param name="gainChoice" value="LOW"/>
+          <param name="ampReadMode" value="SLOW"/>
+          <param name="detectorManufacturer" value="E2V"/>
+          <param name="disperser" value="MIRROR"/>
+          <param name="fpuMode" value="BUILTIN"/>
+          <param name="fpu" value="FPU_NONE"/>
+          <param name="filter" value="NONE"/>
+          <param name="ccdXBinning" value="ONE"/>
+          <param name="ccdYBinning" value="ONE"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="stageMode" value="FOLLOW_XY"/>
+          <param name="dtaXOffset" value="ZERO"/>
+          <param name="builtinROI" value="FULL_FRAME"/>
+          <param name="useNS" value="FALSE"/>
+          <param name="mosPreimaging" value="NO"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e5b25187-e293-49f0-bd77-efd7bcfd29b9" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="58bc1910-3581-4d07-a6ce-a9c7d9d77a84" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2c2f4268-f32b-4b02-80ed-b8dbaae9bdf4" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="2c2f4268-f32b-4b02-80ed-b8dbaae9bdf4"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e5b25187-e293-49f0-bd77-efd7bcfd29b9"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="cfec9a86-d48c-445f-a852-6cf98fb9a0b7"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e7237a60-3996-4153-a751-87998a55864e"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="58bc1910-3581-4d07-a6ce-a9c7d9d77a84"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="11ec9898-ee95-491e-a29f-e6f2f3047a51"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="be9d40e2-9f9b-4915-8fc8-ae3845f3b8c6"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4fa2f93e-f2b4-4112-8389-f1f3c726f474"/>
+      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
@@ -1,0 +1,57 @@
+package edu.gemini.spModel.io.impl.migration.to2016A
+
+import edu.gemini.pot.sp.{ISPObservation, ISPProgram, SPComponentType}
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import edu.gemini.spModel.target.{SPTargetPio, SPTarget}
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.target.system.ConicTarget
+import org.junit.{Assert, Test}
+
+import scala.collection.JavaConverters._
+
+class PlutoDemotionTest extends MigrationTest {
+
+  @Test def testTemplateConversion(): Unit =
+    withTestProgram("pluto.xml", { (_,p) => validateProgram(p) })
+
+  private def validateProgram(p: ISPProgram): Unit = {
+    p.getAllObservations.asScala.foreach(validateObservation)
+  }
+
+  private def validateObservation(obs: ISPObservation): Unit = {
+    obs.getObsComponents.asScala
+      .find(_.getType == SPComponentType.TELESCOPE_TARGETENV).get
+      .getDataObject.asInstanceOf[TargetObsComp]
+      .getTargetEnvironment
+      .getBase match {
+
+      case sp: SPTarget =>
+
+        sp.getTarget match {
+
+          case ct: ConicTarget => // we know system is correct
+
+            // These are preserved from the fixture
+            Assert.assertEquals("Name", "Pluto", ct.getName)
+            Assert.assertEquals("ValidAt", "10/28/15 7:39:58 PM UTC", SPTargetPio.formatter.format(ct.getDateForPosition))
+            Assert.assertEquals("RA", "15:41:38.380", ct.getRa.toString)
+            Assert.assertEquals("Dec", "-15:52:28.70", ct.getDec.toString)
+
+            // These are all new
+            Assert.assertEquals("Epoch", 2457217.5, ct.getEpoch.getValue, 0.00001)
+            Assert.assertEquals("ANode", 110.2100007229519, ct.getANode.getValue, 0.00001)
+            Assert.assertEquals("AQ", 39.74409337717218, ct.getAQ.getValue, 0.00001)
+            Assert.assertEquals("E", 0.2543036816945946, ct.getE, 0.00001)
+            Assert.assertEquals("Inclination", 17.36609399010031, ct.getInclination.getValue, 0.00001)
+            Assert.assertEquals("LM", 0.0, ct.getLM.getValue, 0.00001)
+            Assert.assertEquals("N", 0.0, ct.getN.getValue, 0.00001)
+            Assert.assertEquals("Perihelion", 114.2248220688449, ct.getPerihelion.getValue, 0.00001)
+            Assert.assertEquals("Epoch of Perihelion", 2447885.60548777, ct.getEpochOfPeri.getValue, 0.00001)
+
+          case t => Assert.fail("Expected ConicTarget, found " + t)
+
+        }
+    }
+  }
+
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/package.scala
@@ -53,10 +53,7 @@ package object details {
   }
 
   implicit class SolarObjectOps(obj: NamedTarget.SolarObject) {
-    def objectType = obj match {
-      case NamedTarget.SolarObject.PLUTO => ObjectType.MINOR_BODY
-      case _ => ObjectType.MAJOR_BODY
-    }
+    def objectType = ObjectType.MAJOR_BODY
   }
 
   implicit class CoordinateParamOps(p: CoordinateParam) {


### PR DESCRIPTION
This PR removes `NamedTarget.Pluto` and adds a `To2016A` conversion that swaps it for a `ConicTarget` with Pluto's orbital elements.