### PR TITLE
REL-2558: Fixes problem with F2 Skeleton

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/xjb/Flamingos2.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/Flamingos2.xjb
@@ -22,7 +22,7 @@
             <jxb:bindings node="./xsd:enumeration[@value='Ks (2.157 um)']">
                 <jxb:typesafeEnumMember name="K_SHORT"/>
             </jxb:bindings>
-            <jxb:bindings node="./xsd:enumeration[@value='K-long (2.20 um)']">
+            <jxb:bindings node="./xsd:enumeration[@value='K-long (2.00 um)']">
                 <jxb:typesafeEnumMember name="K_LONG"/>
             </jxb:bindings>
             <jxb:bindings node="./xsd:enumeration[@value='JH (1.390 um)']">

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Flamingos2.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Flamingos2.xsd
@@ -87,7 +87,7 @@
             <xsd:enumeration value="J-lo (1.122 um)"/>
             <xsd:enumeration value="J (1.255 um)"/>
             <xsd:enumeration value="H (1.631 um)"/>
-            <xsd:enumeration value="K-long (2.20 um)"/>
+            <xsd:enumeration value="K-long (2.00 um)"/>
             <xsd:enumeration value="Ks (2.157 um)"/>
             <xsd:enumeration value="JH (1.390 um)"/>
             <xsd:enumeration value="HK (1.871 um)"/>


### PR DESCRIPTION
This PR removes the changes made to the Phase 1 Model to update the label names for the F2 K-Long Filter. The reason to remove these is that this will make existing Phase 1 documents to generate errors when skeletons are generated in December. The changes to the OT display values are preserved. This was tested with a P1 document sent by Andy and works okay now 

These changes should be added at the same time we release a new version of the PIT in March, if we really want to keep the names of the filters updated in the PIT. 