### PR TITLE
OCSADV-472: Keep SED aux file selection from updating on single key strokes

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
@@ -305,7 +305,8 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
     /** Updates the combobox model with the currently available aux files.*/
     private def updateAuxFileModel(programId: SPProgramID): Unit =  {
 
-      def selected = spt.getTarget.getSpectralDistribution match {
+      // Determines the currently selected SED aux file (if any)
+      def selectedAuxFile = spt.getTarget.getSpectralDistribution match {
         case Some(s: AuxFileSpectrum) => Some(s)
         case _                        => None
       }
@@ -315,18 +316,18 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
       // currently selected aux file has been removed (we don't want to simply replace an invalid selection with
       // another value without letting the user know). If the selected file has been removed, calling the ITC will
       // result in a meaningful error message that tells the user that the selected aux file is not available anymore.
-      def setModel(files: Set[AuxFileSpectrum], sel: Option[AuxFileSpectrum]) = {
-        val all = sel.fold(files)(s => files + s)
-        val all2 = if (all.isEmpty) Set(AuxFileSpectrum.Undefined) else all
-        userDefinedDetails.peer.setModel(ComboBox.newConstantModel(all2.toSeq.sortBy(_.name)))
-        sel.foreach(s => userDefinedDetails.selection.item = s)
+      def setModel(available: Set[AuxFileSpectrum], selected: Option[AuxFileSpectrum]) = {
+        val all1 = selected.fold(available)(s => available + s)               // add current selection to available files if needed
+        val all2 = if (all1.isEmpty) Set(AuxFileSpectrum.Undefined) else all1 // if there isn't anything add a "dummy" element
+        userDefinedDetails.peer.setModel(ComboBox.newConstantModel(all2.toSeq.sortBy(_.name))) // combo box model musn't be empty
+        selected.foreach(s => userDefinedDetails.selection.item = s)
       }
 
-      SourceDetailsEditor.this.deafTo(editElements:_*) // don't trigger any events!
+      SourceDetailsEditor.this.deafTo(editElements:_*)    // DON'T trigger any events!
       getAuxFiles(programId) match {
-        case files => setModel(files, selected)
+        case files => setModel(files, selectedAuxFile)
       }
-      SourceDetailsEditor.this.listenTo(editElements:_*)
+      SourceDetailsEditor.this.listenTo(editElements:_*)  // OK, done with updating UI elements
 
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
@@ -36,7 +36,7 @@ import scalaz.Scalaz._
 final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor with ReentrancyHack {
 
   // ==== The current program ID
-  private[this] var programId: Option[SPProgramID] = None    // this is needed for getting the SED aux files list
+  private[this] var programId: SPProgramID = SPProgramID.toProgramID("")  // this is needed for getting the SED aux files list
 
   // ==== The current target
   private[this] var spt: SPTarget = new SPTarget
@@ -217,13 +217,9 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
   // react to any kind of target change by updating all UI elements
   def edit(obsContext: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = nonreentrant {
 
-    // update target
-    spt = spTarget
-
-    // update current program id
-    if (programId.isEmpty) {
-      programId = Some(node.getProgramID)
-    }
+    // update target and program id
+    spt       = spTarget
+    programId = node.getProgramID
 
     // we only show the source editor for the base/science target, and we also only need to update it if visible
     visible = if (obsContext.isDefined) obsContext.getValue.getTargets.getBase == spTarget else false
@@ -288,7 +284,7 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
     peer.addPopupMenuListener(new PopupMenuListener {
       // If the program id is known and the popup is about to be displayed we need to update the combobox model
       // with all currently available SED aux files.
-      override def popupMenuWillBecomeVisible(e: PopupMenuEvent): Unit    = { programId.foreach(updateAuxFileModel) }
+      override def popupMenuWillBecomeVisible(e: PopupMenuEvent): Unit    = { updateAuxFileModel(programId) }
       override def popupMenuWillBecomeInvisible(e: PopupMenuEvent): Unit  = {}
       override def popupMenuCanceled(e: PopupMenuEvent): Unit             = {}
     })


### PR DESCRIPTION
OCSADV-472 describes some issues with BAGS updates. One of them is that the SED aux file selector for user defined source distributions updates its list of available files on every single key stroke. Needless to say that this wasn't such a brilliant idea.

Currently there is no way to get notified when aux files are changed (added/removed) and therefore the best way to deal with updating the list of available SED aux files seems to be to update it every time the user opens the combobox popup menu.

Because this update is triggered when the user clicks on the combobox to display the available values we need to produce those immediately and therefore the load operation that gets the aux file list from the server is done synchronously and will be aborted after 3 seconds.

I was also thinking about providing some `Publisher` based mechanism on top of the `AuxFileClient` and `AuxFileModel` but the advantage of the approach I followed in this PR is that it is contained in a single place and is less risky. Also, I did not want to start introducing something new; I think the whole event handling in the OT is a topic we need to have some broader discussion at some point.

Example of some user defined spectral distributions in the OT:

![image](https://cloud.githubusercontent.com/assets/7856060/10991119/8a1cb314-83fe-11e5-8155-c1551afd3e7d.png)
