### PR TITLE
REL-2253: TimeRequest dialog box Ok button needs to be pressed twice

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/EphemerisElementEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/EphemerisElementEditor.scala
@@ -42,7 +42,7 @@ class EphemerisElementEditor(e: EphemerisElement) extends StdModalEditor[Ephemer
   }
   object RA extends RATextField(e.coords.toDegDeg.ra.toDouble)
   object Dec extends DecTextField(e.coords.toDegDeg.dec.toDouble)
-  object Mag extends NumberField(e.magnitude)
+  object Mag extends NumberField(e.magnitude, allowEmpty = false)
 
   // Construct our editor
   def editor = Editor

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
@@ -65,7 +65,7 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
       foreground = Color.GRAY
   }
 
-  object Time extends NumberField(obs.time.map(_.value).orElse(Some(1.0))) {
+  object Time extends NumberField(obs.time.map(_.value).orElse(Some(1.0)), allowEmpty = false) {
     enabled = canEdit
     override def valid(d:Double) = d > 0
   }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SubmissionRequestEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SubmissionRequestEditor.scala
@@ -21,7 +21,7 @@ object SubmissionRequestEditor {
     add(Time, BorderPanel.Position.Center)
     add(Units, BorderPanel.Position.East)
 
-    object Time extends NumberField(tu.map(_.value)) {
+    object Time extends NumberField(tu.map(_.value), allowEmpty = false) {
       override def valid(d:Double) = d >= 0
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -296,7 +296,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
       }
 
       // PM dRA
-      object DeltaRA extends NumberField(sidereal.properMotion.map(_.deltaRA)) {
+      object DeltaRA extends NumberField(sidereal.properMotion.map(_.deltaRA), allowEmpty = true) {
         enabled = sidereal.properMotion.isDefined && canEdit
         PMCheck.reactions += {
           case _ => enabled = PMCheck.selected && canEdit
@@ -304,7 +304,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
       }
 
       // PM dRA
-      object DeltaDec extends NumberField(sidereal.properMotion.map(_.deltaDec)) {
+      object DeltaDec extends NumberField(sidereal.properMotion.map(_.deltaDec), allowEmpty = true) {
         enabled = sidereal.properMotion.isDefined && canEdit
         PMCheck.reactions += {
           case _ => enabled = PMCheck.selected && canEdit
@@ -337,7 +337,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean, i
       }
 
       // The input text
-      val text = new NumberField(mag.map(_.value)) {
+      val text = new NumberField(mag.map(_.value), allowEmpty = true) {
         enabled = mag.isDefined && dialog.canEdit
         check.reactions += {
           case _ if check.selected => enabled = canEdit; requestFocus()

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/tac/TacView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/tac/TacView.scala
@@ -245,7 +245,7 @@ class TacView(loc: Locale) extends BorderPanel with BoundView[ProposalClass] { v
       val focus:Lens[SubmissionAccept, String] = Lens.lensu((a, b) => a.copy(email = b), _.email)
     }
 
-    object ranking extends NumberField(None) with OptionText[SubmissionAccept] {
+    object ranking extends NumberField(None, allowEmpty = false) with OptionText[SubmissionAccept] {
       val lens = SubmissionResponse.acceptDecision
       override def enabled_=(b:Boolean) {
         super.enabled = b

--- a/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
+++ b/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
@@ -3,7 +3,7 @@ package edu.gemini.shared.gui.textComponent
 import scala.swing.FormattedTextField
 
 import java.awt.Color
-import swing.event.ValueChanged
+import scala.swing.event.ValueChanged
 import java.text.{ParsePosition, DecimalFormat}
 
 // A class for numeric fields.
@@ -17,7 +17,7 @@ object NumberField {
   }
 }
 
-class NumberField(d: Option[Double]) extends FormattedTextField(NumberField.df) with SelectOnFocus {
+class NumberField(d: Option[Double], allowEmpty: Boolean) extends FormattedTextField(NumberField.df) with SelectOnFocus {
   d.orElse(Some(0)).foreach { d =>
     import NumberField.df
     text = df.format(d)
@@ -37,17 +37,28 @@ class NumberField(d: Option[Double]) extends FormattedTextField(NumberField.df) 
   }
 
   reactions += {
-    case ValueChanged(_) =>
+    case ValueChanged(e) =>
+      // REL-2253 Due to the way scala swing handles a text component you get an extra
+      // ValueChange event with an empty text when the event has focus
+      // This creates a null parsed value and the validation fails
+      // This is not very noticeable as there is a second event with the valid text
+      // However, it means that sometimes you need to press Ok twice
+      // We can workaround this bug by validating only if the field has focus
+      if (this.hasFocus) {
+        if (text.nonEmpty) {
+          valid = try {
+            val pp = new ParsePosition(0)
+            val parsed = NumberField.df.parse(text, pp)
+            (pp.getIndex == text.length()) && valid(parsed.doubleValue)
+          } catch {
+            case _: Exception => false
+          }
 
-      valid = try {
-        val pp = new ParsePosition(0)
-        valid(NumberField.df.parse(text, pp).doubleValue) && (pp.getIndex == text.length())
-      } catch {
-        case _:Exception => false
+          background = if (valid) white else pink
+        } else {
+          valid = allowEmpty
+        }
       }
-
-      background = if (valid) white else pink
-
   }
 
   focusLostBehavior = FormattedTextField.FocusLostBehavior.Commit // ?

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -238,7 +238,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     resultsTable.model match {
       case t: TargetsModel =>
         val tpe = TpeManager.get()
-        TpePlotter(tpe.getImageWidget).select(t, selected)
+        Option(tpe).foreach(p => TpePlotter(p.getImageWidget).select(t, selected))
       case _               => // Ignore, it shouldn't happen
     }
   }
@@ -247,7 +247,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     resultsTable.model match {
       case t: TargetsModel =>
         val tpe = TpeManager.get()
-        TpePlotter(tpe.getImageWidget).unplot(t)
+        Option(tpe).foreach(p => TpePlotter(p.getImageWidget).unplot(t))
       case _               => // Ignore, it shouldn't happen
     }
   }
@@ -313,7 +313,8 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     // Action to disable the query button if there are invalid fields
     val queryButtonEnabling: Reaction = {
       case ValueChanged(a) =>
-        queryButton.enabled = a match {
+        val controls = List(radiusStart, radiusEnd, ra, dec) ++ magnitudeControls.flatMap(f => List(f.faintess, f.saturation))
+        queryButton.enabled = controls.forall {
           case f: AngleTextField[_] => f.valid
           case f: NumberField       => f.valid
           case _                    => true

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -493,7 +493,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
       }
     }
 
-    lazy val radiusStart, radiusEnd = new NumberField(None) {
+    lazy val radiusStart, radiusEnd = new NumberField(None, allowEmpty = false) {
       reactions += queryButtonEnabling
 
       def updateAngle(angle: Angle): Unit = {
@@ -740,10 +740,10 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
     // Make GUI controls for a Magnitude Constraint
     private def filterControls(mc: MagnitudeConstraints, index: Int): List[MagnitudeFilterControls] = {
-      val faint = new NumberField(mc.faintnessConstraint.brightness.some) {
+      val faint = new NumberField(mc.faintnessConstraint.brightness.some, allowEmpty = false) {
         reactions += queryButtonEnabling
       }
-      val sat = new NumberField(mc.saturationConstraint.map(_.brightness)) {
+      val sat = new NumberField(mc.saturationConstraint.map(_.brightness), allowEmpty = false) {
         reactions += queryButtonEnabling
       }
       bandsBoxes(catalogBox.selection.item, mc.searchBands).map(MagnitudeFilterControls(addMagnitudeRowButton(index), faint, new Label("-"), sat, _, removeMagnitudeRowButton(index)))

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleDialog.scala
@@ -15,7 +15,7 @@ import jsky.app.ot.util.TimeZonePreference
 
 import scala.swing.Swing._
 import scala.swing._
-import scala.swing.event.{ButtonClicked, FocusLost}
+import scala.swing.event.{FocusGained, ValueChanged, ButtonClicked, FocusLost}
 
 // Dialog to set the settings needed for the parallactic angle computation.
 
@@ -159,12 +159,16 @@ class ParallacticAngleDialog(owner: java.awt.Window, observation: ISPObservation
 
     listenTo(remainingTimeButton, setToButton)
     reactions += {
-      case ButtonClicked(`remainingTimeButton`) => durationField.enabled = false
-      case ButtonClicked(`setToButton`)         => durationField.enabled = true
+      case ButtonClicked(`remainingTimeButton`) =>
+        durationField.enabled = false
+        okButton.enabled = true
+      case ButtonClicked(`setToButton`)         =>
+        durationField.enabled = true
+        okButton.enabled = durationField.valid
     }
 
     // Set the number of minutes of duration, converting from ms.
-    val durationField = new NumberField(Some(duration.getExplicitDuration / 60000.0)) {
+    val durationField = new NumberField(Some(duration.getExplicitDuration / 60000.0), allowEmpty = false) {
       peer.setColumns(5)
       enabled = duration.getParallacticAngleDurationMode == ParallacticAngleDurationMode.EXPLICITLY_SET
     }
@@ -172,7 +176,10 @@ class ParallacticAngleDialog(owner: java.awt.Window, observation: ISPObservation
     // Reset duration to 0.0 if nonsense is typed in and the focus is lost.
     listenTo(durationField)
     reactions += {
-      case FocusLost(`durationField`,_,_) => if (!durationField.valid) durationField.text = "0"
+      case FocusLost(`durationField`,_,_) =>
+        okButton.enabled = durationField.valid
+      case ValueChanged(_) =>
+        okButton.enabled = durationField.valid
     }
 
     layout(durationField) = new Constraints() {


### PR DESCRIPTION
Fix for a bug on Scala swing `FormattedTextField` that emits an extra `ValueChanged` event with empty text in certain occasions. This event is used on the PIT and the new Catalog Query Tool to do validation and due to this bug we have as a side effect, that the button used to control validation needs to be clicked twice