### PR TITLE
REL-2407-L: Logging Level Updates

### DIFF
--- a/app/spdb/conf/logging.properties
+++ b/app/spdb/conf/logging.properties
@@ -10,7 +10,5 @@ java.util.logging.FileHandler.limit = 10000000
 java.util.logging.FileHandler.count = 100
 
 #edu.gemini.dataman.level = FINE
-#edu.gemini.datasetfile.level = FINE
-#edu.gemini.datasetrecord.level = FINE
 h2database.level = WARNING
 

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
@@ -1,5 +1,6 @@
 package edu.gemini.dataman.app
 
+import edu.gemini.dataman.DetailLevel
 import edu.gemini.dataman.core.DmanId.{Dset, Obs, Prog}
 import edu.gemini.dataman.core._
 import edu.gemini.pot.spdb.IDBDatabaseService
@@ -58,10 +59,10 @@ object Dataman {
     } yield d
 
   private def resetOngoingRequests(config: DmanConfig, odb: IDBDatabaseService): TryDman[Unit] = {
-    Log.info("Data Manager resetting incomplete QA requests.")
+    Log.log(DetailLevel, "Data Manager resetting incomplete QA requests.")
 
     ResetOngoingAction(odb, User).unsafeRun.map { case (_, ex) =>
-      Log.info("Data Manager reset to failed: " + ex.map(_.label).mkString(", "))
+      Log.log(DetailLevel, "Data Manager reset to failed: " + ex.map(_.label).mkString(", "))
     }
   }
 

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsRefreshRunnable.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsRefreshRunnable.scala
@@ -1,5 +1,6 @@
 package edu.gemini.dataman.app
 
+import edu.gemini.dataman.DetailLevel
 import edu.gemini.dataman.core.DmanId
 import edu.gemini.dataman.core.DmanId.Obs
 import edu.gemini.pot.spdb.IDBDatabaseService
@@ -32,17 +33,17 @@ final class ObsRefreshRunnable(
     def obsIds(labs: List[DatasetLabel]): List[DmanId.Obs] =
       labs.map(_.getObservationId).distinct.map(DmanId.Obs)
 
-    Log.info("Dataman dataflow update.")
+    Log.log(DetailLevel, "Dataman dataflow update.")
     DatasetFunctor.collect(odb, user) {
       case dr if updateExpected(dr) => dr.label
     } match {
       case \/-(labs) =>
         if (labs.isEmpty) {
-          Log.info("No expected updates.")
+          Log.log(DetailLevel, "No expected updates.")
         } else {
           val obs = obsIds(labs)
           val (prefix, suffix) = obs.splitAt(50)
-          Log.info("Refreshing expected updates: " + prefix.mkString(", ") + (suffix.isEmpty ? "" | " ..."))
+          Log.log(DetailLevel, "Refreshing expected updates: " + prefix.mkString(", ") + (suffix.isEmpty ? "" | " ..."))
           refresh(obs)
         }
       case -\/(f)   =>

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/PollService.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/PollService.scala
@@ -1,5 +1,6 @@
 package edu.gemini.dataman.app
 
+import edu.gemini.dataman.DetailLevel
 import edu.gemini.dataman.core.DmanId
 import edu.gemini.dataman.core.DmanId.{Prog, Obs, Dset}
 
@@ -140,14 +141,14 @@ object PollService {
           breakable {
             while (true) {
               try {
-                Log.fine(s"$name waiting for job")
+                Log.log(DetailLevel, s"$name waiting for job")
                 queue.doNext { id =>
-                  Log.info(s"$name polling $id")
+                  Log.log(DetailLevel, s"$name polling $id")
                   poll(id)
                 }
               } catch {
                 case _: InterruptedException =>
-                  Log.log(Level.INFO, s"$name stopped")
+                  Log.log(DetailLevel, s"$name stopped")
                   break()
                 case t: Throwable =>
                   Log.log(Level.SEVERE, s"$name exception in poll task", t)
@@ -157,7 +158,7 @@ object PollService {
         }
       }
 
-      Log.info(s"Dataman startup PollService.")
+      Log.log(DetailLevel, s"Dataman startup PollService.")
 
       val workers = (0 until (workerCount max 1)).toList.map { n =>
         val threadName = s"$name PollService Worker $n"
@@ -173,7 +174,7 @@ object PollService {
       override def addAll(ids: List[DmanId]): Boolean = queue.addAll(ids)
 
       override def shutdown(): Unit = {
-        Log.info(s"Dataman shutdown PollService.")
+        Log.log(DetailLevel, s"Dataman shutdown PollService.")
         queue.clearPending()
         workers.foreach(_.interrupt())
       }

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ProgramSyncRunnable.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ProgramSyncRunnable.scala
@@ -1,5 +1,6 @@
 package edu.gemini.dataman.app
 
+import edu.gemini.dataman.DetailLevel
 import edu.gemini.dataman.core.DmanId.Prog
 import edu.gemini.pot.spdb.IDBDatabaseService
 
@@ -21,7 +22,7 @@ final class ProgramSyncRunnable(
   override def run(): Unit =
     PidFunctor.exec(odb, user) match {
       case \/-(pids) =>
-        Log.info(s"Dataman synchronizing ${pids.length} programs.")
+        Log.log(DetailLevel, s"Dataman synchronizing ${pids.length} programs.")
         sync(pids.map(Prog))
 
       case -\/(e)    =>

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/RetryFailedRunnable.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/RetryFailedRunnable.scala
@@ -1,5 +1,6 @@
 package edu.gemini.dataman.app
 
+import edu.gemini.dataman.DetailLevel
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.spModel.dataset.DatasetExecRecord
 import edu.gemini.spModel.dataset.QaRequestStatus.Failed
@@ -29,13 +30,13 @@ final class RetryFailedRunnable(
     def oldEnough(i: Instant): Boolean =
       Duration.between(i, Instant.now()).compareTo(minDelay) > 0
 
-    Log.info("Dataman retry failed QA updates.")
+    Log.log(DetailLevel, "Dataman retry failed QA updates.")
     DatasetFunctor.collectExec(odb, user) {
       case DatasetExecRecord(ds, ActiveRequest(_, _, id0, Failed(_), w, _), _) if oldEnough(w) => (ds.getLabel, id0)
     } match {
       case \/-(labs) =>
         if (labs.isEmpty) {
-          Log.info("No failed QA updates.")
+          Log.log(DetailLevel, "No failed QA updates.")
         } else {
           val (prefix, suffix) = labs.splitAt(50)
           Log.info("Retrying failed datasets: " + prefix.mkString(", ") + (suffix.isEmpty ? "" | " ..."))

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/DatamanCommands.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/osgi/DatamanCommands.scala
@@ -1,0 +1,57 @@
+package edu.gemini.dataman.osgi
+
+import edu.gemini.dataman.DatamanLogger
+import edu.gemini.spModel.core.catchingNonFatal
+
+import java.util.logging.Level
+
+import scalaz._
+import Scalaz._
+
+sealed trait DatamanCommands {
+  def dataman(args: Array[String]): String
+}
+
+object DatamanCommands {
+  def apply(): DatamanCommands =
+    new DatamanCommands {
+      val help =
+        """
+          |Data Manager Help
+          |-----------------
+          |
+          |Grammar:
+          |  <level> := SEVERE | WARNING | INFO | CONFIG | FINE | FINER | FINEST
+          |
+          |Commands:
+          |  dataman detail           Shows the current detail logging level
+          |  dataman detail <level>   Sets the detail logging level
+          |  dataman json             Shows the current json logging level
+          |  dataman json <level>     Sets the json logging level
+          |
+        """.stripMargin
+
+      def showLoggable(l: Level): String =
+        s"logging ${DatamanLogger.isLoggable(l) ? "on" | "off"}"
+
+      def showLevel(l: Level): String =
+        s"${l.toString} (${showLoggable(l)})"
+
+      def setLevel(name: String, level: String)(f: Level => Unit): String =
+        catchingNonFatal {
+          Level.parse(level) <| f
+        }.fold(
+            _ => s"Could not parse $name level '$level'.\n\n$help",
+            l => s"Logging $name level set to $level (${showLoggable(l)})"
+          )
+
+      override def dataman(args: Array[String]): String =
+        args.toList match {
+          case List("detail")        => showLevel(edu.gemini.dataman.DetailLevel)
+          case List("detail", level) => setLevel("detail", level) { edu.gemini.dataman.DetailLevel_= }
+          case List("json")          => showLevel(edu.gemini.dataman.JsonLevel)
+          case List("json", level)   => setLevel("json", level) { edu.gemini.dataman.JsonLevel_= }
+          case _                     => help
+        }
+    }
+}

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/package.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/package.scala
@@ -1,0 +1,17 @@
+package edu.gemini
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.logging.{Logger, Level}
+
+package object dataman {
+  val DatamanLogger = Logger.getLogger("edu.gemini.dataman")
+
+  private val DetailLevelRef = new AtomicReference(Level.INFO)
+  private val JsonLevelRef   = new AtomicReference(Level.FINE)
+
+  def DetailLevel: Level                = DetailLevelRef.get
+  def DetailLevel_=(level: Level): Unit = DetailLevelRef.set(level)
+
+  def JsonLevel: Level                = JsonLevelRef.get
+  def JsonLevel_=(level: Level): Unit = JsonLevelRef.set(level)
+}


### PR DESCRIPTION
The Data Manager is currently generating copious logging output.  While it is probably a good idea to leave it that way initially, it makes it hard to spot non-data manager issues in the log.  This PR creates  shared data manager "detail" and "json" logging levels that are consulted when writing a variety of low-level log messages.  It also adds a shell command to allow changing the logging levels at runtime.

The overall logging level is configured to `INFO` in the spdb.  By default "detail" messages will be written at `INFO` and so will appear in the log.  The "json" level controls whether the JSON posted to and retrieved from the GSA is logged.  By default it will be written at `FINE` and will not appear.  To make general "detail" messages disappear and "json" appear, for example, the relevant commands would be:

````
g! dataman detail
INFO (logging on)
g! dataman detail FINE
Logging detail level set to FINE (logging off)
g! dataman json
FINE (logging off)
g! dataman json INFO
Logging json level set to INFO (logging on)
````