### PR TITLE
Bugfix: Change Error to RuntimeException

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -297,7 +297,7 @@ public abstract class Gmos extends Instrument implements BinningProvider {
             }
 
             if (isIfu2() && gp.ccdType() == GmosCommonType.DetectorManufacturer.HAMAMATSU) {
-                throw new Error("Currently IFU-2 is not supported for Hamamatsu CCD.");
+                throw new RuntimeException("Currently IFU-2 is not supported for Hamamatsu CCD.");
             }
         }
 


### PR DESCRIPTION
Change Error to RuntimeException to have it displayed on the web result page.