### PR TITLE
REL-2323: Altair + GMOS-N AGS strategies

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -5,7 +5,7 @@ import edu.gemini.ags.api.AgsStrategy.Estimate
 import edu.gemini.ags.api.{AgsAnalysis, AgsMagnitude, AgsStrategy}
 import edu.gemini.catalog.api.CatalogQuery
 import edu.gemini.spModel.ags.AgsStrategyKey
-import edu.gemini.spModel.core.{SingleBand, RBandsList, SiderealTarget}
+import edu.gemini.spModel.core.{RBandsList, SiderealTarget}
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -1,0 +1,61 @@
+package edu.gemini.ags.impl
+
+import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
+import edu.gemini.ags.api.AgsStrategy.Estimate
+import edu.gemini.ags.api.{AgsAnalysis, AgsMagnitude, AgsStrategy}
+import edu.gemini.catalog.api.CatalogQuery
+import edu.gemini.spModel.ags.AgsStrategyKey
+import edu.gemini.spModel.core.{SingleBand, RBandsList, SiderealTarget}
+import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
+import edu.gemini.spModel.obs.context.ObsContext
+
+import scala.concurrent.Future
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+case class MultiProbeStrategy(key: AgsStrategyKey, strategies: List[AgsStrategy]) extends AgsStrategy {
+  override def magnitudes(ctx: ObsContext, mt: MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =
+    strategies.flatMap(_.magnitudes(ctx, mt))
+
+  override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
+    strategies.flatMap(_.analyze(ctx, mt))
+
+  override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
+    AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
+
+  override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] =
+    strategies.flatMap(_.catalogQueries(ctx, mt))
+
+  override def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]] =
+    Future.sequence(strategies.map(_.candidates(ctx, mt))).map(_.flatten)
+
+  override def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
+    Future.fold(strategies.map(_.estimate(ctx, mt)))(1.0)((p,est) => p * est.probability).map(Estimate(_))
+
+  // We pick the position angle of the first assignment. May not want to do this.
+  override def select(ctx: ObsContext, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]] = {
+    val selections = Future.sequence(strategies.map(_.select(ctx, mt)))
+    Future.fold(strategies.map(_.select(ctx, mt)))(None: Option[AgsStrategy.Selection])((resOpt,curOpt) =>
+      curOpt.map(cur => AgsStrategy.Selection(cur.posAngle, resOpt.fold(cur.assignments)(cur.assignments ++ _.assignments))).orElse(resOpt)
+    )
+  }
+
+  override val guideProbes: List[GuideProbe] =
+    strategies.flatMap(_.guideProbes)
+
+  override val probeBands = {
+    val bandsLL = strategies.map(_.probeBands)
+
+    // Find a BandsList that is a subset of the others.
+    bandsLL.find(bL => {
+      val bLSet = Set(bL.bands.list)
+      bandsLL.forall(bL2 => bLSet.subsetOf(Set(bL2.bands.list)))
+    }).getOrElse {
+      // TODO: We must have A band, at least, that is a subset of all the bands.
+      // TODO: Otherwise bork and return R bands list. Not sure what else to do here.
+      val bandInt = bandsLL.map(bL => bL.bands.list.toSet).reduce((s1,s2) => s1.intersect(s2))
+      bandInt.headOption.map(SingleBand).getOrElse(RBandsList)
+    }
+  }
+}

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -31,8 +31,6 @@ object Strategy {
   val AltairAowfs          = SingleProbeStrategy(AltairAowfsKey,         AltairAowfsParams)
   val Flamingos2Oiwfs      = SingleProbeStrategy(Flamingos2OiwfsKey,     Flamingos2OiwfsParams)
   val GmosNorthOiwfs       = SingleProbeStrategy(GmosNorthOiwfsKey,      GmosOiwfsParams(Site.GN))
-  val GmosNorthAltairOiwfs = MultiProbeStrategy(GmosNorthAltairOiwfsKey, List(GmosNorthOiwfs, AltairAowfs))
-  val GmosNorthPwfs1Oiwfs  = MultiProbeStrategy(GmosNorthPwfs1OiwfsKey,  List(Pwfs1North, GmosNorthOiwfs))
   val GmosSouthOiwfs       = SingleProbeStrategy(GmosSouthOiwfsKey,      GmosOiwfsParams(Site.GS))
   val GnirsOiwfs           = SingleProbeStrategy(GnirsOiwfsKey,          GnirsOiwfsParams)
   val NifsOiwfs            = SingleProbeStrategy(NifsOiwfsKey,           NifsOiwfsParams)
@@ -44,8 +42,8 @@ object Strategy {
     Flamingos2Oiwfs,
     GemsStrategy,
     GmosNorthOiwfs,
-    GmosNorthAltairOiwfs,
-    GmosNorthPwfs1Oiwfs,
+    GmosNorthOiwfsAltair,
+    GmosNorthOiwfsPwfs1,
     GmosSouthOiwfs,
     GnirsOiwfs,
     NiciOiwfs,
@@ -89,9 +87,9 @@ object Strategy {
       val ao = ctx.getAOComponent.asScalaOpt
       if (ao.exists(_.isInstanceOf[InstAltair])) {
         ao.get.asInstanceOf[InstAltair].getMode match {
-          case AltairParams.Mode.LGS_P1 => List(Pwfs1North, GmosNorthPwfs1Oiwfs)
+          case AltairParams.Mode.LGS_P1 => List(Pwfs1North, GmosNorthOiwfsPwfs1)
           case AltairParams.Mode.LGS_OI => List(GmosNorthOiwfs)
-          case _                        => List(AltairAowfs, GmosNorthAltairOiwfs)
+          case _                        => List(AltairAowfs, GmosNorthOiwfsAltair)
         }
       } else oiStategies(ctx, GmosNorthOiwfs)
     }),
@@ -115,7 +113,7 @@ object Strategy {
     s match {
       case SingleProbeStrategy(_, params, _) => isAvailable(params.guideProbe)
       case ScienceTargetStrategy(_, gp, _)   => isAvailable(gp)
-      case MultiProbeStrategy(_, lst)        => lst.forall(guidersAvailable(ctx))
+      case m: MultiProbeStrategy             => m.strategies.forall(guidersAvailable(ctx))
       case GemsStrategy                      => isAvailable(Canopus.Wfs.cwfs3) // any canopus would serve
       case _                                 => false
     }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -24,10 +24,6 @@ object Strategy {
   // Backend for searching on catalogs
   val backend = ConeSearchBackend
 
-  val Pwfs1North      = SingleProbeStrategy(Pwfs1NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs1))
-  val Pwfs2North      = SingleProbeStrategy(Pwfs2NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs2))
-  val Pwfs1South      = SingleProbeStrategy(Pwfs1SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs1))
-  val Pwfs2South      = SingleProbeStrategy(Pwfs2SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs2))
   val AltairAowfs     = SingleProbeStrategy(AltairAowfsKey,     AltairAowfsParams)
   val Flamingos2Oiwfs = SingleProbeStrategy(Flamingos2OiwfsKey, Flamingos2OiwfsParams)
   val GmosNorthOiwfs  = SingleProbeStrategy(GmosNorthOiwfsKey,  GmosOiwfsParams(Site.GN))
@@ -35,6 +31,10 @@ object Strategy {
   val GnirsOiwfs      = SingleProbeStrategy(GnirsOiwfsKey,      GnirsOiwfsParams)
   val NifsOiwfs       = SingleProbeStrategy(NifsOiwfsKey,       NifsOiwfsParams)
   val NiriOiwfs       = SingleProbeStrategy(NiriOiwfsKey,       NiriOiwfsParams)
+  val Pwfs1North      = SingleProbeStrategy(Pwfs1NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs1))
+  val Pwfs2North      = SingleProbeStrategy(Pwfs2NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs2))
+  val Pwfs1South      = SingleProbeStrategy(Pwfs1SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs1))
+  val Pwfs2South      = SingleProbeStrategy(Pwfs2SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs2))
   val NiciOiwfs       = ScienceTargetStrategy(NiciOiwfsKey,     NiciOiwfsGuideProbe.instance, NiciBandsList)
 
   val All = List(

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -24,18 +24,18 @@ object Strategy {
   // Backend for searching on catalogs
   val backend = ConeSearchBackend
 
-  val Pwfs1North           = SingleProbeStrategy(Pwfs1NorthKey,          PwfsParams(Site.GN, PwfsGuideProbe.pwfs1))
-  val Pwfs2North           = SingleProbeStrategy(Pwfs2NorthKey,          PwfsParams(Site.GN, PwfsGuideProbe.pwfs2))
-  val Pwfs1South           = SingleProbeStrategy(Pwfs1SouthKey,          PwfsParams(Site.GS, PwfsGuideProbe.pwfs1))
-  val Pwfs2South           = SingleProbeStrategy(Pwfs2SouthKey,          PwfsParams(Site.GS, PwfsGuideProbe.pwfs2))
-  val AltairAowfs          = SingleProbeStrategy(AltairAowfsKey,         AltairAowfsParams)
-  val Flamingos2Oiwfs      = SingleProbeStrategy(Flamingos2OiwfsKey,     Flamingos2OiwfsParams)
-  val GmosNorthOiwfs       = SingleProbeStrategy(GmosNorthOiwfsKey,      GmosOiwfsParams(Site.GN))
-  val GmosSouthOiwfs       = SingleProbeStrategy(GmosSouthOiwfsKey,      GmosOiwfsParams(Site.GS))
-  val GnirsOiwfs           = SingleProbeStrategy(GnirsOiwfsKey,          GnirsOiwfsParams)
-  val NifsOiwfs            = SingleProbeStrategy(NifsOiwfsKey,           NifsOiwfsParams)
-  val NiriOiwfs            = SingleProbeStrategy(NiriOiwfsKey,           NiriOiwfsParams)
-  val NiciOiwfs            = ScienceTargetStrategy(NiciOiwfsKey,         NiciOiwfsGuideProbe.instance, NiciBandsList)
+  val Pwfs1North      = SingleProbeStrategy(Pwfs1NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs1))
+  val Pwfs2North      = SingleProbeStrategy(Pwfs2NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs2))
+  val Pwfs1South      = SingleProbeStrategy(Pwfs1SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs1))
+  val Pwfs2South      = SingleProbeStrategy(Pwfs2SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs2))
+  val AltairAowfs     = SingleProbeStrategy(AltairAowfsKey,     AltairAowfsParams)
+  val Flamingos2Oiwfs = SingleProbeStrategy(Flamingos2OiwfsKey, Flamingos2OiwfsParams)
+  val GmosNorthOiwfs  = SingleProbeStrategy(GmosNorthOiwfsKey,  GmosOiwfsParams(Site.GN))
+  val GmosSouthOiwfs  = SingleProbeStrategy(GmosSouthOiwfsKey,  GmosOiwfsParams(Site.GS))
+  val GnirsOiwfs      = SingleProbeStrategy(GnirsOiwfsKey,      GnirsOiwfsParams)
+  val NifsOiwfs       = SingleProbeStrategy(NifsOiwfsKey,       NifsOiwfsParams)
+  val NiriOiwfs       = SingleProbeStrategy(NiriOiwfsKey,       NiriOiwfsParams)
+  val NiciOiwfs       = ScienceTargetStrategy(NiciOiwfsKey,     NiciOiwfsGuideProbe.instance, NiciBandsList)
 
   val All = List(
     AltairAowfs,

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
@@ -6,6 +6,8 @@
 //
 package edu.gemini.spModel.gemini.altair;
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
@@ -242,24 +244,24 @@ public final class AltairParams {
      */
     public enum Mode implements DisplayableSpType, SequenceableSpType {
 
-        NGS     ("NGS",     GuideStarType.NGS, FieldLens.OUT, AltairAowfsGuider.instance),
-        NGS_FL  ("NGS+FL",  GuideStarType.NGS, FieldLens.IN,  AltairAowfsGuider.instance),
-        LGS     ("LGS",     GuideStarType.LGS, FieldLens.IN,  AltairAowfsGuider.instance),
-        LGS_P1  ("LGS+P1",  GuideStarType.LGS, FieldLens.IN,  PwfsGuideProbe.pwfs1),
-        LGS_OI  ("LGS+OI",  GuideStarType.LGS, FieldLens.IN,  GmosOiwfsGuideProbe.instance)
+        NGS     ("NGS",     GuideStarType.NGS, FieldLens.OUT, DefaultImList.<GuideProbe>create(AltairAowfsGuider.instance)),
+        NGS_FL  ("NGS+FL",  GuideStarType.NGS, FieldLens.IN,  DefaultImList.<GuideProbe>create(AltairAowfsGuider.instance)),
+        LGS     ("LGS",     GuideStarType.LGS, FieldLens.IN,  DefaultImList.<GuideProbe>create(AltairAowfsGuider.instance, GmosOiwfsGuideProbe.instance)),
+        LGS_P1  ("LGS+P1",  GuideStarType.LGS, FieldLens.IN,  DefaultImList.<GuideProbe>create(PwfsGuideProbe.pwfs1, GmosOiwfsGuideProbe.instance)),
+        LGS_OI  ("LGS+OI",  GuideStarType.LGS, FieldLens.IN,  DefaultImList.<GuideProbe>create(GmosOiwfsGuideProbe.instance))
         ;
 
         public static final Mode DEFAULT = NGS;
         private final String _displayValue;
         private final GuideStarType _guideStarType;
         private final FieldLens _fieldLens;
-        private final GuideProbe _guider;
+        private final ImList<GuideProbe> _guiders;
 
-        Mode(String displayValue, GuideStarType guideStarType, FieldLens fieldLens, GuideProbe guider) {
+        Mode(final String displayValue, final GuideStarType guideStarType, final FieldLens fieldLens, final ImList<GuideProbe> guiders) {
             _displayValue = displayValue;
             _guideStarType = guideStarType;
             _fieldLens = fieldLens;
-            _guider = guider;
+            _guiders = guiders;
         }
 
         public String displayValue() {
@@ -278,8 +280,8 @@ public final class AltairParams {
             return _guideStarType;
         }
 
-        public GuideProbe guider() {
-            return _guider;
+        public ImList<GuideProbe> guiders() {
+            return _guiders;
         }
 
         /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
@@ -9,6 +9,7 @@ package edu.gemini.spModel.gemini.altair;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.ao.AOConstants;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.data.ISPDataObject;
@@ -362,16 +363,16 @@ public final class InstAltair extends AbstractDataObject implements PropertyProv
     private static final Collection<GuideProbe> ANTI_GUIDERS    =
             GuideProbeUtil.instance.createCollection(PwfsGuideProbe.pwfs1, PwfsGuideProbe.pwfs2);
 
-    private static Set<GuideProbe> allMinus(GuideProbe guideProbe) {
+    private static Set<GuideProbe> allMinus(final ImList<GuideProbe> guideProbes) {
         final Set<GuideProbe> guiders = new TreeSet<>(GuideProbe.KeyComparator.instance);
         guiders.addAll(GuideProbeMap.instance.values());
-        guiders.remove(guideProbe);
+        guideProbes.foreach(guiders::remove);
         return guiders;
     }
 
     public Collection<GuideProbe> getConsumedGuideProbes() {
         if (getGuideStarType() == GuideStarType.LGS) {
-            return allMinus(getMode().guider());
+            return allMinus(getMode().guiders());
         } else {
             return ANTI_GUIDERS;
         }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ags/AgsStrategyKey.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ags/AgsStrategyKey.scala
@@ -29,6 +29,16 @@ object AgsStrategyKey {
     val id = "GMOS-N_OIWFS"
   }
 
+  case object GmosNorthAltairOiwfsKey extends AgsStrategyKey {
+    val id = "ALTAIR_GMOS-N_OIWFS"
+    override def displayName = "Altair + GMOS-N OIWFS"
+  }
+
+  case object GmosNorthPwfs1OiwfsKey extends AgsStrategyKey {
+    val id = "GN_PWFS1_GMOS-N_OIWFS"
+    override def displayName = "GN PWFS1 + GMOS-N OIWFS"
+  }
+
   case object GmosSouthOiwfsKey extends AgsStrategyKey {
     val id = "GMOS-S_OIWFS"
   }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
@@ -9,26 +9,18 @@ import java.awt.*;
 
 public class AltairForm extends JPanel {
     public AltairForm() {
-        JLabel adcLabel = new JLabel();
-        JLabel beamSplitterLabel = new JLabel();
         adcCheck = new CheckBoxWidget();
         eight50Button = new OptionWidget();
         oneButton = new OptionWidget();
-        JLabel cassRotatorLabel = new JLabel();
         cassRotatorFollowingButton = new JRadioButton();
         cassRotatorFixedButton = new JRadioButton();
-        JLabel ndFilterLabel = new JLabel();
         ndFilterInButton = new JRadioButton();
         ndFilterOutButton = new JRadioButton();
-        JLabel guideStarType = new JLabel();
         ngsRadioButton = new JRadioButton();
         ngsWithFieldLensRadioButton = new JRadioButton();
         lgsRadioButton = new JRadioButton();
         lgsP1RadioButton = new JRadioButton();
         lgsOiRadioButton = new JRadioButton();
-        JLabel withFlLabel1 = new JLabel();
-        JLabel withFlLabel2 = new JLabel();
-        JLabel withFlLabel3 = new JLabel();
 
         //======== this ========
         setMinimumSize(new Dimension(400, 453));
@@ -37,8 +29,7 @@ public class AltairForm extends JPanel {
         setLayout(new GridBagLayout());
 
         //---- adcLabel ----
-        adcLabel.setToolTipText("");
-        adcLabel.setText("Atmospheric Dispersion Corrector");
+        final JLabel adcLabel = new JLabel("Atmospheric Dispersion Corrector");
         add(adcLabel, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
@@ -51,8 +42,7 @@ public class AltairForm extends JPanel {
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- beamSplitterLabel ----
-        beamSplitterLabel.setToolTipText("");
-        beamSplitterLabel.setText("Dichroic Beamsplitter");
+        final JLabel beamSplitterLabel = new JLabel("Dichroic Beamsplitter");
         add(beamSplitterLabel, new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
@@ -70,9 +60,8 @@ public class AltairForm extends JPanel {
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- cassRotatorLabel ----
-        cassRotatorLabel.setToolTipText("");
+        final JLabel cassRotatorLabel = new JLabel("Cass Rotator");
         cassRotatorLabel.setVerifyInputWhenFocusTarget(true);
-        cassRotatorLabel.setText("Cass Rotator");
         add(cassRotatorLabel, new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
@@ -90,7 +79,7 @@ public class AltairForm extends JPanel {
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- ndFilterLabel ----
-        ndFilterLabel.setText("ND Filter");
+        final JLabel ndFilterLabel = new JLabel("ND Filter");
         add(ndFilterLabel, new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
@@ -108,7 +97,7 @@ public class AltairForm extends JPanel {
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- guideStarType ----
-        guideStarType.setText("Guide Star Type");
+        final JLabel guideStarType = new JLabel("Guide Star Type");
         add(guideStarType, new GridBagConstraints(0, 7, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
@@ -126,21 +115,24 @@ public class AltairForm extends JPanel {
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsRadioButton ----
-        lgsRadioButton.setText("Laser Guide Star + AOWFS");
+        lgsRadioButton.setText("Laser Guide Star + AOWFS TTF");
+        lgsP1RadioButton.setToolTipText("LGS using AOWFS to measure Tip, Tilt, and Focus");
         add(lgsRadioButton, new GridBagConstraints(1, 9, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
-        withFlLabel1.setText("(with Field Lens)");
+
+        final JLabel withFlLabel1 = new JLabel("(with Field Lens)");
         add(withFlLabel1, new GridBagConstraints(2, 9, 1, 1, 1.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsP1RadioButton ----
-        lgsP1RadioButton.setText("Laser Guide Star + PWFS1");
+        lgsP1RadioButton.setText("Laser Guide Star + PWFS1 TTF");
+        lgsP1RadioButton.setToolTipText("LGS using PWFS1 to measure Tip, Tilt, and Focus");
         add(lgsP1RadioButton, new GridBagConstraints(1, 10, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
-        withFlLabel2.setText("(with Field Lens)");
+        final JLabel withFlLabel2 = new JLabel("(with Field Lens)");
         add(withFlLabel2, new GridBagConstraints(2, 10, 1, 1, 1.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
@@ -148,11 +140,12 @@ public class AltairForm extends JPanel {
         //---- lgsP1RadioButton ----
         // LAYOUT NOTE: bring both elements to the top left and let the last element
         // consume all remaining space (fill weight = 1.0 for x and y)
-        lgsOiRadioButton.setText("Laser Guide Star + OIWFS");
+        lgsOiRadioButton.setText("Laser Guide Star + OIWFS TTF");
+        lgsOiRadioButton.setToolTipText("LGS using OIWFS to measure Tip, Tilt, and Focus");
         add(lgsOiRadioButton, new GridBagConstraints(1, 11, 1, 1, 0.0, 0.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
-        withFlLabel3.setText("(with Field Lens)");
+        final JLabel withFlLabel3 = new JLabel("(with Field Lens)");
         add(withFlLabel3, new GridBagConstraints(2, 11, 1, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
@@ -116,7 +116,7 @@ public class AltairForm extends JPanel {
 
         //---- lgsRadioButton ----
         lgsRadioButton.setText("Laser Guide Star + AOWFS TTF");
-        lgsP1RadioButton.setToolTipText("LGS using AOWFS to measure Tip, Tilt, and Focus");
+        lgsRadioButton.setToolTipText("LGS using AOWFS to measure Tip, Tilt, and Focus");
         add(lgsRadioButton, new GridBagConstraints(1, 9, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));


### PR DESCRIPTION
This PR adds multi-probe strategies to GMOS-N when Altair is being used to allow for flexure targets.
There are two cases in particular that are needed as per REL-2323: Altair + GMOS OI, and PWFS1 + GMOS OI.
To accomplish this, I created a somewhat rudimentary `MultiProbeStrategy` class that has some limitations as described in the comments.

Part of the PR requested some minor changes to `AltairForm` with radio button label changes and tool tip text added, and I used this as an opportunity to clean up the code somewhat.