### PR TITLE
REL-2368: Update QVis to support FT observations on queue nights

### DIFF
--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/charts/VisibilityChart.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/charts/VisibilityChart.scala
@@ -313,24 +313,23 @@ trait VisibilityChart {
       })
 
     val schedule = SolutionProvider(site).telescopeSchedule
-    constraints.toSeq.map {
+    constraints.toSeq.flatMap {
         case InstrumentConstraint     =>
           val paint = new GradientPaint(0, 0, new Color(0, 0, 0), 0, 100, new Color(255, 255, 255, 30))
-          schedule.instrumentSchedules.map(is => {
+          schedule.instrumentSchedules.flatMap(is => {
             markers(s"${is.instrument.readableStr}-Off", paint, is.intervals, labelAtBottom = true)
-          }).flatten
+          })
         case ProgramConstraint      =>
-          schedule.programSchedules.map(cs => {
+          schedule.programSchedules.flatMap(cs => {
             val paint = if (cs.id.ptype == Some(Classical)) claColor else prgColor
             markers(cs.id.toString, paint, cs.intervals)
-          }).flatten
-        case FastTurnaroundConstraint => markers(FastTurnaroundConstraint.label, ftpColor, schedule.fastTurnaroundSchedule.intervals)
+          })
         case LaserConstraint          => markers(LaserConstraint.label, lasColor, schedule.laserSchedule.intervals)
         case ShutdownConstraint       => markers(ShutdownConstraint.label, redColor, schedule.shutdownSchedule.intervals)
         case EngineeringConstraint    => markers(EngineeringConstraint.label, redColor, schedule.engineeringSchedule.intervals)
         case WeatherConstraint        => markers(EngineeringConstraint.label, redColor, schedule.engineeringSchedule.intervals)
         case _ => Seq()
-    }.flatten
+    }
   }
 
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/ui/FilterElement.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/ui/FilterElement.scala
@@ -336,13 +336,14 @@ object FilterElement {
     }
 
     def filter = init match {
-      case IsActive(_) => IsActive(selection)
-      case IsCompleted(_) => IsCompleted(selection)
-      case IsRollover(_) => IsRollover(selection)
-      case HasTimingConstraints(_) => HasTimingConstraints(selection)
+      case IsActive(_)                => IsActive(selection)
+      case IsCompleted(_)             => IsCompleted(selection)
+      case IsRollover(_)              => IsRollover(selection)
+      case HasTimingConstraints(_)    => HasTimingConstraints(selection)
       case HasElevationConstraints(_) => HasElevationConstraints(selection)
-      case HasPreImaging(_) => HasPreImaging(selection)
-      case IsNonSidereal(_) => IsNonSidereal(selection)
+      case HasPreImaging(_)           => HasPreImaging(selection)
+      case IsNonSidereal(_)           => IsNonSidereal(selection)
+      case HasDummyTarget(_)          => HasDummyTarget(selection)
     }
 
     private def selection: Option[Boolean] =

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/selector/ConstraintsSelector.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/selector/ConstraintsSelector.scala
@@ -49,8 +49,8 @@ class ConstraintsSelector(ctx: QvContext) extends Publisher {
       Set(EngineeringConstraint, ShutdownConstraint, WeatherConstraint)),
     ConstraintBtn(
       "Programs",
-      "Take fast turnaround, laser availability and classical observing restrictions into account.",
-      Set(FastTurnaroundConstraint, LaserConstraint, ProgramConstraint))
+      "Take laser availability and classical observing restrictions into account.",
+      Set(LaserConstraint, ProgramConstraint))
   )
 
   private val buttons = mainConstraintsBtns ++ scheduleConstraintsBtns

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/selector/ScheduleEditor.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/selector/ScheduleEditor.scala
@@ -25,6 +25,7 @@ import scala.util.Failure
 import scala.util.Success
 
 /**
+ * Editor UI that allows to add, delete and edit schedule constraints in the calendar.
  */
 class ScheduleEditor(ctx: QvContext, scheduleCache: ScheduleCache) extends Dialog {
 
@@ -177,20 +178,19 @@ class ScheduleEditor(ctx: QvContext, scheduleCache: ScheduleCache) extends Dialo
 
   def update(): Unit = {
     instruments.visible = constraints.selection.item == InstrumentConstraint
-    programs.visible = constraints.selection.item == ProgramConstraint
-    addBtn.visible = constraints.selection.item != LaserConstraint
-    scroll.contents = constraints.selection.item match {
-      case InstrumentConstraint =>
+    programs.visible    = constraints.selection.item == ProgramConstraint
+    addBtn.visible      = constraints.selection.item != LaserConstraint
+    scroll.contents     = constraints.selection.item match {
+      case InstrumentConstraint     =>
         val constraints = schedule.instrumentSchedule(instruments.selection.item).map(_.constraints).getOrElse(Seq())
         constraintsPanel(constraints)
-      case ProgramConstraint =>
+      case ProgramConstraint        =>
         val constraints = schedule.programSchedule(programs.selection.item).map(_.constraints).getOrElse(Seq())
         constraintsPanel(constraints)
       case LaserConstraint => constraintsPanel(schedule.laserSchedule.constraints)
-      case FastTurnaroundConstraint => constraintsPanel(schedule.fastTurnaroundSchedule.constraints)
-      case ShutdownConstraint => constraintsPanel(schedule.shutdownSchedule.constraints)
-      case EngineeringConstraint => constraintsPanel(schedule.engineeringSchedule.constraints)
-      case WeatherConstraint => constraintsPanel(schedule.weatherSchedule.constraints)
+      case ShutdownConstraint       => constraintsPanel(schedule.shutdownSchedule.constraints)
+      case EngineeringConstraint    => constraintsPanel(schedule.engineeringSchedule.constraints)
+      case WeatherConstraint        => constraintsPanel(schedule.weatherSchedule.constraints)
     }
   }
 
@@ -227,13 +227,12 @@ class ScheduleEditor(ctx: QvContext, scheduleCache: ScheduleCache) extends Dialo
   }
 
   def createConstraint(i: Interval) = constraints.selection.item match {
-      case InstrumentConstraint => TelescopeSchedule.InstrumentConstraint(instruments.selection.item, i)
-      case ProgramConstraint => TelescopeSchedule.ProgramConstraint(programs.selection.item, i)
-      case LaserConstraint => TelescopeSchedule.LaserConstraint(i)
-      case WeatherConstraint => TelescopeSchedule.WeatherConstraint(i)
-      case FastTurnaroundConstraint => TelescopeSchedule.FastTurnaroundConstraint(i)
-      case ShutdownConstraint => TelescopeSchedule.ShutdownConstraint(i)
-      case EngineeringConstraint => TelescopeSchedule.EngineeringConstraint(i)
+      case InstrumentConstraint   => TelescopeSchedule.InstrumentConstraint(instruments.selection.item, i)
+      case ProgramConstraint      => TelescopeSchedule.ProgramConstraint(programs.selection.item, i)
+      case LaserConstraint        => TelescopeSchedule.LaserConstraint(i)
+      case WeatherConstraint      => TelescopeSchedule.WeatherConstraint(i)
+      case ShutdownConstraint     => TelescopeSchedule.ShutdownConstraint(i)
+      case EngineeringConstraint  => TelescopeSchedule.EngineeringConstraint(i)
     }
 
   def newConstraint() {

--- a/bundle/edu.gemini.services.client/src/main/scala/edu/gemini/services/client/TelescopeSchedule.scala
+++ b/bundle/edu.gemini.services.client/src/main/scala/edu/gemini/services/client/TelescopeSchedule.scala
@@ -14,7 +14,6 @@ object TelescopeSchedule {
   case class InstrumentConstraint(instrument: SPComponentType, interval: Interval) extends Constraint
   case class ProgramConstraint(id: ProgramId, interval: Interval) extends Constraint
   case class LaserConstraint(interval: Interval) extends Constraint
-  case class FastTurnaroundConstraint(interval: Interval) extends Constraint
   case class ShutdownConstraint(interval: Interval) extends Constraint
   case class WeatherConstraint(interval: Interval) extends Constraint
   case class EngineeringConstraint(interval: Interval) extends Constraint
@@ -26,7 +25,6 @@ object TelescopeSchedule {
   case class InstrumentSchedule(instrument: SPComponentType, constraints: Seq[InstrumentConstraint]) extends Schedule
   case class ProgramSchedule(id: ProgramId, constraints: Seq[ProgramConstraint]) extends Schedule
   case class LaserSchedule(constraints: Seq[LaserConstraint]) extends Schedule
-  case class FastTurnaroundSchedule(constraints: Seq[FastTurnaroundConstraint]) extends Schedule
   case class ShutdownSchedule(constraints: Seq[ShutdownConstraint]) extends Schedule
   case class WeatherSchedule(constraints: Seq[WeatherConstraint]) extends Schedule
   case class EngineeringSchedule(constraints: Seq[EngineeringConstraint]) extends Schedule
@@ -35,7 +33,6 @@ object TelescopeSchedule {
     Set(),
     Set(),
     new LaserSchedule(Seq()),
-    new FastTurnaroundSchedule(Seq()),
     new ShutdownSchedule(Seq()),
     new WeatherSchedule(Seq()),
     new EngineeringSchedule(Seq())
@@ -52,7 +49,6 @@ case class TelescopeSchedule(
   instrumentSchedules: Set[InstrumentSchedule],
   programSchedules: Set[ProgramSchedule],
   laserSchedule: LaserSchedule,
-  fastTurnaroundSchedule: FastTurnaroundSchedule,
   shutdownSchedule: ShutdownSchedule,
   weatherSchedule: WeatherSchedule,
   engineeringSchedule: EngineeringSchedule

--- a/bundle/edu.gemini.services.server/src/main/scala/edu/gemini/services/server/util/TelescopeScheduleServiceImpl.scala
+++ b/bundle/edu.gemini.services.server/src/main/scala/edu/gemini/services/server/util/TelescopeScheduleServiceImpl.scala
@@ -1,24 +1,21 @@
 package edu.gemini.services.server.util
 
+import java.net.URI
+
 import edu.gemini.pot.sp.SPComponentType
-import edu.gemini.services.client.Calendar.Entry
+import edu.gemini.services.client.Calendar.{AllDayEvent, Entry}
+import edu.gemini.services.client.TelescopeSchedule.{LaserConstraint, LaserSchedule, ShutdownSchedule, _}
 import edu.gemini.services.client._
 import edu.gemini.services.server.telescope.LttsService
 import edu.gemini.skycalc.TimeUtils
 import edu.gemini.spModel.core.ProgramId
 import edu.gemini.spModel.gemini.inst.InstRegistry
 import edu.gemini.util.skycalc.calc.Interval
-import edu.gemini.services.client.TelescopeSchedule._
-import edu.gemini.services.client.TelescopeSchedule.LaserConstraint
-import edu.gemini.services.client.TelescopeSchedule.FastTurnaroundSchedule
-import edu.gemini.services.client.Calendar.AllDayEvent
-import edu.gemini.services.client.TelescopeSchedule.ShutdownSchedule
-import edu.gemini.services.client.TelescopeSchedule.LaserSchedule
+
 import scala.collection.JavaConversions._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import java.net.URI
 
 /**
  * Implementation for the telescope schedule service.
@@ -46,7 +43,6 @@ class TelescopeScheduleServiceImpl(calendarService: CalendarService, lttsService
       instrumentSchedules(events, range),
       programSchedules(events),
       laserSchedule,
-      fastTurnaroundSchedule(events),
       shutdownSchedule(events),
       weatherSchedule(events),
       engineeringSchedule(events)
@@ -72,7 +68,6 @@ class TelescopeScheduleServiceImpl(calendarService: CalendarService, lttsService
   // ====
 
   private def laserSchedule(range: Interval) = lttsService.getNights(range).map(n => LaserSchedule(n.map(LaserConstraint)))
-  private def fastTurnaroundSchedule(events: Seq[Entry]) = FastTurnaroundSchedule(filter(events, "Fast Turnaround").map(FastTurnaroundConstraint))
   private def shutdownSchedule(events: Seq[Entry]) = ShutdownSchedule(filter(events, "Shutdown").map(ShutdownConstraint))
   private def engineeringSchedule(events: Seq[Entry]) = EngineeringSchedule(filter(events, "Engineering").map(EngineeringConstraint))
   private def weatherSchedule(events: Seq[Entry]) = WeatherSchedule(filter(events, "Weather").map(WeatherConstraint))
@@ -123,7 +118,6 @@ class TelescopeScheduleServiceImpl(calendarService: CalendarService, lttsService
     case c: InstrumentConstraint => s"Instrument ${c.instrument.readableStr} - Off"
     case c: ProgramConstraint => s"Program ${c.id}"
     case c: LaserConstraint => "Laser"
-    case c: FastTurnaroundConstraint => "Fast Turnaround"
     case c: ShutdownConstraint => "Shutdown"
     case c: EngineeringConstraint => "Engineering"
     case c: WeatherConstraint => "Weather"


### PR DESCRIPTION
The rules for scheduling Fast Turnaround programs have changed: Originally they were meant to be scheduled on specific FT nights only but recently it has been decided that they should be scheduled like additional queue programs on any nights that are available for queue observing.

This means that the special Fast Turnaround constraints in QVis have become obsolete and can be removed unceremoniously, which is what this PR is doing.