### PR TITLE
OCSADV-404: Import search target from the TPE

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -15,6 +15,7 @@ import edu.gemini.catalog.ui.tpe.CatalogImageDisplay
 import edu.gemini.catalog.votable._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.shared.gui.textComponent.{SelectOnFocus, TextRenderer, NumberField}
 import edu.gemini.shared.gui.{ButtonFlattener, GlassLabel, SortableTable}
 import edu.gemini.spModel.core.SiderealTarget
@@ -316,6 +317,13 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           buildQuery.foreach(Function.tupled(reloadSearchData))
       }
     }
+    lazy val fromImageButton = new Button("Sync from Obs.") {
+      reactions += {
+        case ButtonClicked(_) =>
+          // Reload target info from the OT
+          Option(TpeManager.get()).flatMap(_.getImageWidget.getObsContext.asScalaOpt).foreach(QueryResultsFrame.instance.showOn)
+      }
+    }
 
     // Action to disable the query button if there are invalid fields
     val queryButtonEnabling: Reaction = {
@@ -577,7 +585,8 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         }
       }
 
-      add(queryButton, CC().newline().span(7).pushX().alignX(RightAlign).gapTop(10.px))
+      add(fromImageButton, CC().newline().alignX(LeftAlign).gapTop(10.px))
+      add(queryButton, CC().span(7).pushX().alignX(RightAlign).gapTop(10.px))
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -163,7 +163,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
   title = "Catalog Query Tool"
   val tableBorder = new BorderPanel() {
-    border = titleBorder(title)
+    border = titleBorder("Results")
     add(scrollPane, BorderPanel.Position.Center)
   }
   QueryForm.buildLayout(Nil)
@@ -270,7 +270,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         updateResultsModel(model)
 
         // Update the count of rows
-        tableBorder.border = titleBorder(s"$title - ${queryResult.result.targets.rows.length} results found")
+        tableBorder.border = titleBorder(s"Results - ${queryResult.result.targets.rows.length} results found")
 
         // Update the query form
         QueryForm.updateQuery(info, q)
@@ -308,7 +308,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     // Represents a magnitude filter containing the controls that make the row
     case class MagnitudeFilterControls(addButton: Button, faintess: NumberField, separator: Label, saturation: NumberField, bandCB: ComboBox[MagnitudeBand], removeButton: Button)
 
-    border = titleBorder("Query Params")
+    border = titleBorder("Query Parameters")
 
     lazy val queryButton = new Button("Query") {
       reactions += {
@@ -317,7 +317,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           buildQuery.foreach(Function.tupled(reloadSearchData))
       }
     }
-    lazy val fromImageButton = new Button("Sync from Obs.") {
+    lazy val fromImageButton = new Button("Reset") {
       reactions += {
         case ButtonClicked(_) =>
           // Reload target info from the OT
@@ -585,8 +585,9 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         }
       }
 
-      add(fromImageButton, CC().newline().alignX(LeftAlign).gapTop(10.px))
-      add(queryButton, CC().span(7).pushX().alignX(RightAlign).gapTop(10.px))
+      add(new Separator(Orientation.Horizontal), CC().spanX(7).growX().newline())
+      add(fromImageButton, CC().newline().span(6).pushX().alignX(RightAlign).gapTop(10.px))
+      add(queryButton, CC().alignX(RightAlign).gapTop(10.px))
     }
 
     /**


### PR DESCRIPTION
This PR adds a button that will reload the currently selected target from the TPE back into the CQT, thus allowing the user, e.g. to drag the target and have that into the CQT.
I named the button "Sync from Obs." but I'm not that happy with the name. I'm open to suggestions. On the old Catalog Navigator this was called "From Image".

Here is a screenshot:

 
![screenshot 2015-11-30 10 32 42](https://cloud.githubusercontent.com/assets/3615303/11472933/7a204c42-974e-11e5-89b3-ccffd462da82.png)
