### PR TITLE
OCSADV-498: Display multiple IFU plots vertically in OT

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -94,6 +94,12 @@ object ChartAxis {
   def apply(label: String) = new ChartAxis(label)
 }
 
+/** Multiple charts can be grouped.
+  * This is for example useful to stack IFU results for different offsets on top of each other in the OT.
+  * (At a later stage we maybe also want to add group labels like IFU offsets etc instead of repeating that
+  * information in every chart title.)*/
+final case class SpcChartGroup(charts: List[SpcChartData])
+
 /** Charts are made up of a set of data series which are all plotted in the same XY-plot. */
 final case class SpcChartData(chartType: SpcChartType, title: String, xAxis: ChartAxis, yAxis: ChartAxis, series: List[SpcSeriesData], axes: List[ChartAxis] = List()) {
   // JFreeChart requires a unique name for each series
@@ -106,16 +112,16 @@ final case class SpcChartData(chartType: SpcChartType, title: String, xAxis: Cha
   def allSeriesAsJava(t: SpcDataType): java.util.List[SpcSeriesData] = series.filter(_.dataType == t)
 }
 
-/** The result of a spectroscopy ITC calculation is some numbers per CCD and a set of charts.
-  * Individual charts and data series can be referenced by their types and an index. For most instruments there
-  * is only one chart and data series of each type, however for NIFS for example there will be several charts
-  * of each type in case of multiple IFU elements. */
-final case class ItcSpectroscopyResult(ccds: List[ItcCcd], charts: List[SpcChartData]) extends ItcResult {
+/** The result of a spectroscopy ITC calculation contains some numbers per CCD and a set of groups of charts.
+  * Individual charts and data series can be referenced by their types and group index. For most instruments there
+  * is only one chart and data series of each type, however for NIFS and GMOS there will be several charts
+  * of each type for each IFU element. */
+final case class ItcSpectroscopyResult(ccds: List[ItcCcd], chartGroups: List[SpcChartGroup]) extends ItcResult {
 
-  /** Gets chart data by type and index.
+  /** Gets chart data by type and its group index.
     * This method will fail if the result you're looking for does not exist.
     */
-  def chart(t: SpcChartType, i: Int = 0): SpcChartData      = charts.filter(_.chartType == t)(i)
+  def chart(t: SpcChartType, i: Int = 0): SpcChartData = chartGroups(i).charts.filter(_.chartType == t).head
 
   /** Gets all data series by chart type and data type.
     * This method will fail if the result (chart/data) you're looking for does not exist.

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -45,19 +45,21 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
     }
 
     public ItcSpectroscopyResult serviceResult(final SpectroscopyResult[] r) {
-        final List<SpcChartData> dataSets = new ArrayList<SpcChartData>() {{
-            // The array specS2N models the different IFUs, for each one we produce a separate set of charts.
-            // For completeness: The result array holds the results for the different CCDs. For each CCD
-            // the specS2N array holds the single result or the different IFU results. This needs to be modelled differently..
-            for (int i = 0; i < r[0].specS2N().length; i++) {
-                add(createSignalChart(r, i));
-                add(createS2NChart(r, i));
-                if (((Gmos) r[0].instrument()).isIfu2()) {
-                    add(createSignalPixelChart(r, i));
-                }
+        final List<List<SpcChartData>> groups = new ArrayList<>();
+        // The array specS2N represents the different IFUs, for each one we produce a separate set of charts.
+        // For completeness: The result array holds the results for the different CCDs. For each CCD
+        // the specS2N array holds the single result or the different IFU results. This should be made more obvious.
+        for (int i = 0; i < r[0].specS2N().length; i++) {
+            final List<SpcChartData> charts = new ArrayList<>();
+            charts.add(createSignalChart(r, i));
+            charts.add(createS2NChart(r, i));
+            // IFU-2 case has an additional chart with signal in pixel space
+            if (((Gmos) r[0].instrument()).isIfu2()) {
+                charts.add(createSignalPixelChart(r, i));
             }
-        }};
-        return Recipe$.MODULE$.serviceResult(r, dataSets);
+            groups.add(charts);
+        }
+        return Recipe$.MODULE$.serviceGroupedResult(r, groups);
     }
 
     public SpectroscopyResult[] calculateSpectroscopy() {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -51,13 +51,15 @@ public final class NifsRecipe implements SpectroscopyRecipe {
      * Performs recipe calculation.
      */
     public ItcSpectroscopyResult serviceResult(final SpectroscopyResult r) {
-        final List<SpcChartData> dataSets = new ArrayList<>();
+        final List<List<SpcChartData>> groups = new ArrayList<>();
         // The array specS2N models the different IFUs, for each one we produce a separate output.
         for (int i = 0; i < r.specS2N().length; i++) {
-            dataSets.add(createNifsSignalChart(r, i));
-            dataSets.add(createNifsS2NChart(r, i));
+            final List<SpcChartData> charts = new ArrayList<>();
+            charts.add(createNifsSignalChart(r, i));
+            charts.add(createNifsS2NChart(r, i));
+            groups.add(charts);
         }
-        return Recipe$.MODULE$.serviceResult(r, dataSets);
+        return Recipe$.MODULE$.serviceGroupedResult(r, groups);
     }
 
     public SpectroscopyResult calculateSpectroscopy() {


### PR DESCRIPTION
This is a layout change that should make it easier for users to check the charts that are generated for ITC calculations with multiple IFU elements for GMOS and NIFS.

For each IFU element ITC creates a set of charts. These are currently all displayed horizontally in the OT which is cumbersome if there are many IFU elements. This PR changes this by allowing charts to be grouped (in this case per IFU element) and then display the charts for each group (IFU element) stacked vertically instead of horizontally.

Example: GMOS-N with multiple IFU elements, results per IFU element stacked vertically in the OT:

![image](https://cloud.githubusercontent.com/assets/7856060/11354949/a75e2a4e-91f4-11e5-93bd-3e6161dc24bb.png)
