### PR TITLE
Fix for weird compilation error

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateTypes.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/CoordinateTypes.java
@@ -1,5 +1,8 @@
 package edu.gemini.spModel.target.system;
 
+//noinspection UnusedImport
+import edu.gemini.spModel.target.system.CoordinateParam.Units; //Don't delete, it triggers a weird compilation bug
+
 /**
  * A container class for localizing the various parameter types used by
  * the target coordinate systems.


### PR DESCRIPTION
Strange compilation error when referencing `CoordinateTypes.Epoch` from `ModelConverters`
It is fixed by adding an explicit import of the Units class, maybe it is a compiler bug?