### PR TITLE
REL-2407-J: Minor Data Manager Updates

### DIFF
--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
@@ -72,12 +72,12 @@ object Dataman {
     val pollSummit   = GsaPollActions(config.summitHost, config.site, odb)
     val pollArchive  = GsaPollActions(config.archiveHost, config.site, odb)
 
-    val pollServices = List(pollSummit, pollArchive).map { pa =>
-      PollService(workerCount = 10) { id =>
+    val pollServices = List(("Summit", pollSummit), ("Archive", pollArchive)).map { case (name, act) =>
+      PollService(name, workerCount = 10) { id =>
         exec.now(id match {
-          case Prog(pid) => pa.program(pid)
-          case Obs(oid)  => pa.observation(oid)
-          case Dset(lab) => pa.dataset(lab)
+          case Prog(pid) => act.program(pid)
+          case Obs(oid)  => act.observation(oid)
+          case Dset(lab) => act.dataset(lab)
         })
       }
     }

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
@@ -71,18 +71,18 @@ object Dataman {
 
     val pollSummit   = GsaPollActions(config.summitHost, config.site, odb)
     val pollArchive  = GsaPollActions(config.archiveHost, config.site, odb)
-    val allPolls     = List(pollSummit, pollArchive)
 
-    val pollService  = PollService(workerCount = 25) { id =>
-      val actions = id match {
-        case Prog(pid) => allPolls.map(_.program(pid))
-        case Obs(oid)  => allPolls.map(_.observation(oid))
-        case Dset(lab) => allPolls.map(_.dataset(lab))
+    val pollServices = List(pollSummit, pollArchive).map { pa =>
+      PollService(workerCount = 10) { id =>
+        exec.now(id match {
+          case Prog(pid) => pa.program(pid)
+          case Obs(oid)  => pa.observation(oid)
+          case Dset(lab) => pa.dataset(lab)
+        })
       }
-      actions.foreach(exec.now)
     }
 
-    val progSync = new ProgramSyncRunnable(odb, User, pollService)
+    val progSync = new ProgramSyncRunnable(odb, User, pids => pollServices.foreach(_.addAll(pids)))
     val trigger  = new QaRequestTrigger(odb, (qaRequest: List[QaRequest]) => {
       exec.fork(obsLogAction.setQa(qaRequest))
     })
@@ -96,7 +96,7 @@ object Dataman {
 
     def shutdownNow(): Unit = {
       trigger.stop()
-      pollService.shutdown()
+      pollServices.foreach(_.shutdown())
       pool.shutdownNow()
     }
 
@@ -113,7 +113,10 @@ object Dataman {
       schedulePoll(pollArchive.thisWeek, config.thisWeekPeriod)
 
       schedule(progSync, progSyncDelay, config.allPeriod.time)
-      schedule(new ObsRefreshRunnable(odb, User, pollService), obsRefreshDelay, config.obsRefreshPeriod.time)
+      val orr = new ObsRefreshRunnable(odb, User, oids =>
+        pollServices.foreach(_.addAll(oids))
+      )
+      schedule(orr, obsRefreshDelay, config.obsRefreshPeriod.time)
       schedule(new RetryFailedRunnable(odb, User, retryMinDelay, exec), retryMinDelay.plusMillis(1), retryPeriod)
 
       trigger.start()

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsRefreshRunnable.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsRefreshRunnable.scala
@@ -1,6 +1,7 @@
 package edu.gemini.dataman.app
 
 import edu.gemini.dataman.core.DmanId
+import edu.gemini.dataman.core.DmanId.Obs
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.spModel.dataset.DataflowStatus.{Diverged, SummitOnly, UpdateInProgress, SyncPending}
 import edu.gemini.spModel.dataset.{DatasetLabel, DataflowStatus, DatasetRecord}
@@ -17,7 +18,7 @@ import scalaz._
 final class ObsRefreshRunnable(
               odb: IDBDatabaseService,
               user: java.util.Set[Principal],
-              pollService: PollService) extends Runnable {
+              refresh: List[Obs] => Unit) extends Runnable {
 
   private val Log = Logger.getLogger(getClass.getName)
 
@@ -42,7 +43,7 @@ final class ObsRefreshRunnable(
           val obs = obsIds(labs)
           val (prefix, suffix) = obs.splitAt(50)
           Log.info("Refreshing expected updates: " + prefix.mkString(", ") + (suffix.isEmpty ? "" | " ..."))
-          pollService.addAll(obs)
+          refresh(obs)
         }
       case -\/(f)   =>
         Log.log(Level.WARNING, f.explain, f.exception.orNull)

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/PollService.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/PollService.scala
@@ -129,7 +129,7 @@ object PollService {
 
   private val Log = Logger.getLogger(getClass.getName)
 
-  def apply(workerCount: Int)(poll: DmanId => Unit): PollService =
+  def apply(name: String, workerCount: Int)(poll: DmanId => Unit): PollService =
     new PollService {
       val queue = RequestQueue.empty()
 
@@ -160,8 +160,8 @@ object PollService {
       Log.info(s"Dataman startup PollService.")
 
       val workers = (0 until (workerCount max 1)).toList.map { n =>
-        val name = s"PollService Worker $n"
-        new Thread(new PollRunnable(name), name) {
+        val threadName = s"$name PollService Worker $n"
+        new Thread(new PollRunnable(threadName), threadName) {
           setPriority(Thread.NORM_PRIORITY - 1)
           setDaemon(true)
         }

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ProgramSyncRunnable.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ProgramSyncRunnable.scala
@@ -14,7 +14,7 @@ import scalaz._
 final class ProgramSyncRunnable(
               odb: IDBDatabaseService,
               user: java.util.Set[Principal],
-              poller: PollService) extends Runnable {
+              sync: List[Prog] => Unit) extends Runnable {
 
   private val Log = Logger.getLogger(getClass.getName)
 
@@ -22,7 +22,7 @@ final class ProgramSyncRunnable(
     PidFunctor.exec(odb, user) match {
       case \/-(pids) =>
         Log.info(s"Dataman synchronizing ${pids.length} programs.")
-        poller.addAll(pids.map(Prog))
+        sync(pids.map(Prog))
 
       case -\/(e)    =>
         Log.log(Level.WARNING, e.explain, e.exception.orNull)

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/core/DmanId.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/core/DmanId.scala
@@ -1,7 +1,7 @@
 package edu.gemini.dataman.core
 
 import edu.gemini.pot.sp.SPObservationID
-import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.core.{SPProgramID, catchingNonFatal}
 import edu.gemini.spModel.dataset.DatasetLabel
 
 import scalaz._
@@ -28,7 +28,7 @@ object DmanId {
 
   def parse(s: String): Option[DmanId] = {
     def parse[A](c: String => A): Option[A] =
-      \/.fromTryCatch { c(s) }.toOption
+      catchingNonFatal { c(s) }.toOption
 
     parse(s => Dset(new DatasetLabel(s)))     orElse
      parse(s => Obs(new SPObservationID(s)))  orElse

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/Activator.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/Activator.scala
@@ -3,6 +3,7 @@ package edu.gemini.dataman.osgi
 import edu.gemini.dataman.app.Dataman
 import edu.gemini.dataman.core.{PollPeriod, DmanConfig, GsaAuth, GsaHost}
 import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.spModel.core.catchingNonFatal
 import edu.gemini.spModel.core.osgi.SiteProperty
 import edu.gemini.util.osgi.Tracker
 import org.osgi.framework.{ServiceRegistration, BundleContext, BundleActivator}
@@ -91,7 +92,7 @@ object Activator {
 
     def lookupPollPeriod[A](name: String)(f: Duration => A): ValidationNel[String, A] =
       lookup(name).flatMap { timeString =>
-        \/.fromTryCatch(Duration.parse(timeString)).leftMap { _ =>
+        catchingNonFatal(Duration.parse(timeString)).leftMap { _ =>
           s"Couldn't parse $name property value '$timeString' as an ISO-8601 time duration."
         }.ensure(s"$name time value must be greater than zero.") { d =>
           !(d.isNegative || d.isZero)

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/GsaCommands.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/GsaCommands.scala
@@ -4,6 +4,7 @@ import edu.gemini.dataman.app.{DmanActionExec, GsaPollActions}
 import edu.gemini.dataman.core._
 import edu.gemini.dataman.query.{GsaRecordQuery, GsaQaUpdateQuery, GsaResponse, TimeFormat}
 import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.spModel.core.catchingNonFatal
 import edu.gemini.spModel.dataset.{DatasetQaState, DatasetLabel}
 
 import scalaz._
@@ -99,7 +100,7 @@ object GsaCommands {
         // Parse the arguments into List[GsaQaUpdate.Request] if possible.
         val requests = for {
           qa <- DatasetQaState.values.find(_.displayValue.toLowerCase == qaString.toLowerCase) \/> s"Could not parse `$qaString` as a QA state."
-          ls <- labelStrings.map { s => \/.fromTryCatch(new DatasetLabel(s)).leftMap(_ => s"Could not parse `$s` as a dataset label.") }.sequenceU
+          ls <- labelStrings.map { s => catchingNonFatal(new DatasetLabel(s)).leftMap(_ => s"Could not parse `$s` as a dataset label.") }.sequenceU
         } yield ls.map { lab => QaRequest(lab, qa) }
 
         // Send the update request to the server.

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaQuery.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaQuery.scala
@@ -2,6 +2,7 @@ package edu.gemini.dataman.query
 
 import edu.gemini.dataman.core.GsaAuth
 import edu.gemini.dataman.query.GsaQueryError._
+import edu.gemini.spModel.core.catchingNonFatal
 
 import argonaut._
 import Argonaut._
@@ -58,7 +59,7 @@ private[query] object GsaQuery {
     logIf(LogLevel) { s"Start GSA query: ${url.toString}" }
 
     val startTime = Instant.now()
-    val result    = \/.fromTryCatch { unsafeDoQuery[A](url, prep) }.fold({
+    val result    = catchingNonFatal { unsafeDoQuery[A](url, prep) }.fold({
       case io: IOException => IoException(io).left
       case t: Throwable    => Unexpected(t).left
     }, identity)

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/query/GsaRecordQuery.scala
@@ -45,10 +45,10 @@ object GsaRecordQuery {
       def url(filter: String): URL = new URL(s"$prefix/RAW/$filter")
 
       override def program(pid: SPProgramID): GsaResponse[List[GsaRecord]] =
-        GsaQuery.get(url(pid.stringValue))
+        GsaQuery.get(url(s"progid=${pid.stringValue}"))
 
       override def observation(oid: SPObservationID): GsaResponse[List[GsaRecord]] =
-        GsaQuery.get(url(oid.stringValue))
+        GsaQuery.get(url(s"obsid=${oid.stringValue}"))
 
       override def dataset(label: DatasetLabel): GsaResponse[Option[GsaRecord]] =
         GsaQuery.get[List[GsaRecord]](url(label.toString)).map(_.headOption)

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsRefreshRunnableSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsRefreshRunnableSpec.scala
@@ -1,0 +1,28 @@
+package edu.gemini.dataman.app
+
+import edu.gemini.dataman.core.DmanId.Obs
+import edu.gemini.spModel.dataset.DataflowStatus
+import edu.gemini.spModel.dataset.DataflowStatus.{Diverged, SummitOnly, UpdateInProgress, SyncPending}
+
+import scalaz._
+import Scalaz._
+
+object ObsRefreshRunnableSpec extends TestSupport {
+  "ObsRefreshRunnable" should {
+    "find all exepected updates" ! forAllPrograms { (odb, progs) =>
+
+      val expected = allDatasets(progs).filter { ds =>
+        DataflowStatus.derive(ds) match {
+          case SyncPending | UpdateInProgress | SummitOnly | Diverged => true
+          case _                                                      => false
+        }
+      }.map(_.label.getObservationId).distinct.map(Obs).toSet
+
+      var actual = Set.empty[Obs]
+      val orr = new ObsRefreshRunnable(odb, User, oids => actual = oids.toSet)
+      orr.run()
+
+      expected == actual
+    }
+  }
+}

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/PollServiceSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/PollServiceSpec.scala
@@ -135,7 +135,7 @@ object PollServiceSpec extends Specification with ScalaCheck with Arbitraries {
 
       val log = List.newBuilder[(DmanId, String)]
 
-      val ps = PollService(2) { id =>
+      val ps = PollService("Test", 2) { id =>
         Thread.`yield`()
         log.synchronized {
           log += ((id, Thread.currentThread().getName))

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/dataset/DatasetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/dataset/DatasetCodecs.scala
@@ -1,5 +1,6 @@
 package edu.gemini.spModel.dataset
 
+import edu.gemini.spModel.core.catchingNonFatal
 import edu.gemini.spModel.pio.xml.PioXmlFactory
 import edu.gemini.spModel.pio.{PioParseException, ParamSet, Param}
 import edu.gemini.spModel.pio.codec._
@@ -36,7 +37,7 @@ object DatasetCodecs {
         a.toParamSet(pf) <| (_.setName(key))
 
       def decode(ps: ParamSet): PioError \/ Dataset =
-        \/.fromTryCatch {
+        catchingNonFatal {
           new Dataset(ps)
         }.leftMap(ex => ParseError(ps.getName, ex.getMessage, "Dataset"))
     }
@@ -61,7 +62,7 @@ object DatasetCodecs {
 
       def decode(p: Param): PioError \/ Instant =
         ParamCodec[String].decode(p).flatMap { s =>
-          \/.fromTryCatch {
+          catchingNonFatal {
             dtf.parse(s, new TemporalQuery[Instant]() {
                         override def queryFrom(ta: TemporalAccessor): Instant = Instant.from(ta)
                       })
@@ -76,7 +77,7 @@ object DatasetCodecs {
 
       def decode(p: Param): PioError \/ UUID =
         ParamCodec[String].decode(p).flatMap { s =>
-          \/.fromTryCatch {
+          catchingNonFatal {
             UUID.fromString(s)
           }.leftMap(_ => ParseError(p.getName, s, "UUID"))
         }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/dataset/DatasetMd5.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/dataset/DatasetMd5.scala
@@ -1,5 +1,6 @@
 package edu.gemini.spModel.dataset
 
+import edu.gemini.spModel.core.catchingNonFatal
 import edu.gemini.spModel.pio.Param
 import edu.gemini.spModel.pio.codec.{ParseError, PioError, ParamCodec}
 
@@ -32,7 +33,7 @@ object DatasetMd5 {
   val empty = new DatasetMd5(Array.fill[Byte](16)(0))
 
   def parse(hexString: String): Option[DatasetMd5] =
-    \/.fromTryCatch {
+    catchingNonFatal {
       new DatasetMd5(DatatypeConverter.parseHexBinary(hexString))
     }.toOption
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
@@ -1,9 +1,21 @@
 package edu.gemini.spModel
 
+import scala.util.control.NonFatal
 import scalaz._, Scalaz._
 import scala.collection.immutable.NumericRange
 
 package object core {
+
+  /** Turns any non-fatal exceptions in the given block into lefts.
+    * This is the same as scalaz `\/.fromTryCatchNonFatal`, so we should
+    * switch to that at some point after we update to a newer version.
+    */
+  def catchingNonFatal[T](a: => T): Throwable \/ T =
+    try {
+      \/-(a)
+    } catch {
+      case NonFatal(t) => -\/(t)
+    }
 
   type RA = RightAscension
   val  RA = RightAscension
@@ -13,14 +25,14 @@ package object core {
 
   type Ephemeris = Long ==>> Coordinates
 
-  /** Operations for maps of types that we can interpolate.  We use these for Ephemerides. */ 
+  /** Operations for maps of types that we can interpolate.  We use these for Ephemerides. */
   implicit class MoreMapOps[K, V](m: K ==>> V)(implicit O: Order[K], I: Interpolate[K,V]) {
 
     /** Perform an exact or interpolated lookup. */
     def iLookup(k: K): Option[V] =
       m.lookup(k) match {
         case Some(v) => Some(v)
-        case None    => 
+        case None    =>
           val (lt, gt) = m.split(k)
           for {
             a <- lt.findMax
@@ -31,7 +43,7 @@ package object core {
 
     /** Construct an exact or interpolated slice. */
     def iSlice(lo: K, hi: K): Option[K ==>> V] =
-      ^(iLookup(lo), iLookup(hi)) { (lov, hiv) => 
+      ^(iLookup(lo), iLookup(hi)) { (lov, hiv) =>
         m.trim(O(_, lo), O(_, hi)) + (lo -> lov) + (hi -> hiv)
       }
 


### PR DESCRIPTION
Three updates:

1. Split the thread pool that polls the summit and archive in two.  One half dedicated to the summit polling and one half to the public archive.  Since the network is so sketchy at GS, the public archive link is likely to be slow and unreliable and I don't think that should impact the relatively more important summit poll.

2. Resume filtering with the `progid=` and `obsid=` feature of the archive server.  This should allow us to put all non-standard program ids back in the test database.

3. Don't eat `java.lang.InterruptedException`. `\/.fromTryCatch` catches non-fatal exceptions, including `InterruptedException`.  Interrupts are sent to threads to stop them. Catching `InterruptedException` prevents the thread from stopping normally.  Switched `\/.fromTryCatch` for the same implementation used in a later version of scalaz, in `\/.fromTryCatchNonFatal`.  Also, rethrow the `InterruptedException` caught by `Task.attemptRun`.