### PR TITLE
REL-2559: Don't show CC90 in Cloud Cover menu

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -441,7 +441,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
       override def text(a: SPSiteQuality.SkyBackground) = a.displayValue()
     }
-    lazy val ccBox = new ComboBox(List(SPSiteQuality.CloudCover.values(): _*)) with TextRenderer[SPSiteQuality.CloudCover] {
+    lazy val ccBox = new ComboBox(List(SPSiteQuality.CloudCover.values().filter(!_.isObsolete): _*)) with TextRenderer[SPSiteQuality.CloudCover] {
       renderer = conditionsRenderer(_.map(_.cc), this)
 
       listenTo(selection)


### PR DESCRIPTION
This PR hides the obsolete Cloud Cover modes on the Catalog Query Tool