### PR TITLE
REL-2165: reapply nighttime cal should not lose observing conditions

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/ReapplicationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/ReapplicationFunctor.java
@@ -27,7 +27,7 @@ import static edu.gemini.spModel.template.FunctorHelpers.lookupNode;
  * (whose templates don't contain targets) the re-application preserves the target environment and position angle
  * (if any). Note that the target node for execute() is ignored.
  */
-public class ReapplicationFunctor extends DBAbstractFunctor {
+public final class ReapplicationFunctor extends DBAbstractFunctor {
 
     private static final Logger LOGGER = Logger.getLogger(ReapplicationFunctor.class.getName());
 
@@ -109,9 +109,10 @@ public class ReapplicationFunctor extends DBAbstractFunctor {
         templateObs.setChildren(Collections.<ISPNode>emptyList()); // must detach children first
         obs.setChildren(children);
 
-        // If it's a science observation, restore the target and position angle
+        // Unless it is a DAY_CAL, restore the target, conditions and position angle.
+        // See REL-2165.
         final ObsClass newObsClass = ObsClassService.lookupObsClass(obs);
-        if (newObsClass == ObsClass.SCIENCE || newObsClass == ObsClass.ACQ) {
+        if (newObsClass != ObsClass.DAY_CAL) {
             restoreScienceDetails(obs, oldTarget, oldConditions, oldInstrument);
         }
     }


### PR DESCRIPTION
This PR addresses an issue wherein the observing conditions would be reset upon template reapply. The previous PR (feature/REL-2165) updated template instantiation to copy the science observing conditions for nighttime calibrations as well as science and acquisitions.  It did not update template reapply though, so nighttime calibrations would lose observing conditions when updated.  In discussions with Bryan, it was decided that not only should conditions be kept on reapply, but also any changes to the target component or position angle.