### PR TITLE
REL-2167: GNIRS P2 check for Decker / Acquisition Mirror

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gnirs/GnirsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gnirs/GnirsRule.java
@@ -387,7 +387,7 @@ public class GnirsRule implements IRule {
      */
     private static IConfigRule DECKER_ACQ_MIRROR_OUT_RULE = new IConfigRule() {
         private final static String NAME = "M_DECKER_ACQ_MIRROR_OUT";
-        private final static String M_DECKER_ACQ_OUT = "The Decker is set to acquisition but the Acquisition Mirror is out.";
+        private final static String M_DECKER_ACQ_MIRROR_OUT = "The Decker is set to acquisition but the Acquisition Mirror is out.";
 
         @Override
         public Problem check(final Config config, final int step, final ObservationElements elems, final Object state) {
@@ -395,7 +395,7 @@ public class GnirsRule implements IRule {
             final GNIRSParams.AcquisitionMirror mirror =
                     ((GNIRSParams.AcquisitionMirror) SequenceRule.getInstrumentItem(config, InstGNIRS.ACQUISITION_MIRROR_PROP));
             if (mirror == AcquisitionMirror.OUT && decker == Decker.ACQUISITION)
-                return new Problem(WARNING, PREFIX + NAME, M_DECKER_ACQ_OUT, elems.getSeqComponentNode());
+                return new Problem(WARNING, PREFIX + NAME, M_DECKER_ACQ_MIRROR_OUT, elems.getSeqComponentNode());
             return null;
         }
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gnirs/GnirsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gnirs/GnirsRule.java
@@ -391,8 +391,12 @@ public class GnirsRule implements IRule {
 
         @Override
         public Problem check(Config config, int step, ObservationElements elems, Object state) {
-            final InstGNIRS inst = (InstGNIRS) elems.getInstrument();
-            if (inst.getAcquisitionMirror() == AcquisitionMirror.OUT && inst.getDecker() == Decker.ACQUISITION)
+            //final InstGNIRS inst = (InstGNIRS) elems.getInstrument();
+            final GNIRSParams.Decker decker = ((GNIRSParams.Decker) SequenceRule.getInstrumentItem(config, InstGNIRS.DECKER_PROP));
+            final GNIRSParams.AcquisitionMirror mirror =
+                    ((GNIRSParams.AcquisitionMirror) SequenceRule.getInstrumentItem(config, InstGNIRS.ACQUISITION_MIRROR_PROP));
+            //if (inst.getAcquisitionMirror() == AcquisitionMirror.OUT && inst.getDecker() == Decker.ACQUISITION)
+            if (mirror == AcquisitionMirror.OUT && decker == Decker.ACQUISITION)
                 return new Problem(WARNING, PREFIX + NAME, M_DECKER_ACQ_OUT, SequenceRule.getInstrumentOrSequenceNode(step, elems));
             return null;
         }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gnirs/GnirsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gnirs/GnirsRule.java
@@ -385,19 +385,17 @@ public class GnirsRule implements IRule {
     /**
      * REL-2167: Warn if acq mirror is out and decker is acq.
      */
-    private static IConfigRule DECKER_ACQ_MIRROR_OUT = new IConfigRule() {
-        private final static String NAME = "M_DECKER_ACQ_OUT";
+    private static IConfigRule DECKER_ACQ_MIRROR_OUT_RULE = new IConfigRule() {
+        private final static String NAME = "M_DECKER_ACQ_MIRROR_OUT";
         private final static String M_DECKER_ACQ_OUT = "The Decker is set to acquisition but the Acquisition Mirror is out.";
 
         @Override
-        public Problem check(Config config, int step, ObservationElements elems, Object state) {
-            //final InstGNIRS inst = (InstGNIRS) elems.getInstrument();
+        public Problem check(final Config config, final int step, final ObservationElements elems, final Object state) {
             final GNIRSParams.Decker decker = ((GNIRSParams.Decker) SequenceRule.getInstrumentItem(config, InstGNIRS.DECKER_PROP));
             final GNIRSParams.AcquisitionMirror mirror =
                     ((GNIRSParams.AcquisitionMirror) SequenceRule.getInstrumentItem(config, InstGNIRS.ACQUISITION_MIRROR_PROP));
-            //if (inst.getAcquisitionMirror() == AcquisitionMirror.OUT && inst.getDecker() == Decker.ACQUISITION)
             if (mirror == AcquisitionMirror.OUT && decker == Decker.ACQUISITION)
-                return new Problem(WARNING, PREFIX + NAME, M_DECKER_ACQ_OUT, SequenceRule.getInstrumentOrSequenceNode(step, elems));
+                return new Problem(WARNING, PREFIX + NAME, M_DECKER_ACQ_OUT, elems.getSeqComponentNode());
             return null;
         }
 
@@ -426,7 +424,7 @@ public class GnirsRule implements IRule {
         GNIRS_RULES.add(ACQUISITION_FILTER_RULE);
         GNIRS_RULES.add(ALTAIR_RULE);
         GNIRS_RULES.add(NO_P_OFFSETS_WITH_SLIT_SPECTROSCOPY_RULE);
-        GNIRS_RULES.add(DECKER_ACQ_MIRROR_OUT);
+        GNIRS_RULES.add(DECKER_ACQ_MIRROR_OUT_RULE);
     }
 
     public IP2Problems check(final ObservationElements elements)  {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/config2/ItemKey.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/config2/ItemKey.java
@@ -46,7 +46,7 @@ public final class ItemKey implements Comparable, Serializable {
      *
      * @param path encoded hierarchy of config key names (or a single root
      * config key name); names may not contain the {@link #SEPARATOR_CHAR}
-     * since this will be interpeted as a separator between two distinct
+     * since this will be interpreted as a separator between two distinct
      * names
      */
     public ItemKey(String path) {


### PR DESCRIPTION
We want to generate a warning for GNIRS when the Decker is set to Acquisition Mirror and the acquisition mirror is Out.

Previously, I was looking at the instrument node for the settings for decker and acquisition mirror.
The decker, however, is never changed in the instrument node (why it is included here, I don't know, since this seems unused), and can only be set in GNIRS sequence items.

If not set in the sequence items, it is inferred to be "empty" by SeqExec and set to something other than Acquisition Mirror based on other parameters.

Thus, now the P2 check examines the sequence instead of the instrument configuration to properly generate the warning.

(Also fixed a spelling error in comments in `ItemKey`.)