### PR TITLE
OCSADV-475: BAGS disable and RA / Dec restore.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -60,24 +60,25 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
    * consideration for a BAGS lookup.
    */
   def watch(prog: ISPProgram): Unit = {
-    synchronized {
-      state += prog.getProgramID
-      prog.addStructureChangeListener(StructurePropertyChangeListener)
-      prog.addCompositeChangeListener(CompositePropertyChangeListener)
-    }
-    prog.getAllObservations.asScala.foreach(enqueue(_, 0L, initialEnqueue = true))
+    //    synchronized {
+    //      state += prog.getProgramID
+    //      prog.addStructureChangeListener(StructurePropertyChangeListener)
+    //      prog.addCompositeChangeListener(CompositePropertyChangeListener)
+    //    }
+    //    prog.getAllObservations.asScala.foreach(enqueue(_, 0L, initialEnqueue = true))
   }
 
   /**
    * Atomically remove a program from our watch list and remove listeners. Any queued observations
    * will be discarded as they come up for consideration.
    */
-  def unwatch(prog: ISPProgram): Unit =
-    synchronized {
-      state -= prog.getProgramID
-      prog.removeStructureChangeListener(StructurePropertyChangeListener)
-      prog.removeCompositeChangeListener(CompositePropertyChangeListener)
-    }
+  def unwatch(prog: ISPProgram): Unit = {
+    //    synchronized {
+    //      state -= prog.getProgramID
+    //      prog.removeStructureChangeListener(StructurePropertyChangeListener)
+    //      prog.removeCompositeChangeListener(CompositePropertyChangeListener)
+    //    }
+  }
 
   /**
    * Remove the specified key from the task queue, if present. Return true if the key was present
@@ -200,8 +201,8 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
 
 object BagsManager {
   private val NumThreads = math.max(1, Runtime.getRuntime.availableProcessors - 1)
-  val instance = new BagsManager(new ScheduledThreadPoolExecutor(NumThreads))
-
+  //val instance = new BagsManager(new ScheduledThreadPoolExecutor(NumThreads))
+  val instance = new BagsManager(new ScheduledThreadPoolExecutor(0))
 
   // Check two target environments to see if the BAGS targets match exactly between them.
   def bagsTargetsMatch(oldEnv: TargetEnvironment, newEnv: TargetEnvironment): Boolean = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
@@ -22,60 +22,60 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
     w.setMinimumSize(w.getPreferredSize)
   }
 
-  //  ra.addWatcher(watcher { s =>
-  //    nonreentrant {
-  //      try {
-  //        spt.setRaString(clean(s))
-  //      } catch {
-  //        case _: IllegalArgumentException => spt.setRaDegrees(0)
-  //      }
-  //    }
-  //  })
-  ra.addWatcher(new TextBoxWidgetWatcher {
-    override def textBoxDoneEditing(tbwe: TextBoxWidget): Unit = {
-      val s = tbwe.getValue
+    ra.addWatcher(watcher { s =>
       nonreentrant {
         try {
           spt.setRaString(clean(s))
         } catch {
-          case _: IllegalArgumentException =>
-            spt.setRaDegrees(0)
+          case _: IllegalArgumentException => spt.setRaDegrees(0)
         }
       }
-    }
-  })
-
-//  dec.addWatcher(watcher { s =>
-//    nonreentrant {
-//      clean(s) match {
-//        case "-" | "+" => // nop
-//        case s =>
-//          try {
-//            spt.setDecString(s)
-//          } catch {
-//            case _: IllegalArgumentException =>
-//              spt.setDecDegrees(0)
-//          }
+    })
+//  ra.addWatcher(new TextBoxWidgetWatcher {
+//    override def textBoxDoneEditing(tbwe: TextBoxWidget): Unit = {
+//      val s = tbwe.getValue
+//      nonreentrant {
+//        try {
+//          spt.setRaString(clean(s))
+//        } catch {
+//          case _: IllegalArgumentException =>
+//            spt.setRaDegrees(0)
+//        }
 //      }
 //    }
 //  })
-  dec.addWatcher(new TextBoxWidgetWatcher {
-    override def textBoxDoneEditing(tbwe: TextBoxWidget): Unit = {
-      val s = tbwe.getValue
-      nonreentrant {
-        clean(s) match {
-          case "-" | "+" => // nop
-          case _ =>
-            try {
-              spt.setDecString(s)
-            } catch {
-              case _: IllegalArgumentException =>
-                spt.setDecDegrees(0)
-            }
-        }
+
+  dec.addWatcher(watcher { s =>
+    nonreentrant {
+      clean(s) match {
+        case "-" | "+" => // nop
+        case s =>
+          try {
+            spt.setDecString(s)
+          } catch {
+            case _: IllegalArgumentException =>
+              spt.setDecDegrees(0)
+          }
       }
     }
   })
+//  dec.addWatcher(new TextBoxWidgetWatcher {
+//    override def textBoxDoneEditing(tbwe: TextBoxWidget): Unit = {
+//      val s = tbwe.getValue
+//      nonreentrant {
+//        clean(s) match {
+//          case "-" | "+" => // nop
+//          case _ =>
+//            try {
+//              spt.setDecString(s)
+//            } catch {
+//              case _: IllegalArgumentException =>
+//                spt.setDecDegrees(0)
+//            }
+//        }
+//      }
+//    }
+//  })
 
   def edit(ctx: GOption[ObsContext], target0: SPTarget, node: ISPNode): Unit = {
     spt = target0


### PR DESCRIPTION
This temporarily turns off BAGS by commenting out the `watch` and `unwatch` methods for programs so that they are never registered for automatic lookups.

Furthermore, the behavior of the RA and Dec text widgets in `CoordinateEditor` have been restored to previous behavior (with changes commented out - we can decide whether or not to remove these when we have a solution to the precision and updating issues).