### PR TITLE
OCSADV-500: Display the aperture size in ITC Signal plot title

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -60,7 +60,7 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
 
     public ItcSpectroscopyResult serviceResult(final SpectroscopyResult r) {
         final List<SpcChartData> dataSets = new ArrayList<SpcChartData>() {{
-            add(Recipe$.MODULE$.createSignalChartWithApInTitle(r, 0));
+            add(Recipe$.MODULE$.createSignalChart(r, 0));
             add(Recipe$.MODULE$.createS2NChart(r));
         }};
         return Recipe$.MODULE$.serviceResult(r, dataSets);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -60,7 +60,7 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
 
     public ItcSpectroscopyResult serviceResult(final SpectroscopyResult r) {
         final List<SpcChartData> dataSets = new ArrayList<SpcChartData>() {{
-            add(Recipe$.MODULE$.createSignalChart(r));
+            add(Recipe$.MODULE$.createSignalChartWithApInTitle(r, 0));
             add(Recipe$.MODULE$.createS2NChart(r));
         }};
         return Recipe$.MODULE$.serviceResult(r, dataSets);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -276,11 +276,11 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         final Gmos[] ccdArray     = mainInstrument.getDetectorCcdInstruments();
         final DetectorsTransmissionVisitor tv = mainInstrument.getDetectorTransmision();
 
-        final boolean ifuMultiple = mainInstrument.isIfuUsed() && mainInstrument.getIFU().getApertureOffsetList().size() > 1;
-        final double  ifuOffset   = ifuMultiple ? mainInstrument.getIFU().getApertureOffsetList().get(i) : 0.0;
+        final boolean ifuUsed   = mainInstrument.isIfuUsed();
+        final double  ifuOffset = ifuUsed ? mainInstrument.getIFU().getApertureOffsetList().get(i) : 0.0;
 
         final List<ChartAxis> axes = new ArrayList<>();
-        final String title    = "Signal and Background " + (ifuMultiple ? "(IFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec)" : "");
+        final String title    = "Signal and SQRT(Background)" + (ifuUsed ? "\nIFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec" : "");
         final ChartAxis xAxis = ChartAxis.apply("Wavelength (nm)");
         final ChartAxis yAxis = ChartAxis.apply("e- per exposure per spectral pixel");
 
@@ -306,11 +306,11 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         final Gmos[] ccdArray      = mainInstrument.getDetectorCcdInstruments();
         final DetectorsTransmissionVisitor tv = mainInstrument.getDetectorTransmision();
 
-        final boolean ifuMultiple  = mainInstrument.isIfuUsed() && mainInstrument.getIFU().getApertureOffsetList().size() > 1;
-        final double  ifuOffset    = ifuMultiple ? mainInstrument.getIFU().getApertureOffsetList().get(i) : 0.0;
+        final boolean ifuUsed   = mainInstrument.isIfuUsed();
+        final double  ifuOffset = ifuUsed ? mainInstrument.getIFU().getApertureOffsetList().get(i) : 0.0;
         final List<ChartAxis> axes = new ArrayList<>();
 
-        final String title    = "Intermediate Single Exp and Final S/N" + (ifuMultiple ? " (IFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec)" : "");
+        final String title    = "Intermediate Single Exp and Final S/N" + (ifuUsed ? "\nIFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec" : "");
         final ChartAxis xAxis = ChartAxis.apply("Wavelength (nm)");
         final ChartAxis yAxis = ChartAxis.apply("Signal / Noise per spectral pixel");
 
@@ -336,11 +336,11 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         final Gmos[] ccdArray     = mainInstrument.getDetectorCcdInstruments();
         final DetectorsTransmissionVisitor tv = mainInstrument.getDetectorTransmision();
 
-        final boolean ifuMultiple = mainInstrument.isIfuUsed() && mainInstrument.getIFU().getApertureOffsetList().size() > 1;
-        final double  ifuOffset   = ifuMultiple ? mainInstrument.getIFU().getApertureOffsetList().get(i) : 0.0;
+        final boolean ifuUsed   = mainInstrument.isIfuUsed();
+        final double  ifuOffset = ifuUsed ? mainInstrument.getIFU().getApertureOffsetList().get(i) : 0.0;
 
         final List<ChartAxis> axes = new ArrayList<>();
-        final String title    = "Pixel Signal and Background" + (ifuMultiple ? " (IFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec)" : "");
+        final String title    = "Pixel Signal and SQRT(Background)" + (ifuUsed ? "\nIFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec" : "");
         final ChartAxis xAxis = new ChartAxis("Pixels", true, new Some<>(new ChartAxisRange(0, 6218)));
         final ChartAxis yAxis = ChartAxis.apply("e- per exposure per spectral pixel");
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -278,9 +278,13 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
 
         final boolean ifuUsed   = mainInstrument.isIfuUsed();
         final double  ifuOffset = ifuUsed ? mainInstrument.getIFU().getApertureOffsetList().get(i) : 0.0;
+        final double  aperture  = results[0].specS2N()[0].getSpecNpix(); // same value for all CCDs (results) and specS2Ns, use first one
 
         final List<ChartAxis> axes = new ArrayList<>();
-        final String title    = "Signal and SQRT(Background)" + (ifuUsed ? "\nIFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec" : "");
+        final String title    =
+                "Signal and SQRT(Background)" +
+                        (ifuUsed ? "\nIFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec" :
+                                   "\nSummed in an aperture of " + aperture + " pix diameter");
         final ChartAxis xAxis = ChartAxis.apply("Wavelength (nm)");
         final ChartAxis yAxis = ChartAxis.apply("e- per exposure per spectral pixel");
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -58,7 +58,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
                 add(createGnirsSignalChart(r));
                 add(createGnirsS2NChart(r));
             } else {
-                add(Recipe$.MODULE$.createSigSwAppChart(r, 0));
+                add(Recipe$.MODULE$.createSignalChartWithApInTitle(r, 0));
                 add(Recipe$.MODULE$.createS2NChart(r));
             }
         }};
@@ -221,7 +221,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
     // == GNIRS CHARTS
 
     private static SpcChartData createGnirsSignalChart(final SpectroscopyResult result) {
-        final String title = "Signal and Background in software aperture of " + result.specS2N()[0].getSpecNpix() + " pixels";
+        final String title = "Signal and SQRT(Background)\nSummed in an aperture of " + result.specS2N()[0].getSpecNpix() + " pix diameter";
         final String xAxis = "Wavelength (nm)";
         final String yAxis = "e- per exposure per spectral pixel";
         final List<SpcSeriesData> data = new ArrayList<>();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -58,7 +58,7 @@ public final class GnirsRecipe implements SpectroscopyRecipe {
                 add(createGnirsSignalChart(r));
                 add(createGnirsS2NChart(r));
             } else {
-                add(Recipe$.MODULE$.createSignalChartWithApInTitle(r, 0));
+                add(Recipe$.MODULE$.createSignalChart(r, 0));
                 add(Recipe$.MODULE$.createS2NChart(r));
             }
         }};

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java
@@ -190,11 +190,11 @@ public final class NifsRecipe implements SpectroscopyRecipe {
         final Nifs instrument = (Nifs) result.instrument();
         final List<Double> ap_offset_list = instrument.getIFU().getApertureOffsetList();
         final String title = instrument.getIFUMethod() instanceof IfuSummed ?
-                "Signal and Background (IFU summed apertures: " +
+                "Signal and SQRT(Background)\nIFU summed apertures: " +
                         instrument.getIFUNumX() + "x" + instrument.getIFUNumY() +
                         ", " + String.format("%.3f", instrument.getIFUNumX() * IFUComponent.IFU_LEN_X) + "\"x" +
-                        String.format("%.3f", instrument.getIFUNumY() * IFUComponent.IFU_LEN_Y) + "\")" :
-                "Signal and Background (IFU element offset: " + String.format("%.3f", ap_offset_list.get(index)) + " arcsec)";
+                        String.format("%.3f", instrument.getIFUNumY() * IFUComponent.IFU_LEN_Y) + "\"" :
+                "Signal and SQRT(Background)\nIFU element offset: " + String.format("%.3f", ap_offset_list.get(index)) + " arcsec";
         return Recipe$.MODULE$.createSignalChart(result, title, index);
     }
 
@@ -202,11 +202,11 @@ public final class NifsRecipe implements SpectroscopyRecipe {
         final Nifs instrument = (Nifs) result.instrument();
         final List<Double> ap_offset_list = instrument.getIFU().getApertureOffsetList();
         final String title = instrument.getIFUMethod() instanceof IfuSummed ?
-                "Intermediate Single Exp and Final S/N \n(IFU apertures:" +
+                "Intermediate Single Exp and Final S/N\nIFU apertures: " +
                         instrument.getIFUNumX() + "x" + instrument.getIFUNumY() +
                         ", " + String.format("%.3f", instrument.getIFUNumX() * IFUComponent.IFU_LEN_X) + "\"x" +
-                        String.format("%.3f", instrument.getIFUNumY() * IFUComponent.IFU_LEN_Y) + "\")" :
-                "Intermediate Single Exp and Final S/N (IFU element offset: " + String.format("%.3f", ap_offset_list.get(index)) + " arcsec)";
+                        String.format("%.3f", instrument.getIFUNumY() * IFUComponent.IFU_LEN_Y) + "\"" :
+                "Intermediate Single Exp and Final S/N\nIFU element offset: " + String.format("%.3f", ap_offset_list.get(index)) + " arcsec";
         return Recipe$.MODULE$.createS2NChart(result, title, index);
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -58,7 +58,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
 
     public ItcSpectroscopyResult serviceResult(final SpectroscopyResult r) {
         final List<SpcChartData> dataSets = new ArrayList<SpcChartData>() {{
-            add(Recipe$.MODULE$.createSignalChart(r, 0));
+            add(Recipe$.MODULE$.createSignalChartWithApInTitle(r, 0));
             add(Recipe$.MODULE$.createS2NChart(r, 0));
         }};
         return Recipe$.MODULE$.serviceResult(r, dataSets);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java
@@ -58,7 +58,7 @@ public final class NiriRecipe implements ImagingRecipe, SpectroscopyRecipe {
 
     public ItcSpectroscopyResult serviceResult(final SpectroscopyResult r) {
         final List<SpcChartData> dataSets = new ArrayList<SpcChartData>() {{
-            add(Recipe$.MODULE$.createSignalChartWithApInTitle(r, 0));
+            add(Recipe$.MODULE$.createSignalChart(r, 0));
             add(Recipe$.MODULE$.createS2NChart(r, 0));
         }};
         return Recipe$.MODULE$.serviceResult(r, dataSets);

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
@@ -39,11 +39,6 @@ object Recipe {
 
   // create signal/background chart
   def createSignalChart(result: SpectroscopyResult, index: Int): SpcChartData = {
-    createSignalChart(result, "Signal & SQRT(Background)", index)
-  }
-
-  // same as createSignalChart but with a more elaborate title
-  def createSignalChartWithApInTitle(result: SpectroscopyResult, index: Int): SpcChartData = {
     createSignalChart(result, "Signal & SQRT(Background)\nSummed in an aperture of " + result.specS2N(index).getSpecNpix + " pix diameter", index)
   }
 

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
@@ -37,22 +37,20 @@ object Recipe {
   // GENERIC CHART CREATION
   // Utility functions that create generic signal and signal to noise charts for several instruments.
 
-  def createSignalChart(result: SpectroscopyResult): SpcChartData = {
-    createSignalChart(result, 0)
-  }
-
+  // create signal/background chart
   def createSignalChart(result: SpectroscopyResult, index: Int): SpcChartData = {
-    createSignalChart(result, "Signal and Background ", index)
+    createSignalChart(result, "Signal & SQRT(Background)", index)
   }
 
-  def createSigSwAppChart(result: SpectroscopyResult, index: Int): SpcChartData = {
-    createSignalChart(result, "Signal and SQRT(Background) in software aperture of " + result.specS2N(index).getSpecNpix + " pixels", index)
+  // same as createSignalChart but with a more elaborate title
+  def createSignalChartWithApInTitle(result: SpectroscopyResult, index: Int): SpcChartData = {
+    createSignalChart(result, "Signal & SQRT(Background)\nSummed in an aperture of " + result.specS2N(index).getSpecNpix + " pix diameter", index)
   }
 
   def createSignalChart(result: SpectroscopyResult, title: String, index: Int): SpcChartData = {
     val data: java.util.List[SpcSeriesData] = new java.util.ArrayList[SpcSeriesData]()
-    data.add(new SpcSeriesData(SignalData,     "Signal ",            result.specS2N(index).getSignalSpectrum.getData))
-    data.add(new SpcSeriesData(BackgroundData, "SQRT(Background)  ", result.specS2N(index).getBackgroundSpectrum.getData))
+    data.add(new SpcSeriesData(SignalData,     "Signal",               result.specS2N(index).getSignalSpectrum.getData))
+    data.add(new SpcSeriesData(BackgroundData, "SQRT(Background)",     result.specS2N(index).getBackgroundSpectrum.getData))
     new SpcChartData(SignalChart, title, ChartAxis("Wavelength (nm)"), ChartAxis("e- per exposure per spectral pixel"), data.toList)
   }
 


### PR DESCRIPTION
From the JIRA task: The 2015A infrared ITCs (F2, GNIRS, NIFS, NIRI) displayed the aperture size in the spectroscopy "Signal and sqrt(Background)" plot title. It would be useful to display this information in all of the 2016A ITC spectroscopy plot titles to remind users when multiple pixels are being summed. A suggested title is: "Signal & Sqrt(Background) summed in an aperture of N pix diameter"

I also streamlined the titles a little bit and added a line break for titles that are (too) long for a single line.

This is a low risk last minute change, low risk because it only impacts the chart titles, but no calculations etc.