### PR TITLE
REL-2165: copy science observing conditions during template instantiation

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
@@ -28,8 +28,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
 
     private static final Logger LOGGER = Logger.getLogger(InstantiationFunctor.class.getName());
 
-    private final Map<ISPTemplateGroup, Set<ISPTemplateParameters>> selection =
-            new HashMap<ISPTemplateGroup, Set<ISPTemplateParameters>>();
+    private final Map<ISPTemplateGroup, Set<ISPTemplateParameters>> selection = new HashMap<>();
 
     /**
      * Add a group/params pair to the set of instantiations to be performed.
@@ -39,7 +38,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
     public void add(ISPTemplateGroup group, ISPTemplateParameters params) {
         Set<ISPTemplateParameters> list = selection.get(group);
         if (list == null) {
-            list = new HashSet<ISPTemplateParameters>();
+            list = new HashSet<>();
             selection.put(group, list);
         }
         list.add(params);
@@ -47,7 +46,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
 
     public void execute(IDBDatabaseService db, ISPNode node, Set<Principal> principals) {
         try {
-            List<ISPGroup> newGroups = new ArrayList<ISPGroup>();
+            List<ISPGroup> newGroups = new ArrayList<>();
             final ISPProgram prog = db.lookupProgram(node.getProgramKey());
             for (Map.Entry<ISPTemplateGroup, Set<ISPTemplateParameters>> e : selection.entrySet()) {
                 for (ISPTemplateParameters ps : e.getValue()) {
@@ -75,7 +74,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
     // Instantiate a given config, conditions, target triple
     private static ISPGroup instantiate(ISPFactory fact, ISPProgram prog, ISPTemplateGroup templateGroup, SPSiteQuality siteQualityData, SPTarget targetData) throws Exception {
         final TemplateGroup templateGroupData = (TemplateGroup) templateGroup.getDataObject();
-        final ISPGroup group = createGroup(fact, prog, siteQualityData, targetData, templateGroupData);
+        final ISPGroup group = createGroup(fact, prog, targetData, templateGroupData);
         copyNotes(fact, prog, templateGroup, group);
         copyObservations(fact, prog, templateGroup, siteQualityData, targetData, group);
         return group;
@@ -131,17 +130,17 @@ public class InstantiationFunctor extends DBAbstractFunctor {
     }
 
     // Create a scheduling group based on the specified targetData
-    private static ISPGroup createGroup(ISPFactory fact, ISPProgram prog, SPSiteQuality siteQualityData, SPTarget targetData, TemplateGroup templateGroupData) throws SPUnknownIDException, SPNodeNotLocalException, SPTreeStateException {
+    private static ISPGroup createGroup(ISPFactory fact, ISPProgram prog, SPTarget targetData, TemplateGroup templateGroupData) throws SPUnknownIDException, SPNodeNotLocalException, SPTreeStateException {
         final ISPGroup group = fact.createGroup(prog, null);
         final SPGroup groupData = (SPGroup) group.getDataObject();
-        groupData.setTitle(createGroupTitle(templateGroupData, siteQualityData, targetData));
+        groupData.setTitle(createGroupTitle(templateGroupData, targetData));
         groupData.setGroupType(SPGroup.GroupType.TYPE_SCHEDULING);
         group.setDataObject(groupData);
         return group;
     }
 
     // Get a group name from the given config, conditions, target triple
-    private static String createGroupTitle(TemplateGroup templateGroupData, SPSiteQuality siteQualityData, SPTarget targetData) {
+    private static String createGroupTitle(TemplateGroup templateGroupData, SPTarget targetData) {
         return String.format("%s - [%s] %s",
                 targetData.getTarget().getName(),
                 templateGroupData.getVersionToken(),

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
@@ -92,10 +92,14 @@ public class InstantiationFunctor extends DBAbstractFunctor {
             newObsData.setOriginatingTemplate(templateObs.getNodeKey());
             newObs.setDataObject(newObsData);
 
-            // Copy target/conds for relevant obs classes
+            // Copy target/conds for relevant obs classes.  Note, if the
+            // template obs has an explicitly defined target or conditions node,
+            // it is not replaced with template values.
             final ObsClass newObsClass = ObsClassService.lookupObsClass(newObs);
-            if (newObsClass == ObsClass.SCIENCE || newObsClass == ObsClass.ACQ) {
+            if (newObsClass != ObsClass.DAY_CAL) {
                 copySiteQuality(fact, prog, siteQualityData, newObs);
+            }
+            if (newObsClass == ObsClass.SCIENCE || newObsClass == ObsClass.ACQ) {
                 copyTarget(fact, prog, targetData, newObs);
             }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
@@ -1,0 +1,156 @@
+package edu.gemini.spModel.template
+
+import edu.gemini.pot.sp.{SPComponentType, ISPObservation, SPNodeKey}
+import edu.gemini.pot.sp.SPComponentType.{OBSERVER_OBSERVE, SCHEDULING_CONDITIONS, TELESCOPE_TARGETENV}
+import edu.gemini.shared.util.TimeValue
+import edu.gemini.spModel.gemini.gmos.GmosSouthType.FilterSouth
+import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintImaging
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover.{PERCENT_50 => CC50}
+import edu.gemini.spModel.obsclass.ObsClass
+import edu.gemini.spModel.obsclass.ObsClass._
+import edu.gemini.spModel.seqcomp.SeqRepeatObserve
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.test.SpModelTestBase
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.JavaConverters._
+import scalaz._
+import Scalaz._
+
+import InstantiationFunctorTest._
+
+class InstantiationFunctorTest extends SpModelTestBase {
+
+  def instantiate(os: ISPObservation*): List[ISPObservation] = {
+    val fact = getFactory
+    val prog = getProgram
+
+    // Setup the test program with a single template group with a single target
+    // at (RA, Dec) (1, 2) and CC50 observing conditions.
+    val tfNode = fact.createTemplateFolder(prog, WithSomeNewKey)
+
+    val bp: SpBlueprint = new SpGmosSBlueprintImaging(List(FilterSouth.g_G0325).asJava)
+    val bpMap = Map("blueprint-0" -> bp)
+    val tf    = new TemplateFolder(bpMap.asJava)
+    tfNode.setDataObject(tf)
+
+    val tgNode = fact.createTemplateGroup(prog, WithSomeNewKey)
+    val tg     = new TemplateGroup()
+    tg.setBlueprintId("blueprint-0")
+    tfNode.setDataObject(tg)
+
+    val tpNode = fact.createTemplateParameters(prog, WithSomeNewKey)
+    val tp     = newParameters(ScienceTargetName, ScienceTargetCC)
+    tpNode.setDataObject(tp)
+
+    tgNode.addTemplateParameters(tpNode)
+    tfNode.addTemplateGroup(tgNode)
+    prog.setTemplateFolder(tfNode)
+
+    // Add an observation for each of the specified obs clsses
+    os.foreach(tgNode.addObservation)
+
+    // Instantiate observations
+    val func = new InstantiationFunctor
+    func.add(tgNode, tpNode)
+    func.execute(getOdb, getProgram, null)
+
+    // Return the instantiated observations
+    val grp = getProgram.getGroups.get(0)
+    grp.getObservations.asScala.toList
+  }
+
+  def newObs(clazz: ObsClass): ISPObservation = {
+    val obsNode     = getFactory.createObservation(getProgram, WithSomeNewKey)
+
+    val filteredChildren = obsNode.getObsComponents.asScala.filter { n =>
+      n.getDataObject.getType match {
+        case TELESCOPE_TARGETENV | SCHEDULING_CONDITIONS => false
+        case _                                           => true
+      }
+    }
+    obsNode.setObsComponents(filteredChildren.asJava)
+
+    val observeNode = getFactory.createSeqComponent(getProgram, OBSERVER_OBSERVE, WithSomeNewKey)
+    val observe     = new SeqRepeatObserve() <| (_.setObsClass(clazz))
+    observeNode.setDataObject(observe)
+
+    obsNode.getSeqComponent.addSeqComponent(observeNode)
+    obsNode
+  }
+
+
+  @Test def testDayCalGetsNeitherConditionsNorTarget(): Unit = {
+    val obsList = instantiate(newObs(DAY_CAL))
+
+    obsList match {
+      case o :: Nil =>
+        // Neither science site quality nor science target are copied.
+        assertTrue(siteQuality(o).isEmpty && target(o).isEmpty)
+      case _        =>
+        fail("Expected a single observation")
+    }
+  }
+
+  @Test def testNightCalHasScienceConditions(): Unit = {
+    List(ACQ_CAL, PARTNER_CAL, PROG_CAL).foreach { c =>
+      val obsList = instantiate(newObs(c))
+
+      obsList match {
+        case o :: Nil =>
+          // Science site quality is copied, but not the science target
+          assertTrue(siteQuality(o).exists(_.getCloudCover == ScienceTargetCC) &&
+                     target(o).isEmpty)
+        case _       =>
+          fail("Expected a single observation")
+      }
+    }
+  }
+
+  @Test def testScienceHasScienceConditionsAndTarget(): Unit = {
+    List(ACQ, SCIENCE).foreach { c =>
+      val obsList = instantiate(newObs(c))
+
+      obsList match {
+        case o :: Nil =>
+          // Science site quality is copied, but not the science target
+          assertTrue(siteQuality(o).exists(_.getCloudCover == ScienceTargetCC) &&
+                     target(o).exists(_.getBase.getTarget.getName == ScienceTargetName))
+        case _       =>
+          fail("Expected a single observation")
+      }
+    }
+  }
+}
+
+object InstantiationFunctorTest {
+    // The program factory interprets a null key as a request to create a new key
+  val WithSomeNewKey: SPNodeKey = null
+
+  val ScienceTargetName = "Biff"
+  val ScienceTargetCC   = CC50
+
+  def newTarget(name: String): SPTarget =
+    new SPTarget() <| (_.setName(name))
+
+  def newSiteQuality(cc: CloudCover): SPSiteQuality =
+    new SPSiteQuality() <| (_.setCloudCover(cc))
+
+  def newParameters(targetName: String, cc: CloudCover): TemplateParameters =
+    TemplateParameters.newInstance(newTarget(targetName), newSiteQuality(cc), new TimeValue(1, TimeValue.Units.hours))
+
+  def siteQuality(o: ISPObservation): Option[SPSiteQuality] =
+    obsComp[SPSiteQuality](o, SCHEDULING_CONDITIONS)
+
+  def target(o: ISPObservation): Option[TargetObsComp] =
+    obsComp[TargetObsComp](o, TELESCOPE_TARGETENV)
+
+  def obsComp[D: Manifest](o: ISPObservation, ct: SPComponentType): Option[D] =
+    o.getObsComponents.asScala.find { _.getType == ct }.map(_.getDataObject).collect {
+      case d: D => d
+    }
+}


### PR DESCRIPTION
A small requested change to the template instantiation functor.  It now copies science observing conditions for all observation classes except `DAY_CAL`.