### PR TITLE
REL-2472:Fix errors in GPI unblocked modes

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -29,6 +29,7 @@ ocsAppManifest := {
           fnussber(v),
           cquiroz(v),
           sraaphorst(v),
+          anunez(v),
           with_remote_gogo(v),
             odbtest(v),
               gsodbtest(v),
@@ -379,6 +380,29 @@ def abrighton(version: Version) = AppConfig(
     "edu.gemini.util.trpc.name"                  -> "Brightons's ODB (Test)"
   )
 ) extending List(with_gogo(version), abrighton_credentials(version))
+
+// ANUNEZ
+def anunez(version: Version) = AppConfig(
+  id = "anunez",
+  distribution = List(TestDistro),
+  vmargs = List(
+    "-Xmx1024M",
+    "-XX:MaxPermSize=196M",
+    "-Dcom.cosylab.epics.caj.CAJContext.addr_list=172.17.2.255",
+    "-Dedu.gemini.site=south",
+    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+  ),
+  props = Map(
+    "edu.gemini.auxfile.root"                    -> "/Users/anunez/.auxfile",
+    "edu.gemini.auxfile.fits.dest"               -> "/gemsoft/var/data/ictd/test/GS@SEMESTER@/@PROG_ID@",
+    "edu.gemini.auxfile.other.dest"              -> "/gemsoft/var/data/finder/GSqueue/Finders-Test/@SEMESTER@/@PROG_ID@",
+    "edu.gemini.auxfile.fits.host"               -> "gsconfig.gemini.edu",
+    "edu.gemini.services.server.start"           -> "false",
+    "edu.gemini.smartgcal.host"                  -> "localhost",
+    "edu.gemini.spdb.dir"                        -> "/Users/anunez/.spdb/",
+    "edu.gemini.util.trpc.name"                  -> "Art's ODB (Test)"
+  )
+) extending List(with_gogo(version), anunez_credentials(version))
 
 // ODBTEST
 def odbtest(version: Version) = AppConfig(

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -215,7 +215,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         UNBLOCKED_K1("K1 Unblocked", Filter.K1, false, Apodizer.APOD_K1, FPM.SCIENCE, Lyot.LYOT_080m12_06_03, 4.0, 6.5) {
             @Override public ObservingMode correspondingH() { return this; }
         },
-        UNBLOCKED_K2("K2 Unblocked", Filter.K2, false, Apodizer.APOD_K1, FPM.SCIENCE, Lyot.LYOT_080m12_07, 4.0, 6.5) {
+        UNBLOCKED_K2("K2 Unblocked", Filter.K2, false, Apodizer.APOD_K2, FPM.SCIENCE, Lyot.LYOT_080m12_07, 4.0, 6.5) {
             @Override public ObservingMode correspondingH() { return this; }
         },
 
@@ -378,7 +378,9 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
 
         /** returns all direct and modes (OT-136, REL-1741) */
         private static ObservingMode[] noCalModes() {
-            return new ObservingMode[] {DIRECT_H_BAND, DIRECT_J_BAND, DIRECT_K1_BAND, DIRECT_K2_BAND, DIRECT_Y_BAND, NRM_H, NRM_J, NRM_K1, NRM_K2, NRM_Y};
+            return new ObservingMode[] {DIRECT_H_BAND, DIRECT_J_BAND, DIRECT_K1_BAND, DIRECT_K2_BAND, DIRECT_Y_BAND,
+                                        NRM_H, NRM_J, NRM_K1, NRM_K2, NRM_Y,
+                                        UNBLOCKED_H, UNBLOCKED_J, UNBLOCKED_K1, UNBLOCKED_K2, UNBLOCKED_Y};
         }
 
         public static LoggableSpType byName(String value) {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/GpiTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/GpiTest.java
@@ -1,5 +1,6 @@
 package edu.gemini.spModel.gemini.gpi;
 
+import edu.gemini.model.p1.mutable.GpiObservingMode;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.config2.Config;
@@ -215,9 +216,20 @@ public class GpiTest  extends TestCase {
     }
 
     public void testUnblockedModes() {
-        Gpi inst = new Gpi();
-        inst.setObservingMode(new Some<>(Gpi.ObservingMode.UNBLOCKED_H));
-        assertEquals(inst.getFpm(), Gpi.FPM.SCIENCE);
+        Gpi.ObservingMode[] unblockedModes = new Gpi.ObservingMode[] {
+                Gpi.ObservingMode.UNBLOCKED_H,
+                Gpi.ObservingMode.UNBLOCKED_J,
+                Gpi.ObservingMode.UNBLOCKED_K1,
+                Gpi.ObservingMode.UNBLOCKED_K2,
+                Gpi.ObservingMode.UNBLOCKED_Y};
+
+        for (Gpi.ObservingMode obsMode: unblockedModes) {
+            Gpi inst = new Gpi();
+            assertTrue(inst.isUseCal());
+            inst.setObservingMode(new Some<>(obsMode));
+            assertEquals(inst.getFpm(), Gpi.FPM.SCIENCE);
+            assertFalse(inst.isUseCal());
+        }
     }
 
     // REL-2229

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
@@ -67,10 +67,10 @@ object To2016A extends Migration {
     val isUnblocked = Set("UNBLOCKED_Y", "UNBLOCKED_H", "UNBLOCKED_J", "UNBLOCKED_K1", "UNBLOCKED_K2")
     for {
       gpi <- d.findContainers(SPComponentType.INSTRUMENT_GPI)
-      ps  <- Option(gpi.getParamSet("GPI")) if Option(ps.getParam("observingMode")).map(_.getValue).exists(isUnblocked)
-    } {
-      Option(ps.getParam("useCal")).foreach(_.setValue("false"))
-    }
+      ps  <- Option(gpi.getParamSet("GPI"))
+      m   <- Option(ps.getParam("observingMode")) if isUnblocked(m.getValue)
+      use <- Option(ps.getParam("useCal"))
+    } use.setValue("false")
   }
 
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
@@ -1,10 +1,11 @@
 package edu.gemini.spModel.io.impl.migration.to2016A
 
+import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.io.impl.SpIOTags
 import edu.gemini.spModel.io.impl.migration.Migration
 import edu.gemini.spModel.io.impl.migration.PioSyntax._
 import edu.gemini.spModel.pio.{Container, Document, Param, Version}
-import edu.gemini.spModel.pio.xml.{PioXmlUtil}
+import edu.gemini.spModel.pio.xml.PioXmlUtil
 
 import scala.collection.JavaConverters._
 
@@ -31,7 +32,7 @@ object To2016A extends Migration {
 
   // These will be applied in the given order
   private val conversions: List[Document => Unit] = List(
-    addUnitsToELine, demotePluto
+    addUnitsToELine, demotePluto, updateGpiUnblockedModes
   )
 
   // Starting 2016A we store squants quantities with their units, older programs need to have units added
@@ -58,6 +59,20 @@ object To2016A extends Migration {
       ps.removeChild(sys)
       plutoParams.foreach(ps.addParam)
     }
+
+
+  //All unblocked modes in GPI must set useCal = false
+  private def updateGpiUnblockedModes(d: Document): Unit = {
+
+    val isUnblocked = Set("UNBLOCKED_Y", "UNBLOCKED_H", "UNBLOCKED_J", "UNBLOCKED_K1", "UNBLOCKED_K2")
+    for {
+      gpi <- d.findContainers(SPComponentType.INSTRUMENT_GPI)
+      ps  <- Option(gpi.getParamSet("GPI")) if Option(ps.getParam("observingMode")).map(_.getValue).exists(isUnblocked)
+    } {
+      Option(ps.getParam("useCal")).foreach(_.setValue("false"))
+    }
+  }
+
 
   // Params taken from a program with a properly resolved Pluto (now an asteroid). This includes
   // only the system and orbital elements. Get a FRESH set of params each time! (important)

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016A/gpi.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016A/gpi.xml
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2015B-1" subtype="basic" key="69c5daf7-95e9-452b-b830-7f9f01693929" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="8417a8d7-6e8e-4fbd-8d26-3193ea54983a" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GPI Observation"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="1138b5c9-8fd1-4357-ab7d-76969453f30b" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="6ab76f1d-2a2b-4f59-aa03-e3861208da20" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GPI" key="b5d47a1b-93de-4c28-8394-41b594b1454d" name="GPI">
+        <paramset name="GPI" kind="dataObj">
+          <param name="exposureTime" value="1.49"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <param name="astrometricFieldEnum" value="NO"/>
+          <param name="adc" value="IN"/>
+          <param name="observingMode" value="UNBLOCKED_H"/>
+          <param name="disperser" value="PRISM"/>
+          <param name="detectorStartX" value="0"/>
+          <param name="detectorStartY" value="0"/>
+          <param name="detectorEndX" value="2047"/>
+          <param name="detectorEndY" value="2047"/>
+          <param name="entranceShutter" value="OPEN"/>
+          <param name="scienceArmShutter" value="OPEN"/>
+          <param name="calEntranceShutter" value="OPEN"/>
+          <param name="referenceArmShutter" value="OPEN"/>
+          <param name="irLaserLamp" value="OFF"/>
+          <param name="visibleLaserLamp" value="OFF"/>
+          <param name="superContinuumLamp" value="OFF"/>
+          <param name="artificialSourceAttenuation" value="60.0"/>
+          <param name="pupilCamera" value="OUT"/>
+          <param name="detectorSamplingMode" value="UTR"/>
+          <param name="alwaysRestoreModel" value="false"/>
+          <param name="useAo" value="true"/>
+          <param name="useCal" value="true"/>
+          <param name="aoOptimize" value="true"/>
+          <param name="alignFpmPinholeBias" value="false"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="6ed914f6-eb26-4da4-b6ba-8fce00fc3645" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="254785b7-a675-484d-98b0-8f935d6b4471" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="69bd9183-327a-4a6e-9a94-3bf4b253e8ef" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="f33a6055-5deb-4cab-8e71-6ebebf030655" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GPI Observation"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="4a18af9e-38ce-4367-951e-bc68d68ae4a0" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="fd60565a-c1a6-490d-8478-c302b2ca6bfd" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GPI" key="97ddc7a3-80b7-4db8-bc5e-710087c7edf0" name="GPI">
+        <paramset name="GPI" kind="dataObj">
+          <param name="exposureTime" value="1.49"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <param name="astrometricFieldEnum" value="NO"/>
+          <param name="adc" value="IN"/>
+          <param name="observingMode" value="UNBLOCKED_K2"/>
+          <param name="disperser" value="PRISM"/>
+          <param name="detectorStartX" value="0"/>
+          <param name="detectorStartY" value="0"/>
+          <param name="detectorEndX" value="2047"/>
+          <param name="detectorEndY" value="2047"/>
+          <param name="entranceShutter" value="OPEN"/>
+          <param name="scienceArmShutter" value="OPEN"/>
+          <param name="calEntranceShutter" value="OPEN"/>
+          <param name="referenceArmShutter" value="OPEN"/>
+          <param name="irLaserLamp" value="OFF"/>
+          <param name="visibleLaserLamp" value="OFF"/>
+          <param name="superContinuumLamp" value="OFF"/>
+          <param name="artificialSourceAttenuation" value="60.0"/>
+          <param name="pupilCamera" value="OUT"/>
+          <param name="detectorSamplingMode" value="UTR"/>
+          <param name="alwaysRestoreModel" value="false"/>
+          <param name="useAo" value="true"/>
+          <param name="useCal" value="true"/>
+          <param name="aoOptimize" value="true"/>
+          <param name="alignFpmPinholeBias" value="false"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="afffd723-3954-4a5b-b9b6-926362c5e769" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="50311d65-a279-4966-9535-4102266fc075" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="da987594-5263-4641-a173-0bc69290d15a" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="d1e940d0-7300-4639-88b1-edd08cfb27f5" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GPI Observation"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="68654ca5-31d7-48c5-ace0-b14dbd128ae6" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="489451dd-3411-49a1-9ed8-435af8c27dce" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GPI" key="fb2f539f-a50c-4d12-9604-efdfbfddda4c" name="GPI">
+        <paramset name="GPI" kind="dataObj">
+          <param name="exposureTime" value="1.49"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <param name="astrometricFieldEnum" value="NO"/>
+          <param name="adc" value="IN"/>
+          <param name="observingMode" value="CORON_Y_BAND"/>
+          <param name="disperser" value="PRISM"/>
+          <param name="detectorStartX" value="0"/>
+          <param name="detectorStartY" value="0"/>
+          <param name="detectorEndX" value="2047"/>
+          <param name="detectorEndY" value="2047"/>
+          <param name="entranceShutter" value="OPEN"/>
+          <param name="scienceArmShutter" value="OPEN"/>
+          <param name="calEntranceShutter" value="OPEN"/>
+          <param name="referenceArmShutter" value="OPEN"/>
+          <param name="irLaserLamp" value="OFF"/>
+          <param name="visibleLaserLamp" value="OFF"/>
+          <param name="superContinuumLamp" value="OFF"/>
+          <param name="artificialSourceAttenuation" value="60.0"/>
+          <param name="pupilCamera" value="OUT"/>
+          <param name="detectorSamplingMode" value="UTR"/>
+          <param name="alwaysRestoreModel" value="false"/>
+          <param name="useAo" value="true"/>
+          <param name="useCal" value="true"/>
+          <param name="aoOptimize" value="true"/>
+          <param name="alignFpmPinholeBias" value="false"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="cd4644d5-4b22-439d-86fb-84651505380f" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="885a2e0f-4686-481a-b22e-37943569aca3" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="b366d0da-0d68-49f9-bd32-53b5aaace18b" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+  </container>
+\</document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/GpiUnblockedModesTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/GpiUnblockedModesTest.scala
@@ -1,0 +1,39 @@
+package edu.gemini.spModel.io.impl.migration.to2016A
+
+import edu.gemini.pot.sp.{SPComponentType, ISPObservation, ISPProgram}
+import edu.gemini.spModel.gemini.gpi.Gpi
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import org.junit.{Assert, Test}
+import scala.collection.JavaConverters._
+
+class GpiUnblockedModesTest extends MigrationTest {
+
+  @Test def testGpiConversion(): Unit =
+    withTestProgram("gpi.xml", { (_,p) => validateProgram(p) })
+
+  private def validateProgram(p: ISPProgram): Unit = {
+    p.getAllObservations.asScala.foreach(validateObservation)
+  }
+
+  private def validateObservation(obs: ISPObservation): Unit = {
+
+    val isUnblocked = Set(Gpi.ObservingMode.UNBLOCKED_Y,
+      Gpi.ObservingMode.UNBLOCKED_H,
+      Gpi.ObservingMode.UNBLOCKED_J,
+      Gpi.ObservingMode.UNBLOCKED_K1,
+      Gpi.ObservingMode.UNBLOCKED_K2)
+
+    import edu.gemini.shared.util.immutable.ScalaConverters._
+
+    val gpi = obs.getObsComponents.asScala.find(_.getType == SPComponentType.INSTRUMENT_GPI).map(_.getDataObject).collect {
+      case g: Gpi => g
+    }
+
+    //check that the all unblocked GPI modes have useCal set to false (so they were indeed converted during migration)
+    Assert.assertFalse(gpi.exists(g => g.getObservingMode.asScalaOpt.forall(isUnblocked) && g.isUseCal))
+
+    //also ensure that unrelated modes aren't affected.
+    Assert.assertTrue(gpi.filter(_.getObservingMode.getValue == Gpi.ObservingMode.CORON_Y_BAND).forall(_.isUseCal))
+  }
+
+}


### PR DESCRIPTION
A simple PR to update GPI unblocked modes so they don't set the parameter `useCal` to `true`, and fix the setting of `APOD_K2` when using `K2_UNBLOCKED`. Once these changes are in the OCS, we need to update the GPI SW to be able to match these configurations.