### PR TITLE
REL-2573: Fix ITC GMOS IFU-2 slit separation

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/DetectorsTransmissionVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/DetectorsTransmissionVisitor.java
@@ -30,7 +30,7 @@ public class DetectorsTransmissionVisitor implements SampledSpectrumVisitor {
     private final int spectralBinning;
     private final double centralWavelength;
     private final double nmppx;
-    private final int linesPerMm;
+    private final int rulingDensity; // [lines/mm]
     private VisitableSampledSpectrum detectorsTransmissionValues;
     private List<Integer> detectorCcdIndexes;
 
@@ -38,7 +38,7 @@ public class DetectorsTransmissionVisitor implements SampledSpectrumVisitor {
         this.spectralBinning    = p.spectralBinning();
         this.centralWavelength  = p.centralWavelength().toNanometers();
         this.nmppx              = nmppx;
-        this.linesPerMm         = p.grating().getLinesPerMm();
+        this.rulingDensity      = p.grating().rulingDensity();
         final double[][] data   = DatFile.arrays().apply(filename);
         initialize(data);
     }
@@ -121,7 +121,7 @@ public class DetectorsTransmissionVisitor implements SampledSpectrumVisitor {
 
     /** Calculates the shift for the given IFU-2 configuration in nm. */
     public double ifu2shift() {
-        return 0.5 * nmppx * CCDGapCalc.calcIfu2Shift(centralWavelength, linesPerMm);
+        return 0.5 * nmppx * CCDGapCalc.calcIfu2Shift(centralWavelength, rulingDensity);
     }
 
     /** The start of the "red" area in wavelength space. */

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/DetectorsTransmissionVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/DetectorsTransmissionVisitor.java
@@ -30,6 +30,7 @@ public class DetectorsTransmissionVisitor implements SampledSpectrumVisitor {
     private final int spectralBinning;
     private final double centralWavelength;
     private final double nmppx;
+    private final int linesPerMm;
     private VisitableSampledSpectrum detectorsTransmissionValues;
     private List<Integer> detectorCcdIndexes;
 
@@ -37,6 +38,7 @@ public class DetectorsTransmissionVisitor implements SampledSpectrumVisitor {
         this.spectralBinning    = p.spectralBinning();
         this.centralWavelength  = p.centralWavelength().toNanometers();
         this.nmppx              = nmppx;
+        this.linesPerMm         = p.grating().getLinesPerMm();
         final double[][] data   = DatFile.arrays().apply(filename);
         initialize(data);
     }
@@ -119,7 +121,7 @@ public class DetectorsTransmissionVisitor implements SampledSpectrumVisitor {
 
     /** Calculates the shift for the given IFU-2 configuration in nm. */
     public double ifu2shift() {
-        return 0.5 * nmppx * CCDGapCalc.calcIfu2Shift(centralWavelength, nmppx);
+        return 0.5 * nmppx * CCDGapCalc.calcIfu2Shift(centralWavelength, linesPerMm);
     }
 
     /** The start of the "red" area in wavelength space. */

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -31,7 +31,8 @@ public class GmosCommonType {
 
     public interface Disperser extends DisplayableSpType, LoggableSpType, SequenceableSpType {
         boolean isMirror();
-        int getLinesPerMm();
+        // The dispersers "ruling density" in lines/mm.
+        int rulingDensity();
     }
 
     public static interface DisperserBridge<D extends Enum<D> & Disperser> {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -31,6 +31,7 @@ public class GmosCommonType {
 
     public interface Disperser extends DisplayableSpType, LoggableSpType, SequenceableSpType {
         boolean isMirror();
+        int getLinesPerMm();
     }
 
     public static interface DisperserBridge<D extends Enum<D> & Disperser> {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -1,16 +1,6 @@
-//
-// $Id: GmosNorthType.java 44720 2012-04-24 15:45:03Z nbarriga $
-//
-
 package edu.gemini.spModel.gemini.gmos;
 
 import edu.gemini.spModel.type.*;
-import edu.gemini.spModel.gemini.gmos.GmosCommonType.DetectorManufacturer;
-
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Arrays;
-import java.util.Collections;
 
 /**
  *
@@ -95,34 +85,34 @@ public class GmosNorthType {
         /** The default Disperser value **/
         public static DisperserNorth DEFAULT = MIRROR;
 
-        private final String _displayValue;
-        private final String _logValue;
-        private final int _linesPerMm;
+        private final String displayValue;
+        private final String logValue;
+        private final int    rulingDensity;
 
-        DisperserNorth(final String displayValue, final String logValue, final int linesPerMm) {
-            _displayValue = displayValue;
-            _logValue     = logValue;
-            _linesPerMm   = linesPerMm;
+        DisperserNorth(final String displayValue, final String logValue, final int rulingDensity) {
+            this.displayValue  = displayValue;
+            this.logValue      = logValue;
+            this.rulingDensity = rulingDensity;     // [lines/mm]
         }
 
         public String displayValue() {
-            return _displayValue;
+            return displayValue;
         }
 
         public String logValue() {
-            return _logValue;
+            return logValue;
         }
 
         public String sequenceValue() {
-            return _displayValue;
+            return displayValue;
         }
 
         public boolean isMirror() {
             return (this == MIRROR);
         }
 
-        public int getLinesPerMm() {
-            return _linesPerMm;
+        public int rulingDensity() {
+            return rulingDensity;
         }
 
         public String toString() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -80,27 +80,29 @@ public class GmosNorthType {
         }
     };
 
-    public static enum DisperserNorth implements GmosCommonType.Disperser, ObsoletableSpType {
-        MIRROR("Mirror", "mirror"),
-        B1200_G5301("B1200_G5301", "B1200"),
-        R831_G5302("R831_G5302", "R831"),
-        B600_G5303("B600_G5303", "B600") {public boolean isObsolete() {return true;}},
-        B600_G5307("B600_G5307", "B600"),
-        R600_G5304("R600_G5304", "R600"),
-        R400_G5305("R400_G5305", "R400"),
-        R150_G5306("R150_G5306", "R150"),
-        R150_G5308("R150_G5308", "R150"),
+    public enum DisperserNorth implements GmosCommonType.Disperser, ObsoletableSpType {
+        MIRROR("Mirror", "mirror", 0),
+        B1200_G5301("B1200_G5301", "B1200", 1200),
+        R831_G5302("R831_G5302", "R831", 831),
+        B600_G5303("B600_G5303", "B600", 600) {public boolean isObsolete() {return true;}},
+        B600_G5307("B600_G5307", "B600", 600),
+        R600_G5304("R600_G5304", "R600", 600),
+        R400_G5305("R400_G5305", "R400", 400),
+        R150_G5306("R150_G5306", "R150", 150),
+        R150_G5308("R150_G5308", "R150", 150),
         ;
 
         /** The default Disperser value **/
         public static DisperserNorth DEFAULT = MIRROR;
 
-        private String _displayValue;
-        private String _logValue;
+        private final String _displayValue;
+        private final String _logValue;
+        private final int _linesPerMm;
 
-        private DisperserNorth(String displayValue, String logValue) {
+        DisperserNorth(final String displayValue, final String logValue, final int linesPerMm) {
             _displayValue = displayValue;
-            _logValue = logValue;
+            _logValue     = logValue;
+            _linesPerMm   = linesPerMm;
         }
 
         public String displayValue() {
@@ -117,6 +119,10 @@ public class GmosNorthType {
 
         public boolean isMirror() {
             return (this == MIRROR);
+        }
+
+        public int getLinesPerMm() {
+            return _linesPerMm;
         }
 
         public String toString() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
@@ -80,25 +80,27 @@ public class GmosSouthType {
     };
 
 
-    public static enum DisperserSouth implements GmosCommonType.Disperser {
-        MIRROR("Mirror", "mirror"),
-        B1200_G5321("B1200_G5321", "B1200"),
-        R831_G5322("R831_G5322", "R831"),
-        B600_G5323("B600_G5323", "B600"),
-        R600_G5324("R600_G5324", "R600"),
-        R400_G5325("R400_G5325", "R400"),
-        R150_G5326("R150_G5326", "R150"),
+    public enum DisperserSouth implements GmosCommonType.Disperser {
+        MIRROR("Mirror", "mirror", 0),
+        B1200_G5321("B1200_G5321", "B1200", 1200),
+        R831_G5322("R831_G5322", "R831", 831),
+        B600_G5323("B600_G5323", "B600", 600),
+        R600_G5324("R600_G5324", "R600", 600),
+        R400_G5325("R400_G5325", "R400", 400),
+        R150_G5326("R150_G5326", "R150", 150),
         ;
 
         /** The default Disperser value **/
         public static DisperserSouth DEFAULT = MIRROR;
 
-        private String _displayValue;
-        private String _logValue;
+        private final String _displayValue;
+        private final String _logValue;
+        private final int _linesPerMm;
 
-        private DisperserSouth(String displayValue, String logValue) {
+        DisperserSouth(final String displayValue, final String logValue, final int linesPerMm) {
             _displayValue = displayValue;
-            _logValue = logValue;
+            _logValue     = logValue;
+            _linesPerMm   = linesPerMm;
         }
 
         public String displayValue() {
@@ -119,6 +121,10 @@ public class GmosSouthType {
 
         public boolean isMirror() {
             return (this == MIRROR);
+        }
+
+        public int getLinesPerMm() {
+            return _linesPerMm;
         }
 
         /** Return a Disperser by index **/

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
@@ -1,16 +1,6 @@
-//
-// $Id: GmosSouthType.java 44720 2012-04-24 15:45:03Z nbarriga $
-//
-
 package edu.gemini.spModel.gemini.gmos;
 
 import edu.gemini.spModel.type.SpTypeUtil;
-import edu.gemini.spModel.gemini.gmos.GmosCommonType.DetectorManufacturer;
-
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Arrays;
-import java.util.Collections;
 
 /**
  *
@@ -93,26 +83,26 @@ public class GmosSouthType {
         /** The default Disperser value **/
         public static DisperserSouth DEFAULT = MIRROR;
 
-        private final String _displayValue;
-        private final String _logValue;
-        private final int _linesPerMm;
+        private final String displayValue;
+        private final String logValue;
+        private final int    rulingDensity;        // [lines/mm]
 
-        DisperserSouth(final String displayValue, final String logValue, final int linesPerMm) {
-            _displayValue = displayValue;
-            _logValue     = logValue;
-            _linesPerMm   = linesPerMm;
+        DisperserSouth(final String displayValue, final String logValue, final int rulingDensity) {
+            this.displayValue  = displayValue;
+            this.logValue      = logValue;
+            this.rulingDensity = rulingDensity;
         }
 
         public String displayValue() {
-            return _displayValue;
+            return displayValue;
         }
 
         public String logValue() {
-            return _logValue;
+            return logValue;
         }
 
         public String sequenceValue() {
-            return _displayValue;
+            return displayValue;
         }
 
         public String toString() {
@@ -123,8 +113,8 @@ public class GmosSouthType {
             return (this == MIRROR);
         }
 
-        public int getLinesPerMm() {
-            return _linesPerMm;
+        public int rulingDensity() {
+            return rulingDensity;
         }
 
         /** Return a Disperser by index **/


### PR DESCRIPTION
The IFU-2 slit separation was using a wrong input value and therefore produced wrong results. The value needed is the "lines per mm" value of the GMOS dispersers/gratings, which we currently don't have.

To solve this issue I added the missing value to the different GMOS dispersers and fed it into the calculation of the split separation which now delivers the expected results.

Fiddling around with the enums in the base model is of course a relatively risky operation at this point, however I can not immediately think of any problematic side-effect this particular change could have (?), so I assume this is overall still a relatively low risk change since the added values are new and are not used anywhere else.