### PR TITLE
REL-2567: Default sky fibers for IFU in ITC web form

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -587,7 +587,7 @@
 			</tr>
 			<tr>
 				<td/>
-				<td>Number of IFU fibres for sky: <input name="ifuSkyFibres" size="5" value="5"></td>
+				<td>Number of IFU fibres for sky: <input name="ifuSkyFibres" size="5" value="250"> (250 for IFU red/blue, 500 for IFU-2)</td>
 			</tr>
 			<tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -587,7 +587,7 @@
 			</tr>
 			<tr>
 				<td/>
-				<td>Number of IFU fibres for sky: <input name="ifuSkyFibres" size="5" value="5"> (500 if using the sky IFU)</td>
+				<td>Number of IFU fibres for sky: <input name="ifuSkyFibres" size="5" value="250"> (250 for IFU red/blue, 500 for IFU-2, 1 for IFU nod & shuffle)</td>
 			</tr>
 			<tr>
 


### PR DESCRIPTION
Set default values for IFU sky fibres on web pages to 250 and add some explanatory text. Low impact late minute change.