### PR TITLE
REL-2515 leaky listeners

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/WatchablePos.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/WatchablePos.java
@@ -1,43 +1,32 @@
 package edu.gemini.spModel.target;
 
 import java.io.Serializable;
-import java.util.Vector;
+import java.util.Set;
+import java.util.HashSet;
 
 public class WatchablePos implements Cloneable, Serializable {
 
-    private transient Vector<TelescopePosWatcher> _watchers;
+    private transient Set<TelescopePosWatcher> _watchers;
 
-    public final synchronized void addWatcher(final TelescopePosWatcher tpw) {
+    public final synchronized boolean addWatcher(final TelescopePosWatcher tpw) {
         if (_watchers == null) {
-            _watchers = new Vector<>();
-        } else if (_watchers.contains(tpw)) {
-            return;
+            _watchers = new HashSet<>();
         }
-        _watchers.addElement(tpw);
+        return _watchers.add(tpw);
     }
 
-    public final synchronized void deleteWatcher(final TelescopePosWatcher tpw) {
-        if (_watchers == null) {
-            return;
-        }
-        _watchers.removeElement(tpw);
+    public final synchronized boolean deleteWatcher(final TelescopePosWatcher tpw) {
+        return _watchers != null && _watchers.remove(tpw);
     }
 
-    protected final synchronized Vector _getWatchers() {
-        if (_watchers == null) {
-            return null;
-        }
-
-        return (Vector) _watchers.clone();
+    public final synchronized Set<TelescopePosWatcher> getWatchers() {
+        return _watchers == null ? null : new HashSet<>(_watchers);
     }
 
     protected final void _notifyOfUpdate() {
-        final Vector v = _getWatchers();
-        if (v == null) return;
-        for (int i = 0; i < v.size(); ++i) {
-            final TelescopePosWatcher tpw;
-            tpw = (TelescopePosWatcher) v.elementAt(i);
-            tpw.telescopePosUpdate(this);
+        final Set<TelescopePosWatcher> v = getWatchers();
+        if (v != null) {
+            v.forEach(tpw -> tpw.telescopePosUpdate(this));
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -64,6 +64,7 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
         super(SP_TYPE);
         setVersion(_VERSION);
         targetEnv = createEmptyEnvironment();
+        watchTargets();
     }
 
 
@@ -115,6 +116,7 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
         if (targetEnv == envNotNull) return;
 
         final TargetEnvironment orig = targetEnv;
+        unwatchTargets();
         targetEnv = envNotNull;
         watchTargets();
 
@@ -122,9 +124,14 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
         firePropertyChange(TARGET_ENV_PROP, orig, targetEnv);
     }
 
-    private void watchTargets() {
+    private void unwatchTargets() {
         targetEnv.getTargets().foreach(target -> {
             target.deleteWatcher(prop);
+        });
+    }
+
+    private void watchTargets() {
+        targetEnv.getTargets().foreach(target -> {
             target.addWatcher(prop);
         });
     }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/obsComp/TargetObsCompSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/obsComp/TargetObsCompSpec.scala
@@ -1,0 +1,27 @@
+package edu.gemini.spModel.target.obsComp
+
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.TargetEnvironment
+import org.specs2.mutable.Specification
+
+class TargetObsCompSpec extends Specification {
+
+  "TargetObsComp" should {
+
+    "Add listener on construction" in {
+      val toc  = new TargetObsComp
+      val base = toc.getBase
+      base.getWatchers.size must_== 1
+    }
+
+    "Remove listener when the TargetEnvironment is updated" in {
+      val toc  = new TargetObsComp
+      val base = toc.getBase
+      toc.setTargetEnvironment(TargetEnvironment.create(new SPTarget))
+      base.getWatchers.size must_== 0
+    }
+
+  }
+
+}
+


### PR DESCRIPTION
`TargetObsComp` listens to change events on its contained `SPTargets` but these listeners were not removed when the target environment was updated. This led to out of control leakage during target editing. Fixed that and made `WatchablePos` slightly less idiotic. 