### PR TITLE
REL-2143: Change cut-off semester for "no E2V rule for GS"

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gmos/GmosRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gmos/GmosRule.java
@@ -1243,15 +1243,15 @@ public final class GmosRule implements IRule {
     }
 
     /**
-     * ERROR: If GMOS-S is used with E2V after semester 2015B.
+     * ERROR: If GMOS-S is used with E2V after semester 2014A.
      * This can happen when PIs copy parts of old programs into new ones. PIs will not be able to change the detector
      * settings themselves and will have to have a staff member help them. This is not ideal, but since this is only
      * a transitional problem this seems to be the simplest solution.
      * (Note that very soon we will have to apply this rule to GMOS-N, too.)
      */
-    private static final Semester SEMESTER_2015B = new Semester(2015, Semester.Half.B);
-    private static IConfigRule POST_2015B_GMOS_S_WITH_E2V = new AbstractConfigRule() {
-        private static final String msg = "Starting with 2016A GMOS-S must use the Hamamatsu CCDs. Please create a new observation or ask your contact scientist to update the CCD settings.";
+    private static final Semester SEMESTER_2014A = new Semester(2014, Semester.Half.A);
+    private static IConfigRule POST_2014A_GMOS_S_WITH_E2V = new AbstractConfigRule() {
+        private static final String msg = "Starting with 2014B GMOS-S must use the Hamamatsu CCDs. Please create a new observation or ask your contact scientist to update the CCD settings.";
 
         private Option<Semester> semester(final ObservationElements elems) {
             return Optional.ofNullable(elems)                       // null safe access chain
@@ -1262,8 +1262,7 @@ public final class GmosRule implements IRule {
                     .orElse(Option.empty());                        // turn the Java None result into a Scala None
         }
 
-        @Override
-        public Problem check(Config config, int step, ObservationElements elems, Object state) {
+        @Override public Problem check(Config config, int step, ObservationElements elems, Object state) {
             // apply this rule to GMOS-S
             final SPInstObsComp instrument = elems.getInstrument();
             if (instrument.getType() == InstGmosSouth.SP_TYPE) {
@@ -1271,11 +1270,11 @@ public final class GmosRule implements IRule {
                 final Option<Semester> semester = semester(elems);
                 if (semester.isDefined()) {
                     // apply it to observations for 2016A or later
-                    if (semester.get().compareTo(SEMESTER_2015B) > 0) {
+                    if (semester.get().compareTo(SEMESTER_2014A) > 0) {
                         // apply if E2V is selected
                         final DetectorManufacturer ccd = ((InstGmosSouth) instrument).getDetectorManufacturer();
                         if (ccd == DetectorManufacturer.E2V) {
-                            return new Problem(ERROR, PREFIX + "POST_2015B_GMOS_S_WITH_E2V_RULE", msg, SequenceRule.getInstrumentOrSequenceNode(step, elems));
+                            return new Problem(ERROR, PREFIX + "POST_2014A_GMOS_S_WITH_E2V_RULE", msg, SequenceRule.getInstrumentOrSequenceNode(step, elems));
                         }
                     }
                 }
@@ -1896,7 +1895,7 @@ public final class GmosRule implements IRule {
         GMOS_RULES.add(NO_P_OFFSETS_WITH_SLIT_SPECTROSCOPY_RULE);
         GMOS_RULES.add(new MdfMaskNameRule(Problem.Type.ERROR));
         GMOS_RULES.add(new MdfMaskNameRule(Problem.Type.WARNING));
-        GMOS_RULES.add(POST_2015B_GMOS_S_WITH_E2V);
+        GMOS_RULES.add(POST_2014A_GMOS_S_WITH_E2V);
     }
 
     public IP2Problems check(ObservationElements elems) {

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/GmosSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/GmosSpec.scala
@@ -11,14 +11,14 @@ final class GmosSpec extends RuleSpec {
 
   val ruleSet = new GmosRule()
 
-  // === REL-2143: Don't allow E2V CCDs for GMOS-S programs after 2015B.
+  // === REL-2143: Don't allow E2V CCDs for GMOS-S programs after 2014A.
 
-  "No E2V for GMOS-S after 2015B rule" should {
+  "No E2V for GMOS-S after 2014A rule" should {
 
     import GmosCommonType.DetectorManufacturer._
     import SPComponentType._
 
-    val E2VErrId = "GmosRule_POST_2015B_GMOS_S_WITH_E2V_RULE"
+    val E2VErrId = "GmosRule_POST_2014A_GMOS_S_WITH_E2V_RULE"
 
     "give no error for unknown semester with E2V" in {
       expectNoneOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH) { d =>
@@ -32,14 +32,14 @@ final class GmosSpec extends RuleSpec {
       }}
     }
 
-    "give no error for semester 2015B with E2V" in {
-      expectNoneOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-2015B-Q-34") { d =>
+    "give no error for semester 2014A with E2V" in {
+      expectNoneOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-2014A-Q-34") { d =>
         d.setDetectorManufacturer(E2V)
       }}
     }
 
-    "give an error for semester 2016A with E2V" in {
-      expectAllOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-2016A-Q-34") { d =>
+    "give an error for semester 2014B with E2V" in {
+      expectAllOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-2014B-Q-34") { d =>
         d.setDetectorManufacturer(E2V)
       }}
     }
@@ -50,14 +50,26 @@ final class GmosSpec extends RuleSpec {
       }}
     }
 
-    "give no error for semester 2017A with Hamamatsu" in {
-      expectNoneOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-2017A-Q-34") { d =>
+    "give an error for calibration for semester 2015A with E2V" in {
+      expectAllOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-CAL20150613") { d =>
+        d.setDetectorManufacturer(E2V)
+      }}
+    }
+
+    "give an error for engineering for semester 2015A with E2V" in {
+      expectAllOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-ENG20150222") { d =>
+        d.setDetectorManufacturer(E2V)
+      }}
+    }
+
+    "give no error for semester 2015A with Hamamatsu" in {
+      expectNoneOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH, "GS-2015A-Q-34") { d =>
         d.setDetectorManufacturer(HAMAMATSU)
       }}
     }
 
-    "not affect GMOS-N for semester 2016A with E2V" in {
-      expectNoneOf(E2VErrId) { setup[InstGmosNorth](INSTRUMENT_GMOS, "GN-2016A-Q-34") { d =>
+    "not affect GMOS-N for semester 2015A with E2V" in {
+      expectNoneOf(E2VErrId) { setup[InstGmosNorth](INSTRUMENT_GMOS, "GN-2015A-Q-34") { d =>
         d.setDetectorManufacturer(E2V)
       }}
     }


### PR DESCRIPTION
Cut off date has been changed to 2014A, i.e. GMOS-S must use Hamamatsu for 2014B and later. Added test cases to make sure that error is also given for ENG and CAL programs.