### PR TITLE
REL-2048: make executables world executable

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/app/package.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/package.scala
@@ -51,7 +51,11 @@ package object app {
         write(f) { os =>
           stream(is, os)
         }
-        if (src.canExecute) f.setExecutable(true)
+        if (src.canExecute) {
+          // Make it executable for owner, group, and world.
+          // executable = true, ownerOnly = false
+          f.setExecutable(true, false)
+        }
       }
     } else {
       val dir = mkdir(dest, src.getName)


### PR DESCRIPTION
This PR makes the distributed JRE (and every thing else that's executable) executable for group and world.  See REL-2048 for background.