### PR TITLE
Support publishing p1 model to artifactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ Each project in `app/` defines an application, which is a collection of bundles 
 - The build dependencies declared in `project/OcsApp.scala` and the bundle dependencies declared (and calculated) by the `Application` object in each app's `build.sbt` are independent; the former is simply a convenience that allows you to build the app from sbt, and the latter is used for generating IDEA projects and app distributions.
 - The `all-bundles` app is not computed; if you add a new bundle to the OCS project you will need to add it manually to `all-bundles`.
 
+#### Artifact Publication
 
+At least 2 bundles need to be shared via a maven repository for use on other projects. To publish go to the project and type `publish`. That will create a maven compatible artifact and deploy it
 
+You need to setup your credentials for the repository adding an sbt file, e.g. `artifactory.sbt` to your sbt settings at `~/.sbt/0.13/` with the following content
 
-
-
+`credentials += Credentials("Artifactory Realm", "<artifactory host>", "<username>", "<pwd>")`

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import OcsKeys._
 
 name := "ocs"
 
+organization := "edu.gemini.ocs"
+
 ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 0)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import OcsKeys._
 
 name := "ocs"
 
-organization := "edu.gemini.ocs"
+organization in Global := "edu.gemini.ocs"
 
 ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
@@ -69,6 +69,15 @@ publishArtifact in (ThisBuild, packageDoc) := false
 
 // Don't build package source (for now)
 publishArtifact in (ThisBuild, packageSrc) := false
+
+publishTo in Global := {
+    val repo = if (isSnapshot.value) {
+      "libs-snapshot-local"
+    } else {
+      "libs-release-local"
+    }
+    Some("Gemini Artifactory" at s"http://sbfosxdev-mp1.cl.gemini.edu:8081/artifactory/$repo")
+  }
 
 // No poms
 publishMavenStyle in ThisBuild := false

--- a/bundle/edu.gemini.model.p1/build.sbt
+++ b/bundle/edu.gemini.model.p1/build.sbt
@@ -68,12 +68,3 @@ publishArtifact in (ThisBuild, packageSrc) := true
 
 publishMavenStyle in ThisBuild := true
 
-// Add your credentials to the artifactory repository
-publishTo := {
-    val repo = if (isSnapshot.value) {
-      "libs-snapshot-local"
-    } else {
-      "libs-release-local"
-    }
-    Some("Gemini Artifactory" at s"http://sbfosxdev-mp1.cl.gemini.edu:8081/artifactory/$repo")
-  }

--- a/bundle/edu.gemini.model.p1/build.sbt
+++ b/bundle/edu.gemini.model.p1/build.sbt
@@ -63,3 +63,17 @@ commands += {
     state
   }
 }
+
+publishArtifact in (ThisBuild, packageSrc) := true
+
+publishMavenStyle in ThisBuild := true
+
+// Add your credentials to the artifactory repository
+publishTo := {
+    val repo = if (isSnapshot.value) {
+      "libs-snapshot-local"
+    } else {
+      "libs-release-local"
+    }
+    Some("Gemini Artifactory" at s"http://sbfosxdev-mp1.cl.gemini.edu:8081/artifactory/$repo")
+  }

--- a/bundle/edu.gemini.spModel.core/build.sbt
+++ b/bundle/edu.gemini.spModel.core/build.sbt
@@ -38,3 +38,17 @@ scalacOptions in (Compile, doc) ++= Seq(
   "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath, 
   "-doc-source-url", "https://github.com/gemini-hlws/ocs/master€{FILE_PATH}.scala" 
 )
+
+publishArtifact in (ThisBuild, packageSrc) := true
+
+publishMavenStyle in ThisBuild := true
+
+// Add your credentials to the artifactory repository
+publishTo := {
+    val repo = if (isSnapshot.value) {
+      "libs-snapshot-local"
+    } else {
+      "libs-release-local"
+    }
+    Some("Gemini Artifactory" at s"http://sbfosxdev-mp1.cl.gemini.edu:8081/artifactory/$repo")
+  }

--- a/bundle/edu.gemini.spModel.core/build.sbt
+++ b/bundle/edu.gemini.spModel.core/build.sbt
@@ -43,12 +43,3 @@ publishArtifact in (ThisBuild, packageSrc) := true
 
 publishMavenStyle in ThisBuild := true
 
-// Add your credentials to the artifactory repository
-publishTo := {
-    val repo = if (isSnapshot.value) {
-      "libs-snapshot-local"
-    } else {
-      "libs-release-local"
-    }
-    Some("Gemini Artifactory" at s"http://sbfosxdev-mp1.cl.gemini.edu:8081/artifactory/$repo")
-  }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -8,7 +8,5 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-effect" % "7.0.4"
 )
 
-
 // TODO: remove this, it's for the inlined sbt-osgi plugin
 libraryDependencies += "biz.aQute.bnd" % "bndlib" % "2.1.0"
-


### PR DESCRIPTION
With this PR we are able to publish the bundles p1 and spModel to the internal artifactory repository directly from sbt. I couldn't enable it globally to publish all bundles but we need these 2 for ITAC