### PR TITLE
seqexec config syntax

### DIFF
--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
@@ -2,6 +2,8 @@ package edu.gemini.seqexec.server
 
 import edu.gemini.spModel.config2.{ItemKey, Config}
 
+import java.beans.PropertyDescriptor
+
 import scala.reflect.ClassTag
 import scalaz._
 import Scalaz._
@@ -15,7 +17,8 @@ object ConfigUtil {
 
   // key syntax: parent / child
   implicit class ItemKeyOps(k: ItemKey) {
-    def /(s: String) = new ItemKey(k, s)
+    def /(s: String): ItemKey = new ItemKey(k, s)
+    def /(p: PropertyDescriptor): ItemKey = /(p.getName)
   }
 
   // config syntax: cfg.extract(key).as[Type]

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
@@ -8,37 +8,26 @@ import Scalaz._
 
 /**
  * Created by jluhrs on 8/17/15.
- * Code graciously lifted from edu.gemini.itc.shared.ConfigExtractor
  */
 object ConfigUtil {
-  // Extract an optional integer, values in the configuration are Java objects
-  def extractOptionalInteger(c: Config, key: ItemKey): Option[Int] =
-    extract[java.lang.Integer](c, key).map(_.toInt).toOption
 
-  // Extract a value of the given type from the configuration
-  def extract[A](c: Config, key: ItemKey)(implicit clazz: ClassTag[A]): String \/ A =
-    extractWithThrowable[A](c, key).leftMap(_.getMessage)
+  type ExtractFailure = String // for now
 
-  // Extract a double value from a string in the configuration
-  def extractDoubleFromString(c: Config, key: ItemKey): String \/ Double = {
-    val v = for {
-      s <- extractWithThrowable[String](c, key)
-      d <- \/.fromTryCatch(s.toDouble)
-    } yield d
-    v.leftMap(_.getMessage)
-   }
+  // key syntax: parent / child
+  implicit class ItemKeyOps(k: ItemKey) {
+    def /(s: String) = new ItemKey(k, s)
+  }
 
-  // Helper method that enforces that whatever we get from the config
-  // for the given key is not null and matches the type we expect.
-  private def extractWithThrowable[A](c: Config, key: ItemKey)(implicit clazz: ClassTag[A]): Throwable \/ A = {
-
-    def missingKey(key: ItemKey): \/[Throwable, A] =
-      new Error(s"Missing config value for key ${key.getPath}").left[A]
-
-    Option(c.getItemValue(key)).fold(missingKey(key)) { v =>
-      \/.fromTryCatch(clazz.runtimeClass.cast(v).asInstanceOf[A])
+  // config syntax: cfg.extract(key).as[Type]
+  implicit class ConfigOps(c: Config) {
+    final class Extracted(key: ItemKey) {
+      def as[A](implicit clazz: ClassTag[A]): ExtractFailure \/ A =
+        for {
+          v <- Option(c.getItemValue(key)) \/> s"Missing config value for key ${key.getPath}"
+          b <- \/.fromTryCatch(clazz.runtimeClass.cast(v).asInstanceOf[A]).leftMap(_.getMessage)
+        } yield b
     }
-
+    def extract(key: ItemKey) = new Extracted(key)  
   }
 
 }

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/FLAMINGOS2.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/FLAMINGOS2.scala
@@ -2,7 +2,7 @@ package edu.gemini.seqexec.server
 
 import edu.gemini.seqexec.server.DhsClient.{StringKeyword, KeywordBag, ObsId}
 import edu.gemini.seqexec.server.Flamingos2Controller._
-import edu.gemini.seqexec.server.ConfigUtil.extract
+import edu.gemini.seqexec.server.ConfigUtil._
 import edu.gemini.spModel.config2.{ItemKey, Config}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Decker
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Filter
@@ -80,9 +80,9 @@ object FLAMINGOS2 {
     val a = new ItemKey(INSTRUMENT_KEY, FPU_PROP.getName)
     val b = new ItemKey(INSTRUMENT_KEY, FPU_MASK_PROP.getName)
 
-    extract[FPUnit](config, a).flatMap(x =>
+    config.extract(a).as[FPUnit].flatMap(x =>
       if(x != FPUnit.CUSTOM_MASK) \/-(fpuFromFPUnit(x))
-      else extract[String](config, b).map(FocalPlaneUnit.Custom)
+      else config.extract(b).as[String].map(FocalPlaneUnit.Custom)
     )
   }
 
@@ -93,30 +93,30 @@ object FLAMINGOS2 {
 
   def ccConfigFromSequenceConfig(config: Config): TrySeq[CCConfig] = ( for {
       // WINDOW_COVER_PROP is optional. If not present, then window cover position is inferred from observe type.
-      p <- extract[WindowCover](config, new ItemKey(INSTRUMENT_KEY, WINDOW_COVER_PROP.getName)) match {
+      p <- config.extract(INSTRUMENT_KEY / WINDOW_COVER_PROP.getName).as[WindowCover] match {
             case a: \/-[WindowCover] => a
-            case _         => extract[String](config, new ItemKey(OBSERVE_KEY, OBSERVE_TYPE_PROP))
+            case _         => config.extract(OBSERVE_KEY / OBSERVE_TYPE_PROP).as[String]
                               .map(windowCoverFromObserveType)
           }
-      q <- extract[Decker](config, new ItemKey(INSTRUMENT_KEY, DECKER_PROP.getName))
+      q <- config.extract(INSTRUMENT_KEY / DECKER_PROP.getName).as[Decker]
       r <- fpuConfig(config)
-      s <- extract[Filter](config, new ItemKey(INSTRUMENT_KEY, FILTER_PROP.getName))
-      t <- extract[LyotWheel](config, new ItemKey(INSTRUMENT_KEY, LYOT_WHEEL_PROP.getName))
-      u <- extract[Disperser](config, new ItemKey(INSTRUMENT_KEY, DISPERSER_PROP.getName))
+      s <- config.extract(INSTRUMENT_KEY / FILTER_PROP.getName).as[Filter]
+      t <- config.extract(INSTRUMENT_KEY / LYOT_WHEEL_PROP.getName).as[LyotWheel]
+      u <- config.extract(INSTRUMENT_KEY / DISPERSER_PROP.getName).as[Disperser]
 
     } yield CCConfig(p, q, r, s, t, u) ).leftMap(SeqexecFailure.Unexpected)
 
   def dcConfigFromSequenceConfig(config: Config): TrySeq[DCConfig] = ( for {
-    p <- extract[java.lang.Double](config, new ItemKey(OBSERVE_KEY, EXPOSURE_TIME_PROP.getName)).map(x => Duration(x, SECONDS))
+    p <- config.extract(OBSERVE_KEY / EXPOSURE_TIME_PROP.getName).as[java.lang.Double].map(x => Duration(x, SECONDS))
     // Reads is usually inferred from the read mode, but it can be explicit.
-    q <- extract[Reads](config, new ItemKey(OBSERVE_KEY, READS_PROP.getName)) match {
+    q <- config.extract(OBSERVE_KEY / READS_PROP.getName).as[Reads] match {
           case a: \/-[Reads] => a
-          case _         => extract[ReadMode](config, new ItemKey(INSTRUMENT_KEY, READMODE_PROP.getName))
+          case _         => config.extract(INSTRUMENT_KEY / READMODE_PROP.getName).as[ReadMode]
                             .map(readsFromReadMode)
         }
     // Readout mode defaults to SCIENCE if not present.
-    r <- \/-(extract[ReadoutMode](config, new ItemKey(INSTRUMENT_KEY, READOUT_MODE_PROP.getName)).getOrElse(ReadoutMode.SCIENCE))
-    s <- extract[Decker](config, new ItemKey(INSTRUMENT_KEY, DECKER_PROP.getName))
+    r <- \/-(config.extract(INSTRUMENT_KEY / READOUT_MODE_PROP.getName).as[ReadoutMode].getOrElse(ReadoutMode.SCIENCE))
+    s <- config.extract(INSTRUMENT_KEY / DECKER_PROP.getName).as[Decker]
   } yield DCConfig(p, q, r, s) ).leftMap(SeqexecFailure.Unexpected)
 
   def fromSequenceConfig(config: Config): SeqAction[Flamingos2Config] = EitherT( Task ( for {

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/FLAMINGOS2.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/FLAMINGOS2.scala
@@ -77,8 +77,8 @@ object FLAMINGOS2 {
   }
 
   def fpuConfig(config: Config): \/[String, FocalPlaneUnit] = {
-    val a = new ItemKey(INSTRUMENT_KEY, FPU_PROP.getName)
-    val b = new ItemKey(INSTRUMENT_KEY, FPU_MASK_PROP.getName)
+    val a = INSTRUMENT_KEY / FPU_PROP
+    val b = INSTRUMENT_KEY / FPU_MASK_PROP
 
     config.extract(a).as[FPUnit].flatMap(x =>
       if(x != FPUnit.CUSTOM_MASK) \/-(fpuFromFPUnit(x))
@@ -93,30 +93,30 @@ object FLAMINGOS2 {
 
   def ccConfigFromSequenceConfig(config: Config): TrySeq[CCConfig] = ( for {
       // WINDOW_COVER_PROP is optional. If not present, then window cover position is inferred from observe type.
-      p <- config.extract(INSTRUMENT_KEY / WINDOW_COVER_PROP.getName).as[WindowCover] match {
+      p <- config.extract(INSTRUMENT_KEY / WINDOW_COVER_PROP).as[WindowCover] match {
             case a: \/-[WindowCover] => a
             case _         => config.extract(OBSERVE_KEY / OBSERVE_TYPE_PROP).as[String]
                               .map(windowCoverFromObserveType)
           }
-      q <- config.extract(INSTRUMENT_KEY / DECKER_PROP.getName).as[Decker]
+      q <- config.extract(INSTRUMENT_KEY / DECKER_PROP).as[Decker]
       r <- fpuConfig(config)
-      s <- config.extract(INSTRUMENT_KEY / FILTER_PROP.getName).as[Filter]
-      t <- config.extract(INSTRUMENT_KEY / LYOT_WHEEL_PROP.getName).as[LyotWheel]
-      u <- config.extract(INSTRUMENT_KEY / DISPERSER_PROP.getName).as[Disperser]
+      s <- config.extract(INSTRUMENT_KEY / FILTER_PROP).as[Filter]
+      t <- config.extract(INSTRUMENT_KEY / LYOT_WHEEL_PROP).as[LyotWheel]
+      u <- config.extract(INSTRUMENT_KEY / DISPERSER_PROP).as[Disperser]
 
     } yield CCConfig(p, q, r, s, t, u) ).leftMap(SeqexecFailure.Unexpected)
 
   def dcConfigFromSequenceConfig(config: Config): TrySeq[DCConfig] = ( for {
-    p <- config.extract(OBSERVE_KEY / EXPOSURE_TIME_PROP.getName).as[java.lang.Double].map(x => Duration(x, SECONDS))
+    p <- config.extract(OBSERVE_KEY / EXPOSURE_TIME_PROP).as[java.lang.Double].map(x => Duration(x, SECONDS))
     // Reads is usually inferred from the read mode, but it can be explicit.
-    q <- config.extract(OBSERVE_KEY / READS_PROP.getName).as[Reads] match {
+    q <- config.extract(OBSERVE_KEY / READS_PROP).as[Reads] match {
           case a: \/-[Reads] => a
-          case _         => config.extract(INSTRUMENT_KEY / READMODE_PROP.getName).as[ReadMode]
+          case _         => config.extract(INSTRUMENT_KEY / READMODE_PROP).as[ReadMode]
                             .map(readsFromReadMode)
         }
     // Readout mode defaults to SCIENCE if not present.
-    r <- \/-(config.extract(INSTRUMENT_KEY / READOUT_MODE_PROP.getName).as[ReadoutMode].getOrElse(ReadoutMode.SCIENCE))
-    s <- config.extract(INSTRUMENT_KEY / DECKER_PROP.getName).as[Decker]
+    r <- \/-(config.extract(INSTRUMENT_KEY / READOUT_MODE_PROP).as[ReadoutMode].getOrElse(ReadoutMode.SCIENCE))
+    s <- config.extract(INSTRUMENT_KEY / DECKER_PROP).as[Decker]
   } yield DCConfig(p, q, r, s) ).leftMap(SeqexecFailure.Unexpected)
 
   def fromSequenceConfig(config: Config): SeqAction[Flamingos2Config] = EitherT( Task ( for {


### PR DESCRIPTION
This cleans up the syntax for extracting a value from a config, so instead of

```scala
extract[FPUnit](config, a)
```

You say

```scala
config.extract(a).as[FPUnit]
```

Debatable whether this is an actual improvement but I think it reads better.