### PR TITLE
REL-2407: temporarily remove progid and obsid filters

### DIFF
--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
@@ -45,10 +45,10 @@ object GsaRecordQuery {
       def url(filter: String): URL = new URL(s"$prefix/RAW/$filter")
 
       override def program(pid: SPProgramID): GsaResponse[List[GsaRecord]] =
-        GsaQuery.get(url(s"progid=${pid.stringValue}"))
+        GsaQuery.get(url(pid.stringValue))
 
       override def observation(oid: SPObservationID): GsaResponse[List[GsaRecord]] =
-        GsaQuery.get(url(s"obsid=${oid.stringValue}"))
+        GsaQuery.get(url(oid.stringValue))
 
       override def dataset(label: DatasetLabel): GsaResponse[Option[GsaRecord]] =
         GsaQuery.get[List[GsaRecord]](url(label.toString)).map(_.headOption)


### PR DESCRIPTION
Need to take out the `progid=` and `obsid=` filters until an issue with them can be clarified.  Removing for testing.