### PR TITLE
REL-2407-E: improve error messages

### DIFF
--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/GsaPostAction.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/GsaPostAction.scala
@@ -40,7 +40,7 @@ object GsaPostAction {
             // Individual results returned.  Pair them up with their IDs.
             val idMap   = reqs.map { case (r,i) => r.label -> i }.toMap
             val missing = (idMap.keySet &~ rs.map(_.label).toSet).map { label =>
-              (label, idMap(label), s"No response from server for '$label'.".left[Unit])
+              (label, idMap(label), s"No response from archive server for '$label'.".left[Unit])
             }
 
             missing.toList ++ rs.flatMap { r => idMap.get(r.label).map(i => (r.label, i, r.failure <\/(()))) }

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/core/DmanFailure.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/core/DmanFailure.scala
@@ -8,7 +8,7 @@ import Scalaz._
 
 sealed trait DmanFailure {
   def explain: String = this match {
-    case QueryFailure(e)   => s"GSA query failure: ${e.explain}"
+    case QueryFailure(e)   => e.explain
     case Unexpected(msg)   => s"Unexpected error: $msg"
     case DmanException(ex) => s"Unexpected exception: ${ex.getMessage}"
   }

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaQaUpdateQuery.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaQaUpdateQuery.scala
@@ -7,8 +7,11 @@ import edu.gemini.spModel.dataset.{DatasetLabel, DatasetQaState}
 
 import java.net.URL
 
+import scalaz.\/
+
 /** A synchronous GSA query that sets the dataset QA state for one or more
-  * datasets. */
+  * datasets.
+  */
 sealed trait GsaQaUpdateQuery {
   def setQaStates(updates: List[QaRequest]): GsaResponse[List[QaResponse]]
 
@@ -18,18 +21,59 @@ sealed trait GsaQaUpdateQuery {
 
 object GsaQaUpdateQuery {
 
+  /** The archive will return an error message without an ID or else a valid
+    * `QaRresponse`.  We will convert all the error messages into a single
+    * String and apply it to any dataset for which a valid response wasn't
+    * returned.  `EitherQaResponse` should not be visible outside of this
+    * package.  It's a quirk of how the FITS server works.
+    */
+  private[query] type EitherQaResponse = String \/ QaResponse
+
+
   /** Constructs a QA update query for the given host and site.  The `auth`
     * parameter is how the GSA service provides some minimal protection against
     * inappropriate setting of QA states.  The value is sent in a cookie that
-    * is checked on the server. */
+    * is checked on the server.
+    */
   def apply(host: GsaHost.Summit, site: Site, auth: GsaAuth): GsaQaUpdateQuery =
     new GsaQaUpdateQuery {
-      override def setQaStates(requests: List[QaRequest]): GsaResponse[List[QaResponse]] =
-        GsaQuery.post[List[QaRequest], List[QaResponse]](new URL(s"${host.protocol}://${host.host}/update_headers"), requests, auth).map { responses =>
-          // Prepend errors for any update requests that were silently ignored.
-          (requests.map(_.label).toSet &~ responses.map(_.label).toSet).toList.map { lab =>
-            QaResponse(lab, Some(s"No response returned for $lab update request."))
-          } ++ responses
-        }
+      override def setQaStates(requests: List[QaRequest]): GsaResponse[List[QaResponse]] = {
+        val url = new URL(s"${host.protocol}://${host.host}/update_headers")
+        GsaQuery.post[List[QaRequest], List[EitherQaResponse]](url, requests, auth).map(toQaResponses(requests, _))
+      }
     }
+
+  private[query] def noResponseMessage(lab: DatasetLabel): String =
+    s"Archive did not return a response for the $lab update request."
+
+  private[query] def archiveFailureMessage(m: String): String =
+    s"Archive server returned: $m"
+
+  private[query] def toQaResponses(requests: List[QaRequest], responses: List[EitherQaResponse]): List[QaResponse] = {
+
+    // Partition the responses into a Set of general error messages and a list
+    // of valid responses.
+    val (errors, validResponses) = ((Set.empty[String], List.empty[QaResponse])/:responses) { case ((errSet,valids), r) =>
+        r.fold(e => (errSet + e, valids), v => (errSet, v :: valids))
+    }
+
+    // Sort and concatenate the errors, turning them into a string with one
+    // error per line.
+    val errorMessage  = archiveFailureMessage(errors.toList.sorted.mkString("\n"))
+
+    val requestLabels = requests.map(_.label).toSet
+    val qaLabels      = validResponses.map(_.label).toSet
+    val missingLabels = requestLabels &~ qaLabels
+
+    // Create a valid QaResponse for each missing response from the server.
+    val errorResponses = missingLabels.map { lab =>
+      val msg = if (errors.isEmpty) noResponseMessage(lab) else errorMessage
+      QaResponse(lab, Some(msg))
+    }
+
+    // Prepend errors for any update requests that were silently ignored by the
+    // server. Ignore any extra responses the server might return.  The goal
+    // is to have 1:1 request:response ratio in the end.
+    errorResponses.toList ++ validResponses.filter(r => requestLabels(r.label))
+  }
 }

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaQueryError.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaQueryError.scala
@@ -8,10 +8,10 @@ import java.io.IOException
 sealed trait GsaQueryError {
   def explain: String = {
     val explanation = this match {
-      case InvalidResponse(m)    => s"GSA server returned invalid results: $m."
-      case RequestError(code, m) => s"GSA server rejected the request (http code=$code, message=$m)."
+      case InvalidResponse(m)    => s"Archive returned invalid results: $m."
+      case RequestError(code, m) => s"Archive rejected the request (http code=$code, message=$m)."
       case IoException(_)        => s"A network issue prevented executing the query."
-      case Unexpected(_)         => s"Unexpected exception while working with the GSA server."
+      case Unexpected(_)         => s"Unexpected exception while working with the archive server."
     }
 
     val exMessage = for {

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/core/Arbitraries.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/core/Arbitraries.scala
@@ -1,7 +1,7 @@
 package edu.gemini.dataman.core
 
 import edu.gemini.spModel.core.{ProgramType, Site, SPProgramID}
-import edu.gemini.spModel.dataset.{DatasetGsaState, DatasetLabel}
+import edu.gemini.spModel.dataset.{DatasetQaState, DatasetGsaState, DatasetLabel}
 
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
@@ -41,6 +41,14 @@ trait Arbitraries extends edu.gemini.spModel.dataset.Arbitraries {
 
   implicit val arbPid: Arbitrary[SPProgramID] =
     Arbitrary { Gen.oneOf(scienceId, dailyId) }
+
+  implicit val arbQaRequest: Arbitrary[QaRequest] =
+    Arbitrary {
+      for {
+        label <- arbitrary[DatasetLabel]
+        qa    <- arbitrary[DatasetQaState]
+      } yield QaRequest(label, qa)
+    }
 
   implicit val arbQaResponse: Arbitrary[QaResponse] =
     Arbitrary {

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/query/GsaQaUpdateQuerySpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/query/GsaQaUpdateQuerySpec.scala
@@ -1,0 +1,138 @@
+package edu.gemini.dataman.query
+
+import edu.gemini.dataman.core.{QaResponse, QaRequest, Arbitraries}
+import edu.gemini.spModel.dataset.DatasetLabel
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import scalaz.{-\/, \/-}
+
+object GsaQaUpdateQuerySpec extends Specification with ScalaCheck with Arbitraries {
+  import GsaQaUpdateQuery._
+
+  val requestResponsePair: Gen[(List[QaRequest], List[EitherQaResponse])] =
+    for {
+      reqs <- Gen.listOf(arbitrary[QaRequest])
+      reps <- genResponses(reqs)
+    } yield (reqs, reps)
+
+
+  "GsaQaUpdateQuery" should {
+    "produce a response for every request" in {
+      forAll(requestResponsePair) { case (reqs, ereps) =>
+
+        val reqLabs = requestLabels(reqs)
+        val repLabs = responseLabels(toQaResponses(reqs, ereps))
+
+        (reqLabs &~ repLabs).isEmpty
+      }
+    }
+
+    "not produce a response for a dataset that wasn't requested" in {
+      forAll(requestResponsePair) { case (reqs, ereps) =>
+
+        val reqLabs = requestLabels(reqs)
+        val repLabs = responseLabels(toQaResponses(reqs, ereps))
+
+        (repLabs &~ reqLabs).isEmpty
+      }
+    }
+
+    "produce a `no response' message if nothing was returned from server" in {
+      forAll(requestResponsePair) { case (reqs, ereps) =>
+        // if there is no general failure, all requests for which the server
+        // didn't generate a response should be the "no response" message
+        ereps.exists(_.isLeft) || {
+          actualNoResponseMessages(reqs, ereps).forall {
+            case (lab, msgOption) => msgOption.exists(_ == noResponseMessage(lab))
+          }
+        }
+      }
+    }
+
+    "use general errors for missing server responses if available" in {
+      forAll(requestResponsePair) { case (reqs, ereps) =>
+        // Unless all the failures were specific to individual datasets, any
+        // dataset for which the server didn't generate a specific response
+        // should be attributed to the general failure(s)
+        ereps.forall(_.isRight) || {
+
+          // Gather up all expected messages, put them in a Set to remove
+          // duplicates, convert back to a sorted list, and then make a single
+          // string.
+          val expectedMessage = archiveFailureMessage(ereps.collect {
+            case -\/(m) => m
+          }.toSet.toList.sorted.mkString("\n"))
+
+          actualNoResponseMessages(reqs, ereps).forall {
+            case (_, msgOption) => msgOption.exists(_ == expectedMessage)
+          }
+        }
+      }
+    }
+  }
+
+  private def labels[A](lst: List[A])(f: A => DatasetLabel): Set[DatasetLabel] =
+    lst.map(f).toSet
+
+  private def requestLabels(reqs: List[QaRequest]): Set[DatasetLabel] =
+    labels(reqs)(_.label)
+
+  private def responseLabels(reps: List[QaResponse]): Set[DatasetLabel] =
+    labels(reps)(_.label)
+
+  private def ereponseLabels(ereps: List[EitherQaResponse]): Set[DatasetLabel] =
+    responseLabels(ereps.collect { case \/-(r) => r })
+
+  // Gets a map of all the messages for requests for which the server did not
+  // send a specific response.
+  private def actualNoResponseMessages(reqs: List[QaRequest], ereps: List[EitherQaResponse]): Map[DatasetLabel, Option[String]] = {
+    val noServerResponse = requestLabels(reqs) &~ ereponseLabels(ereps)
+    val repMap           = toQaResponses(reqs, ereps).map(r => r.label -> r).toMap
+
+    reqs.filter(r => noServerResponse(r.label)).map { r =>
+      r.label -> (for {
+        rep <- repMap.get(r.label)
+        msg <- rep.failure
+      } yield msg)
+    }.toMap
+  }
+
+
+  private def genResponses(reqs: List[QaRequest]): Gen[List[EitherQaResponse]] = {
+    def genValidResponse(req: QaRequest): Gen[EitherQaResponse] =
+      for {
+        lab     <- Gen.frequency((95, req.label), (5, arbitrary[DatasetLabel]))
+        msg     <- Gen.alphaStr.map(_.take(10))
+        failure <- Gen.frequency((9, Option.empty[String]), (1, Some(msg)))
+      } yield \/-(QaResponse(lab, failure))
+
+    def genOptionalValidResponse(req: QaRequest): Gen[Option[EitherQaResponse]] =
+      for {
+        valid  <- genValidResponse(req)
+        result <- Gen.frequency((95, Option(valid)), (5, Option.empty[EitherQaResponse]))
+      } yield result
+
+    val normalResponses: Gen[List[EitherQaResponse]] = {
+      val gens = reqs.map(r => genOptionalValidResponse(r))
+      Gen.sequence[List, Option[EitherQaResponse]](gens).map(_.flatten)
+    }
+
+    val errorResponses: Gen[List[EitherQaResponse]] =
+      for {
+        n    <- Gen.frequency((75, 1), (25, Gen.posNum[Int]))
+        msgs <- Gen.listOfN(n, Gen.alphaStr.map(_.take(10)))
+      } yield msgs.map(-\/(_))
+
+    val mixedResponses: Gen[List[EitherQaResponse]] =
+      for {
+        norm <- normalResponses
+        err  <- errorResponses
+      } yield (norm ++ err).sortBy(_.hashCode())
+
+    Gen.frequency((80, normalResponses), (10, errorResponses), (10, mixedResponses))
+  }
+}

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/query/JsonCodecsSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/query/JsonCodecsSpec.scala
@@ -8,14 +8,23 @@ import edu.gemini.spModel.dataset.{DatasetQaState, DatasetLabel, DatasetMd5, Dat
 import argonaut.{CodecJson, DecodeResult}
 
 import org.scalacheck.Prop.forAll
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Gen, Arbitrary}
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
 import java.time.Instant
 
+import scalaz.syntax.id._
+
 
 object JsonCodecsSpec extends Specification with ScalaCheck with Arbitraries {
+
+  import GsaQaUpdateQuery.EitherQaResponse
+
+  implicit val arbArchiveResponse: Arbitrary[EitherQaResponse] =
+    Arbitrary {
+      Gen.oneOf(Gen.alphaStr.map(_.left), arbQaResponse.arbitrary.map(_.right))
+    }
 
   def roundTrip[A: CodecJson: Arbitrary](implicit mf: Manifest[A]) =
     mf.runtimeClass.getName ! forAll { (value: A) =>
@@ -31,6 +40,7 @@ object JsonCodecsSpec extends Specification with ScalaCheck with Arbitraries {
     roundTrip[GsaRecord]
     roundTrip[Instant]
     roundTrip[QaResponse]
+    roundTrip[EitherQaResponse]
   }
 
 }


### PR DESCRIPTION
The goal of this Data Manager update is to improve error handling for problems that come up while working with the archive server.  Specifically there was a type of error response that could be generated by the server that would be handled as an "invalid response" instead of reporting the actual error message.