### PR TITLE
REL-2407-H: Data Manager Bug Fixes

### DIFF
--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/GsaPollActions.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/GsaPollActions.scala
@@ -107,7 +107,7 @@ object GsaPollActions {
           } yield log.getRecord.getAllDatasetExecRecords.asScala.map(_.label).toSet) | Set.empty
 
         def diff(inProgram: Set[DatasetLabel]): List[DatasetLabel] =
-          (inProgram &~ inGsa.map(_.label).toSet).toList
+          (inProgram &~ inGsa.flatMap(_.label).toSet).toList
 
         did match {
           case DmanId.Prog(_)   =>

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/core/GsaRecord.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/core/GsaRecord.scala
@@ -10,7 +10,7 @@ import scalaz.Equal
   * The `time` parameter is the GSA ingestion instant which, lacking a more
   * explicit alternative, is used as a version number.
   */
-final case class GsaRecord(label: DatasetLabel, filename: String, state: DatasetGsaState)
+final case class GsaRecord(label: Option[DatasetLabel], filename: String, state: DatasetGsaState)
 
 object GsaRecord {
   implicit val EqualGsaRecord: Equal[GsaRecord] = Equal.equalA

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/GsaCommands.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/GsaCommands.scala
@@ -52,7 +52,7 @@ object GsaCommands {
       def list(arg: String): String = {
         def format(lst: List[GsaRecord]): String = {
           val rows = List("Dataset Label", "QA State", "Time", "MD5", "Filename") :: lst.sortBy(_.label).map { f =>
-            List(f.label.toString, f.state.qa.displayValue, TimeFormat.format(f.state.timestamp), f.state.md5.hexString, f.filename)
+            List(f.label.map(_.toString) | "", f.state.qa.displayValue, TimeFormat.format(f.state.timestamp), f.state.md5.hexString, f.filename)
           }
           rows.transpose.map { col =>
             val w = col.maxBy(_.length).length

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
@@ -45,10 +45,10 @@ object GsaRecordQuery {
       def url(filter: String): URL = new URL(s"$prefix/$filter")
 
       override def program(pid: SPProgramID): GsaResponse[List[GsaRecord]] =
-        GsaQuery.get(url(pid.stringValue))
+        GsaQuery.get(url(s"progid=${pid.stringValue}"))
 
       override def observation(oid: SPObservationID): GsaResponse[List[GsaRecord]] =
-        GsaQuery.get(url(oid.stringValue))
+        GsaQuery.get(url(s"obsid=${oid.stringValue}"))
 
       override def dataset(label: DatasetLabel): GsaResponse[Option[GsaRecord]] =
         GsaQuery.get[List[GsaRecord]](url(label.toString)).map(_.headOption)

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
@@ -42,7 +42,7 @@ object GsaRecordQuery {
     new GsaRecordQuery {
       val prefix = s"${host.protocol}://${host.host}/jsonqastate/${gsaSite(site)}/present"
 
-      def url(filter: String): URL = new URL(s"$prefix/$filter")
+      def url(filter: String): URL = new URL(s"$prefix/RAW/$filter")
 
       override def program(pid: SPProgramID): GsaResponse[List[GsaRecord]] =
         GsaQuery.get(url(s"progid=${pid.stringValue}"))

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/JsonCodecs.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/JsonCodecs.scala
@@ -12,7 +12,8 @@ import java.time.Instant
 import java.time.format.DateTimeParseException
 import java.time.temporal.{TemporalAccessor, TemporalQuery}
 
-import scalaz.Scalaz._
+import scalaz._
+import Scalaz._
 
 /** A collection of JSON codecs for existing Gemini Java types, as they are
   * encoded by the GSA server.
@@ -114,7 +115,7 @@ private[query] object JsonCodecs {
   implicit val DecodeJsonGsaRecord: DecodeJson[GsaRecord] =
     DecodeJson { c =>
       for {
-        l <- (c --\ "data_label").as[DatasetLabel]
+        l <- (c --\ "data_label").as[DatasetLabel].map(some) ||| DecodeResult.ok(none[DatasetLabel])
         f <- (c --\ "filename").as[String]
         s <- implicitly[DecodeJson[DatasetGsaState]].decode(c)
       } yield GsaRecord(l, f, s)

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/core/Arbitraries.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/core/Arbitraries.scala
@@ -9,11 +9,14 @@ import org.scalacheck.Arbitrary._
 import java.time.{LocalDate, ZoneId}
 import java.time.format.DateTimeFormatter
 
+import scalaz._
+import Scalaz._
+
 trait Arbitraries extends edu.gemini.spModel.dataset.Arbitraries {
   implicit val arbGsaRecord: Arbitrary[GsaRecord] =
     Arbitrary {
       for {
-        label <- arbitrary[DatasetLabel]
+        label <- Gen.frequency((95, arbDatasetLabel.arbitrary.map(some)), (5, none[DatasetLabel]))
         file  <- arbitrary[String]
         state <- arbitrary[DatasetGsaState]
       } yield GsaRecord(label, file, state)

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/query/GsaRecordCodecSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/query/GsaRecordCodecSpec.scala
@@ -25,6 +25,9 @@ object GsaRecordCodecSpec extends Specification {
       |}
     """.stripMargin
 
+  val file0 =
+    GsaRecord(Some(new DatasetLabel("GN-2015A-Q-4-95-019")), "N20150912S0124.fits",  DatasetGsaState(PASS, Instant.parse("2015-09-12T03:06:39.00Z").plusNanos(961433000), DatasetMd5.parse("0bee89b07a248e27c83fc3d5951213c1").get))
+
   val json1 =
   """
     |{
@@ -36,11 +39,33 @@ object GsaRecordCodecSpec extends Specification {
     |}
   """.stripMargin
 
-  val file0 =
-    GsaRecord(new DatasetLabel("GN-2015A-Q-4-95-019"), "N20150912S0124.fits",  DatasetGsaState(PASS, Instant.parse("2015-09-12T03:06:39.00Z").plusNanos(961433000), DatasetMd5.parse("0bee89b07a248e27c83fc3d5951213c1").get))
-
   val file1 =
-    GsaRecord(new DatasetLabel("GN-2015A-Q-4-92-004"), "N20150912S0125.fits", DatasetGsaState(USABLE, Instant.parse("2015-09-12T03:06:41.00Z").plusNanos(803116000), DatasetMd5.parse("ba1f2511fc30423bdbb183fe33f3dd0f").get))
+    GsaRecord(Some(new DatasetLabel("GN-2015A-Q-4-92-004")), "N20150912S0125.fits", DatasetGsaState(USABLE, Instant.parse("2015-09-12T03:06:41.00Z").plusNanos(803116000), DatasetMd5.parse("ba1f2511fc30423bdbb183fe33f3dd0f").get))
+
+  val badLabel =
+    """
+      |{
+      |  "qa_state": "Usable",
+      |  "data_label": "GN-2015A-Q-4-92-004-R",
+      |  "entrytime": "2015-09-12 03:06:41.803116+00:00",
+      |  "filename": "N20150912S0125.fits",
+      |  "data_md5": "ba1f2511fc30423bdbb183fe33f3dd0f"
+      |}
+    """.stripMargin
+
+  val nullLabel =
+    """
+      |{
+      |  "qa_state": "Usable",
+      |  "data_label": null,
+      |  "entrytime": "2015-09-12 03:06:41.803116+00:00",
+      |  "filename": "N20150912S0125.fits",
+      |  "data_md5": "ba1f2511fc30423bdbb183fe33f3dd0f"
+      |}
+    """.stripMargin
+
+  val badOrNullFile =
+    GsaRecord(None, "N20150912S0125.fits", DatasetGsaState(USABLE, Instant.parse("2015-09-12T03:06:41.00Z").plusNanos(803116000), DatasetMd5.parse("ba1f2511fc30423bdbb183fe33f3dd0f").get))
 
   def jsonList(js: String*): String = js.mkString("[\n", ",\n", "\n]")
 
@@ -103,6 +128,14 @@ object GsaRecordCodecSpec extends Specification {
         case -\/(_) => success
         case _      => failure("Expecting unparseable QA state warning")
       }
+    }
+
+    "handle bad labels" in {
+      Parse.decodeOption[GsaRecord](badLabel).get must_== badOrNullFile
+    }
+
+    "handle null labels" in {
+      Parse.decodeOption[GsaRecord](nullLabel).get must_== badOrNullFile
     }
   }
 }


### PR DESCRIPTION
A handful of updates to archive queries and parsing:

1. Adds "progid=" and "obsid=" filters so that arbitrary program names like `Andy` will work and not result in attempts to download the entire archive.
2. Adds the "RAW" filter on the query to avoid getting processed datasets in the results.
3. Treats the dataset label as optional in archive query results.  This is necessary because sometimes datasets are created from engineering screens without an associated science program.  The failure to parse one such dataset in a list shouldn't invalidate them all.