### PR TITLE
REL-2557: OT memory leak?

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -415,10 +415,8 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         get(originalConditions) match {
           case Some(i) if i.compareTo(a) != 0 =>
             component.foreground = Color.red
-            foreground = Color.red
           case _                             =>
             component.foreground = Color.black
-            foreground = Color.black
         }
       }
     }


### PR DESCRIPTION
This PR fixes a bug on the way a combo box is rendered, the extra foreground call makes Swing to call the rendering method over and over leading to a CPU spike.