### PR TITLE
REL-2542: Unbagging the OT

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -89,7 +89,7 @@ object AgsStrategy {
       (env /: assignments) { (curEnv, ass) =>
         val target = new SPTarget(HmsDegTarget.fromSkyObject(ass.guideStar.toOldModel))
         val oldGpt = curEnv.getPrimaryGuideProbeTargets(ass.guideProbe).asScalaOpt
-        val newGpt = oldGpt.getOrElse(GuideProbeTargets.create(ass.guideProbe)).withBagsResult(BagsResult.WithTarget(target))
+        val newGpt = oldGpt.getOrElse(GuideProbeTargets.create(ass.guideProbe)).withManualPrimary(target)
         curEnv.putPrimaryGuideProbeTargets(newGpt)
       }
   }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -71,11 +71,9 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
             if (gptOpt.exists(gpt -> gpt.containsTarget(guideStar)))
                 return env;
 
-            final GuideProbeTargets gptNew = gptOpt.map(gpt -> isBags
-                    ? gpt.withBagsResult(BagsResult.WithTarget$.MODULE$.apply(guideStar))
-                    : gpt.addManualTarget(guideStar)).
-                    getOrElse(GuideProbeTargets.create(probe, guideStar)).
-                    withExistingPrimary(guideStar);
+            final GuideProbeTargets gptNew = gptOpt.map(gpt -> gpt.addManualTarget(guideStar))
+                    .getOrElse(GuideProbeTargets.create(probe, guideStar))
+                    .withExistingPrimary(guideStar);
             final GuideGroup grpNew = grp.put(gptNew);
             return env.setPrimaryGuideGroup(grpNew);
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/AgsStrategyCombo.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/AgsStrategyCombo.java
@@ -62,7 +62,7 @@ public final class AgsStrategyCombo extends AgsSelectorControl implements Action
 
         final Option<ComboEntry> defaultEntry = opts.defaultStrategy.map(agsStrategy -> {
             final String name = String.format("Auto (%s)", agsStrategy.key().displayName());
-            return new ComboEntry(name, None.<AgsStrategy>instance());
+            return new ComboEntry(name, None.instance());
         });
 
         final ImList<ComboEntry> allEntries = defaultEntry.isEmpty() ? validEntries : validEntries.cons(defaultEntry.getValue());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -19,6 +19,7 @@ import edu.gemini.spModel.target.system.ITarget;
 import jsky.app.ot.OTOptions;
 import jsky.app.ot.ags.*;
 import jsky.app.ot.editor.OtItemEditor;
+import jsky.app.ot.tpe.AgsClient;
 import jsky.app.ot.tpe.GuideStarSupport;
 import jsky.app.ot.tpe.TelescopePosEditor;
 import jsky.app.ot.tpe.TpeManager;
@@ -67,6 +68,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.duplicateButton.addActionListener(duplicateListener);
         _w.primaryButton  .addActionListener(primaryListener);
 
+        _w.guidingControls.autoGuideStarButton().peer().addActionListener(autoGuideStarListener);
         _w.guidingControls.manualGuideStarButton().peer().addActionListener(manualGuideStarListener);
 
         _w.guidingControls.autoGuideStarGuiderSelector().addSelectionListener(strategy ->
@@ -650,9 +652,28 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         try {
             final TelescopePosEditor tpe = TpeManager.open();
             tpe.reset(getNode());
-            tpe.getImageWidget().manualGuideStarSearch();
+            tpe.getImageWidget().guideStarSearch(true);
         } catch (Exception e) {
             DialogUtil.error(e);
+        }
+    };
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private final ActionListener autoGuideStarListener = new ActionListener() {
+        public void actionPerformed(ActionEvent evt) {
+            try {
+                if (GuideStarSupport.hasGemsComponent(getNode())) {
+                    final TelescopePosEditor tpe = TpeManager.open();
+                    tpe.reset(getNode());
+                    tpe.getImageWidget().guideStarSearch(false);
+                } else {
+                    // In general, we don't want to pop open the TPE just to
+                    // pick a guide star.
+                    AgsClient.launch(getNode(), _w);
+                }
+            } catch (Exception e) {
+                DialogUtil.error(e);
+            }
         }
     };
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -652,7 +652,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         try {
             final TelescopePosEditor tpe = TpeManager.open();
             tpe.reset(getNode());
-            tpe.getImageWidget().guideStarSearch(true);
+            tpe.getImageWidget().manualGuideStarSearch();
         } catch (Exception e) {
             DialogUtil.error(e);
         }
@@ -665,7 +665,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 if (GuideStarSupport.hasGemsComponent(getNode())) {
                     final TelescopePosEditor tpe = TpeManager.open();
                     tpe.reset(getNode());
-                    tpe.getImageWidget().guideStarSearch(false);
+                    tpe.getImageWidget().autoGuideStarSearch();
                 } else {
                     // In general, we don't want to pop open the TPE just to
                     // pick a guide star.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -290,20 +290,13 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                     final GuideProbe guideProbe = gt.getGuider();
                     final boolean isActive = ctx.exists(c -> GuideProbeUtil.instance.isAvailable(c, guideProbe));
                     final Option<SPTarget> primary = gt.getPrimary();
-                    final Option<SPTarget> bagsTarget = gt.getBagsResult().targetAsJava();
-
-                    // If the first target is a bags target, we do not add to the index.
-                    final int bagsIndexModifier = bagsTarget.isDefined() ? 0 : 1;
 
                     gt.getTargets().zipWithIndex().foreach(tup -> {
                         final SPTarget target = tup._1();
                         final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
                         final boolean isPrimary = primary.exists(target::equals);
-                        final boolean isBagsTarget = bagsTarget.exists(target::equals);
 
-                        final Row row = isBagsTarget ?
-                                new BagsTargetRow(isActive, quality, isPrimary, guideProbe, target, baseCoords, when) :
-                                new GuideTargetRow(isActive, quality, isPrimary, guideProbe, tup._2() + bagsIndexModifier, target, baseCoords, when);
+                        final Row row = new GuideTargetRow(isActive, quality, isPrimary, guideProbe, tup._2(), target, baseCoords, when);
                         tmp.add(row);
                     });
                 }
@@ -316,20 +309,13 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                         final GuideProbe guideProbe = gt.getGuider();
                         final boolean isActive = ctx.exists(c -> GuideProbeUtil.instance.isAvailable(c, guideProbe));
                         final Option<SPTarget> primary = gt.getPrimary();
-                        final Option<SPTarget> bagsTarget = gt.getBagsResult().targetAsJava();
-
-                        // If the first target is a bags target, we do not add to the index.
-                        final int bagsIndexModifier = bagsTarget.isDefined() ? 0 : 1;
 
                         gt.getTargets().zipWithIndex().foreach(tup -> {
                             final SPTarget target = tup._1();
                             final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
                             final boolean enabled = isPrimaryGroup && primary.exists(target::equals);
-                            final boolean isBagsTarget = bagsTarget.exists(target::equals);
 
-                            final Row row = isBagsTarget ?
-                                    new BagsTargetRow(isActive, quality, enabled, guideProbe, target, baseCoords, when) :
-                                    new GuideTargetRow(isActive, quality, enabled, guideProbe, tup._2() + bagsIndexModifier, target, baseCoords, when);
+                            final Row row = new GuideTargetRow(isActive, quality, enabled, guideProbe, tup._2(), target, baseCoords, when);
                             rowList.add(row);
                         });
                     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -88,6 +88,7 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
     }
 
     public void finished() {
+        tpe.setGemsGuideStarWorkerFinished();
         Object o = getValue();
         if (o instanceof CancellationException) {
             DialogUtil.message("The guide star search was canceled.");

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -124,7 +124,57 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
     }
 
     public static void applyResults(final TpeContext ctx, final GemsGuideStars gemsGuideStars) {
-        applyResults(ctx, new Some<>(gemsGuideStars), false);
+        SPInstObsComp inst = ctx.instrument().orNull();
+        if (inst != null) {
+            inst.setPosAngleDegrees(gemsGuideStars.pa().toDegrees());
+            ctx.instrument().commit();
+        }
+
+        TargetObsComp targetObsComp = ctx.targets().orNull();
+        if (targetObsComp != null) {
+            TargetEnvironment env = targetObsComp.getTargetEnvironment();
+            targetObsComp.setTargetEnvironment(env.setPrimaryGuideGroup(gemsGuideStars.guideGroup()));
+            ctx.targets().commit();
+        }
+    }
+
+    /**
+     * Apply the results of the guide star search to the current observation,
+     * setting the selected position angle and guide probes.
+     *
+     * @param selectedAsterisms information used to create the guide groups
+     * @param primaryIndex      if more than one item in list, the index of the primary guide group
+     */
+    public void applyResults(final List<GemsGuideStars> selectedAsterisms, final int primaryIndex) {
+        applyResults(tpe.getContext(), selectedAsterisms, primaryIndex);
+    }
+
+    public static void applyResults(final TpeContext ctx, final List<GemsGuideStars> selectedAsterisms, final int primaryIndex) {
+        final TargetObsComp targetObsComp = ctx.targets().orNull();
+        if (targetObsComp != null) {
+            final TargetEnvironment env = targetObsComp.getTargetEnvironment();
+            final List<GuideGroup> guideGroupList = new ArrayList<>();
+            int i = 0;
+            for (final GemsGuideStars gemsGuideStars : selectedAsterisms) {
+                if (i++ == 0) {
+                    // Set position angle only for first (primary) group
+                    final SPInstObsComp inst = ctx.instrument().orNull();
+                    if (inst != null) {
+                        inst.setPosAngle(gemsGuideStars.pa().toDegrees());
+                        ctx.instrument().commit();
+                    }
+                }
+                guideGroupList.add(gemsGuideStars.guideGroup());
+            }
+            if (guideGroupList.size() == 0) {
+                targetObsComp.setTargetEnvironment(env.setGuideEnvironment(env.getGuideEnvironment().setOptions(
+                        DefaultImList.create(guideGroupList))));
+            } else {
+                targetObsComp.setTargetEnvironment(env.setGuideEnvironment(env.getGuideEnvironment().setOptions(
+                        DefaultImList.create(guideGroupList)).setPrimaryIndex(primaryIndex)));
+            }
+            ctx.targets().commit();
+        }
     }
 
     public static void applyResults(final TpeContext ctx, final Option<GemsGuideStars> gemsGuideStarsOpt, boolean isBags) {
@@ -178,45 +228,6 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
                 targetObsComp.setTargetEnvironment(finalEnv);
                 ctx.targets().commit();
             }
-        }
-    }
-
-    /**
-     * Apply the results of the guide star search to the current observation,
-     * setting the selected position angle and guide probes.
-     *
-     * @param selectedAsterisms information used to create the guide groups
-     * @param primaryIndex      if more than one item in list, the index of the primary guide group
-     */
-    public void applyResults(final List<GemsGuideStars> selectedAsterisms, final int primaryIndex) {
-        applyResults(tpe.getContext(), selectedAsterisms, primaryIndex);
-    }
-
-    public static void applyResults(final TpeContext ctx, final List<GemsGuideStars> selectedAsterisms, final int primaryIndex) {
-        final TargetObsComp targetObsComp = ctx.targets().orNull();
-        if (targetObsComp != null) {
-            final TargetEnvironment env = targetObsComp.getTargetEnvironment();
-            final List<GuideGroup> guideGroupList = new ArrayList<>();
-            int i = 0;
-            for (final GemsGuideStars gemsGuideStars : selectedAsterisms) {
-                if (i++ == 0) {
-                    // Set position angle only for first (primary) group
-                    final SPInstObsComp inst = ctx.instrument().orNull();
-                    if (inst != null) {
-                        inst.setPosAngle(gemsGuideStars.pa().toDegrees());
-                        ctx.instrument().commit();
-                    }
-                }
-                guideGroupList.add(gemsGuideStars.guideGroup());
-            }
-            if (guideGroupList.size() == 0) {
-                targetObsComp.setTargetEnvironment(env.setGuideEnvironment(env.getGuideEnvironment().setOptions(
-                        DefaultImList.create(guideGroupList))));
-            } else {
-                targetObsComp.setTargetEnvironment(env.setGuideEnvironment(env.getGuideEnvironment().setOptions(
-                        DefaultImList.create(guideGroupList)).setPrimaryIndex(primaryIndex)));
-            }
-            ctx.targets().commit();
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -60,6 +60,16 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
     }
 
     /**
+     * Create an instance for one time use.
+     */
+    public GemsGuideStarWorker() {
+        ProgressPanel progressPanel = ProgressPanel.makeProgressPanel("GeMS Strehl Calculations",
+                TpeManager.create().getImageWidget());
+        progressPanel.addActionListener(e -> interrupted = true);
+        init(progressPanel);
+    }
+
+    /**
      * Called by constructors
      */
     public void init(StatusLogger statusLogger) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageDisplayMenuBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageDisplayMenuBar.java
@@ -34,6 +34,7 @@ public class TpeImageDisplayMenuBar extends CatalogImageDisplayMenuBar {
         JMenu catalogMenu = getCatalogMenu();
         catalogMenu.addSeparator();
         catalogMenu.add(imageDisplay.getManualGuideStarAction());
+        catalogMenu.add(imageDisplay.getAutoGuideStarAction());
 
         _popupMenu = new JPopupMenu();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageDisplayToolBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageDisplayToolBar.java
@@ -12,6 +12,7 @@ public class TpeImageDisplayToolBar extends ImageDisplayToolBar {
     // toolbar buttons
     private JButton skyImageButton;
     private JButton manualGuideStarButton;
+    private JButton autoGuideStarButton;
 
     /**
      * Create the toolbar for the given window
@@ -35,6 +36,8 @@ public class TpeImageDisplayToolBar extends ImageDisplayToolBar {
         addSeparator();
 
         add(makeManualGuideStarButton());
+
+        add(makeAutoGuideStarButton());
     }
 
     /**
@@ -50,11 +53,28 @@ public class TpeImageDisplayToolBar extends ImageDisplayToolBar {
         }
 
         updateButton(manualGuideStarButton,
-                     "Manual GS",
-                     jsky.util.Resources.getIcon("gsmanual.png", this.getClass()));
+                "Manual GS",
+                jsky.util.Resources.getIcon("gsmanual.png", this.getClass()));
         return manualGuideStarButton;
     }
 
+    /**
+     * Make the guide star search button, if it does not yet exists. Otherwise update the display
+     * using the current options for displaying text or icons.
+     *
+     * @return the guide star button
+     */
+    protected JButton makeAutoGuideStarButton() {
+        if (autoGuideStarButton == null) {
+            final AbstractAction a = ((TpeImageWidget)getImageDisplay()).getAutoGuideStarAction();
+            autoGuideStarButton = makeButton((String)a.getValue(Action.SHORT_DESCRIPTION), a);
+        }
+
+        updateButton(autoGuideStarButton,
+                "Auto GS",
+                jsky.util.Resources.getIcon("gsauto.png", this.getClass()));
+        return autoGuideStarButton;
+    }
 
     /**
      * Make the default Image search button, if it does not yet exists.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -1,10 +1,12 @@
 package jsky.app.ot.tpe;
 
+import edu.gemini.ags.api.AgsStrategy;
 import edu.gemini.catalog.ui.QueryResultsFrame;
 import edu.gemini.catalog.ui.tpe.CatalogImageDisplay;
 import edu.gemini.shared.skyobject.SkyObject;
 import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
 import edu.gemini.shared.util.immutable.*;
+import edu.gemini.spModel.ags.AgsStrategyKey;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
@@ -15,6 +17,7 @@ import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
 import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.util.Angle;
+import jsky.app.ot.ags.AgsStrategyUtil;
 import jsky.app.ot.tpe.gems.GemsGuideStarSearchDialog;
 import jsky.app.ot.util.OtColor;
 import jsky.app.ot.util.PolygonD;
@@ -79,6 +82,9 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
     // Base pos not visible
     private boolean _baseOutOfView = false;
 
+    // Background task to automatically select GEMS guide stars
+    private GemsGuideStarWorker _gemsGuideStarWorker;
+
     // Dialog for GeMS manual guide star selection
     private GemsGuideStarSearchDialog _gemsGuideStarSearchDialog;
 
@@ -104,13 +110,28 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
 
         @Override public void actionPerformed(ActionEvent evt) {
             try {
-                manualGuideStarSearch();
+                guideStarSearch(true);
             } catch (Exception e) {
                 DialogUtil.error(e);
             }
         }
     };
 
+    private final AbstractAction _autoGuideStarAction = new AbstractAction(
+            "Auto GS",
+            Resources.getIcon("gsauto.png")) {
+        {
+            putValue(Action.SHORT_DESCRIPTION, "Have the OT automatically select the best guide star for your observation");
+        }
+
+        @Override public void actionPerformed(ActionEvent actionEvent) {
+            try {
+                guideStarSearch(false);
+            } catch (Exception e) {
+                DialogUtil.error(e);
+            }
+        }
+    };
     private boolean _viewingOffsets;
 
     /**
@@ -643,6 +664,8 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
             basePosUpdate(base.getTarget());
         }
 
+        _autoGuideStarAction.setEnabled(GuideStarSupport.supportsAutoGuideStarSelection(_ctx));
+
         repaint();
     }
 
@@ -1005,8 +1028,47 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
         return super.getBasePos();
     }
 
+    /**
+     * Do a manual guide star search if manual is true, otherwise, if supported, do an automatic search.
+     *
+     * @param manual true for manual search
+     */
+    public void guideStarSearch(boolean manual) {
+        if (manual) {
+            manualGuideStarSearch();
+        } else {
+            Option<ObsContext> maybeObsContext = _ctx.obsContextJava();
+            if (maybeObsContext.isEmpty()) {
+                // UX-1012: there's no obsContext which means some vital information is missing
+                // in this case do not allow an automated guide star search to be launched
+                final String missingComponent;
+                if (_ctx.targets().isEmpty()) {
+                    missingComponent = "Target";
+                } else if (_ctx.instrument().isEmpty()) {
+                    missingComponent = "Instrument";
+                } else if (_ctx.siteQuality().isEmpty()) {
+                    missingComponent = "Site Quality";
+                } else {
+                    missingComponent = "Some";
+                }
+                DialogUtil.error(String.format("%s component is missing. It is not possible to select a guide star.", missingComponent));
+            } else {
+                if (GuideStarSupport.supportsAutoGuideStarSelection(_ctx)) {
+                    final Option<AgsStrategy> ass = AgsStrategyUtil.currentStrategy(maybeObsContext);
+                    if (!ass.isEmpty()) {
+                        if (ass.getValue().key() == AgsStrategyKey.GemsKey$.MODULE$ && GuideStarSupport.hasGemsComponent(_ctx)) {
+                            gemsGuideStarSearch();
+                        } else {
+                            AgsClient.launch(_ctx, this);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // manual guide star selection dialog
-    public void manualGuideStarSearch() {
+    private  void manualGuideStarSearch() {
         if (GuideStarSupport.hasGemsComponent(_ctx)) {
             showGemsGuideStarSearchDialog();
         } else {
@@ -1016,6 +1078,19 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
 
     public void openCatalogNavigator() {
         QueryResultsFrame.instance().showOn(this, _ctx);
+    }
+
+    // OT-36: Gems guide star auto selection
+    private void gemsGuideStarSearch() {
+        if (_gemsGuideStarWorker == null) {
+            _gemsGuideStarWorker = new GemsGuideStarWorker();
+            // Change button/menu label while searching
+            _autoGuideStarAction.putValue(Action.NAME, "Cancel Search");
+            _gemsGuideStarWorker.start();
+        } else {
+            // button changes to Cancel during processing. If pressed, interrupt the background thread.
+            _gemsGuideStarWorker.interrupt();
+        }
     }
 
     private void showGemsGuideStarSearchDialog() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -1,5 +1,6 @@
 package jsky.app.ot.tpe;
 
+import edu.gemini.ags.api.AgsRegistrar;
 import edu.gemini.ags.api.AgsStrategy;
 import edu.gemini.catalog.ui.QueryResultsFrame;
 import edu.gemini.catalog.ui.tpe.CatalogImageDisplay;
@@ -1054,7 +1055,10 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
                 DialogUtil.error(String.format("%s component is missing. It is not possible to select a guide star.", missingComponent));
             } else {
                 if (GuideStarSupport.supportsAutoGuideStarSelection(_ctx)) {
-                    final Option<AgsStrategy> ass = AgsStrategyUtil.currentStrategy(maybeObsContext);
+                    // TODO: ******************************
+                    // TODO: Ask Carlos if this is correct.
+                    // TODO: ******************************
+                    final Option<AgsStrategy> ass = maybeObsContext.flatMap(AgsRegistrar::currentStrategyForJava);
                     if (!ass.isEmpty()) {
                         if (ass.getValue().key() == AgsStrategyKey.GemsKey$.MODULE$ && GuideStarSupport.hasGemsComponent(_ctx)) {
                             gemsGuideStarSearch();
@@ -1112,6 +1116,16 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
      */
     public AbstractAction getManualGuideStarAction() {
         return _manualGuideStarAction;
+    }
+
+    public AbstractAction getAutoGuideStarAction() {
+        return _autoGuideStarAction;
+    }
+
+    // Called from GemsGuideStarWorker when finished
+    void setGemsGuideStarWorkerFinished() {
+        _autoGuideStarAction.putValue(Action.NAME, "Auto GS");
+        _gemsGuideStarWorker = null;
     }
 
     public AbstractAction getSkyImageAction() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -1054,9 +1054,6 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
                 DialogUtil.error(String.format("%s component is missing. It is not possible to select a guide star.", missingComponent));
             } else {
                 if (GuideStarSupport.supportsAutoGuideStarSelection(_ctx)) {
-                    // TODO: ******************************
-                    // TODO: Ask Carlos if this is correct.
-                    // TODO: ******************************
                     final Option<AgsStrategy> ass = maybeObsContext.flatMap(AgsRegistrar::currentStrategyForJava);
                     if (!ass.isEmpty()) {
                         if (ass.getValue().key() == AgsStrategyKey.GemsKey$.MODULE$ && GuideStarSupport.hasGemsComponent(_ctx)) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -18,7 +18,6 @@ import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
 import edu.gemini.spModel.target.system.ITarget;
 import edu.gemini.spModel.util.Angle;
-import jsky.app.ot.ags.AgsStrategyUtil;
 import jsky.app.ot.tpe.gems.GemsGuideStarSearchDialog;
 import jsky.app.ot.util.OtColor;
 import jsky.app.ot.util.PolygonD;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -60,12 +60,12 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
    * consideration for a BAGS lookup.
    */
   def watch(prog: ISPProgram): Unit = {
-        synchronized {
-          state += prog.getProgramID
-          prog.addStructureChangeListener(StructurePropertyChangeListener)
-          prog.addCompositeChangeListener(CompositePropertyChangeListener)
-        }
-        prog.getAllObservations.asScala.foreach(enqueue(_, 0L, initialEnqueue = true))
+//        synchronized {
+//          state += prog.getProgramID
+//          prog.addStructureChangeListener(StructurePropertyChangeListener)
+//          prog.addCompositeChangeListener(CompositePropertyChangeListener)
+//        }
+//        prog.getAllObservations.asScala.foreach(enqueue(_, 0L, initialEnqueue = true))
   }
 
   /**
@@ -73,11 +73,11 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
    * will be discarded as they come up for consideration.
    */
   def unwatch(prog: ISPProgram): Unit = {
-        synchronized {
-          state -= prog.getProgramID
-          prog.removeStructureChangeListener(StructurePropertyChangeListener)
-          prog.removeCompositeChangeListener(CompositePropertyChangeListener)
-        }
+//        synchronized {
+//          state -= prog.getProgramID
+//          prog.removeStructureChangeListener(StructurePropertyChangeListener)
+//          prog.removeCompositeChangeListener(CompositePropertyChangeListener)
+//        }
   }
 
   /**

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -162,7 +162,7 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
                 LOG.info(s"Performing $bagsIdMsg.")
                 AgsRegistrar.currentStrategy(ctx).foreach { strategy =>
                   if (GuideStarSupport.hasGemsComponent(obs)) {
-                    lookup((x: GOption[GemsGuideStars]) => x.asScalaOpt)(GemsGuideStarWorker.applyResults(_, _, true))(Try(GemsGuideStarWorker.findGuideStars(ctx)))
+//                    lookup((x: GOption[GemsGuideStars]) => x.asScalaOpt)(GemsGuideStarWorker.applyResults(_, _, true))(Try(GemsGuideStarWorker.findGuideStars(ctx)))
                   } else {
                     val fut = strategy.select(ctx, OT.getMagnitudeTable)
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -200,8 +200,9 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
 }
 
 object BagsManager {
-  private val NumThreads = math.max(1, Runtime.getRuntime.availableProcessors - 1)
-  val instance = new BagsManager(new ScheduledThreadPoolExecutor(NumThreads))
+  //private val NumThreads = math.max(1, Runtime.getRuntime.availableProcessors - 1)
+  //val instance = new BagsManager(new ScheduledThreadPoolExecutor(NumThreads))
+  val instance = new BagsManager(new ScheduledThreadPoolExecutor(0))
 
   // Check two target environments to see if the BAGS targets match exactly between them.
   def bagsTargetsMatch(oldEnv: TargetEnvironment, newEnv: TargetEnvironment): Boolean = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -162,7 +162,7 @@ final class BagsManager(executor: ScheduledThreadPoolExecutor) {
                 LOG.info(s"Performing $bagsIdMsg.")
                 AgsRegistrar.currentStrategy(ctx).foreach { strategy =>
                   if (GuideStarSupport.hasGemsComponent(obs)) {
-//                    lookup((x: GOption[GemsGuideStars]) => x.asScalaOpt)(GemsGuideStarWorker.applyResults(_, _, true))(Try(GemsGuideStarWorker.findGuideStars(ctx)))
+                    lookup((x: GOption[GemsGuideStars]) => x.asScalaOpt)(GemsGuideStarWorker.applyResults(_, _, true))(Try(GemsGuideStarWorker.findGuideStars(ctx)))
                   } else {
                     val fut = strategy.select(ctx, OT.getMagnitudeTable)
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
@@ -1,5 +1,6 @@
 package jsky.app.ot.gemini.editor.targetComponent
 
+import edu.gemini.ags.api.AgsAnalysis
 import edu.gemini.spModel.obs.context.ObsContext
 
 import jsky.app.ot.ags.AgsContext
@@ -27,10 +28,21 @@ class GuidingControls extends GridBagPanel {
     insets = new Insets(0, 5, 0, 10)
   }
 
+  val autoGuideStarButton = new Button("Auto GS") {
+    def update(analysis: List[AgsAnalysis]): Unit = {
+      enabled = analysis.nonEmpty // if empty, no strategy so no search
+    }
+  }
+
+  layout(autoGuideStarButton) = new Constraints {
+    gridx = 2
+    insets = new Insets(0, 0, 0, 5)
+  }
+
   val manualGuideStarButton = new Button("Manual GS")
 
   layout(manualGuideStarButton) = new Constraints {
-    gridx  = 2
+    gridx  = 3
   }
 
   def update(ctxOpt: edu.gemini.shared.util.immutable.Option[ObsContext]): Unit = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
@@ -53,18 +53,8 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
 
     nonreentrant {
       val when = ctx.asScalaOpt.flatMap(_.getSchedulingBlock.asScalaOpt).map(_.start).map(java.lang.Long.valueOf).asGeminiOpt
-
-      // We want to see if the current text in the fields, when formatted properly, is different from what would be assigned.
-      // The targetChanged is not a foolproof catch, since two ITargets could be considered the same if their values are
-      // identical, but this is not really consequential: it is just included to reset a partially completed field to a
-      // fully completed one (e.g. RA: 12 to 12:00:00.000) if the RAs are the same but the targets are different.
-      def setField[F <: CoordinateFormat](widget: TextBoxWidget, formatter: F, extractor: GOption[java.lang.Long] => GOption[String]): Unit = {
-        val original  = widget.getText
-        val formatted = Try { formatter.format(formatter.parse(original)) }.getOrElse(original)
-        extractor(when).asScalaOpt.filter(_ != formatted || original.isEmpty || targetChanged).foreach(widget.setText)
-      }
-      setField(ra,  HMS.DEFAULT_FORMAT, target.getRaString)
-      setField(dec, DMS.DEFAULT_FORMAT, target.getDecString)
+      target.getRaString(when).asScalaOpt.foreach(ra.setText)
+      target.getDecString(when).asScalaOpt.foreach(dec.setText)
     }
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
@@ -199,7 +199,9 @@ class AgsClient(ctx: TpeContext) extends Dialog {
     listenTo(acceptButton)
     reactions += {
       case ButtonClicked(`acceptButton`) =>
-        TpeManager.open.getImageWidget.guideStarSearch(true)
+        val tpe = TpeManager.open
+        ctx.node.foreach(tpe.reset)
+        tpe.getImageWidget.guideStarSearch(true)
         quit()
     }
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
@@ -201,7 +201,7 @@ class AgsClient(ctx: TpeContext) extends Dialog {
       case ButtonClicked(`acceptButton`) =>
         val tpe = TpeManager.open
         ctx.node.foreach(tpe.reset)
-        tpe.getImageWidget.guideStarSearch(true)
+        tpe.getImageWidget.manualGuideStarSearch()
         quit()
     }
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
@@ -1,0 +1,245 @@
+package jsky.app.ot.tpe
+
+import edu.gemini.ags.api.{AgsRegistrar, AgsStrategy}
+import edu.gemini.pot.sp.ISPNode
+import edu.gemini.spModel.guide.GuideProbe
+import jsky.app.ot.OT
+import jsky.app.ot.gemini.altair.Altair_WFS_Feature
+import jsky.app.ot.gemini.inst.OIWFS_Feature
+import jsky.app.ot.gemini.tpe.TpePWFSFeature
+import jsky.app.ot.util.Resources
+
+import java.awt.{Color, Font}
+import javax.swing._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.swing._
+import scala.swing.GridBagPanel.Anchor.West
+import scala.swing.GridBagPanel.Fill.{Both, Horizontal}
+import scala.swing.event.{ButtonClicked, WindowClosing}
+import scala.util.{Failure, Success}
+import java.util.logging.{Level, Logger}
+
+
+/**
+ * Placeholder.  We needed something to replace the old AgsClient which uses
+ * the old AGS API.  A better UI is planned.
+ */
+
+object AgsClient {
+  private val Note = "The Automatic Guide Star selection feature attempts to " +
+    "find the best guide star (s) for your observation."
+
+  private val NothingFoundMessage =
+    "Sorry, could not find any guide stars for the current conditions."
+
+  private val ExceptionMessage =
+    "There was a problem communicating with the remote catalog servers."
+
+  private val SearchingIcon = Resources.getIcon("spinner.gif")
+
+  private def javaIcon(k: String) = UIManager.getLookAndFeelDefaults.get(k).asInstanceOf[Icon]
+  private val FailureIcon = javaIcon("OptionPane.errorIcon")
+
+  private val Log = Logger.getLogger(this.getClass.getName)
+
+  def launch(n: ISPNode, relativeTo: JComponent): Unit = launch(TpeContext.apply(n), relativeTo)
+
+  def launch(tpeCtx: TpeContext, relativeTo: JComponent): Unit =
+    tpeCtx.obsContext.foreach { obsCtx =>
+      AgsRegistrar.currentStrategy(obsCtx).foreach { strategy =>
+        val fut    = strategy.select(obsCtx, OT.getMagnitudeTable)
+        val dialog = new AgsClient(tpeCtx)
+
+        fut.onComplete {
+          case Success(sel) => Swing.onEDT { dialog.handleSuccess(sel) }
+          case Failure(ex)  => Swing.onEDT { dialog.handleFailure(ex) }
+        }
+
+        dialog.pack()
+        dialog.location = SwingUtilities.windowForComponent(relativeTo).getLocationOnScreen
+        dialog.visible  = true
+      }
+    }
+}
+
+import AgsClient._
+
+class AgsClient(ctx: TpeContext) extends Dialog {
+  modal         = true
+  resizable     = false
+  preferredSize = new Dimension(500,200)
+  minimumSize   = preferredSize
+
+  var cancelled = false
+
+  reactions += {
+    case WindowClosing(e) => quit()
+  }
+
+  object mainPanel extends GridBagPanel {
+    border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+
+    val statusIcon = new Label() {
+      icon = SearchingIcon
+    }
+    layout(statusIcon) = new Constraints {
+      gridx   = 0
+      gridy   = 0
+      weightx = 0.0
+      insets  = new Insets(0, 0, 0, 10)
+    }
+
+    val statusMessage = new Label("Searching for guide stars ...") {
+      horizontalAlignment = Alignment.Left
+      font       = font.deriveFont(Font.BOLD).deriveFont(font.getSize2D + 8.0f)
+      foreground = Color.BLACK
+    }
+    layout(statusMessage) = new Constraints {
+      gridx   = 1
+      gridy   = 0
+      fill    = Horizontal
+      weightx = 1.0
+      anchor  = West
+    }
+
+    val explanatoryText = new TextArea() {
+      wordWrap      = true
+      lineWrap      = true
+      editable      = false
+      preferredSize = new Dimension(0, 50)
+      foreground    = Color.DARK_GRAY
+      text          = Note
+    }
+    layout(explanatoryText) = new Constraints {
+      gridx     = 0
+      gridy     = 1
+      gridwidth = 2
+      fill      = Horizontal
+      weightx   = 1.0
+      insets    = new Insets(15, 10, 5, 10)
+    }
+
+    layout(new BorderPanel()) = new Constraints {
+      gridx     = 0
+      gridy     = 2
+      gridwidth = 2
+      fill      = Both
+      weightx   = 1.0
+      weighty   = 1.0
+    }
+
+    object buttonPanel extends GridBagPanel {
+      border = BorderFactory.createCompoundBorder(
+        BorderFactory.createMatteBorder(1, 0, 0, 0, Color.LIGHT_GRAY),
+        BorderFactory.createEmptyBorder(10, 0, 0, 0))
+
+      layout(new BorderPanel()) = new Constraints {
+        gridx   = 0
+        fill    = Horizontal
+        weightx = 1.0
+      }
+
+      val acceptButton = new Button("OK") {
+        enabled = false
+      }
+      layout(acceptButton) = new Constraints {
+        gridx = 1
+      }
+      val cancelButton = new Button("Cancel")
+      layout(cancelButton) = new Constraints {
+        gridx  = 2
+        insets = new Insets(0, 5, 0, 0)
+      }
+    }
+
+    layout(buttonPanel) = new Constraints {
+      gridx     = 0
+      gridy     = 4
+      gridwidth = 2
+      fill      = Horizontal
+      weightx   = 1.0
+    }
+  }
+
+  contents = mainPanel
+
+  import mainPanel.buttonPanel.cancelButton
+  listenTo(cancelButton)
+  reactions += {
+    case ButtonClicked(`cancelButton`) => quit()
+  }
+
+  private def quit(): Unit = {
+    cancelled = true
+    visible   = false
+    dispose()
+  }
+
+  private def handleSuccess(selOpt: Option[AgsStrategy.Selection]): Unit =
+    if (!cancelled) {
+      selOpt match {
+        case Some(sel) =>
+          applySelection(sel)
+          showTpeFeatures(sel)
+          quit()
+        case _ =>
+          setupManualSearch(NothingFoundMessage)
+      }
+    }
+
+  private def setupManualSearch(msg: String): Unit = {
+    mainPanel.explanatoryText.text = msg + "  Try changing the conditions, moving the field, or doing a manual search."
+    mainPanel.statusIcon.icon      = FailureIcon
+    mainPanel.statusMessage.text   = "No guide star was found."
+
+    import mainPanel.buttonPanel.acceptButton
+    acceptButton.text = "Manual Search"
+    acceptButton.enabled = true
+    listenTo(acceptButton)
+    reactions += {
+      case ButtonClicked(`acceptButton`) =>
+        TpeManager.open.getImageWidget.guideStarSearch(true)
+        quit()
+    }
+  }
+
+  private def handleFailure(ex: Throwable): Unit =
+    if (!cancelled) {
+      Log.log(Level.WARNING, "AGS lookup failure", ex)
+      setupManualSearch(ExceptionMessage)
+    }
+
+  private def showTpeFeatures(sel: AgsStrategy.Selection): Unit =
+    Option(TpeManager.get()).filter(_.isVisible).foreach { tpe =>
+      sel.assignments.foreach { ass =>
+        val clazz = ass.guideProbe.getType match {
+          case GuideProbe.Type.AOWFS => classOf[Altair_WFS_Feature]
+          case GuideProbe.Type.OIWFS => classOf[OIWFS_Feature]
+          case GuideProbe.Type.PWFS  => classOf[TpePWFSFeature]
+        }
+        Option(tpe.getFeature(clazz)).foreach { tpe.selectFeature }
+      }
+    }
+
+  private def applySelection(sel: AgsStrategy.Selection): Unit = {
+    // Make a new TargetEnvironment with the guide probe assignments.
+    val newEnv = sel.applyTo(ctx.targets.envOrDefault)
+
+    // Update the TargetEnvironment.
+    ctx.targets.dataObject.foreach { targetComp =>
+      targetComp.setTargetEnvironment(newEnv)
+      ctx.targets.commit()
+
+      // Update the position angle, if necessary.
+      ctx.instrument.dataObject.foreach { inst =>
+        val deg = sel.posAngle.toDegrees
+        val old = inst.getPosAngleDegrees
+        if (deg != old) {
+          inst.setPosAngleDegrees(deg)
+          ctx.instrument.commit()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The aim of this PR is to restore the pre-BAGS manually executed AGS functionality to the OT in a minimal way for the 2016A release, while maintaining the essential "guts" of BAGS for future work.

This involves, primarily:
1. Restoring the previous behaviour of the RA and Dec text fields in the CoordinateEditor.
2. Adding the Auto GS buttons back to the TPE and Guiding Controls in the target editor.
3. Restoring the AgsClient to indicate that an AGS lookup is being performed, and to prompt for a manual catalog search if no targets can be found.
4. Restoring the previous GeMS AGS behaviour, i.e. opening the TPE and displaying a dialog indicating the status of the GeMS lookup.
5. Storing AGS stars once again as primary guide stars in `GuideProbeTargets` instead of as BAGS targets.
6. Removing the BAGS modifications to the target list to ensure correct behaviour of this widget.
7. Disabling the `BagsManager` methods to register and unregister programs.