### PR TITLE
OCSADV-271: Support 'embiggen' feature

### DIFF
--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQuerySpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/CatalogQuerySpec.scala
@@ -34,7 +34,7 @@ class CatalogQuerySpec extends SpecificationWithJUnit {
   def beSuperSetOf(cq: CatalogQuery) =  new Matcher[CatalogQuery] {
     override def apply[S <: CatalogQuery](t: Expectable[S]) = {
       val actual = t.value
-      result(actual.isSuperSetOf(cq) && !cq.isSuperSetOf(actual), s"$actual is a superset of $cq", s"$actual is not a proper superset of $cq", t)
+      result(actual.isSuperSetOf(cq), s"$actual is a superset of $cq", s"$actual is not a proper superset of $cq", t)
     }
   }
 
@@ -46,6 +46,9 @@ class CatalogQuerySpec extends SpecificationWithJUnit {
   }
 
   "CatalogQuerySpec" should {
+    "be a superset of itself" in {
+      par10_10 should beSuperSetOf(par10_10)
+    }
     "be a superset of the same base" in {
       par10_10 should beSuperSetOf(par5_10)
     }


### PR DESCRIPTION
In the old catalog severs the queries were widened to increase cache efficiency. This meant that when searching for nearby objects there was a good chance that the data would be already available locally
This PR brings this capability into the new catalogs. Queries are widened 150% with up to 10 arcmins to avoid covering too large of a sky swath