### PR TITLE
OCSADV-468 fix pluto conversion

### DIFF
--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
@@ -60,8 +60,8 @@ object To2016A extends Migration {
     }
 
   // Params taken from a program with a properly resolved Pluto (now an asteroid). This includes
-  // only the system and orbital elements.
-  lazy val plutoParams: List[Param] = {
+  // only the system and orbital elements. Get a FRESH set of params each time! (important)
+  def plutoParams: List[Param] = {
     PioXmlUtil.read(
       <document>
         <container>

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016A/pluto.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016A/pluto.xml
@@ -14,6 +14,90 @@
       <param name="completed" value="false"/>
       <param name="notifyPi" value="YES"/>
     </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="fffff0e2-9f9b-4915-8fc8-ae3845f3b8c6" name="">
+        <paramset name="Observation" kind="dataObj">
+            <param name="title" value="GMOS-N Observation"/>
+            <param name="libraryId" value=""/>
+            <param name="priority" value="LOW"/>
+            <param name="tooOverrideRapid" value="false"/>
+            <param name="phase2Status" value="PI_TO_COMPLETE"/>
+            <param name="qaState" value="UNDEFINED"/>
+            <param name="overrideQaState" value="false"/>
+        </paramset>
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="fffff93e-f2b4-4112-8389-f1f3c726f474" name="Observing Conditions">
+            <paramset name="Observing Conditions" kind="dataObj">
+                <param name="CloudCover" value="ANY"/>
+                <param name="ImageQuality" value="ANY"/>
+                <param name="SkyBackground" value="ANY"/>
+                <param name="WaterVapor" value="ANY"/>
+                <param name="ElevationConstraintType" value="NONE"/>
+                <param name="ElevationConstraintMin" value="0.0"/>
+                <param name="ElevationConstraintMax" value="0.0"/>
+                <paramset name="timing-window-list"/>
+            </paramset>
+        </container>
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="fffffa60-3996-4153-a751-87998a55864e" name="Targets">
+            <paramset name="Targets" kind="dataObj">
+                <paramset name="targetEnv">
+                    <paramset name="base">
+                        <param name="name" value="Pluto"/>
+                        <param name="c1" value="15:41:38.380"/>
+                        <param name="c2" value="-15:52:28.70"/>
+                        <param name="validAt" value="10/28/15 7:39:58 PM UTC"/>
+                        <param name="system" value="Solar system object"/>
+                        <param name="object" value="PLUTO"/>
+                    </paramset>
+                    <paramset name="guideEnv"/>
+                </paramset>
+            </paramset>
+        </container>
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="fffff898-ee95-491e-a29f-e6f2f3047a51" name="GMOS-N">
+            <paramset name="GMOS-N" kind="dataObj">
+                <param name="exposureTime" value="300.0"/>
+                <param name="posAngle" value="0"/>
+                <param name="coadds" value="1"/>
+                <paramset name="parallacticAngleDuration">
+                    <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
+                    <param name="explicitDuration" value="0"/>
+                </paramset>
+                <param name="adc" value="NONE"/>
+                <param name="ampCount" value="SIX"/>
+                <param name="gainChoice" value="LOW"/>
+                <param name="ampReadMode" value="SLOW"/>
+                <param name="detectorManufacturer" value="E2V"/>
+                <param name="disperser" value="MIRROR"/>
+                <param name="fpuMode" value="BUILTIN"/>
+                <param name="fpu" value="FPU_NONE"/>
+                <param name="filter" value="NONE"/>
+                <param name="ccdXBinning" value="ONE"/>
+                <param name="ccdYBinning" value="ONE"/>
+                <param name="issPort" value="SIDE_LOOKING"/>
+                <param name="posAngleConstraint" value="FIXED"/>
+                <param name="stageMode" value="FOLLOW_XY"/>
+                <param name="dtaXOffset" value="ZERO"/>
+                <param name="builtinROI" value="FULL_FRAME"/>
+                <param name="useNS" value="FALSE"/>
+                <param name="mosPreimaging" value="NO"/>
+            </paramset>
+        </container>
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="fffff187-e293-49f0-bd77-efd7bcfd29b9" name="Observing Log">
+            <paramset name="Observing Log" kind="dataObj">
+                <paramset name="obsQaRecord"/>
+            </paramset>
+        </container>
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="fffff910-3581-4d07-a6ce-a9c7d9d77a84" name="Observation Exec Log">
+            <paramset name="Observation Exec Log" kind="dataObj">
+                <paramset name="obsExecRecord">
+                    <paramset name="datasets"/>
+                    <paramset name="events"/>
+                    <paramset name="configMap"/>
+                </paramset>
+            </paramset>
+        </container>
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="fffff268-f32b-4b02-80ed-b8dbaae9bdf4" name="Sequence">
+            <paramset name="Sequence" kind="dataObj"/>
+        </container>
+    </container>
     <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="be9d40e2-9f9b-4915-8fc8-ae3845f3b8c6" name="">
       <paramset name="Observation" kind="dataObj">
         <param name="title" value="GMOS-N Observation"/>
@@ -98,39 +182,5 @@
         <paramset name="Sequence" kind="dataObj"/>
       </container>
     </container>
-  </container>
-  <container kind="versions" type="versions" version="1.0">
-    <paramset name="node">
-      <param name="key" value="2c2f4268-f32b-4b02-80ed-b8dbaae9bdf4"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
-    </paramset>
-    <paramset name="node">
-      <param name="key" value="e5b25187-e293-49f0-bd77-efd7bcfd29b9"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
-    </paramset>
-    <paramset name="node">
-      <param name="key" value="cfec9a86-d48c-445f-a852-6cf98fb9a0b7"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
-    </paramset>
-    <paramset name="node">
-      <param name="key" value="e7237a60-3996-4153-a751-87998a55864e"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="4"/>
-    </paramset>
-    <paramset name="node">
-      <param name="key" value="58bc1910-3581-4d07-a6ce-a9c7d9d77a84"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
-    </paramset>
-    <paramset name="node">
-      <param name="key" value="11ec9898-ee95-491e-a29f-e6f2f3047a51"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
-    </paramset>
-    <paramset name="node">
-      <param name="key" value="be9d40e2-9f9b-4915-8fc8-ae3845f3b8c6"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
-    </paramset>
-    <paramset name="node">
-      <param name="key" value="4fa2f93e-f2b4-4112-8389-f1f3c726f474"/>
-      <param name="98c69511-0173-4d16-ad38-b7a163a7d94d" value="1"/>
-    </paramset>
   </container>
 </document>


### PR DESCRIPTION
I was re-using the PIO `Params` defining Pluto's orbital elements, which you can't do ... adding the same `Param` to a second `ParamSet` removes it from wherever it was, so a program with more than one instance of Pluto ended up with the orbital elements only on the last instance.

Fixed, test updated to include two instances of Pluto. Fails without change, works with.

Note: this is a re-do of an earlier PR, with a more minimal test setup.