### PR TITLE
OCSADV-466: Add an Unplot button to the Catalog Navigator

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/BasicTablePlotter.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/BasicTablePlotter.java
@@ -163,8 +163,8 @@ public class BasicTablePlotter
         final ListIterator<TableListItem> it = _tableList.listIterator(0);
         while (it.hasNext()) {
             final TableListItem item = it.next();
-            if (item.table == table || item.table.getName().equals(table.getName())) {
-                if (item.table.getCatalog() == table.getCatalog()) {
+            if (item.table.equals(table) || item.table.getName().equals(table.getName())) {
+                if (item.table.getCatalog().equals(table.getCatalog())) {
                     it.remove();
                     break;
                 }


### PR DESCRIPTION
Tiny PR, the bogus `==` check messes the state of plotted tables