### PR TITLE
OCSADV-443: RA / Dec field fix for BAGS

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -124,7 +124,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             // other detail editors are swapped in when the target type changes,
             // update them explicitly so they behave as if they were contained
             // in the panel.
-            _w.detailEditor.allEditorsJava().stream().filter(ed -> _w.detailEditor.curDetailEditorJava().forall(cur -> cur != ed)).forEach(ed -> updateEnabledState(new Component[]{ed}, enabled));
+            _w.detailEditor.allEditorsJava().stream().filter(ed -> _w.detailEditor.curDetailEditorJava().forall(cur -> cur != ed)).
+                    forEach(ed -> updateEnabledState(new Component[]{ed}, enabled));
         }
 
         final TargetEnvironment env = getDataObject().getTargetEnvironment();

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -60,12 +60,12 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
    * consideration for a BAGS lookup.
    */
   def watch(prog: ISPProgram): Unit = {
-    //    synchronized {
-    //      state += prog.getProgramID
-    //      prog.addStructureChangeListener(StructurePropertyChangeListener)
-    //      prog.addCompositeChangeListener(CompositePropertyChangeListener)
-    //    }
-    //    prog.getAllObservations.asScala.foreach(enqueue(_, 0L, initialEnqueue = true))
+        synchronized {
+          state += prog.getProgramID
+          prog.addStructureChangeListener(StructurePropertyChangeListener)
+          prog.addCompositeChangeListener(CompositePropertyChangeListener)
+        }
+        prog.getAllObservations.asScala.foreach(enqueue(_, 0L, initialEnqueue = true))
   }
 
   /**
@@ -73,11 +73,11 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
    * will be discarded as they come up for consideration.
    */
   def unwatch(prog: ISPProgram): Unit = {
-    //    synchronized {
-    //      state -= prog.getProgramID
-    //      prog.removeStructureChangeListener(StructurePropertyChangeListener)
-    //      prog.removeCompositeChangeListener(CompositePropertyChangeListener)
-    //    }
+        synchronized {
+          state -= prog.getProgramID
+          prog.removeStructureChangeListener(StructurePropertyChangeListener)
+          prog.removeCompositeChangeListener(CompositePropertyChangeListener)
+        }
   }
 
   /**
@@ -201,8 +201,7 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
 
 object BagsManager {
   private val NumThreads = math.max(1, Runtime.getRuntime.availableProcessors - 1)
-  //val instance = new BagsManager(new ScheduledThreadPoolExecutor(NumThreads))
-  val instance = new BagsManager(new ScheduledThreadPoolExecutor(0))
+  val instance = new BagsManager(new ScheduledThreadPoolExecutor(NumThreads))
 
   // Check two target environments to see if the BAGS targets match exactly between them.
   def bagsTargetsMatch(oldEnv: TargetEnvironment, newEnv: TargetEnvironment): Boolean = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
@@ -48,13 +48,16 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
   })
 
   def edit(ctx: GOption[ObsContext], target0: SPTarget, node: ISPNode): Unit = {
-    val targetChanged = !target0.equals(spt)
+    val targetChanged = !target0.getTarget.equals(spt.getTarget)
     spt = target0
 
     nonreentrant {
       val when = ctx.asScalaOpt.flatMap(_.getSchedulingBlock.asScalaOpt).map(_.start).map(java.lang.Long.valueOf).asGeminiOpt
 
       // We want to see if the current text in the fields, when formatted properly, is different from what would be assigned.
+      // The targetChanged is not a foolproof catch, since two ITargets could be considered the same if their values are
+      // identical, but this is not really consequential: it is just included to reset a partially completed field to a
+      // fully completed one (e.g. RA: 12 to 12:00:00.000) if the RAs are the same but the targets are different.
       val raFormatted = Try { new HMS(ra.getText).toString }.getOrElse(ra.getText)
       target.getRaString(when).asScalaOpt.filter(_ != raFormatted || ra.getText.isEmpty || targetChanged).foreach(ra.setText)
       val decFormatted = Try { new DMS(dec.getText).toString }.getOrElse(dec.getText)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
@@ -5,11 +5,11 @@ import edu.gemini.shared.util.immutable.{ Option => GOption }
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
-import edu.gemini.spModel.target.system.CoordinateParam.Units
-import edu.gemini.spModel.target.system.ITarget
+import edu.gemini.spModel.target.system.{DMS, HMS, ITarget}
 import jsky.app.ot.gemini.editor.targetComponent.TelescopePosEditor
-import jsky.util.gui.{TextBoxWidgetWatcher, TextBoxWidget}
+import jsky.util.gui.TextBoxWidget
 
+import scala.util.Try
 import scalaz.syntax.id._
 
 // RA and Dec
@@ -31,19 +31,6 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
         }
       }
     })
-//  ra.addWatcher(new TextBoxWidgetWatcher {
-//    override def textBoxDoneEditing(tbwe: TextBoxWidget): Unit = {
-//      val s = tbwe.getValue
-//      nonreentrant {
-//        try {
-//          spt.setRaString(clean(s))
-//        } catch {
-//          case _: IllegalArgumentException =>
-//            spt.setRaDegrees(0)
-//        }
-//      }
-//    }
-//  })
 
   dec.addWatcher(watcher { s =>
     nonreentrant {
@@ -59,30 +46,19 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
       }
     }
   })
-//  dec.addWatcher(new TextBoxWidgetWatcher {
-//    override def textBoxDoneEditing(tbwe: TextBoxWidget): Unit = {
-//      val s = tbwe.getValue
-//      nonreentrant {
-//        clean(s) match {
-//          case "-" | "+" => // nop
-//          case _ =>
-//            try {
-//              spt.setDecString(s)
-//            } catch {
-//              case _: IllegalArgumentException =>
-//                spt.setDecDegrees(0)
-//            }
-//        }
-//      }
-//    }
-//  })
 
   def edit(ctx: GOption[ObsContext], target0: SPTarget, node: ISPNode): Unit = {
+    val targetChanged = !target0.equals(spt)
     spt = target0
+
     nonreentrant {
       val when = ctx.asScalaOpt.flatMap(_.getSchedulingBlock.asScalaOpt).map(_.start).map(java.lang.Long.valueOf).asGeminiOpt
-      target.getRaString(when).asScalaOpt.foreach(ra.setText)
-      target.getDecString(when).asScalaOpt.foreach(dec.setText)
+
+      // We want to see if the current text in the fields, when formatted properly, is different from what would be assigned.
+      val raFormatted = Try { new HMS(ra.getText).toString }.getOrElse(ra.getText)
+      target.getRaString(when).asScalaOpt.filter(_ != raFormatted || ra.getText.isEmpty || targetChanged).foreach(ra.setText)
+      val decFormatted = Try { new DMS(dec.getText).toString }.getOrElse(dec.getText)
+      target.getDecString(when).asScalaOpt.filter(_ != decFormatted || dec.getText.isEmpty || targetChanged).foreach(dec.setText)
     }
   }
 

--- a/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TextBoxWidget.java
+++ b/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TextBoxWidget.java
@@ -19,16 +19,12 @@ public class TextBoxWidget extends JTextField {
 
     final private ArrayList<TextBoxWidgetWatcher> _watchers;
 
-    // The previous contents, used to compare to see whether a textBoxDoneEditing should be triggered on watchers.
-    private String _oldContents;
-
     // if true, ignore changes in the text box content
     private boolean _ignoreChanges = false;
 
     /** Default constructor */
     public TextBoxWidget() {
         _watchers = new ArrayList<>();
-        _oldContents = "";
 
         getDocument().addDocumentListener(new DocumentListener() {
             @Override
@@ -49,7 +45,7 @@ public class TextBoxWidget extends JTextField {
         addActionListener(e -> {
             if (!_ignoreChanges) {
                 _notifyAction();
-                _notifyDoneEditingUpdateContents();
+                _notifyDoneEditing();
             }
         });
 
@@ -57,21 +53,9 @@ public class TextBoxWidget extends JTextField {
             @Override
             public void focusLost(FocusEvent e) {
                 if (!_ignoreChanges)
-                    _notifyDoneEditingUpdateContents();
-            }
-
-            @Override
-            public void focusGained(final FocusEvent e) {
-                _oldContents = getValue().trim();
+                    _notifyDoneEditing();
             }
         });
-    }
-
-    private void _notifyDoneEditingUpdateContents() {
-        final String trimmedContents = getValue().trim();
-        if (!trimmedContents.equals(_oldContents))
-            _notifyDoneEditing();
-        _oldContents = trimmedContents;
     }
 
     /**
@@ -170,7 +154,6 @@ public class TextBoxWidget extends JTextField {
         } catch (Exception e) {
             DialogUtil.error(e);
         }
-        _oldContents = s;
         _ignoreChanges = false;
     }
 


### PR DESCRIPTION
The primary purpose of this PR is to:
1. Re-enable BAGS. (I will do a second PR soon to disable BAGS for those who wish to do so.)
2. Fix the RA and Dec fields of the `CoordinateEditor` to work with BAGS.

There is also a couple items of general cleanup and a small bug fix in `TextBoxWidget`, although we might consider getting rid of the `TextBoxWidgetWatcher.textBoxDoneEditing` since this is no longer used. I will leave it for now.