### PR TITLE
REL-2584: Add ITC URL in PIT Help menu

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
@@ -120,15 +120,15 @@ class ShellAdvisor(
     // Add root listeners. Note that the robots don't affect undo status when they manipulate the model.
     addRoot(targetImportAction)
     addRoot(targetExportAction)
-    addRoot(AgsRobot, false)
-    addRoot(VisibilityRobot, false)
-    addRoot(GsaRobot, false)
-    addRoot(catalogHandler, false)
-    addRoot(problemHandler, false)
+    addRoot(AgsRobot, undoable = false)
+    addRoot(VisibilityRobot, undoable = false)
+    addRoot(GsaRobot, undoable = false)
+    addRoot(catalogHandler, undoable = false)
+    addRoot(problemHandler, undoable = false)
 
     // Update the title bar if the mode or model change
-    shell.listen(updateTitle)
-    AppPreferences.addListener(_ => updateTitle)
+    shell.listen(updateTitle())
+    AppPreferences.addListener(_ => updateTitle())
 
     // Set the frame icon, useful for Windows and Linux
     if (!Platform.IS_MAC) {
@@ -226,11 +226,12 @@ class ShellAdvisor(
 
     context.actionManager.add(helpMenu,
       Some(new BrowseAction("http://www.gemini.edu/node/11760", "Phase I Tool Help")),
-      Some(new BrowseAction(URLConstants.GET_TEMPLATES._1, URLConstants.GET_TEMPLATES._2))
+      Some(new BrowseAction(URLConstants.GET_TEMPLATES._1, URLConstants.GET_TEMPLATES._2)),
+      Some(new BrowseAction(URLConstants.OPEN_ITC._1, URLConstants.OPEN_ITC._2))
     )
 
     // Debug Menu -- for developers only
-    Option(System.getProperty("edu.gemini.pit.test")).map {
+    Option(System.getProperty("edu.gemini.pit.test")).foreach {
       _ =>
         val debugMenu = Menu("Debug", NextSiblingOf, Some(helpMenu))
         context.actionManager.add(debugMenu,

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/URLConstants.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/URLConstants.scala
@@ -7,4 +7,5 @@ import edu.gemini.model.p1.immutable.Semester
  */
 object URLConstants {
   val GET_TEMPLATES = (s"http://software.gemini.edu/phase1/templates/${Semester.current.display}/", "Open directory for LaTeX/Word text section templates in browser.")
+  val OPEN_ITC = ("http://www.gemini.edu/node/10241", "Open Integration Time Calculator page in browser.")
 }


### PR DESCRIPTION
Small PR adding a menu entry to open the ITC URL, see the screenshot:

![screenshot 2015-12-10 11 38 43](https://cloud.githubusercontent.com/assets/3615303/11718148/5b88fa4e-9f33-11e5-9e10-17f51f62a42e.png)
