### PR TITLE
OCSADV-491: Remove ITC sky aperture from IR instruments

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -5,8 +5,12 @@ import javax.swing._
 
 import edu.gemini.itc.shared._
 import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gmos.{InstGmosSouth, InstGmosNorth}
+import edu.gemini.spModel.gemini.gnirs.InstGNIRS
+import edu.gemini.spModel.gemini.gsaoi.Gsaoi
 import edu.gemini.spModel.gemini.nifs.InstNIFS
+import edu.gemini.spModel.gemini.niri.InstNIRI
 import jsky.app.ot.itc._
 import jsky.app.ot.util.OtColor
 import org.jfree.chart.{ChartPanel, JFreeChart}
@@ -42,16 +46,17 @@ sealed trait ItcPanel extends GridBagPanel {
   def display: Component
   def visibleFor(t: SPComponentType): Boolean
 
-  private val currentConditions = new ConditionsPanel(owner)
-  private val analysisApertureMethod    = new AnalysisApertureMethodPanel(owner)
-  private val analysisIfuNifsMethod     = new AnalysisIfuMethodPanel(owner, skyEditable = false)
-  private val analysisIfuGmosMethod     = new AnalysisIfuMethodPanel(owner, summedAllowed = false)
-  private val message           = new ItcFeedbackPanel(table)
+  private val conditionsPanel        = new ConditionsPanel(owner)
+  private val aperturePanel          = new AnalysisApertureMethodPanel(owner)
+  private val apertureFixedSkyPanel  = new AnalysisApertureMethodPanel(owner, fixedSkyValue = Some(1.0))
+  private val ifuNifsPanel           = new AnalysisIfuMethodPanel(owner, skyEditable = false)
+  private val ifuGmosPanel           = new AnalysisIfuMethodPanel(owner, summedAllowed = false)
+  private val messagePanel           = new ItcFeedbackPanel(table)
 
-  private var analysisMethod: AnalysisMethodPanel = analysisApertureMethod
+  private var analysisMethod: AnalysisMethodPanel = aperturePanel
 
   border = BorderFactory.createEmptyBorder(5, 10, 5, 10)
-  layout(currentConditions) = new Constraints {
+  layout(conditionsPanel) = new Constraints {
     anchor    = Anchor.NorthWest
     gridx     = 0
     gridy     = 0
@@ -73,7 +78,7 @@ sealed trait ItcPanel extends GridBagPanel {
     fill      = Fill.Both
     insets    = new Insets(10, 0, 0, 0)
   }
-  layout(message) = new Constraints {
+  layout(messagePanel) = new Constraints {
     anchor    = Anchor.West
     gridx     = 0
     gridy     = 3
@@ -83,31 +88,35 @@ sealed trait ItcPanel extends GridBagPanel {
     insets    = new Insets(10, 0, 0, 0)
   }
 
-  listenTo(currentConditions, analysisMethod)
+  listenTo(conditionsPanel, analysisMethod)
   reactions += {
     case SelectionChanged(_) => table.update()
   }
 
   def update(): Unit = {
-    deafTo(currentConditions, analysisMethod)
+    deafTo(conditionsPanel, analysisMethod)
     updateAnalysisPanel()
-    currentConditions.update()
+    conditionsPanel.update()
     analysisMethod.update()
     table.update()
-    listenTo(currentConditions, analysisMethod)
+    listenTo(conditionsPanel, analysisMethod)
   }
 
   def analysis: Option[AnalysisMethod] = analysisMethod.analysisMethod
 
-  def conditions: ObservingConditions = currentConditions.conditions
+  def conditions: ObservingConditions = conditionsPanel.conditions
 
   private def updateAnalysisPanel() = {
     peer.remove(analysisMethod.peer)
     analysisMethod = owner.getContextInstrumentDataObject match {
-      case _: InstNIFS                            => analysisIfuNifsMethod
-      case i: InstGmosNorth if i.getFPUnit.isIFU  => analysisIfuGmosMethod
-      case i: InstGmosSouth if i.getFPUnit.isIFU  => analysisIfuGmosMethod
-      case _                                      => analysisApertureMethod
+      case _: InstNIFS                            => ifuNifsPanel          // NIFS ifu method
+      case i: InstGmosNorth if i.getFPUnit.isIFU  => ifuGmosPanel          // GMOS ifu method (without summed)
+      case i: InstGmosSouth if i.getFPUnit.isIFU  => ifuGmosPanel
+      case i: Flamingos2                          => apertureFixedSkyPanel // for IR instruments always use sky aperture = 1.0
+      case i: InstGNIRS                           => apertureFixedSkyPanel
+      case i: Gsaoi                               => apertureFixedSkyPanel
+      case i: InstNIRI                            => apertureFixedSkyPanel
+      case _                                      => aperturePanel         // as default use aperture method
     }
     layout(analysisMethod) = new Constraints {
       anchor    = Anchor.NorthWest

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -48,7 +48,7 @@ sealed trait ItcPanel extends GridBagPanel {
 
   private val conditionsPanel        = new ConditionsPanel(owner)
   private val aperturePanel          = new AnalysisApertureMethodPanel(owner)
-  private val apertureFixedSkyPanel  = new AnalysisApertureMethodPanel(owner, fixedSkyValue = Some(1.0))
+  private val apertureFixedSkyPanel  = new AnalysisApertureMethodPanel(owner, fixedSkyValue = true)
   private val ifuNifsPanel           = new AnalysisIfuMethodPanel(owner, skyEditable = false)
   private val ifuGmosPanel           = new AnalysisIfuMethodPanel(owner, summedAllowed = false)
   private val messagePanel           = new ItcFeedbackPanel(table)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -62,13 +62,6 @@ sealed trait ItcPanel extends GridBagPanel {
     gridy     = 0
     insets    = new Insets(5, 0, 5, 20)
   }
-  layout(analysisMethod) = new Constraints {
-    anchor    = Anchor.NorthWest
-    gridx     = 1
-    gridy     = 0
-    weightx   = 1
-    insets    = new Insets(5, 0, 5, 0)
-  }
   layout(display) = new Constraints {
     gridx     = 0
     gridy     = 2
@@ -112,10 +105,10 @@ sealed trait ItcPanel extends GridBagPanel {
       case _: InstNIFS                            => ifuNifsPanel          // NIFS ifu method
       case i: InstGmosNorth if i.getFPUnit.isIFU  => ifuGmosPanel          // GMOS ifu method (without summed)
       case i: InstGmosSouth if i.getFPUnit.isIFU  => ifuGmosPanel
-      case i: Flamingos2                          => apertureFixedSkyPanel // for IR instruments always use sky aperture = 1.0
-      case i: InstGNIRS                           => apertureFixedSkyPanel
-      case i: Gsaoi                               => apertureFixedSkyPanel
-      case i: InstNIRI                            => apertureFixedSkyPanel
+      case _: Flamingos2                          => apertureFixedSkyPanel // for IR instruments always use sky aperture = 1.0
+      case _: InstGNIRS                           => apertureFixedSkyPanel
+      case _: Gsaoi                               => apertureFixedSkyPanel
+      case _: InstNIRI                            => apertureFixedSkyPanel
       case _                                      => aperturePanel         // as default use aperture method
     }
     layout(analysisMethod) = new Constraints {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/AnalysisMethodPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/AnalysisMethodPanel.scala
@@ -115,10 +115,10 @@ final class AnalysisApertureMethodPanel(owner: EdIteratorFolder, fixedSkyValue: 
 
   // generate a default analysis method for observations for which we don't have anything in the cache yet
   private def defaultMethod: ApertureMethod = owner.getContextInstrumentDataObject match {
-    case i: InstNIRI   => AutoAperture(1.0)
-    case i: Flamingos2 => AutoAperture(1.0)
-    case i: Gsaoi      => AutoAperture(1.0)
-    case i: InstGNIRS  => AutoAperture(1.0)
+    case _: InstNIRI   => AutoAperture(1.0)
+    case _: Flamingos2 => AutoAperture(1.0)
+    case _: Gsaoi      => AutoAperture(1.0)
+    case _: InstGNIRS  => AutoAperture(1.0)
     case _             => AutoAperture(5.0)
   }
 
@@ -273,7 +273,7 @@ final class AnalysisIfuMethodPanel(owner: EdIteratorFolder, summedAllowed: Boole
       case FPUnitSouth.IFU_2 | FPUnitSouth.IFU_3  => IfuSingle(250, 0.0)  // GMOS-S IFU-B / IFU-R
       case _                                      => sys.error("not IFU")
     }
-    case i: InstNIFS                              => IfuSingle(  1, 0.0)  // everything else (currently NIFS only)
+    case _: InstNIFS                              => IfuSingle(  1, 0.0)  // everything else (currently NIFS only)
     case _                                        => sys.error("not IFU")
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/AnalysisMethodPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/AnalysisMethodPanel.scala
@@ -46,7 +46,7 @@ abstract class AnalysisMethodPanel(owner: EdIteratorFolder) extends GridBagPanel
 /**
   * UI element that allows to enter ITC analysis method parameters for aperture analysis methods.
   */
-final class AnalysisApertureMethodPanel(owner: EdIteratorFolder, fixedSkyValue: Option[Double] = None) extends AnalysisMethodPanel(owner) {
+final class AnalysisApertureMethodPanel(owner: EdIteratorFolder, fixedSkyValue: Boolean = false) extends AnalysisMethodPanel(owner) {
 
   val autoAperture  = new RadioButton("Auto") { focusable = false; selected = true }
   val userAperture  = new RadioButton("User") { focusable = false }
@@ -68,10 +68,9 @@ final class AnalysisApertureMethodPanel(owner: EdIteratorFolder, fixedSkyValue: 
   layout(sky)                           = new Constraints { gridx = 3; gridy = 2; anchor = Anchor.West; insets = new Insets(0, 0, 0, 3) }
   layout(skyUnits)                      = new Constraints { gridx = 4; gridy = 2; anchor = Anchor.West }
 
-  // IR instruments (GNIRS, NIRI, F2 and GSAOI) use a fixed sky value (1.0) (OCSADV-345)
-  fixedSkyValue.foreach { s =>
+  // IR instruments (GNIRS, NIRI, F2 and GSAOI) don't allow the user to change the sky value (OCSADV-345)
+  if (fixedSkyValue) {
     List(sky, skyLabel, skyUnits).foreach(_.visible = false)
-    sky.peer.setValue(s)
   }
 
   listenTo(autoAperture, userAperture, target, sky)
@@ -115,11 +114,11 @@ final class AnalysisApertureMethodPanel(owner: EdIteratorFolder, fixedSkyValue: 
 
   // generate a default analysis method for observations for which we don't have anything in the cache yet
   private def defaultMethod: ApertureMethod = owner.getContextInstrumentDataObject match {
-    case _: InstNIRI   => AutoAperture(1.0)
+    case _: InstNIRI   => AutoAperture(1.0)   // IR instruments use default of 1 for sky aperture
     case _: Flamingos2 => AutoAperture(1.0)
     case _: Gsaoi      => AutoAperture(1.0)
     case _: InstGNIRS  => AutoAperture(1.0)
-    case _             => AutoAperture(5.0)
+    case _             => AutoAperture(5.0)   // default for everything else is 5
   }
 
   // helper to activate/deactivate the user value for the target aperture


### PR DESCRIPTION
This PR hides the "Sky Aperture" edit field from the analysis method panel for all IR instruments. A fixed value (1) is used for these instruments.