### PR TITLE
OCSADV-443: Fixed broken GPT PIO.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/BagsResult.scala
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/BagsResult.scala
@@ -5,6 +5,8 @@ import edu.gemini.spModel.pio.{Pio, PioFactory, ParamSet}
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.rich.shared.immutable._
 
+import scala.collection.JavaConverters._
+
 sealed trait BagsResult extends Cloneable {
   val id: String
   val target: Option[SPTarget] = None
@@ -17,6 +19,7 @@ sealed trait BagsResult extends Cloneable {
     target.foreach { t =>
       val bagsParamSet = factory.createParamSet(BagsResult.BagsTargetParamSetName)
       bagsParamSet.addParamSet(t.getParamSet(factory))
+      paramSet.addParamSet(bagsParamSet)
     }
     paramSet
   }
@@ -52,7 +55,7 @@ object BagsResult {
     Option(parent.getParamSet(BagsResultParamSetName)).flatMap { ps =>
       // We get the param ID and then use that to construct the object.
       val paramId = Option(ps.getParam(BagsResultParamIdName)).map(_.getValue)
-      val target = Option(ps.getParamSet(BagsTargetParamSetName)).map(SPTarget.fromParamSet)
+      val target = Option(ps.getParamSet(BagsTargetParamSetName)).flatMap(_.getParamSets.asScala.headOption).map(SPTarget.fromParamSet)
 
       paramId.collect {
         case NoTargetFound.id => NoTargetFound

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -550,9 +550,6 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
             Pio.addIntParam(factory, paramSet, "primary", i)
         );
 
-//        final ParamSet mtParamSet = factory.createParamSet(MANUAL_TARGETS_PARAM_SET_NAME);
-//        getManualTargets().foreach(t -> mtParamSet.addParamSet(t.getParamSet(factory)));
-//        paramSet.addParamSet(mtParamSet);
         getManualTargets().foreach(t -> paramSet.addParamSet(t.getParamSet(factory)));
 
         return paramSet;
@@ -574,8 +571,6 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
 
         final List<SPTarget> lst = new ArrayList<>();
         parent.getParamSets(SPTargetPio.PARAM_SET_NAME).forEach(ps -> lst.add(SPTarget.fromParamSet(ps)));
-        //ImOption.apply(parent.getParamSet(MANUAL_TARGETS_PARAM_SET_NAME)).foreach(mtps -> mtps.getParamSets().forEach(ps -> lst.add(SPTarget.fromParamSet(ps))));
-
         final ImList<SPTarget> manualTargets = DefaultImList.create(lst);
 
         final GuideProbeTargets gpt = new GuideProbeTargets(probe, bagsResult, NO_TARGET, manualTargets);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -536,7 +536,6 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
 
 
     public static final String GUIDER_PARAM_SET_NAME = "guider";
-    public static final String MANUAL_TARGETS_PARAM_SET_NAME = "manualTargets";
 
     public ParamSet getParamSet(final PioFactory factory) {
         final ParamSet paramSet = factory.createParamSet(GUIDER_PARAM_SET_NAME);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -7,6 +7,7 @@ import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.SPTargetPio;
 
 import java.io.Serializable;
 import java.util.*;
@@ -549,9 +550,10 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
             Pio.addIntParam(factory, paramSet, "primary", i)
         );
 
-        final ParamSet mtParamSet = factory.createParamSet(MANUAL_TARGETS_PARAM_SET_NAME);
-        getManualTargets().foreach(t -> mtParamSet.addParamSet(t.getParamSet(factory)));
-        paramSet.addParamSet(mtParamSet);
+//        final ParamSet mtParamSet = factory.createParamSet(MANUAL_TARGETS_PARAM_SET_NAME);
+//        getManualTargets().foreach(t -> mtParamSet.addParamSet(t.getParamSet(factory)));
+//        paramSet.addParamSet(mtParamSet);
+        getManualTargets().foreach(t -> paramSet.addParamSet(t.getParamSet(factory)));
 
         return paramSet;
     }
@@ -571,7 +573,8 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
 
 
         final List<SPTarget> lst = new ArrayList<>();
-        ImOption.apply(parent.getParamSet(MANUAL_TARGETS_PARAM_SET_NAME)).foreach(mtps -> mtps.getParamSets().forEach(ps -> lst.add(SPTarget.fromParamSet(ps))));
+        parent.getParamSets(SPTargetPio.PARAM_SET_NAME).forEach(ps -> lst.add(SPTarget.fromParamSet(ps)));
+        //ImOption.apply(parent.getParamSet(MANUAL_TARGETS_PARAM_SET_NAME)).foreach(mtps -> mtps.getParamSets().forEach(ps -> lst.add(SPTarget.fromParamSet(ps))));
 
         final ImList<SPTarget> manualTargets = DefaultImList.create(lst);
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -535,19 +535,23 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
 
 
     public static final String GUIDER_PARAM_SET_NAME = "guider";
+    public static final String MANUAL_TARGETS_PARAM_SET_NAME = "manualTargets";
 
     public ParamSet getParamSet(final PioFactory factory) {
         final ParamSet paramSet = factory.createParamSet(GUIDER_PARAM_SET_NAME);
 
         Pio.addParam(factory, paramSet, "key", getGuider().getKey());
-        bagsResult.getParamSet(factory);
+        paramSet.addParamSet(bagsResult.getParamSet(factory));
+
 
         // If a primary target is set, store the index.
         getPrimaryIndex().foreach(i ->
             Pio.addIntParam(factory, paramSet, "primary", i)
         );
 
-        getManualTargets().foreach(t -> paramSet.addParamSet(t.getParamSet(factory)));
+        final ParamSet mtParamSet = factory.createParamSet(MANUAL_TARGETS_PARAM_SET_NAME);
+        getManualTargets().foreach(t -> mtParamSet.addParamSet(t.getParamSet(factory)));
+        paramSet.addParamSet(mtParamSet);
 
         return paramSet;
     }
@@ -567,7 +571,8 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
 
 
         final List<SPTarget> lst = new ArrayList<>();
-        parent.getParamSets().forEach(ps -> lst.add(SPTarget.fromParamSet(ps)));
+        ImOption.apply(parent.getParamSet(MANUAL_TARGETS_PARAM_SET_NAME)).foreach(mtps -> mtps.getParamSets().forEach(ps -> lst.add(SPTarget.fromParamSet(ps))));
+
         final ImList<SPTarget> manualTargets = DefaultImList.create(lst);
 
         final GuideProbeTargets gpt = new GuideProbeTargets(probe, bagsResult, NO_TARGET, manualTargets);


### PR DESCRIPTION
I had a fundamental misunderstanding about how PIO worked and thus thought I had tested it when it turns out that I hadn't.

This repairs the PIO break that was introduced by the changes to the data model for `GuideProbeTargets`, making things more robust at the same time. I have tested this manually, but it still requires a formal test case, which I will add later.
(I didn't want to leave this broken in the build.)