### PR TITLE
REL-2552:UI pause when changing conditions in Catalog Query Tool

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
@@ -34,10 +34,10 @@ object CatalogQueryDemo extends SwingApplication {
 
     UIManager.put("Button.defaultButtonFollowsFocus", true)
 
-    val ra = Angle.fromHMS(0, 12, 30.286).getOrElse(Angle.zero)
-    val dec = Declination.fromAngle(Angle.zero - Angle.fromDMS(22, 4, 2.34).getOrElse(Angle.zero)).getOrElse(Declination.zero)
+    val ra = Angle.fromHMS(16, 17, 2.410).getOrElse(Angle.zero)
+    val dec = Declination.fromAngle(Angle.zero - Angle.fromDMS(22, 58, 33.888).getOrElse(Angle.zero)).getOrElse(Declination.zero)
     val guiders = Set[GuideProbe](NiriOiwfsGuideProbe.instance, PwfsGuideProbe.pwfs1, PwfsGuideProbe.pwfs2)
-    val target = new SPTarget(ra.toDegrees, dec.toDegrees) <| {_.setName("HIP 1000")}
+    val target = new SPTarget(ra.toDegrees, dec.toDegrees) <| {_.setName("Messier 80")}
     val env = TargetEnvironment.create(target)
     val inst = new InstNIRI <| {_.setPosAngle(0.0)}
 

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -429,10 +429,12 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           foreground = originalConditions.map(_.sb).exists(_ == selection.item) ? Color.black | Color.red
           resultsTable.model match {
             case t: TargetsModel =>
-              unplotCurrent()
-              updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.sb(selection.item))))))
-              plotResults()
-              updateGuideSpeedText()
+              Swing.onEDT {
+                unplotCurrent()
+                updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.sb(selection.item))))))
+                plotResults()
+                updateGuideSpeedText()
+              }
           }
       }
 
@@ -447,10 +449,12 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           foreground = originalConditions.map(_.cc).exists(_ == selection.item) ? Color.black | Color.red
           resultsTable.model match {
             case t: TargetsModel =>
-              unplotCurrent()
-              updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.cc(selection.item))))))
-              plotResults()
-              updateGuideSpeedText()
+              Swing.onEDT {
+                unplotCurrent()
+                updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.cc(selection.item))))))
+                plotResults()
+                updateGuideSpeedText()
+              }
           }
       }
 
@@ -465,10 +469,12 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           foreground = originalConditions.map(_.iq).exists(_ == selection.item) ? Color.black | Color.red
           resultsTable.model match {
             case t: TargetsModel =>
-              unplotCurrent()
-              updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.iq(selection.item))))))
-              plotResults()
-              updateGuideSpeedText()
+              Swing.onEDT {
+                unplotCurrent()
+                updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.iq(selection.item))))))
+                plotResults()
+                updateGuideSpeedText()
+              }
           }
       }
 


### PR DESCRIPTION
Refreshing the table model during a conditions change may take some time and block the UI. This PR moves the table model update and replotting to be executed on the swing thread outside the event loop