### PR TITLE
BUGFIX: Update to failing ITC test.

### DIFF
--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/base/DatFileTest.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/base/DatFileTest.scala
@@ -174,8 +174,8 @@ class DatFileTest {
   def parseFile2(): Unit = {
     val data = DatFile.arrays("/flamingos2/HK.dat")
     assert(data.size == 2)
-    assert(data(1).size == 2900)
-    assert(data(0).size == 2900)
+    assert(data(1).size == 2901)
+    assert(data(0).size == 2901)
   }
 
   @Test


### PR DESCRIPTION
Forgot to update a test whose result was impacted by a previous change to the data file it uses.