### PR TITLE
REL-2517: update program container version

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -45,7 +45,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     // for serialization
     private static final long serialVersionUID = 4L;
 
-    public static final String VERSION = "2015B-1";
+    public static final String VERSION = "2016A-1";
 
     /** This property records the program queue/classical state. */
     public static final String PROGRAM_MODE_PROP = "programMode";


### PR DESCRIPTION
The 2016A migration code will always run, even in the future, if we don't update the program container version.

````scala
object To2016A extends Migration {

  val Version_2016A = Version.`match`("2016A-1")

  def isPre2016A(c: Container): Boolean =
    c.getVersion.compareTo(Version_2016A) < 0

  // Entry point here
  def updateProgram(d: Document): Unit =
    d.containers.find(_.getKind == SpIOTags.PROGRAM).filter(isPre2016A).foreach { _ =>
      conversions.foreach(_.apply(d))
    }

````