### PR TITLE
REL-2544: Fixed editability of target details

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -148,7 +148,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         final boolean curNotBase = _curPos != env.getBase();
         _w.removeButton.setEnabled(curNotBase && curNotBags && editable);
         _w.primaryButton.setEnabled(enablePrimary(_curPos, env) && editable);
-        updateDetailEditorEnabledState(curNotBags);
+        updateDetailEditorEnabledState(curNotBags && editable);
     }
 
     private final ActionListener _tagListener = new ActionListener() {


### PR DESCRIPTION
When making the updates for BAGS, I used the incorrect boolean expression to set whether target details are editable.

This tiny PR fixes that oversight.