### PR TITLE
REL-2560: ODB telnet settings

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -155,8 +155,10 @@ def with_gogo(version: Version) = AppConfig(
 def with_remote_gogo(version: Version) = AppConfig(
   id = "with-remote-gogo",
   props = Map(
-    "gosh.args"              -> "--nointeractive",
-    "osgi.shell.telnet.port" -> "8224"
+    "gosh.args"                       -> "--nointeractive",
+    "osgi.shell.telnet.port"          -> "8224",
+    "osgi.shell.telnet.maxconn"       -> "4",
+    "osgi.shell.telnet.socketTimeout" -> "30000"
   ),
   bundles = List(
     BundleSpec(10, "org.apache.felix.shell.remote", Version(1, 1, 2))


### PR DESCRIPTION
We ran into an issue this morning where two telnet connections were closed on the client end, but still maintained / blocked on the ODB server, and as the default settings of no timeout and only allowing two active telnet connections, we could not access the ODB through telnet.

This tiny PR increases the number of maximum allowed telnet connections and sets a timeout for blocking reads to prevent this problem in the future.