### PR TITLE
REL-2359: Add Daytime Calibration option to QPT

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -3,10 +3,9 @@ package edu.gemini.ags.api
 import edu.gemini.ags.api.AgsGuideQuality.Unusable
 import edu.gemini.ags.api.AgsMagnitude._
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.spModel.core.SiderealTarget
-import edu.gemini.spModel.core.{BandsList, Magnitude}
+import edu.gemini.spModel.core.{BandsList, Magnitude, SiderealTarget}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.ImageQuality
-import edu.gemini.spModel.guide.{GuideStarValidation, ValidatableGuideProbe, GuideProbe, GuideProbeGroup, GuideSpeed}
+import edu.gemini.spModel.guide.{GuideProbe, GuideProbeGroup, GuideSpeed, GuideStarValidation, ValidatableGuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.SPTarget
@@ -102,7 +101,7 @@ object AgsAnalysis {
       if (probeBands.bands.length == 1) {
         s"${p}uide star ${probeBands.bands.head}-band magnitude is missing. Cannot determine guiding performance."
       } else {
-        s"${p}uide star ${probeBands.bands.map(_.name).list.mkString(", ")}-band magnitudes are missing. Cannot determine guiding performance."
+        s"${p}uide star ${probeBands.bands.map(_.name).mkString(", ")}-band magnitudes are missing. Cannot determine guiding performance."
       }
     }
     override val quality = AgsGuideQuality.PossiblyUnusable
@@ -157,8 +156,8 @@ object AgsAnalysis {
   }
 
   private def magnitudeAnalysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget, bands: BandsList): Option[AgsAnalysis] = {
-    import GuideSpeed._
     import AgsGuideQuality._
+    import GuideSpeed._
 
     val conds = ctx.getConditions
 
@@ -200,7 +199,7 @@ object AgsAnalysis {
     }
 
     // Find the first band in the guide star that is on the list of possible bands
-    def usableMagnitude:Option[Magnitude] = bands.bands.list.map(guideStar.magnitudeIn).find(_.isDefined).flatten
+    def usableMagnitude:Option[Magnitude] = bands.bands.map(guideStar.magnitudeIn).find(_.isDefined).flatten
 
     for {
       mc  <- mt(ctx, guideProbe)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
@@ -243,7 +243,7 @@ case class AgsTest(ctx: ObsContext, guideProbe: GuideProbe, usable: List[(Sidere
       val m    = GuideSpeed.values.toList.map { gs => gs -> mc.apply(ctx.getConditions, gs) }.toMap
       val fast = m(FAST)
       // Randomly pick one of the allowed bands
-      val band = strategy.probeBands.bands.list(scala.util.Random.nextInt(strategy.probeBands.bands.size))
+      val band = strategy.probeBands.bands(scala.util.Random.nextInt(strategy.probeBands.bands.size))
 
       def magList(base: Double)(adjs: (Double, Option[GuideSpeed])*): List[(Magnitude, Option[GuideSpeed])] =
         adjs.toList.map { case (adj, gs) => (new Magnitude(base + adj, band), gs) }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsclass/ObsClass.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsclass/ObsClass.java
@@ -1,7 +1,3 @@
-//
-// $Id: ObsClass.java 44610 2012-04-18 18:57:38Z swalker $
-//
-
 package edu.gemini.spModel.obsclass;
 
 import edu.gemini.spModel.time.ChargeClass;
@@ -110,7 +106,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
     private String _logValue;
 
 
-    private ObsClass(String headerVal, String displayVal, int priority, ChargeClass charge, String logValue) {
+    ObsClass(String headerVal, String displayVal, int priority, ChargeClass charge, String logValue) {
         _headerValue  = headerVal;
         _displayValue = displayVal;
         _priority     = priority;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/ShellAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/ShellAdvisor.java
@@ -95,7 +95,7 @@ public class ShellAdvisor implements IShellAdvisor, PropertyChangeListener {
 		final IViewAdvisor.Relation relation;
 		final ViewAdvisor relative;
 
-		private ViewAdvisor(IViewAdvisor advisor, Relation relation, ViewAdvisor relative) {
+		ViewAdvisor(IViewAdvisor advisor, Relation relation, ViewAdvisor relative) {
 			this.advisor = advisor;
 			this.relation = relation;
 			this.relative = relative;
@@ -121,7 +121,7 @@ public class ShellAdvisor implements IShellAdvisor, PropertyChangeListener {
 		final IActionManager.Relation relation;
 		final Menu relative;
 
-		private Menu(edu.gemini.ui.workspace.IActionManager.Relation relation, Menu relative) {
+		Menu(edu.gemini.ui.workspace.IActionManager.Relation relation, Menu relative) {
 			this.relation = relation;
 			this.relative = relative;
 		}
@@ -228,7 +228,8 @@ public class ShellAdvisor implements IShellAdvisor, PropertyChangeListener {
 			null,
 			new BooleanPreferenceAction(VIEW_INACTIVE_PROGRAMS, VIEW_ALL, "Inactive Programs"),
 			new BooleanPreferenceAction(VIEW_SCIENCE_OBS, VIEW_ALL, "Science Observations"),
-			new BooleanPreferenceAction(VIEW_CALIBRATIONS, VIEW_ALL, "Calibration Observations"),
+			new BooleanPreferenceAction(VIEW_NIGHTTIME_CALIBRATIONS, VIEW_ALL, "Nighttime Calibration Observations"),
+			new BooleanPreferenceAction(VIEW_DAYTIME_CALIBRATIONS, VIEW_ALL, "Daytime Calibration Observations"),
 			null,
 			new BooleanPreferenceAction(VIEW_BAND_1, VIEW_ALL, "Science Band 1", KeyEvent.VK_1),
 			new BooleanPreferenceAction(VIEW_BAND_2, VIEW_ALL, "Science Band 2", KeyEvent.VK_2),

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/BooleanViewPreference.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/BooleanViewPreference.java
@@ -1,8 +1,5 @@
 package edu.gemini.qpt.ui.util;
 
-
-
-
 public enum BooleanViewPreference implements PreferenceManager.Key<Boolean> {
 
 	// Show All (normally off)
@@ -22,8 +19,9 @@ public enum BooleanViewPreference implements PreferenceManager.Key<Boolean> {
 //	VIEW_BAND_0("Non-Queue Programs", false),
 	VIEW_INACTIVE_PROGRAMS(false),	
 	VIEW_SCIENCE_OBS(true),
-	VIEW_CALIBRATIONS(false),
-	
+	VIEW_NIGHTTIME_CALIBRATIONS(false),
+	VIEW_DAYTIME_CALIBRATIONS(false),
+
 	VIEW_BAND_1(true),
 	VIEW_BAND_2(true),
 	VIEW_BAND_3(true),

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/ClientExclusion.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/ClientExclusion.java
@@ -30,7 +30,8 @@ public enum ClientExclusion {
     HIDDEN_PCAL("Program is of type " + StructuredProgramID.Type.CAL.getDescription(), VIEW_SP_CAL),
 	HIDDEN_INACTIVE_PROGRAMS("Program is inactive.", VIEW_INACTIVE_PROGRAMS),
 
-	HIDDEN_CALS("Obs is a calibration.", VIEW_CALIBRATIONS),
+	HIDDEN_NIGHT_CALS("Obs is a nighttime calibration.", VIEW_NIGHTTIME_CALIBRATIONS),
+	HIDDEN_DAY_CALS("Obs is a daytime calibration.", VIEW_DAYTIME_CALIBRATIONS),
 	HIDDEN_SCI("Obs is science.", VIEW_SCIENCE_OBS),
 
 	HIDDEN_OVER_QUALIFIED_OBSERVATIONS("Obs is over-qualified.", VIEW_OVER_QUALIFIED_OBSERVATIONS),
@@ -63,30 +64,35 @@ public enum ClientExclusion {
         // Daily Engineering and Calibration observations are not filtered by band
         if ( !obs.getProg().isEngOrCal() ) {
             switch (obs.getProg().getBand()) {
-            case 1: if (!VIEW_BAND_1.get()) return HIDDEN_BAND_1; break;
-            case 2: if (!VIEW_BAND_2.get()) return HIDDEN_BAND_2; break;
-            case 3: if (!VIEW_BAND_3.get()) return HIDDEN_BAND_3; break;
-            case 4: if (!VIEW_BAND_4.get()) return HIDDEN_BAND_4; break;
+                case 1: if (!VIEW_BAND_1.get()) return HIDDEN_BAND_1; break;
+                case 2: if (!VIEW_BAND_2.get()) return HIDDEN_BAND_2; break;
+                case 3: if (!VIEW_BAND_3.get()) return HIDDEN_BAND_3; break;
+                case 4: if (!VIEW_BAND_4.get()) return HIDDEN_BAND_4; break;
             default:
                 LOGGER.warning("Program " + obs.getProg() + " has unexpected science band: " + obs.getProg().getBand());
             }
         }
 		// SP Type filtering
 		switch (obs.getProg().getStructuredProgramId().getType()) {
-        case LP: if (!VIEW_SP_LP.get()) return HIDDEN_LP; break;
-		case C: if (!VIEW_SP_C.get()) return HIDDEN_C; break;
-        case FT: if (!VIEW_SP_FT.get()) return HIDDEN_FT; break;
-		case Q: if (!VIEW_SP_Q.get()) return HIDDEN_Q; break;
-		case SV: if (!VIEW_SP_SV.get()) return HIDDEN_SV; break;
-		case DD: if (!VIEW_SP_DD.get()) return HIDDEN_DD; break;
-		case DS: if (!VIEW_SP_DS.get()) return HIDDEN_DS; break;
-        case ENG: if (!VIEW_SP_ENG.get()) return HIDDEN_ENG; break;
-        case CAL: if (!VIEW_SP_CAL.get()) return HIDDEN_PCAL; break;
+			case LP: 	if (!VIEW_SP_LP.get()) 	return HIDDEN_LP; 	break;
+			case C: 	if (!VIEW_SP_C.get()) 	return HIDDEN_C; 	break;
+			case FT: 	if (!VIEW_SP_FT.get()) 	return HIDDEN_FT; 	break;
+			case Q: 	if (!VIEW_SP_Q.get()) 	return HIDDEN_Q; 	break;
+			case SV: 	if (!VIEW_SP_SV.get()) 	return HIDDEN_SV; 	break;
+			case DD: 	if (!VIEW_SP_DD.get()) 	return HIDDEN_DD; 	break;
+			case DS: 	if (!VIEW_SP_DS.get()) 	return HIDDEN_DS; 	break;
+			case ENG: 	if (!VIEW_SP_ENG.get()) return HIDDEN_ENG; 	break;
+			case CAL: 	if (!VIEW_SP_CAL.get()) return HIDDEN_PCAL; break;
 		}
 		
-		// Obs type
-        if (obs.getObsClass().isCalibration() && !VIEW_CALIBRATIONS.get()) return HIDDEN_CALS;
-        if (!obs.getObsClass().isCalibration() && !VIEW_SCIENCE_OBS.get())  return HIDDEN_SCI;
+		// Obs type filtering
+        // (ObsQueryFunctor/MiniModel is configured to let only the obs classes through listed below.)
+		switch (obs.getObsClass()) {
+            case PROG_CAL:      if (!VIEW_NIGHTTIME_CALIBRATIONS.get()) return HIDDEN_NIGHT_CALS;   break;
+            case PARTNER_CAL:   if (!VIEW_NIGHTTIME_CALIBRATIONS.get()) return HIDDEN_NIGHT_CALS;   break;
+            case DAY_CAL:       if (!VIEW_DAYTIME_CALIBRATIONS.get())   return HIDDEN_DAY_CALS;     break;
+            case SCIENCE:       if (!VIEW_SCIENCE_OBS.get())            return HIDDEN_SCI;          break;
+        }
 
 		// Flag-based filters
 		if (!VIEW_LOW_IN_SKY.get() && flags.contains(Flag.ELEVATION_CNS))  return HIDDEN_LOW_IN_SKY;
@@ -107,7 +113,7 @@ public enum ClientExclusion {
 	private final String string;
 	private final BooleanViewPreference pref;
 
-	private ClientExclusion(final String string, final BooleanViewPreference pref) {
+	ClientExclusion(final String string, final BooleanViewPreference pref) {
 		this.string = string;
 		this.pref = pref;
 	}

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/MiniModel.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/MiniModel.java
@@ -26,14 +26,15 @@ import java.util.concurrent.TimeoutException;
 public class MiniModel {
 
     /** Set of observation classes that are considered to be relevant by default (QPT). */
-    private static final Set<ObsClass> RELEVANT_OBS_CLASSES = new HashSet<ObsClass>();
+    private static final Set<ObsClass> RELEVANT_OBS_CLASSES = new HashSet<>();
     static {
         RELEVANT_OBS_CLASSES.add(ObsClass.PARTNER_CAL);
         RELEVANT_OBS_CLASSES.add(ObsClass.PROG_CAL);
+        RELEVANT_OBS_CLASSES.add(ObsClass.DAY_CAL);
         RELEVANT_OBS_CLASSES.add(ObsClass.SCIENCE);
     }
     /** Set of observation statuses that are considered to be relevant by default (QPT). */
-    private static final Set<ObservationStatus> RELEVANT_OBS_STATUSES = new HashSet<ObservationStatus>();
+    private static final Set<ObservationStatus> RELEVANT_OBS_STATUSES = new HashSet<>();
     static {
         RELEVANT_OBS_STATUSES.add(ObservationStatus.READY);
         RELEVANT_OBS_STATUSES.add(ObservationStatus.ONGOING);
@@ -43,7 +44,7 @@ public class MiniModel {
     private final SortedSet<Obs> allObservations;
     private final SortedSet<String> misconfiguredObservations;
     private final SortedSet<String> allSemesters;
-    private final Map<String, Obs> obsMap = new TreeMap<String, Obs>();
+    private final Map<String, Obs> obsMap = new TreeMap<>();
     private final Site site;
     private final long timestamp = System.currentTimeMillis();
     private final Map<SPProgramID, ProgramExclusion> programExclusions;
@@ -56,12 +57,12 @@ public class MiniModel {
                       Map<SPProgramID, ProgramExclusion> programExclusions,
                       Map<SPObservationID, ObsExclusion> obsExclusions) {
         this.site = site;
-        this.programs = Collections.unmodifiableSortedSet(new TreeSet<Prog>(programs));
-        this.misconfiguredObservations = Collections.unmodifiableSortedSet(new TreeSet<String>(misconfiguredObservations));
-        this.allSemesters = Collections.unmodifiableSortedSet(new TreeSet<String>(allSemesters));
+        this.programs = Collections.unmodifiableSortedSet(new TreeSet<>(programs));
+        this.misconfiguredObservations = Collections.unmodifiableSortedSet(new TreeSet<>(misconfiguredObservations));
+        this.allSemesters = Collections.unmodifiableSortedSet(new TreeSet<>(allSemesters));
         this.programExclusions = Collections.unmodifiableMap(programExclusions);
         this.obsExclusions = Collections.unmodifiableMap(obsExclusions);
-        SortedSet<Obs> accum = new TreeSet<Obs>();
+        SortedSet<Obs> accum = new TreeSet<>();
         for (Prog prog: programs) accum.addAll(prog.getFullObsSet());
         allObservations = Collections.unmodifiableSortedSet(accum);
         for (Obs obs: allObservations) obsMap.put(obs.getObsId(), obs);

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/BandsList.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/BandsList.scala
@@ -1,7 +1,5 @@
 package edu.gemini.spModel.core
 
-import edu.gemini.spModel.core.SiderealTarget
-
 import scalaz._
 import Scalaz._
 
@@ -10,9 +8,9 @@ import Scalaz._
  * It is used, e.g. to extract a magnitude from a target
  */
 sealed trait BandsList {
-  val bands: NonEmptyList[MagnitudeBand]
-  def extract(t: SiderealTarget) = bands.map(t.magnitudeIn).list.find(_.isDefined).flatten
-  def bandSupported(b: MagnitudeBand) = bands.list.contains(b)
+  val bands: List[MagnitudeBand]
+  def extract(t: SiderealTarget) = bands.map(t.magnitudeIn).find(_.isDefined).flatten
+  def bandSupported(b: MagnitudeBand) = bands.contains(b)
 }
 
 /**
@@ -21,21 +19,21 @@ sealed trait BandsList {
 case object RBandsList extends BandsList {
   val instance = this
 
-  val bands = NonEmptyList(MagnitudeBand._r, MagnitudeBand.R, MagnitudeBand.UC)
+  val bands = List(MagnitudeBand._r, MagnitudeBand.R, MagnitudeBand.UC)
 }
 
 /**
  * Extractor for Nici containing 4 bands
  */
 case object NiciBandsList extends BandsList {
-  val bands = NonEmptyList(MagnitudeBand._r, MagnitudeBand.R, MagnitudeBand.UC, MagnitudeBand.V)
+  val bands = List(MagnitudeBand._r, MagnitudeBand.R, MagnitudeBand.UC, MagnitudeBand.V)
 }
 
 /**
  * Extracts a single band from a target if available
  */
 case class SingleBand(band: MagnitudeBand) extends BandsList {
-  val bands = NonEmptyList(band)
+  val bands = List(band)
 }
 
 object BandsList {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
@@ -43,7 +43,7 @@ object GuidingFeedback {
     import ProbeLimits.{le, lim}
 
     def searchRange: String =
-      s"${lim(sat)} $le ${bands.bands.list.map(_.name).mkString(", ")} $le ${lim(slow)}"
+      s"${lim(sat)} $le ${bands.bands.map(_.name).mkString(", ")} $le ${lim(slow)}"
 
     def detailRange: String =
       s"${lim(sat)} $le FAST $le ${lim(fast)} < MEDIUM $le ${lim(medium)} < SLOW $le ${lim(slow)}"


### PR DESCRIPTION
Currently the QPT only allows to schedule night time calibrations. The aim of this PR is to allow QCs to schedule daytime calibrations as part of the nightly plans if needed.

This PR also deals with a serialization issue that stems from the use of `NonEmptyList` in `BandsList`. `NonEmptyList` is not serializable and breaks the communication between the ODB and the QPT. I am planning to add a serialization test case to cover this, but for now my main goal is to push the functionality into the test release. @cquiroz : you probably want to have a quick look at the changes I made to `BandsList`.