### PR TITLE
REL-2562: Speed improvements to Catalog Query Tool for larger sets

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
@@ -2,8 +2,8 @@ package edu.gemini.catalog.ui
 
 import javax.swing.UIManager
 
-import edu.gemini.catalog.api._
 import edu.gemini.spModel.core._
+import edu.gemini.spModel.gemini.gmos.{GmosOiwfsGuideProbe, InstGmosSouth}
 import edu.gemini.spModel.obs.context.ObsContext
 
 import scala.swing.SwingApplication
@@ -25,8 +25,6 @@ object CatalogQueryDemo extends SwingApplication {
   import edu.gemini.spModel.target.obsComp.PwfsGuideProbe
   import jsky.util.gui.Theme
 
-  val query = CatalogQuery(Coordinates(RightAscension.fromAngle(Angle.fromDegrees(3.1261166666666895)),Declination.fromAngle(Angle.fromDegrees(337.93268333333333)).getOrElse(Declination.zero)),RadiusConstraint.between(Angle.zero,Angle.fromDegrees(0.16459874517619255)),List(MagnitudeConstraints(RBandsList,FaintnessConstraint(16.0),Some(SaturationConstraint(3.1999999999999993)))),UCAC4)
-
   def startup(args: Array[String]) {
     System.setProperty("apple.awt.antialiasing", "on")
     System.setProperty("apple.awt.textantialiasing", "on")
@@ -34,12 +32,12 @@ object CatalogQueryDemo extends SwingApplication {
 
     UIManager.put("Button.defaultButtonFollowsFocus", true)
 
-    val ra = Angle.fromHMS(16, 17, 2.410).getOrElse(Angle.zero)
-    val dec = Declination.fromAngle(Angle.zero - Angle.fromDMS(22, 58, 33.888).getOrElse(Angle.zero)).getOrElse(Declination.zero)
-    val guiders = Set[GuideProbe](NiriOiwfsGuideProbe.instance, PwfsGuideProbe.pwfs1, PwfsGuideProbe.pwfs2)
+    val ra = Angle.fromHMS(20, 34, 11.369).getOrElse(Angle.zero)
+    val dec = Declination.fromAngle(Angle.fromDMS(7, 24, 16.092).getOrElse(Angle.zero)).getOrElse(Declination.zero)
+    val guiders = Set[GuideProbe](GmosOiwfsGuideProbe.instance, PwfsGuideProbe.pwfs1, PwfsGuideProbe.pwfs2)
     val target = new SPTarget(ra.toDegrees, dec.toDegrees) <| {_.setName("Messier 80")}
     val env = TargetEnvironment.create(target)
-    val inst = new InstNIRI <| {_.setPosAngle(0.0)}
+    val inst = new InstGmosSouth <| {_.setPosAngle(0.0)}
 
     val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.PERCENT_80).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
     val ctx = ObsContext.create(env, inst, new JSome(Site.GN), conditions, null, null, JNone.instance())

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -55,12 +55,17 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     override val flipAction = "Plot"
   }
 
+  private object GuidingFeedbackRenderer {
+    val icons = AgsGuideQuality.All.map(q => q -> GuidingIcon(q, enabled = true)).toMap
+    val dimensions = new Dimension(GuidingIcon.sideLength + 2, GuidingIcon.sideLength + 2)
+  }
+
   private class GuidingFeedbackRenderer extends Table.AbstractRenderer[AgsGuideQuality, Label](new Label) {
     override def configure(t: Table, sel: Boolean, foc: Boolean, value: AgsGuideQuality, row: Int, col: Int): Unit = {
-      component.icon = GuidingIcon(value, enabled = true)
+      component.icon = GuidingFeedbackRenderer.icons.get(value).orNull
       component.text = ""
-      component.preferredSize = new Dimension(GuidingIcon.sideLength + 2, GuidingIcon.sideLength + 2)
-      component.maximumSize = new Dimension(GuidingIcon.sideLength  + 2, GuidingIcon.sideLength + 2)
+      component.preferredSize = GuidingFeedbackRenderer.dimensions
+      component.maximumSize = GuidingFeedbackRenderer.dimensions
     }
   }
 
@@ -89,7 +94,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           new GuidingFeedbackRenderer().componentFor(this, isSelected, focused, q, row, column)
         case (m: TargetsModel, value) =>
           // Delegate rendering to the model
-          m.rendererComponent(value ,isSelected, focused, row, column, this.peer).getOrElse(super.rendererComponent(isSelected, focused, row, column))
+          m.rendererComponent(value, isSelected, focused, row, column, this.peer).getOrElse(super.rendererComponent(isSelected, focused, row, column))
       }
   }
 
@@ -228,7 +233,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
   private def plotResults(): Unit = {
     resultsTable.model match {
       case t: TargetsModel =>
-        Option(TpeManager.get()).foreach(p => TpePlotter(p.getImageWidget).plot(t))
+        Option(TpeManager.open()).foreach(p => TpePlotter(p.getImageWidget).plot(t))
       case _               => // Ignore, it shouldn't happen
     }
   }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -56,7 +56,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
   }
 
   private object GuidingFeedbackRenderer {
-    val icons = AgsGuideQuality.All.map(q => q -> GuidingIcon(q, enabled = true)).toMap
+    val icons = AgsGuideQuality.All.fproduct(GuidingIcon(_, enabled = true)).toMap
     val dimensions = new Dimension(GuidingIcon.sideLength + 2, GuidingIcon.sideLength + 2)
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -8,7 +8,7 @@ import edu.gemini.ags.api.{AgsAnalysis, AgsGuideQuality, AgsRegistrar, AgsStrate
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api._
 import edu.gemini.pot.sp.SPComponentType
-import edu.gemini.shared.util.immutable.{None => JNone, Some => JSome}
+import edu.gemini.shared.util.immutable.{None => JNone}
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.altair.{AltairParams, InstAltair}
@@ -202,11 +202,13 @@ case class IdColumn(title: String) extends CatalogNavigatorColumn[String] {
 
 object GuidingQuality {
   implicit val analysisOrder:Order[AgsAnalysis] = Order.orderBy(_.quality)
+  val paFlip = Angle.fromDegrees(180)
+
   // Calculate the guiding quality of the target, allowing for PA flipping
   def target2Analysis(info: Option[ObservationInfo], t: Target):Option[AgsAnalysis] =
     if (info.exists(_.allowPAFlip)) {
       // Note we use min, as AgsGuideQuality is better when the position on the index is lower
-      target2Analysis(info, t, Angle.zero) min target2Analysis(info, t, Angle.fromDegrees(180))
+      target2Analysis(info, t, Angle.zero) min target2Analysis(info, t, paFlip)
     } else {
       target2Analysis(info, t, Angle.zero)
     }
@@ -326,7 +328,7 @@ case class TargetsModel(info: Option[ObservationInfo], base: Coordinates, radius
   override def getColumnCount = columns.size
 
   override def getColumnName(column: Int): String =
-    columns(column).title
+    ~columns.lift(column).map(_.title)
 
   override def getValueAt(rowIndex: Int, columnIndex: Int):AnyRef =
     targets.lift(rowIndex).flatMap { t =>
@@ -335,22 +337,27 @@ case class TargetsModel(info: Option[ObservationInfo], base: Coordinates, radius
 
   override def getColumnClass(columnIndex: Int): Class[_] = columns(columnIndex).clazz
 
+  // The control can be reused by the renderer
+  val label = new Label("")
+
   def rendererComponent(value: Any, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int, table: JTable): Option[Component]= {
     columns.lift(column).flatMap { c =>
-      c.displayValue(value).map(new Label(_) {
-        horizontalAlignment = Alignment.Right
+      c.displayValue(value).map { v =>
+        label.text = v
+        label.horizontalAlignment = Alignment.Right
 
         // Required to set the background
-        opaque = true
+        label.opaque = true
 
         if (isSelected) {
-          background = table.getSelectionBackground
-          foreground = table.getSelectionForeground
+          label.background = table.getSelectionBackground
+          label.foreground = table.getSelectionForeground
         } else {
-          background = table.getBackground
-          foreground = table.getForeground
+          label.background = table.getBackground
+          label.foreground = table.getForeground
         }
-      })
+        label
+      }
     }
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -82,7 +82,7 @@ case class ObservationInfo(ctx: Option[ObsContext],
    * An obscontext is required for guide quality calculation. The method below will attempt to create a context out of the information on the query form
    * TODO: Review if this is the best way to proceed
    */
-  def toContext: Option[ObsContext] = ctx.orElse {
+  val toContext: Option[ObsContext] = ctx.orElse {
     val inst = instrument.collect {
       case SPComponentType.INSTRUMENT_FLAMINGOS2 => new Flamingos2()
       case SPComponentType.INSTRUMENT_GMOS       => new InstGmosNorth()


### PR DESCRIPTION
Small updates to the Catalog Query Tool improving performance by reusing calculated objects and swing components. The most important change is avoiding multiple redraws when updating the conditions boxes. The last change breaks REL-2535, but a different fix is included in this PR