### PR TITLE
OCSADV-447: GNIRS ITC error -7847

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/ArraySpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/ArraySpectrum.java
@@ -55,12 +55,6 @@ public interface ArraySpectrum extends Spectrum, Cloneable {
     void smoothY(int smoothing_element);
 
     /**
-     * Returns the sum of values in the ArraySpectrum in
-     * the specified range.
-     */
-    double getSum(int indexStart, int indexEnd);
-
-    /**
      * This returns a 2d array of the SED data used to chart the SED
      * using JClass Chart.  The array has the following dimensions
      * double data[][] = new double[2][getLength()];

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultArraySpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultArraySpectrum.java
@@ -34,7 +34,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
     }
 
     /**
-     * Construce a DefaultSpectrum.  Data array must be of this form:
+     * Construct a DefaultSpectrum.  Data array must be of this form:
      * double data[][] = new double[2][length];
      * data[0][i] = x values
      * data[1][i] = y values
@@ -69,7 +69,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
     /**
      * Implements Cloneable interface
      */
-    public Object clone() {
+    @Override public Object clone() {
         // constructor will clone the data array
         return new DefaultArraySpectrum(_data);
     }
@@ -77,28 +77,28 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
     /**
      * @return starting x value
      */
-    public double getStart() {
+    @Override public double getStart() {
         return _data[0][0];
     }
 
     /**
      * @return ending x value
      */
-    public double getEnd() {
+    @Override public double getEnd() {
         return _data[0][_data[0].length - 1];
     }
 
     /**
      * Returns x value of specified data point.
      */
-    public double getX(int index) {
+    @Override public double getX(int index) {
         return _data[0][index];
     }
 
     /**
      * Returns y value of specified data point.
      */
-    public double getY(int index) {
+    @Override public double getY(int index) {
         return _data[1][index];
     }
 
@@ -106,7 +106,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      * @return y value at specified x using linear interpolation.
      * Silently returns zero if x is out of spectrum range.
      */
-    public double getY(double x) {
+    @Override public double getY(double x) {
         if (x < getStart() || x > getEnd()) return 0;
         int low_index = getLowerIndex(x);
         int high_index = low_index + 1;
@@ -121,14 +121,14 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
     /**
      * @return number of bins in the histogram (number of data points)
      */
-    public int getLength() {
+    @Override public int getLength() {
         return _data[0].length;
     }
 
     /**
      * Returns the index of the data point with largest x value less than x
      */
-    public int getLowerIndex(double x) {
+    @Override public int getLowerIndex(double x) {
         // In a general spectrum we don't have an idea which bin a particular
         // x value is in.  The only solution is to search for it.
         // Could just walk through, but do a binary search for it.
@@ -145,7 +145,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
         return low_index;
     }
 
-    public void applyWavelengthCorrection() {
+    @Override public void applyWavelengthCorrection() {
 
         for (int i = 0; i < getLength(); ++i) {
             _data[1][i] = _data[1][i] * _data[0][i];
@@ -156,7 +156,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      * Sets y value in specified x bin.
      * If specified bin is out of range, this is a no-op.
      */
-    public void setY(int index, double y) {
+    @Override public void setY(int index, double y) {
         if (index < 0 || index >= getLength()) return;  // no-op
         _data[1][index] = y;
     }
@@ -164,7 +164,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
     /**
      * Rescales X axis by specified factor.
      */
-    public void rescaleX(double factor) {
+    @Override public void rescaleX(double factor) {
         if (factor == 1.0) return;
         for (int i = 0; i < getLength(); ++i) {
             _data[0][i] *= factor;
@@ -174,14 +174,14 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
     /**
      * Rescales Y axis by specified factor.
      */
-    public void rescaleY(double factor) {
+    @Override public void rescaleY(double factor) {
         if (factor == 1.0) return;
         for (int i = 0; i < getLength(); ++i) {
             _data[1][i] *= factor;
         }
     }
 
-    public void smoothY(int smoothing_element) {
+    @Override public void smoothY(int smoothing_element) {
         if (smoothing_element == 1.0) return;
         for (int i = 0; i < getLength(); ++i) {
             try {
@@ -198,66 +198,10 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
 
 
     /**
-     * Returns the sum of all the y values in the entire spectrum.
-     */
-    public double getSum() {
-        return getSum(0, getLength() - 1);
-    }
-
-    /**
      * Returns the integral of entire spectrum.
      */
-    public double getIntegral() {
+    @Override public double getIntegral() {
         return getIntegral(getStart(), getEnd());
-    }
-
-    /**
-     * Returns the average of all the y values in the entire spectrum
-     */
-    public double getAverage() {
-        return getAverage(getStart(), getEnd());
-    }
-
-    /**
-     * Returns the sum of y values in the spectrum in
-     * the specified index range.
-     */
-    public double getSum(int startIndex, int endIndex) {
-        assert startIndex >= 0 && startIndex < getLength();
-        assert endIndex   >= 0 && endIndex   < getLength();
-
-        if (startIndex > endIndex) {
-            int temp = startIndex;
-            startIndex = endIndex;
-            endIndex = temp;
-        }
-
-        double sum = 0;
-        for (int i = startIndex; i <= endIndex; ++i) {
-            sum += getY(i);
-        }
-        return sum;
-    }
-
-    /**
-     * Returns the sum of y values in the spectrum in
-     * the specified range.
-     */
-    public double getSum(double x_start, double x_end) {
-        assert x_start >= getStart() && x_start <= getEnd();
-        assert x_end   >= getStart() && x_end   <= getEnd();
-
-        if (x_start > x_end) {
-            double temp = x_start;
-            x_start = x_end;
-            x_end = temp;
-        }
-
-        int startIndex = getLowerIndex(x_start);
-        int endIndex = getLowerIndex(x_end);
-        if (getX(endIndex) < x_end) endIndex++;
-
-        return getSum(startIndex, endIndex);
     }
 
     /**
@@ -341,7 +285,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      * Returns the average of values in the SampledSpectrum in
      * the specified range.
      */
-    public double getAverage(double x_start, double x_end) {
+    @Override public double getAverage(double x_start, double x_end) {
         return getIntegral(x_start, x_end) / (x_end - x_start);
     }
 
@@ -349,7 +293,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      * Returns the average of values in the SampledSpectrum in
      * the specified range.
      */
-    public double getAverage(int indexStart, int indexEnd) {
+    private double getAverage(int indexStart, int indexEnd) {
         return getIntegral(indexStart, indexEnd) /
                 (getX(indexEnd) - getX(indexStart));
     }
@@ -363,7 +307,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      * May return reference to member data, so client should not
      * alter the return value.
      */
-    public double[][] getData() {
+    @Override public double[][] getData() {
         return _data;
     }
 
@@ -378,7 +322,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      *                 x bin.  If maxIndex >= number of data points, maxIndex
      *                 will be truncated.
      */
-    public double[][] getData(int maxIndex) {
+    @Override public double[][] getData(int maxIndex) {
         return getData(0, maxIndex);
     }
 
@@ -394,7 +338,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      *                 x bin.  If maxIndex >= number of data points, maxIndex
      *                 will be truncated.
      */
-    public double[][] getData(int minIndex, int maxIndex) {
+    @Override public double[][] getData(int minIndex, int maxIndex) {
         if (minIndex < 0) minIndex = 0;
         if (maxIndex >= _data[0].length) maxIndex = _data[0].length - 1;
         double[][] data = new double[2][maxIndex - minIndex + 1];

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultArraySpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultArraySpectrum.java
@@ -209,16 +209,9 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      * the specified range.
      */
     public double getIntegral(double x_start, double x_end) {
+        assert x_start <= x_end;
         assert x_start >= getStart() && x_start <= getEnd();
         assert x_end   >= getStart() && x_end   <= getEnd();
-
-        boolean negative = false;
-        if (x_start > x_end) {
-            double temp = x_start;
-            x_start = x_end;
-            x_end = temp;
-            negative = true;
-        }
 
         // Add up trapezoid areas.
         // x1 and x2 may not be exactly on sampling points so do
@@ -246,7 +239,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
 
         area += getIntegral(start_index, end_index);
 
-        return (negative) ? -area : area;
+        return area;
     }
 
     /**
@@ -254,19 +247,12 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
      * specified range between specified indices.
      */
     public double getIntegral(int start_index, int end_index) {
+        assert start_index <= end_index;
         assert start_index >= 0 && start_index < getLength();
         assert end_index   >= 0 && end_index   < getLength();
 
-        boolean negative = false;
-        if (start_index > end_index) {
-            int temp = start_index;
-            start_index = end_index;
-            end_index = temp;
-            negative = true;
-        }
-
         double area = 0.0;
-        double delta_x, delta_y, y_min, y1, y2, x1, x2;
+        double delta_x,y1, y2, x1, x2;
 
         // Add up trapezoid areas.
         for (int index = start_index; index < end_index; ++index) {
@@ -278,7 +264,7 @@ public final class DefaultArraySpectrum implements ArraySpectrum {
             area += delta_x * (y2 + y1) / 2.0;
         }
 
-        return (negative) ? -area : area;
+        return area;
     }
 
     /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
@@ -283,14 +283,9 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * @throws Exception If either limit is out of range.
      */
     private double getSum(int startIndex, int endIndex) {
+        assert startIndex <= endIndex;
         assert startIndex >= 0 && startIndex < getLength();
         assert endIndex   >= 0 && endIndex   < getLength();
-
-        if (startIndex > endIndex) {
-            int temp = startIndex;
-            startIndex = endIndex;
-            endIndex = temp;
-        }
 
         double sum = 0.0;
         for (int i = startIndex; i <= endIndex; ++i) {
@@ -306,16 +301,9 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * @throws Exception If either limit is out of range.
      */
     public double getIntegral(double x_start, double x_end) {
+        assert x_start <= x_end;
         assert x_start >= getStart() && x_start <= getEnd();
         assert x_end   >= getStart() && x_end   <= getEnd();
-
-        boolean negative = false;
-        if (x_start > x_end) {
-            double temp = x_start;
-            x_start = x_end;
-            x_end = temp;
-            negative = true;
-        }
 
         // Add up trapezoid areas.
         // x1 and x2 may not be exactly on sampling points so do
@@ -343,7 +331,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
 
         area += getIntegral(start_index, end_index);
 
-        return (negative) ? -area : area;
+        return area;
     }
 
     /**
@@ -351,19 +339,12 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * specified range between specified indices.
      */
     private double getIntegral(int start_index, int end_index) {
+        assert start_index <= end_index;
         assert start_index >= 0 && start_index < getLength();
         assert end_index   >= 0 && end_index   < getLength();
 
         if (start_index == end_index) {
             return 0.0; // REL-478
-        }
-
-        boolean negative = false;
-        if (start_index > end_index) {
-            int temp = start_index;
-            start_index = end_index;
-            end_index = temp;
-            negative = true;
         }
 
         // Add up trapezoidal areas.
@@ -377,7 +358,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
         area += getY(start_index) + getY(end_index);
         area *= getSampling() / 2.0;
 
-        return (negative) ? -area : area;
+        return area;
     }
 
     /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
@@ -1,8 +1,5 @@
 package edu.gemini.itc.base;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-
 /**
  * Default implementation of SampledSpectrum interface.
  * This implementation internally has a uniformly-spaced data points.
@@ -60,13 +57,13 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
     /**
      * Implements the Cloneable interface.
      */
-    public Object clone() {
+    @Override public Object clone() {
         double[] data = new double[getLength()];
         System.arraycopy(getValues(), 0, data, 0, getLength());
         return new DefaultSampledSpectrum(data, getStart(), getSampling());
     }
 
-    public void trim(double newStart, double newEnd) {
+    @Override public void trim(double newStart, double newEnd) {
         if (newStart < getStart()) {
             newStart = getStart();
         }
@@ -90,7 +87,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * I don't like a method that sets everything at once, but I inherited
      * this code so I will leave it.
      */
-    public void reset(double[] y, double xStart,
+    @Override public void reset(double[] y, double xStart,
                       double xInterval) {
         _y = new double[y.length];
         // need our own copy so client can't mess with it.
@@ -112,7 +109,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * SampledSpectrumVisitor r = new Resample();
      * s.Accept(r);
      */
-    public void accept(SampledSpectrumVisitor v) {
+    @Override public void accept(SampledSpectrumVisitor v) {
         v.visit(this);
     }
 
@@ -125,42 +122,42 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * referenct to actual member data.  The client must not alter this
      * return value.
      */
-    public double[] getValues() {
+    @Override public double[] getValues() {
         return _y;
     }
 
     /**
      * @return starting x
      */
-    public double getStart() {
+    @Override public double getStart() {
         return _xStart;
     }
 
     /**
      * @return ending x
      */
-    public double getEnd() {
+    @Override public double getEnd() {
         return _xEnd;
     }
 
     /**
      * @return x sample size (bin size)
      */
-    public double getSampling() {
+    @Override public double getSampling() {
         return _xInterval;
     }
 
     /**
      * @return flux value in specified bin
      */
-    public double getY(int index) {
+    @Override public double getY(int index) {
         return _y[index];
     }
 
     /**
      * @return x of specified bin
      */
-    public double getX(int index) {
+    @Override public double getX(int index) {
         return getStart() + index * getSampling();
     }
 
@@ -168,7 +165,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * @return y value at specified x using linear interpolation.
      * Silently returns zero if x is out of spectrum range.
      */
-    public double getY(double x) {
+    @Override public double getY(double x) {
         if (x < getStart() || x > getEnd()) return 0;
         if (x == getEnd()) return getY(getLength() - 1);
         int low_index = getLowerIndex(x);
@@ -184,14 +181,14 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
     /**
      * Returns the index of the data point with largest x value less than x
      */
-    public int getLowerIndex(double x) {
+    @Override public int getLowerIndex(double x) {
         return (int) ((x - getStart()) / getSampling());
     }
 
     /**
      * @return number of bins in the histogram (number of data points)
      */
-    public int getLength() {
+    @Override public int getLength() {
         return _y.length;
     }
 
@@ -201,7 +198,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
     //
 
 
-    public void applyWavelengthCorrection() {
+    @Override public void applyWavelengthCorrection() {
         double start = getStart();
         double sampling = getSampling();
 
@@ -214,7 +211,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * Sets y value in specified x bin.
      * If specified bin is out of range, this is a no-op.
      */
-    public void setY(int bin, double y) {
+    @Override public void setY(int bin, double y) {
         if (bin < 0 || bin >= getLength()) return;  // no-op
         _y[bin] = y;
     }
@@ -222,7 +219,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
     /**
      * Rescales X axis by specified factor. Doesn't change sampling size.
      */
-    public void rescaleX(double factor) {
+    @Override public void rescaleX(double factor) {
         if (factor == 1.0) return;
         double xStart = getStart() * factor;
         double xEnd = getEnd() * factor;
@@ -239,14 +236,14 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
     /**
      * Rescales Y axis by specified factor.
      */
-    public void rescaleY(double factor) {
+    @Override public void rescaleY(double factor) {
         if (factor == 1.0) return;
         for (int i = 0; i < getLength(); ++i) {
             _y[i] *= factor;
         }
     }
 
-    public void smoothY(int smoothing_element) {
+    @Override public void smoothY(int smoothing_element) {
         double[] _y_temp;
         _y_temp = new double[_y.length];
 
@@ -273,24 +270,10 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
     }
 
     /**
-     * Returns the sum of all the y values in the SampledSpectrum
-     */
-    public double getSum() {
-        return getSum(0, getLength() - 1);
-    }
-
-    /**
      * Returns the integral of all the y values in the SampledSpectrum
      */
-    public double getIntegral() {
+    @Override public double getIntegral() {
         return getIntegral(getStart(), getEnd());
-    }
-
-    /**
-     * Returns the average of all the y values in the SampledSpectrum
-     */
-    public double getAverage() {
-        return getAverage(getStart(), getEnd());
     }
 
     /**
@@ -299,7 +282,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      *
      * @throws Exception If either limit is out of range.
      */
-    public double getSum(int startIndex, int endIndex) {
+    private double getSum(int startIndex, int endIndex) {
         assert startIndex >= 0 && startIndex < getLength();
         assert endIndex   >= 0 && endIndex   < getLength();
 
@@ -314,29 +297,6 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
             sum += getY(i);
         }
         return sum;
-    }
-
-    /**
-     * Returns the sum of y values in the spectrum in
-     * the specified range.
-     *
-     * @throws Exception If either limit is out of range.
-     */
-    public double getSum(double x_start, double x_end) {
-        assert x_start >= getStart() && x_start <= getEnd();
-        assert x_end   >= getStart() && x_end   <= getEnd();
-
-        if (x_start > x_end) {
-            double temp = x_start;
-            x_start = x_end;
-            x_end = temp;
-        }
-
-        int startIndex = getLowerIndex(x_start);
-        int endIndex = getLowerIndex(x_end);
-        if (getX(endIndex) < x_end) endIndex++;
-
-        return getSum(startIndex, endIndex);
     }
 
     /**
@@ -390,7 +350,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * Returns the integral of values in the SampledSpectrum in the
      * specified range between specified indices.
      */
-    public double getIntegral(int start_index, int end_index) {
+    private double getIntegral(int start_index, int end_index) {
         assert start_index >= 0 && start_index < getLength();
         assert end_index   >= 0 && end_index   < getLength();
 
@@ -424,7 +384,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * Returns the average of values in the SampledSpectrum in
      * the specified range.
      */
-    public double getAverage(double x_start, double x_end) {
+    @Override public double getAverage(double x_start, double x_end) {
         return getIntegral(x_start, x_end) / (x_end - x_start);
     }
 
@@ -432,7 +392,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * Returns the average of values in the SampledSpectrum in
      * the specified range.
      */
-    public double getAverage(int indexStart, int indexEnd) {
+    private double getAverage(int indexStart, int indexEnd) {
         return getIntegral(indexStart, indexEnd) /
                 (getX(indexEnd) - getX(indexStart));
     }
@@ -444,7 +404,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * data[0][i] = x values
      * data[1][i] = y values
      */
-    public double[][] getData() {
+    @Override public double[][] getData() {
         return getData(_y.length - 1);  // the whole SampledSpectrum
     }
 
@@ -457,7 +417,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      *
      * @param maxXIndex data is returned up to maximum specified x bin
      */
-    public double[][] getData(int maxXIndex) {
+    @Override public double[][] getData(int maxXIndex) {
         return getData(0, maxXIndex);
     }
 
@@ -471,7 +431,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      * @param minXIndex data is returned starts at minimum specified x bin
      * @param maxXIndex data is returned up to maximum specified x bin
      */
-    public double[][] getData(int minXIndex, int maxXIndex) {
+    @Override public double[][] getData(int minXIndex, int maxXIndex) {
         if (maxXIndex >= _y.length) maxXIndex = _y.length - 1;
         if (minXIndex < 0) maxXIndex = 0;
         double data[][] = new double[2][maxXIndex - minXIndex + 1];

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/EmissionLineSpectrum.java
@@ -69,21 +69,21 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
 
 
     //Implements the clonable interface
-    public Object clone() {
+    @Override public Object clone() {
         final DefaultSampledSpectrum spectrum =
                 (DefaultSampledSpectrum) _spectrum.clone();
         return new EmissionLineSpectrum(spectrum);
     }
 
-    public void trim(final double startWavelength, final double endWavelength) {
+    @Override public void trim(final double startWavelength, final double endWavelength) {
         _spectrum.trim(startWavelength, endWavelength);
     }
 
-    public void reset(final double[] s, final double v, final double r) {
+    @Override public void reset(final double[] s, final double v, final double r) {
         _spectrum.reset(s, v, r);
     }
 
-    public void accept(final SampledSpectrumVisitor v) {
+    @Override public void accept(final SampledSpectrumVisitor v) {
         _spectrum.accept(v);
     }
 
@@ -96,42 +96,42 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
      * referenct to actual member data.  The client must not alter this
      * return value.
      */
-    public double[] getValues() {
+    @Override public double[] getValues() {
         return _spectrum.getValues();
     }
 
     /**
      * @return starting x
      */
-    public double getStart() {
+    @Override public double getStart() {
         return _spectrum.getStart();
     }
 
     /**
      * @return ending x
      */
-    public double getEnd() {
+    @Override public double getEnd() {
         return _spectrum.getEnd();
     }
 
     /**
      * @return x sample size (bin size)
      */
-    public double getSampling() {
+    @Override public double getSampling() {
         return _spectrum.getSampling();
     }
 
     /**
      * @return flux value in specified bin
      */
-    public double getY(final int index) {
+    @Override public double getY(final int index) {
         return _spectrum.getY(index);
     }
 
     /**
      * @return x of specified bin
      */
-    public double getX(final int index) {
+    @Override public double getX(final int index) {
         return _spectrum.getX(index);
     }
 
@@ -140,7 +140,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
      * @return y value at specified x using linear interpolation.
      * Silently returns zero if x is out of spectrum range.
      */
-    public double getY(final double x) {
+    @Override public double getY(final double x) {
         return _spectrum.getY(x);
     }
 
@@ -148,7 +148,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
     /**
      * Returns the index of the data point with largest x value less than x
      */
-    public int getLowerIndex(final double x) {
+    @Override public int getLowerIndex(final double x) {
         return _spectrum.getLowerIndex(x);
     }
 
@@ -156,7 +156,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
     /**
      * @return number of bins in the histogram (number of data points)
      */
-    public int getLength() {
+    @Override public int getLength() {
         return _spectrum.getLength();
     }
 
@@ -166,7 +166,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
     //
 
 
-    public void applyWavelengthCorrection() {
+    @Override public void applyWavelengthCorrection() {
         _spectrum.applyWavelengthCorrection();
     }
 
@@ -174,14 +174,14 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
      * Sets y value in specified x bin.
      * If specified bin is out of range, this is a no-op.
      */
-    public void setY(final int bin, final double y) {
+    @Override public void setY(final int bin, final double y) {
         _spectrum.setY(bin, y);
     }
 
     /**
      * Rescales X axis by specified factor. Doesn't change sampling size.
      */
-    public void rescaleX(final double factor) {
+    @Override public void rescaleX(final double factor) {
         _spectrum.rescaleX(factor);
     }
 
@@ -189,59 +189,26 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
     /**
      * Rescales Y axis by specified factor.
      */
-    public void rescaleY(final double factor) {
+    @Override public void rescaleY(final double factor) {
         _spectrum.rescaleY(factor);
     }
 
-    public void smoothY(final int factor) {
+    @Override public void smoothY(final int factor) {
         _spectrum.smoothY(factor);
-    }
-
-    /**
-     * Returns the sum of all the y values in the SampledSpectrum
-     */
-    public double getSum() {
-        return _spectrum.getSum();
     }
 
     /**
      * Returns the integral of all the y values in the SampledSpectrum
      */
-    public double getIntegral() {
+    @Override public double getIntegral() {
         return _spectrum.getIntegral();
-    }
-
-
-    /**
-     * Returns the average of all the y values in the SampledSpectrum
-     */
-    public double getAverage() {
-        return _spectrum.getAverage();
-    }
-
-
-    /**
-     * Returns the sum of y values in the spectrum in
-     * the specified index range.
-     */
-    public double getSum(final int startIndex, final int endIndex) {
-        return _spectrum.getSum(startIndex, endIndex);
-    }
-
-
-    /**
-     * Returns the sum of y values in the spectrum in
-     * the specified range.
-     */
-    public double getSum(final double x_start, final double x_end) {
-        return _spectrum.getSum(x_start, x_end);
     }
 
     /**
      * Returns the average of values in the SampledSpectrum in
      * the specified range.
      */
-    public double getAverage(final double x_start, final double x_end) {
+    @Override public double getAverage(final double x_start, final double x_end) {
         return _spectrum.getAverage(x_start, x_end);
 
     }
@@ -253,7 +220,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
      * data[0][i] = x values
      * data[1][i] = y values
      */
-    public double[][] getData() {
+    @Override public double[][] getData() {
         return _spectrum.getData();
 
     }
@@ -267,7 +234,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
      *
      * @param maxXIndex data is returned up to maximum specified x bin
      */
-    public double[][] getData(final int maxXIndex) {
+    @Override public double[][] getData(final int maxXIndex) {
         return _spectrum.getData(maxXIndex);
     }
 
@@ -281,7 +248,7 @@ public final class EmissionLineSpectrum implements VisitableSampledSpectrum {
      * @param minXIndex data is returned from the minimum specified x bin
      * @param maxXIndex data is returned up to maximum specified x bin
      */
-    public double[][] getData(final int minXIndex, final int maxXIndex) {
+    @Override public double[][] getData(final int minXIndex, final int maxXIndex) {
         return _spectrum.getData(minXIndex, maxXIndex);
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Spectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Spectrum.java
@@ -28,25 +28,9 @@ public interface Spectrum extends Cloneable {
     double getY(double x);
 
     /**
-     * Returns the sum of entire spectrum.
-     */
-    double getSum();
-
-    /**
      * Returns the integral of entire spectrum.
      */
     double getIntegral();
-
-    /**
-     * Returns the average of entire spectrum.
-     */
-    double getAverage();
-
-    /**
-     * Returns the Sum of y values in the spectrum in
-     * the specified range.
-     */
-    double getSum(double x_start, double x_end);
 
     /**
      * Returns the average of values in the Spectrum in

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/operation/BlackBodySpectrum.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/operation/BlackBodySpectrum.scala
@@ -114,31 +114,9 @@ final class BlackBodySpectrum(spectrum: DefaultSampledSpectrum) extends Visitabl
   }
 
   /**
-   * Returns the sum of all the y values in the SampledSpectrum
-   */
-  def getSum: Double = spectrum.getSum
-
-  /**
    * Returns the integral of all the y values in the SampledSpectrum
    */
   def getIntegral: Double =spectrum.getIntegral
-
-  /**
-   * Returns the average of all the y values in the SampledSpectrum
-   */
-  def getAverage: Double = spectrum.getAverage
-
-  /**
-   * Returns the sum of y values in the spectrum in
-   * the specified index range.
-   */
-  def getSum(startIndex: Int, endIndex: Int): Double = spectrum.getSum(startIndex, endIndex)
-
-  /**
-   * Returns the sum of y values in the spectrum in
-   * the specified range.
-   */
-  def getSum(x_start: Double, x_end: Double): Double = spectrum.getSum(x_start, x_end)
 
   /**
    * Returns the average of values in the SampledSpectrum in

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
@@ -13,9 +13,9 @@ sealed abstract class MagnitudeBand private (val name: String, val center: Wavel
   private def this(name: String, center: Wavelength, width: Wavelength, description: String, defaultMagnitudeSystem: MagnitudeSystem) =
     this(name, center, width, Some(description), defaultMagnitudeSystem)
 
-  val start: Wavelength = center + width / 2
+  val start: Wavelength = center - width / 2
 
-  val end:   Wavelength = center - width / 2
+  val end:   Wavelength = center + width / 2
 
 }
 

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/MagnitudeBandSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/MagnitudeBandSpec.scala
@@ -1,0 +1,30 @@
+package edu.gemini.spModel.core
+
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import scalaz.Scalaz._
+import scalaz._
+
+object MagnitudeBandSpec extends Specification with ScalaCheck with Arbitraries with Helpers {
+
+  "MagnitudeBand " should {
+
+    "have ascending start, center and end values" !
+      forAll { (b: MagnitudeBand) =>
+        b.start <= b.center && b.center <= b.end
+      }
+  }
+
+  "MagnitudeBand serialization" should {
+
+   "support Java binary" !
+     forAll { (ee: MagnitudeBand) =>
+       canSerialize(ee)
+     }
+  }
+
+}
+
+


### PR DESCRIPTION
Some input values caused errors in ITC and debugging the issue showed that the root cause was an error in how the `start` and `end` values in `MagnitudeBand` were calculated. This was fixed and a simple sanity test introduced.

Then I was wondering why, after fixing this, all my regression tests were still working. Turns out that there was some special code in some classes that (accidentally) deals with this case. This code has been there forever and by chance masked out the problem with the `MagnitudeBand` start and end values, which only caused another error for some specific cases.

Since I can not see why this special code would be needed I just removed it and while doing that I also removed some unused methods from some interfaces together with their implementations.

All regression tests are still running. Some manual tests show that the error is gone now.