### PR TITLE
REL-2542: A couple issues with unbagging

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -90,7 +90,7 @@ object AgsStrategy {
         def name(t: SPTarget): Option[String] =
           Option(t.getTarget.getName).map(_.trim)
 
-        name(target).flatMap(n => gpt.getTargets.asScalaList.find(name(_).exists(_ == n.trim)))
+        name(target).flatMap(n => gpt.getTargets.asScalaList.find(name(_).exists(_ == n)))
       }
 
       (env /: assignments) { (curEnv, ass) =>

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -86,12 +86,12 @@ object AgsStrategy {
      * the Selection.
      */
     def applyTo(env: TargetEnvironment): TargetEnvironment = {
-      def findMatching(gpt: GuideProbeTargets, target: SPTarget): Option[SPTarget] =
-        Option(target.getTarget.getName).flatMap { n =>
-          gpt.getTargets.asScalaList.find { t =>
-            Option(t.getTarget.getName).map(_.trim).exists(_ == n.trim)
-          }
-        }
+      def findMatching(gpt: GuideProbeTargets, target: SPTarget): Option[SPTarget] = {
+        def name(t: SPTarget): Option[String] =
+          Option(t.getTarget.getName).map(_.trim)
+
+        name(target).flatMap(n => gpt.getTargets.asScalaList.find(name(_).exists(_ == n.trim)))
+      }
 
       (env /: assignments) { (curEnv, ass) =>
         val target = new SPTarget(HmsDegTarget.fromSkyObject(ass.guideStar.toOldModel))

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/GuideProbeTargets.java
@@ -419,6 +419,14 @@ public final class GuideProbeTargets implements Serializable, TargetContainer, I
         return new GuideProbeTargets(guider, bagsResult, new Some<>(target), manualTargetsNew);
     }
 
+    public GuideProbeTargets setPrimary(final SPTarget primary) {
+        final Option<Integer> primaryIndex = getPrimaryIndex();
+        return primaryIndex.map(idx -> {
+            final ImList<SPTarget> manualTargetsNew = manualTargets.updated(idx, primary);
+            return GuideProbeTargets.create(guider, bagsResult, new Some<>(primary), manualTargetsNew);
+        }).getOrElse(withManualPrimary(primary));
+    }
+
     /**
      * Return the index of the primary target, if one exists, or None if there is no primary target.
      * Note that if a BAGS target exists, we count the BAGS target as index 0 and then begin counting the manual targets at index 1.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -296,7 +296,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                         final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
                         final boolean isPrimary = primary.exists(target::equals);
 
-                        final Row row = new GuideTargetRow(isActive, quality, isPrimary, guideProbe, tup._2(), target, baseCoords, when);
+                        final Row row = new GuideTargetRow(isActive, quality, isPrimary, guideProbe, tup._2() + 1, target, baseCoords, when);
                         tmp.add(row);
                     });
                 }
@@ -315,7 +315,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                             final Option<AgsGuideQuality> quality = guideQuality(ags, guideProbe, target);
                             final boolean enabled = isPrimaryGroup && primary.exists(target::equals);
 
-                            final Row row = new GuideTargetRow(isActive, quality, enabled, guideProbe, tup._2(), target, baseCoords, when);
+                            final Row row = new GuideTargetRow(isActive, quality, enabled, guideProbe, tup._2() + 1, target, baseCoords, when);
                             rowList.add(row);
                         });
                     }


### PR DESCRIPTION
This short PR fixes two issues that Bryan identified in the rolling back of BAGS to the previous AGS logic:

1. The targets in the target editor are indexed by guide probe. Previously, they were indexed starting at 1, but in the BAGS unrolling, this was accidentally changed to have them indexing at 0. They are now once again indexed starting at 1 by the changes to `TelescopePosTableWidget`.

2. If AGS was run multiple times, an old target, if having the same name as the new target, was replaced by the new target and set as the primary. In the unrolling of BAGS, the new target was simply added, so the same target could appear multiple times. The old behaviour has been restored through restoring code to `AgsStrategy` and adding a method to `GuideProbeTargets` that corresponds to the old `OptionsList.setPrimary` method.