### PR TITLE
OCSADV-515: Target Editor BAGS changes and cleanup

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/TelescopePosWatcher.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/TelescopePosWatcher.java
@@ -6,9 +6,7 @@ package edu.gemini.spModel.target;
  */
 @FunctionalInterface
 public interface TelescopePosWatcher {
-
     void telescopePosUpdate(WatchablePos tp);
-
 }
 
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
@@ -36,17 +36,17 @@ public final class TargetSelection {
 
     private static final Index NO_SELECTION = new Index(-1);
 
-    private static boolean isValid(ISPNode node) {
+    private static boolean isValid(final ISPNode node) {
         return (node instanceof ISPObsComponent) && ((ISPObsComponent) node).getType() == SPComponentType.TELESCOPE_TARGETENV;
     }
 
-    public static int getIndex(ISPNode node) {
+    public static int getIndex(final ISPNode node) {
         if (!isValid(node)) return NO_SELECTION.value;
         final Object cd = node.getTransientClientData(KEY);
         return ((cd == null) ? NO_SELECTION : (Index) cd).value;
     }
 
-    public static void setIndex(ISPNode node, int index) {
+    public static void setIndex(final ISPNode node, final int index) {
         if (isValid(node)) node.putTransientClientData(KEY, new Index(index));
     }
 
@@ -54,76 +54,76 @@ public final class TargetSelection {
         final GuideGroup guideGroup;
         final SPTarget target;
 
-        private Selection(GuideGroup grp, SPTarget target) {
+        private Selection(final GuideGroup grp, final SPTarget target) {
             this.guideGroup = grp;
             this.target     = target;
         }
     }
 
-    private static ImList<Selection> toSelections(TargetEnvironment env) {
+    private static ImList<Selection> toSelections(final TargetEnvironment env) {
         if (env == null) return ImCollections.emptyList();
 
         final List<Selection> res = new ArrayList<>();
         res.add(new Selection(null, env.getBase()));
-        for (final GuideGroup g : env.getGroups()) {
+        env.getGroups().foreach(g -> {
             res.add(new Selection(g, null));
             g.getTargets().foreach(t -> res.add(new Selection(g, t)));
-        }
+        });
         env.getUserTargets().foreach(t -> res.add(new Selection(null, t)));
         return DefaultImList.create(res);
     }
 
     private static final MapOp<Tuple2<Selection, Integer>, Integer> INDEX_OF = Tuple2::_2;
 
-    public static int indexOf(TargetEnvironment env, final SPTarget target) {
+    public static int indexOf(final TargetEnvironment env, final SPTarget target) {
         return toSelections(env).zipWithIndex().
                 find(tup -> target.equals(tup._1().target)).
                 map(INDEX_OF).getOrElse(NO_SELECTION.value);
     }
 
-    public static int indexOf(TargetEnvironment env, final GuideGroup grp) {
+    public static int indexOf(final TargetEnvironment env, final GuideGroup grp) {
         return toSelections(env).zipWithIndex().
                 find(tup -> grp.equals(tup._1().guideGroup)).
                 map(INDEX_OF).getOrElse(NO_SELECTION.value);
     }
 
-    private static Selection selectionAt(TargetEnvironment env, int index) {
+    private static Selection selectionAt(final TargetEnvironment env, final int index) {
         if (index < 0) return null;
         final ImList<Selection> lst = toSelections(env);
         return (index < lst.size()) ? lst.get(index) : null;
     }
 
-    public static SPTarget get(TargetEnvironment env, int index) {
+    public static SPTarget get(final TargetEnvironment env, final int index) {
         final Selection s = selectionAt(env, index);
         return (s == null) ? null : s.target;
     }
 
-    public static SPTarget get(TargetEnvironment env, ISPNode node) {
+    public static SPTarget get(final TargetEnvironment env, final ISPNode node) {
         return get(env, getIndex(node));
     }
 
-    public static void set(TargetEnvironment env, ISPNode node, SPTarget target) {
+    public static void set(final TargetEnvironment env, final ISPNode node, final SPTarget target) {
         setIndex(node, indexOf(env, target));
     }
 
-    public static GuideGroup getGuideGroup(TargetEnvironment env, int index) {
+    public static GuideGroup getGuideGroup(final TargetEnvironment env, final int index) {
         final Selection s = selectionAt(env, index);
         return (s == null) ? null : s.guideGroup;
     }
 
-    public static void setGuideGroup(TargetEnvironment env, ISPNode node, GuideGroup grp) {
+    public static void setGuideGroup(final TargetEnvironment env, final ISPNode node, final GuideGroup grp) {
         setIndex(node, indexOf(env, grp));
     }
 
-    public static GuideGroup getGuideGroup(TargetEnvironment env, ISPNode node) {
+    public static GuideGroup getGuideGroup(final TargetEnvironment env, final ISPNode node) {
         return getGuideGroup(env, getIndex(node));
     }
 
-    public static void listenTo(ISPNode node, PropertyChangeListener listener) {
+    public static void listenTo(final ISPNode node, final PropertyChangeListener listener) {
         if (isValid(node)) node.addTransientPropertyChangeListener(PROP, listener);
     }
 
-    public static void deafTo(ISPNode node, PropertyChangeListener listener) {
+    public static void deafTo(final ISPNode node, final PropertyChangeListener listener) {
         if (isValid(node)) node.removeTransientPropertyChangeListener(PROP, listener);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
@@ -1,14 +1,6 @@
 package edu.gemini.spModel.obs
 
-/**
- * Created with IntelliJ IDEA.
- * User: sraaphor
- * Date: 3/15/14
- * Time: 4:07 PM
- * To change this template use File | Settings | File Templates.
- */
-case class SchedulingBlock(start: Long, duration: Long) {
-}
+case class SchedulingBlock(start: Long, duration: Long)
 
 object SchedulingBlock {
   def valueOf(startString: String, durationString: String): SchedulingBlock = {

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
@@ -8,4 +8,12 @@ public class ImOption {
             return new Some<>(value);
         }
     }
+
+    public static <T> Option<T> fromScalaOpt(final scala.Option<T> scalaOpt) {
+        return scalaOpt.isDefined() ? new Some<>(scalaOpt.get()) : None.instance();
+    }
+
+    public static <T> scala.Option<T> toScalaOpt(final Option<T> geminiOpt) {
+        return scala.Option.apply(geminiOpt.getOrNull());
+    }
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
@@ -12,8 +12,4 @@ public class ImOption {
     public static <T> Option<T> fromScalaOpt(final scala.Option<T> scalaOpt) {
         return scalaOpt.isDefined() ? new Some<>(scalaOpt.get()) : None.instance();
     }
-
-    public static <T> scala.Option<T> toScalaOpt(final Option<T> geminiOpt) {
-        return scala.Option.apply(geminiOpt.getOrNull());
-    }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/ags/AgsContextPublisher.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/ags/AgsContextPublisher.java
@@ -1,6 +1,7 @@
 package jsky.app.ot.ags;
 
 import edu.gemini.pot.sp.ISPObservation;
+import edu.gemini.shared.util.immutable.Option;
 
 import javax.swing.*;
 import java.beans.PropertyChangeEvent;
@@ -46,14 +47,25 @@ public final class AgsContextPublisher {
         }
     }
 
-    public void watch(ISPObservation obs) {
-        if (this.obs != null) {
-            this.obs.removeCompositeChangeListener(obsListener);
+    public void watch(final Option<ISPObservation> obsShell) {
+        if (obsShell.isDefined()) watch(obsShell.getValue());
+        else unwatch();
+    }
+
+    public void unwatch() {
+        if (obs != null) {
+            obs.removeCompositeChangeListener(obsListener);
         }
-        this.obs        = obs;
-        this.agsContext = AgsContext.create(obs);
-        if (this.obs != null) {
-            this.obs.addCompositeChangeListener(obsListener);
+        obs        = null;
+        agsContext = AgsContext.EMPTY;
+    }
+
+    private void watch(final ISPObservation newObs) {
+        unwatch();
+        obs        = newObs;
+        agsContext = AgsContext.create(newObs);
+        if (obs != null) {
+            obs.addCompositeChangeListener(obsListener);
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -11,7 +11,6 @@ import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.xml.PioXmlFactory;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.TelescopePosWatcher;
-import edu.gemini.spModel.target.WatchablePos;
 import edu.gemini.spModel.target.env.*;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
@@ -57,7 +56,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w = new TelescopeForm(this);
 
         _w.addComponentListener(new ComponentAdapter() {
-            public void componentShown(ComponentEvent componentEvent) {
+            public void componentShown(final ComponentEvent componentEvent) {
                 toggleAgsGuiElements();
             }
         });
@@ -76,7 +75,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         );
 
         _w.guideGroupName.addWatcher(new TextBoxWidgetWatcher() {
-            public void textBoxKeyPress(TextBoxWidget tbwe) {
+            @Override public void textBoxKeyPress(final TextBoxWidget tbwe) {
                 SwingUtilities.invokeLater(() -> {
                     final String name = _w.guideGroupName.getText();
                     final GuideGroup newGroup = _curGroup.setName(name);
@@ -93,13 +92,10 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                     _w.guideGroupName.requestFocus(); // otherwise focus is lost during event handling
                 });
             }
-            public void textBoxAction(TextBoxWidget tbwe) {
-            }
         });
 
         _w.positionTable.addKeyListener(new KeyAdapter() {
-            @Override
-            public void keyPressed(KeyEvent event) {
+            @Override public void keyPressed(final KeyEvent event) {
                 switch (event.getKeyCode()) {
                     // Make the delete and backspace buttons delete selected positions.
                     case KeyEvent.VK_DELETE:
@@ -114,7 +110,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
     }
 
-    @Override protected void updateEnabledState(boolean enabled) {
+    @Override protected void updateEnabledState(final boolean enabled) {
         if (enabled != isEnabled()) {
             setEnabled(enabled);
             updateEnabledState(getWindow().getComponents(), enabled);
@@ -136,7 +132,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.newMenu.setEnabled(enabled && inst != null);
     }
 
-    protected void updateDetailEditorEnabledState(boolean enabled) {
+    protected void updateDetailEditorEnabledState(final boolean enabled) {
         // Update enabled state for all detail widgets.
         _w.detailEditor.allEditorsJava().stream().forEach(ed -> updateEnabledState(new Component[]{ed}, enabled));
     }
@@ -146,163 +142,64 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
      */
     private void updateRemovePrimaryButtonsAndDetailEditor(final TargetEnvironment env) {
         final boolean editable   = OTOptions.areRootAndCurrentObsIfAnyEditable(getProgram(), getContextObservation());
-        final boolean curNotBags = !env.getGroups().exists(gg -> gg.getAllContaining(_curPos).exists(gpt -> gpt.getBagsResult().targetAsJava().exists(_curPos::equals)));
         final boolean curNotBase = _curPos != env.getBase();
-        _w.removeButton.setEnabled(curNotBase && curNotBags && editable);
+        _w.removeButton.setEnabled(curNotBase && editable);
         _w.primaryButton.setEnabled(enablePrimary(_curPos, env) && editable);
-        updateDetailEditorEnabledState(curNotBags && editable);
-    }
-
-    private final ActionListener _tagListener = new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-            final PositionType pt = (PositionType) _w.tag.getSelectedItem();
-            pt.morphTarget(getDataObject(), _curPos);
-            if (getDataObject() != null) {
-                final TargetEnvironment env = getDataObject().getTargetEnvironment();
-                if (env.getTargets().contains(_curPos)) {
-
-                    final Option<ObsContext> ctx = getObsContext(env);
-
-                    if (_curPos != null) _curPos.deleteWatcher(posWatcher);
-
-                    _w.detailEditor.edit(ctx, _curPos, getNode());
-
-                    if (_curPos != null) {
-                        _curPos.addWatcher(posWatcher);
-                        refreshAll();
-                        updateRemovePrimaryButtonsAndDetailEditor(env);
-                    }
-                }
-            }
-        }
-    };
-
-    /**
-     * A renderer of target type options.  Shows a guider type that isn't available in the current
-     * context with a warning icon.
-     */
-    private final DefaultListCellRenderer tagRenderer = new DefaultListCellRenderer() {
-        private final Icon errorIcon = Resources.getIcon("eclipse/error.gif");
-        @Override public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-            final JLabel lab = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-            final PositionType pt = (PositionType) value;
-            if (!pt.isAvailable()) {
-                lab.setFont(lab.getFont().deriveFont(Font.ITALIC));
-                lab.setIcon(errorIcon);
-            }
-            return lab;
-        }
-    };
-
-    private static final class TargetClipboard {
-        private ITarget target;
-        private GuideGroup group;
-        private ImList<Magnitude> mag;
-
-        static Option<TargetClipboard> copy(TargetEnvironment env, ISPObsComponent obsComponent) {
-            if (obsComponent == null) return None.instance();
-
-            final SPTarget target = TargetSelection.get(env, obsComponent);
-            if (target == null) {
-                final GuideGroup group = TargetSelection.getGuideGroup(env, obsComponent);
-                if (group == null) {
-                    return None.instance();
-                }
-                return new Some<>(new TargetClipboard(group));
-            }
-            return new Some<>(new TargetClipboard(target));
-        }
-
-        TargetClipboard(SPTarget spTarget) {
-            this.target = spTarget.getTarget().clone();
-            this.mag = spTarget.getTarget().getMagnitudes();
-        }
-
-        TargetClipboard(GuideGroup group) {
-            this.group = group;
-        }
-
-        // Groups in their entirety should be copied, pasted, and duplicated by the existing
-        // copy, paste, and duplicate buttons.  Disallow pasting a group on top of an individual target.
-        // Pasting on top of a group should replace the group contents just as the target paste replaces
-        // the coordinates of the selected target.
-        void paste(ISPObsComponent obsComponent, TargetObsComp dataObject) {
-            if ((obsComponent == null) || (dataObject == null)) return;
-
-            final SPTarget spTarget = TargetSelection.get(dataObject.getTargetEnvironment(), obsComponent);
-            if (spTarget != null) {
-                if (target != null) {
-                    spTarget.setTarget(target.clone());
-                    spTarget.setMagnitudes(mag);
-                }
-            } else {
-                final GuideGroup group = TargetSelection.getGuideGroup(dataObject.getTargetEnvironment(), obsComponent);
-                if (group != null) {
-                    if (this.group != null) {
-                        final GuideGroup newGroup = group.setAll(this.group.cloneTargets().getAll());
-                        // XXX TODO: add a helper method in the model to replace a guide group
-                        final TargetEnvironment env = dataObject.getTargetEnvironment();
-                        final GuideEnvironment ge = dataObject.getTargetEnvironment().getGuideEnvironment();
-                        final ImList<GuideGroup> options = ge.getOptions();
-                        final ArrayList<GuideGroup> list = new ArrayList<>(options.size());
-                        for (GuideGroup gg : options) {
-                            list.add(gg == group ? newGroup : gg);
-                        }
-                        dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setOptions(DefaultImList.create(list))));
-                    }
-                }
-            }
-        }
+        updateDetailEditorEnabledState(editable);
     }
 
     // OtItemEditor
-    public JPanel getWindow() {
+    @Override public JPanel getWindow() {
         return _w;
     }
 
-    // OtItemEditor
-    public void init() {
+    // Common code to manage the position watcher on the current position around an action that modifies it.
+    // We also check for the presence of a specified target in the target environment.
+    private void manageCurPosIfEnvContainsTarget(final SPTarget target, final Runnable action) {
+        final TargetObsComp obsComp = getDataObject();
+        if (obsComp == null) return;
 
+        final TargetEnvironment env = obsComp.getTargetEnvironment();
+        if (env == null || !env.getTargets().contains(target)) return;
+
+        if (_curPos != null)
+            _curPos.deleteWatcher(posWatcher);
+
+        action.run();
+
+        if (_curPos != null) {
+            _curPos.addWatcher(posWatcher);
+            refreshAll();
+            updateRemovePrimaryButtonsAndDetailEditor(env);
+        }
+    }
+
+    // OtItemEditor
+    @Override public void init() {
         final ISPObsComponent node = getContextTargetObsComp();
         TargetSelection.listenTo(node, selectionListener);
 
-        getDataObject().addPropertyChangeListener(TargetObsComp.TARGET_ENV_PROP, primaryButtonUpdater);
-        getDataObject().addPropertyChangeListener(TargetObsComp.TARGET_ENV_PROP, guidingPanelUpdater);
-
-        final TargetEnvironment env = getDataObject().getTargetEnvironment();
-        final SPTarget selTarget = TargetSelection.get(env, node);
-        if (getDataObject() != null) {
-            final TargetEnvironment env2 = getDataObject().getTargetEnvironment();
-            if (env2.getTargets().contains(selTarget)) {
-
-                if (_curPos != null) _curPos.deleteWatcher(posWatcher);
-
-                _curPos = selTarget;
-
-                if (_curPos != null) {
-                    _curPos.addWatcher(posWatcher);
-                    refreshAll();
-                    updateRemovePrimaryButtonsAndDetailEditor(env2);
-                }
-            }
-        }
-
         final TargetObsComp obsComp = getDataObject();
+        obsComp.addPropertyChangeListener(TargetObsComp.TARGET_ENV_PROP, primaryButtonUpdater);
+        obsComp.addPropertyChangeListener(TargetObsComp.TARGET_ENV_PROP, guidingPanelUpdater);
+
+        final TargetEnvironment env = obsComp.getTargetEnvironment();
+        final SPTarget selTarget = TargetSelection.get(env, node);
+        manageCurPosIfEnvContainsTarget(selTarget, () -> _curPos = selTarget);
+
         final SPInstObsComp inst = getContextInstrumentDataObject();
         _w.newMenu.removeAll();
-        if (obsComp == null || inst == null) {
+        if (inst == null) {
             _w.newMenu.setEnabled(false);
         } else {
             _w.newMenu.setEnabled(true);
             if (inst.hasGuideProbes()) {
                 final List<GuideProbe> guiders = new ArrayList<>(GuideProbeUtil.instance.getAvailableGuiders(getContextObservation()));
                 Collections.sort(guiders, GuideProbe.KeyComparator.instance);
-
-                for (final GuideProbe probe : guiders) {
+                guiders.forEach(probe ->
                     _w.newMenu.add(new JMenuItem(probe.getKey()) {{
                         addActionListener(new AddGuideStarAction(obsComp, probe, _w.positionTable));
-                    }});
-                }
+                    }}));
             }
 
             _w.newMenu.add(new JMenuItem("User") {{
@@ -317,29 +214,22 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
                 // OT-34: disable create group menu if no guide stars defined
                 _w.newMenu.addMenuListener(new MenuListener() {
-                    @Override
-                    public void menuSelected(MenuEvent e) {
-                        guideGroupMenu.setEnabled(obsComp.getTargetEnvironment().getGuideEnvironment().getTargets().size() != 0);
+                    @Override public void menuSelected(final MenuEvent e) {
+                        guideGroupMenu.setEnabled(obsComp.getTargetEnvironment().getGuideEnvironment().getTargets().nonEmpty());
                     }
-
-                    @Override
-                    public void menuDeselected(MenuEvent e) {
-                    }
-
-                    @Override
-                    public void menuCanceled(MenuEvent e) {
-                    }
+                    @Override public void menuDeselected(final MenuEvent e) {}
+                    @Override public void menuCanceled(final MenuEvent e) {}
                 });
             }
         }
-        _w.positionTable.reinit(getDataObject());
+        _w.positionTable.reinit(obsComp);
         _w.guidingControls.manualGuideStarButton().peer().setVisible(GuideStarSupport.supportsManualGuideStarSelection(getNode()));
         updateGuiding();
         _agsPub.watch(getContextObservation());
     }
 
     // OtItemEditor
-    protected void cleanup() {
+    @Override protected void cleanup() {
         _agsPub.watch(null);
         TargetSelection.deafTo(getContextTargetObsComp(), selectionListener);
         getDataObject().removePropertyChangeListener(TargetObsComp.TARGET_ENV_PROP, primaryButtonUpdater);
@@ -351,10 +241,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         final boolean supports = GuideStarSupport.supportsAutoGuideStarSelection(getNode());
         _w.guidingControls.supportsAgs_$eq(supports); // hide the ags related buttons
     }
-
-    // Guider panel property change listener to modify status and magnitude limits.
-    private final PropertyChangeListener guidingPanelUpdater = (evt) ->
-        updateGuiding((TargetEnvironment) evt.getNewValue());
 
     private Option<ObsContext> getObsContext(final TargetEnvironment env) {
         return ObsContext.create(getContextObservation()).map(obsContext -> obsContext.withTargets(env));
@@ -372,164 +258,11 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         // Update the guiding feedback.
         final ISPObsComponent node = getContextTargetObsComp();
         final SPTarget      target = TargetSelection.get(env, node);
-        _w.detailEditor.gfe().edit(getObsContext(env), target, node);
+        _w.detailEditor.gfe().edit(ctx, target, node);
     }
 
-    private final PropertyChangeListener selectionListener = new PropertyChangeListener() {
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            final ISPObsComponent node = getContextTargetObsComp();
-            final TargetEnvironment env = getDataObject().getTargetEnvironment();
-            final SPTarget target = TargetSelection.get(env, node);
-            if (target != null) {
-                if (getDataObject() != null) {
-                    final TargetEnvironment env1 = getDataObject().getTargetEnvironment();
-                    if (env1.getTargets().contains(target)) {
 
-                        if (_curPos != null) _curPos.deleteWatcher(posWatcher);
-                        _curPos = target;
-                        _curPos.addWatcher(posWatcher);
-                        refreshAll();
-                        updateRemovePrimaryButtonsAndDetailEditor(env1);
-                    }
-                }
-            } else {
-                final GuideGroup grp = TargetSelection.getGuideGroup(env, node);
-                if (grp != null) if (getDataObject() != null) {
-                    final TargetEnvironment env1 = getDataObject().getTargetEnvironment();
-                    if (env1.getGroups().contains(grp)) {
-
-                        if (_curPos != null) _curPos.deleteWatcher(posWatcher);
-
-                        _curPos = null;
-                        _curGroup = grp;
-
-                        _w.guideGroupPanel.setVisible(true);
-                        _w.detailEditor.setVisible(false);
-
-                        // N.B. don't trim, otherwise user can't include space in group name
-                        final String name = _curGroup.getName().getOrElse("");
-                        _w.guideGroupName.setValue(name);
-
-                        final boolean editable = OTOptions.areRootAndCurrentObsIfAnyEditable(getProgram(), getContextObservation());
-                        _w.removeButton.setEnabled(editable);
-                        _w.primaryButton.setEnabled(editable);
-                    }
-                }
-            }
-        }
-    };
-
-    // Updates the enabled state of the primary guide target button when the target environment changes.
-    private final PropertyChangeListener primaryButtonUpdater = new PropertyChangeListener() {
-        public void propertyChange(PropertyChangeEvent evt) {
-            boolean enabled = false;
-            if (_curPos != null) {
-                final TargetEnvironment env = getDataObject().getTargetEnvironment();
-                final ImList<GuideProbeTargets> gtList = env.getOrCreatePrimaryGuideGroup().getAllContaining(_curPos);
-                enabled = gtList.size() > 0;
-            } else if (_curGroup != null) {
-                enabled = true;
-            }
-            _w.primaryButton.setEnabled(enabled && OTOptions.areRootAndCurrentObsIfAnyEditable(getProgram(), getContextObservation()));
-        }
-    };
-
-    // Action that handles adding a new guide star when a probe is picked from the add menu.
-    private class AddGuideStarAction implements ActionListener {
-        private final TargetObsComp obsComp;
-        private final GuideProbe probe;
-        private final TelescopePosTableWidget positionTable;
-
-        AddGuideStarAction(TargetObsComp obsComp, GuideProbe probe, TelescopePosTableWidget positionTable) {
-            this.obsComp = obsComp;
-            this.probe = probe;
-            this.positionTable = positionTable;
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent actionEvent) {
-            TargetEnvironment env = obsComp.getTargetEnvironment();
-            GuideEnvironment ge = env.getGuideEnvironment();
-            if (ge.getPrimary().isEmpty()) {
-                ge = ge.setPrimary(env.getOrCreatePrimaryGuideGroup());
-                env = env.setGuideEnvironment(ge);
-            }
-
-            // OT-16: add new guide star to selected group, if any, otherwise the primary group
-            GuideGroup guideGroup = positionTable.getSelectedGroupOrParentGroup(env);
-            final Option<GuideProbeTargets> opt = guideGroup == null ?
-                    env.getPrimaryGuideProbeTargets(probe) :
-                    guideGroup.get(probe);
-            if (guideGroup == null) {
-                guideGroup = ge.getPrimary().getValue();
-            }
-
-            final GuideProbeTargets targets;
-            final SPTarget target = new SPTarget();
-            if (opt.isEmpty()) {
-                targets = GuideProbeTargets.create(probe, target).withExistingPrimary(target);
-            } else {
-                targets = opt.getValue().addManualTarget(target).withExistingPrimary(target);
-            }
-            obsComp.setTargetEnvironment(env.setGuideEnvironment(
-                    env.getGuideEnvironment().putGuideProbeTargets(guideGroup, targets)));
-
-            // XXX OT-35 hack to work around recursive call to TargetObsComp.setTargetEnvironment() in
-            // SPProgData.ObsContextManager.update()
-            SwingUtilities.invokeLater(EdCompTargetList.this::showTargetTag);
-        }
-    }
-
-    private static class AddUserTargetAction implements ActionListener {
-        private final TargetObsComp obsComp;
-
-        AddUserTargetAction(TargetObsComp obsComp) {
-            this.obsComp = obsComp;
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent actionEvent) {
-            TargetEnvironment env = obsComp.getTargetEnvironment();
-            env = env.setUserTargets(env.getUserTargets().append(new SPTarget()));
-            obsComp.setTargetEnvironment(env);
-        }
-    }
-
-    private static class AddGroupAction implements ActionListener {
-        private final TargetObsComp obsComp;
-        private final TelescopePosTableWidget positionTable;
-
-        AddGroupAction(TargetObsComp obsComp, TelescopePosTableWidget positionTable) {
-            this.obsComp = obsComp;
-            this.positionTable = positionTable;
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent actionEvent) {
-            final TargetEnvironment env = obsComp.getTargetEnvironment();
-            GuideEnvironment ge = env.getGuideEnvironment();
-            if (ge.getPrimary().isEmpty()) {
-                ge = ge.setPrimary(env.getOrCreatePrimaryGuideGroup());
-            }
-            final GuideGroup primaryGroup = ge.getPrimary().getValue();
-            final ImList<GuideGroup> options = ge.getOptions();
-            final GuideGroup group = GuideGroup.create(null);
-            final ImList<GuideGroup> groups = options.append(group);
-
-            // OT-34: make new group primary and select it
-            if (!positionTable.confirmGroupChange(primaryGroup, group)) return;
-            obsComp.setTargetEnvironment(env.setGuideEnvironment(ge.setOptions(groups).selectPrimary(group)));
-            if (groups.size() == 2) {
-                // expand primary group tree node, which was previously hidden (implicit)
-                positionTable.expandGroup(options.get(0));
-            }
-            // expand new group tree node
-            positionTable.expandGroup(group);
-        }
-    }
-
-    private static boolean enablePrimary(SPTarget target, TargetEnvironment env) {
+    private static boolean enablePrimary(final SPTarget target, final TargetEnvironment env) {
         return env.getBase() != target && !env.getUserTargets().contains(target);
     }
 
@@ -551,7 +284,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         // the guide probe to the list of choices so that this target may be selected in order to
         // change its type or delete it.
         GuideProbe illegal = null;
-        for (GuideProbe guider : illegalSet) {
+        for (final GuideProbe guider : illegalSet) {
             final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(guider);
             if (gtOpt.getValue().getTargets().contains(_curPos)) {
                 illegal = guider;
@@ -584,10 +317,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         // Update target details
         _w.detailEditor.edit(getObsContext(env), _curPos, getNode());
-
-        // TODO: Why is this doing nothing???
-        // final boolean isBags = _curPos != null && env.getGroups().exists(gg -> gg.getAllContaining(_curPos).exists(gpt -> gpt.getBagsResult().exists(_curPos::equals)));
-        // _w.detailEditor.allEditorsJava().stream().filter(ed -> _w.detailEditor.curDetailEditorJava().forall(cur -> cur != ed)).forEach(ed -> updateEnabledState(new Component[]{ed}, !isBags));
     }
 
     private void showTargetTag() {
@@ -603,46 +332,219 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         }
     }
 
-    private final TelescopePosWatcher posWatcher = new TelescopePosWatcher() {
-        public void telescopePosUpdate(WatchablePos tp) {
-            if (tp != _curPos) {
-                // This shouldn't happen ...
-                System.out.println(getClass().getName() + ": received a position " +
-                        " update for a position other than the current one: " + tp);
-                return;
+
+    /**
+     * Listeners and watchers.
+     */
+
+    // Action that handles adding a new guide star when a probe is picked from the add menu.
+    private class AddGuideStarAction implements ActionListener {
+        private final TargetObsComp obsComp;
+        private final GuideProbe probe;
+        private final TelescopePosTableWidget positionTable;
+
+        AddGuideStarAction(final TargetObsComp obsComp, final GuideProbe probe, final TelescopePosTableWidget positionTable) {
+            this.obsComp = obsComp;
+            this.probe = probe;
+            this.positionTable = positionTable;
+        }
+
+        @Override public void actionPerformed(final ActionEvent actionEvent) {
+            TargetEnvironment env = obsComp.getTargetEnvironment();
+            GuideEnvironment ge = env.getGuideEnvironment();
+            if (ge.getPrimary().isEmpty()) {
+                ge = ge.setPrimary(env.getOrCreatePrimaryGuideGroup());
+                env = env.setGuideEnvironment(ge);
             }
-            refreshAll();
-            updateGuiding();
+
+            // OT-16: add new guide star to selected group, if any, otherwise the primary group
+            GuideGroup guideGroup = positionTable.getSelectedGroupOrParentGroup(env);
+            final Option<GuideProbeTargets> opt = guideGroup == null ?
+                    env.getPrimaryGuideProbeTargets(probe) :
+                    guideGroup.get(probe);
+            if (guideGroup == null) {
+                guideGroup = ge.getPrimary().getValue();
+            }
+
+            final SPTarget target = new SPTarget();
+            final GuideProbeTargets targets = opt
+                    .map(gpt -> gpt.addManualTarget(target))
+                    .getOrElse(GuideProbeTargets.create(probe, target))
+                    .withExistingPrimary(target);
+
+            obsComp.setTargetEnvironment(env.setGuideEnvironment(
+                    env.getGuideEnvironment().putGuideProbeTargets(guideGroup, targets)));
+
+            // XXX OT-35 hack to work around recursive call to TargetObsComp.setTargetEnvironment() in
+            // SPProgData.ObsContextManager.update()
+            SwingUtilities.invokeLater(EdCompTargetList.this::showTargetTag);
+        }
+    }
+
+    private static class AddUserTargetAction implements ActionListener {
+        private final TargetObsComp obsComp;
+
+        AddUserTargetAction(TargetObsComp obsComp) {
+            this.obsComp = obsComp;
+        }
+
+        @Override public void actionPerformed(final ActionEvent actionEvent) {
+            final TargetEnvironment env = obsComp.getTargetEnvironment();
+            final TargetEnvironment newEnv = env.setUserTargets(env.getUserTargets().append(new SPTarget()));
+            obsComp.setTargetEnvironment(newEnv);
+        }
+    }
+
+    private static class AddGroupAction implements ActionListener {
+        private final TargetObsComp obsComp;
+        private final TelescopePosTableWidget positionTable;
+
+        AddGroupAction(final TargetObsComp obsComp, final TelescopePosTableWidget positionTable) {
+            this.obsComp = obsComp;
+            this.positionTable = positionTable;
+        }
+
+        @Override public void actionPerformed(final ActionEvent actionEvent) {
+            final TargetEnvironment env = obsComp.getTargetEnvironment();
+            GuideEnvironment ge = env.getGuideEnvironment();
+            if (ge.getPrimary().isEmpty()) {
+                ge = ge.setPrimary(env.getOrCreatePrimaryGuideGroup());
+            }
+            final GuideGroup primaryGroup = ge.getPrimary().getValue();
+            final ImList<GuideGroup> options = ge.getOptions();
+            final GuideGroup group = GuideGroup.create(null);
+            final ImList<GuideGroup> groups = options.append(group);
+
+            // OT-34: make new group primary and select it
+            if (!positionTable.confirmGroupChange(primaryGroup, group)) return;
+            obsComp.setTargetEnvironment(env.setGuideEnvironment(ge.setOptions(groups).selectPrimary(group)));
+
+            // expand new group tree node
+            positionTable.selectGroup(group);
+        }
+    }
+
+    /**
+     * A renderer of target type options.  Shows a guider type that isn't available in the current
+     * context with a warning icon.
+     */
+    private final DefaultListCellRenderer tagRenderer = new DefaultListCellRenderer() {
+        private final Icon errorIcon = Resources.getIcon("eclipse/error.gif");
+        @Override public Component getListCellRendererComponent(final JList list, final Object value, final int index,
+                                                                final boolean isSelected, final boolean cellHasFocus) {
+            final JLabel lab = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            final PositionType pt = (PositionType) value;
+            if (!pt.isAvailable()) {
+                lab.setFont(lab.getFont().deriveFont(Font.ITALIC));
+                lab.setIcon(errorIcon);
+            }
+            return lab;
         }
     };
 
-    @SuppressWarnings("FieldCanBeLocal")
-    private final ActionListener removeListener = new ActionListener() {
-        public void actionPerformed(ActionEvent evt) {
-            TargetEnvironment env = getDataObject().getTargetEnvironment();
-            if (env.isBasePosition(_curPos)) {
-                DialogUtil.error("You can't remove the Base Position.");
-            } else if (_curPos != null) {
-                env = env.removeTarget(_curPos);
-            } else if (_curGroup != null) {
-                final GuideGroup primary = env.getOrCreatePrimaryGuideGroup();
-                if (_curGroup == primary) {
-                    DialogUtil.error("You can't remove the primary guide group.");
-                    return;
-                }
-                env = env.removeGroup(_curGroup);
-                _curGroup = primary;
+    private final TelescopePosWatcher posWatcher = tp -> {
+        if (tp != _curPos) {
+            // This shouldn't happen ...
+            System.out.println(getClass().getName() + ": received a position " +
+                    " update for a position other than the current one: " + tp);
+            return;
+        }
+        refreshAll();
+        updateGuiding();
+    };
+
+    private final ActionListener _tagListener = new ActionListener() {
+        public void actionPerformed(final ActionEvent e) {
+            final PositionType pt = (PositionType) _w.tag.getSelectedItem();
+            pt.morphTarget(getDataObject(), _curPos);
+            if (getDataObject() != null) {
+                final TargetEnvironment env = getDataObject().getTargetEnvironment();
+                manageCurPosIfEnvContainsTarget(_curPos, () -> _w.detailEditor.edit(getObsContext(env), _curPos, getNode()));
             }
-            getDataObject().setTargetEnvironment(env);
-            final SPTarget selTarget = TargetSelection.get(env, getNode());
-            if (env.getTargets().contains(selTarget)) {
-                if (_curPos != null) _curPos.deleteWatcher(posWatcher);
-                _curPos = selTarget;
-                if (_curPos != null) {
-                    _curPos.addWatcher(posWatcher);
-                    refreshAll();
-                    updateRemovePrimaryButtonsAndDetailEditor(env);
+        }
+    };
+
+    private final PropertyChangeListener selectionListener = new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+
+            final ISPObsComponent node = getContextTargetObsComp();
+            final TargetEnvironment env = getDataObject().getTargetEnvironment();
+            final SPTarget target = TargetSelection.get(env, node);
+
+            if (target != null) {
+                manageCurPosIfEnvContainsTarget(target, () -> _curPos = target);
+            } else {
+                final GuideGroup grp = TargetSelection.getGuideGroup(env, node);
+                if (grp != null) {
+                    final TargetEnvironment env1 = getDataObject().getTargetEnvironment();
+                    if (env1.getGroups().contains(grp)) {
+
+                        if (_curPos != null) _curPos.deleteWatcher(posWatcher);
+
+                        _curPos = null;
+                        _curGroup = grp;
+
+                        _w.guideGroupPanel.setVisible(true);
+                        _w.detailEditor.setVisible(false);
+
+                        // N.B. don't trim, otherwise user can't include space in group name
+                        final String name = _curGroup.getName().getOrElse("");
+                        _w.guideGroupName.setValue(name);
+
+                        final boolean editable = OTOptions.areRootAndCurrentObsIfAnyEditable(getProgram(), getContextObservation());
+                        _w.removeButton.setEnabled(editable);
+                        _w.primaryButton.setEnabled(editable);
+                    }
                 }
+            }
+        }
+    };
+
+    // Updates the enabled state of the primary guide target button when the target environment changes.
+    private final PropertyChangeListener primaryButtonUpdater = new PropertyChangeListener() {
+        public void propertyChange(final PropertyChangeEvent evt) {
+            final boolean enabled;
+            if (_curPos != null) {
+                final TargetEnvironment env = getDataObject().getTargetEnvironment();
+                final ImList<GuideProbeTargets> gtList = env.getOrCreatePrimaryGuideGroup().getAllContaining(_curPos);
+                enabled = gtList.nonEmpty();
+            } else {
+                enabled = _curGroup != null;
+            }
+            _w.primaryButton.setEnabled(enabled && OTOptions.areRootAndCurrentObsIfAnyEditable(getProgram(), getContextObservation()));
+        }
+    };
+
+    // Guider panel property change listener to modify status and magnitude limits.
+    private final PropertyChangeListener guidingPanelUpdater = evt ->
+            updateGuiding((TargetEnvironment) evt.getNewValue());
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private final ActionListener removeListener = evt -> {
+        TargetEnvironment env = getDataObject().getTargetEnvironment();
+        if (env.isBasePosition(_curPos)) {
+            DialogUtil.error("You can't remove the Base Position.");
+        } else if (_curPos != null) {
+            env = env.removeTarget(_curPos);
+        } else if (_curGroup != null) {
+            final GuideGroup primary = env.getOrCreatePrimaryGuideGroup();
+            if (_curGroup == primary) {
+                DialogUtil.error("You can't remove the primary guide group.");
+                return;
+            }
+            env = env.removeGroup(_curGroup);
+            _curGroup = primary;
+        }
+        getDataObject().setTargetEnvironment(env);
+        final SPTarget selTarget = TargetSelection.get(env, getNode());
+        if (env.getTargets().contains(selTarget)) {
+            if (_curPos != null) _curPos.deleteWatcher(posWatcher);
+            _curPos = selTarget;
+            if (_curPos != null) {
+                _curPos.addWatcher(posWatcher);
+                refreshAll();
+                updateRemovePrimaryButtonsAndDetailEditor(env);
             }
         }
     };
@@ -660,7 +562,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
     @SuppressWarnings("FieldCanBeLocal")
     private final ActionListener autoGuideStarListener = new ActionListener() {
-        public void actionPerformed(ActionEvent evt) {
+        @Override public void actionPerformed (final ActionEvent evt){
             try {
                 if (GuideStarSupport.hasGemsComponent(getNode())) {
                     final TelescopePosEditor tpe = TpeManager.open();
@@ -679,7 +581,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
     @SuppressWarnings("FieldCanBeLocal")
     private final ActionListener duplicateListener = new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
+        @Override public void actionPerformed(final ActionEvent evt) {
             final ISPObsComponent obsComponent = getNode();
             final TargetObsComp dataObject = getDataObject();
             if ((obsComponent == null) || (dataObject == null)) return;
@@ -691,7 +593,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 newTarget.setParamSet(ps);
 
                 // Add it to the environment.  First we have to figure out what it is.
-                TargetEnvironment env = dataObject.getTargetEnvironment();
+                final TargetEnvironment env = dataObject.getTargetEnvironment();
 
                 // See if it is a guide star and duplicate it in the correct GuideTargets list.
                 boolean duplicated = false;
@@ -707,38 +609,31 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                     }
                     groups.add(group);
                 }
-                if (duplicated) {
-                    // Update groups list
-                    env = env.setGuideEnvironment(env.getGuideEnvironment().setOptions(DefaultImList.create(groups)));
-                } else {
-                    // Add as a user target
-                    env = env.setUserTargets(env.getUserTargets().append(newTarget));
-                }
 
-                dataObject.setTargetEnvironment(env);
+                final TargetEnvironment newEnv = duplicated ?
+                        env.setGuideEnvironment(env.getGuideEnvironment().setOptions(DefaultImList.create(groups))) :
+                        env.setUserTargets(env.getUserTargets().append(newTarget));
+                dataObject.setTargetEnvironment(newEnv);
             } else {
                 final GuideGroup group = TargetSelection.getGuideGroup(dataObject.getTargetEnvironment(), obsComponent);
                 if (group != null) {
-                    TargetEnvironment env = dataObject.getTargetEnvironment();
+                    final TargetEnvironment env = dataObject.getTargetEnvironment();
                     final List<GuideGroup> groups = new ArrayList<>();
                     groups.addAll(env.getGroups().toList());
                     groups.add(group.cloneTargets());
-                    env = env.setGuideEnvironment(env.getGuideEnvironment().setOptions(DefaultImList.create(groups)));
-                    dataObject.setTargetEnvironment(env);
-                    // save/restore tree state will leave last group closed, since there is one more, so expand it here
-                    _w.positionTable.expandGroup(groups.get(groups.size() - 1));
+                    final TargetEnvironment newEnv = env.setGuideEnvironment(env.getGuideEnvironment().setOptions(DefaultImList.create(groups)));
+                    dataObject.setTargetEnvironment(newEnv);
+                    _w.positionTable.expandAll();
                 }
             }
         }
     };
 
     @SuppressWarnings("FieldCanBeLocal")
-    private final ActionListener copyListener = new ActionListener() {
-        public void actionPerformed(ActionEvent e) {
-            final Option<TargetClipboard> opt = TargetClipboard.copy(getDataObject().getTargetEnvironment(), getNode());
-            if (opt.isEmpty()) return;
-            clipboard = opt.getValue();
-        }
+    private final ActionListener copyListener = evt -> {
+        final Option<TargetClipboard> opt = TargetClipboard.copy(getDataObject().getTargetEnvironment(), getNode());
+        if (opt.isEmpty()) return;
+        clipboard = opt.getValue();
     };
 
     @SuppressWarnings("FieldCanBeLocal")
@@ -748,7 +643,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 clipboard.paste(obsComponent, dataObject);
             }
         }
-        public void actionPerformed(ActionEvent e) {
+        @Override public void actionPerformed(ActionEvent e) {
             if (_curPos != null) {
                 pasteSelectedPosition(getNode(), getDataObject());
             } else if (_curGroup != null) {
@@ -764,6 +659,60 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         }
     };
 
+
+    private static final class TargetClipboard {
+        private ITarget target;
+        private GuideGroup group;
+        private ImList<Magnitude> mag;
+
+        static Option<TargetClipboard> copy(final TargetEnvironment env, final ISPObsComponent obsComponent) {
+            if (obsComponent == null) return None.instance();
+
+            final SPTarget target = TargetSelection.get(env, obsComponent);
+            if (target == null) {
+                final GuideGroup group = TargetSelection.getGuideGroup(env, obsComponent);
+                if (group == null) {
+                    return None.instance();
+                }
+                return new Some<>(new TargetClipboard(group));
+            }
+            return new Some<>(new TargetClipboard(target));
+        }
+
+        TargetClipboard(final SPTarget spTarget) {
+            this.target = spTarget.getTarget().clone();
+            this.mag = spTarget.getTarget().getMagnitudes();
+        }
+
+        TargetClipboard(final GuideGroup group) {
+            this.group = group;
+        }
+
+        // Groups in their entirety should be copied, pasted, and duplicated by the existing
+        // copy, paste, and duplicate buttons.  Disallow pasting a group on top of an individual target.
+        // Pasting on top of a group should replace the group contents just as the target paste replaces
+        // the coordinates of the selected target.
+        void paste(final ISPObsComponent obsComponent, final TargetObsComp dataObject) {
+            if ((obsComponent == null) || (dataObject == null)) return;
+
+            final SPTarget spTarget = TargetSelection.get(dataObject.getTargetEnvironment(), obsComponent);
+            final GuideGroup group = TargetSelection.getGuideGroup(dataObject.getTargetEnvironment(), obsComponent);
+
+            if (spTarget != null && target != null) {
+                spTarget.setTarget(target.clone());
+                spTarget.setMagnitudes(mag);
+            } else if (group != null && this.group != null) {
+                final GuideGroup newGroup = group.setAll(this.group.cloneTargets().getAll());
+                // XXX TODO: add a helper method in the model to replace a guide group
+                final TargetEnvironment env = dataObject.getTargetEnvironment();
+                final GuideEnvironment ge = dataObject.getTargetEnvironment().getGuideEnvironment();
+                final ImList<GuideGroup> options = ge.getOptions();
+                final ArrayList<GuideGroup> list = new ArrayList<>(options.size());
+                options.foreach(gg -> list.add(gg == group ? newGroup : gg));
+                dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setOptions(DefaultImList.create(list))));
+            }
+        }
+    }
 }
 
 interface PositionType {
@@ -775,11 +724,11 @@ interface PositionType {
 enum BasePositionType implements PositionType {
     instance;
 
-    public boolean isAvailable() {
+    @Override public boolean isAvailable() {
         return true;
     }
 
-    public void morphTarget(TargetObsComp obsComp, SPTarget target) {
+    @Override public void morphTarget(final TargetObsComp obsComp, final SPTarget target) {
         TargetEnvironment env = obsComp.getTargetEnvironment();
         if (isMember(env, target)) return;
         env = env.removeTarget(target);
@@ -789,15 +738,15 @@ enum BasePositionType implements PositionType {
         final GuideEnvironment genv = env.getGuideEnvironment();
         final ImList<SPTarget> user = env.getUserTargets().append(base);
 
-        env = TargetEnvironment.create(target, genv, user);
-        obsComp.setTargetEnvironment(env);
+        final TargetEnvironment newEnv = TargetEnvironment.create(target, genv, user);
+        obsComp.setTargetEnvironment(newEnv);
     }
 
-    public boolean isMember(TargetEnvironment env, SPTarget target) {
+    @Override public boolean isMember(final TargetEnvironment env, final SPTarget target) {
         return (env.getBase() == target);
     }
 
-    public String toString() {
+    @Override public String toString() {
         return TargetEnvironment.BASE_NAME;
     }
 }
@@ -806,34 +755,33 @@ class GuidePositionType implements PositionType {
     private final GuideProbe guider;
     private final boolean available;
 
-    GuidePositionType(GuideProbe guider, boolean available) {
+    GuidePositionType(final GuideProbe guider, final boolean available) {
         this.guider = guider;
         this.available = available;
     }
 
-    public boolean isAvailable() {
+    @Override public boolean isAvailable() {
         return available;
     }
 
-    public void morphTarget(TargetObsComp obsComp, SPTarget target) {
+    @Override public void morphTarget(final TargetObsComp obsComp, final SPTarget target) {
         TargetEnvironment env = obsComp.getTargetEnvironment();
         if (isMember(env, target)) return;
         env = env.removeTarget(target);
-
 
         final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(guider);
         final GuideProbeTargets gt = gtOpt.map(gpt -> gpt.addManualTarget(target)).
                 getOrElse(GuideProbeTargets.create(guider, target)).withExistingPrimary(target);
 
-        env = env.putPrimaryGuideProbeTargets(gt);
-        obsComp.setTargetEnvironment(env);
+        final TargetEnvironment newEnv = env.putPrimaryGuideProbeTargets(gt);
+        obsComp.setTargetEnvironment(newEnv);
     }
 
-    public boolean isMember(TargetEnvironment env, SPTarget target) {
+    @Override public boolean isMember(final TargetEnvironment env, final SPTarget target) {
         return env.getGroups().exists(group -> group.get(guider).exists(gt -> gt.getTargets().contains(target)));
     }
 
-    public String toString() {
+    @Override public String toString() {
         return guider.getKey();
     }
 }
@@ -841,26 +789,24 @@ class GuidePositionType implements PositionType {
 enum UserPositionType implements PositionType {
     instance;
 
-    public boolean isAvailable() {
+    @Override public boolean isAvailable() {
         return true;
     }
 
-    public void morphTarget(TargetObsComp obsComp, SPTarget target) {
+    @Override public void morphTarget(final TargetObsComp obsComp, final SPTarget target) {
         TargetEnvironment env = obsComp.getTargetEnvironment();
         if (isMember(env, target)) return;
-
         env = env.removeTarget(target);
-        env = env.setUserTargets(env.getUserTargets().append(target));
-        obsComp.setTargetEnvironment(env);
+
+        final TargetEnvironment newEnv = env.setUserTargets(env.getUserTargets().append(target));
+        obsComp.setTargetEnvironment(newEnv);
     }
 
-    public boolean isMember(TargetEnvironment env, SPTarget target) {
+    @Override public boolean isMember(final TargetEnvironment env, final SPTarget target) {
         return env.getUserTargets().contains(target);
     }
 
-    public String toString() {
+    @Override public String toString() {
         return TargetEnvironment.USER_NAME;
     }
 }
-
-

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1,6 +1,7 @@
 package jsky.app.ot.gemini.editor.targetComponent;
 
 import edu.gemini.pot.sp.ISPObsComponent;
+import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.guide.GuideProbe;
@@ -225,12 +226,12 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.positionTable.reinit(obsComp);
         _w.guidingControls.manualGuideStarButton().peer().setVisible(GuideStarSupport.supportsManualGuideStarSelection(getNode()));
         updateGuiding();
-        _agsPub.watch(getContextObservation());
+        _agsPub.watch(ImOption.apply(getContextObservation()));
     }
 
     // OtItemEditor
     @Override protected void cleanup() {
-        _agsPub.watch(null);
+        _agsPub.unwatch();
         TargetSelection.deafTo(getContextTargetObsComp(), selectionListener);
         getDataObject().removePropertyChangeListener(TargetObsComp.TARGET_ENV_PROP, primaryButtonUpdater);
         getDataObject().removePropertyChangeListener(TargetObsComp.TARGET_ENV_PROP, guidingPanelUpdater);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableDragDropObject.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableDragDropObject.java
@@ -2,6 +2,7 @@ package jsky.app.ot.gemini.editor.targetComponent;
 
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
+import java.util.Objects;
 
 /**
  * This class ties an item to the position table widget in which its associated
@@ -19,61 +20,24 @@ final class TelescopePosTableDragDropObject implements Transferable {
         DATA_FLAVOR, DataFlavor.stringFlavor
     };
 
-    // The treetable that owns the node being dragged.  Will be
-    // null if this item is new and is not in any tree.
+    // The treetable that owns the node being dragged. Will be null if this item is new and is not in any tree.
     private TelescopePosTableWidget _currentOwner;
 
     // The item(s) being dragged.
-    private final TelescopePosTableWidget.TableData.Row[] _nodes;
-
-    /**
-     * This constructor should be used when dragging a newly created object
-     * that hasn't been inserted in any tree.
-     */
-    private TelescopePosTableDragDropObject(TelescopePosTableWidget.TableData.Row node) {
-        _nodes = new TelescopePosTableWidget.TableData.Row[1];
-        _nodes[0] = node;
-    }
+    private final TelescopePosTableWidget.TableData.Row _node;
 
     /**
      * This constructor should be used when dragging an object that currently
      * exists in a tree.
      */
-    private TelescopePosTableDragDropObject(TelescopePosTableWidget.TableData.Row node, TelescopePosTableWidget tree) {
-        this(node);
+    TelescopePosTableDragDropObject(TelescopePosTableWidget.TableData.Row node, TelescopePosTableWidget tree) {
+        _node = Objects.requireNonNull(node);
         _currentOwner = tree;
     }
 
-    /**
-     * This constructor should be used when dragging a newly created set
-     * of items that haven't been inserted in any tree.
-     */
-    private TelescopePosTableDragDropObject(TelescopePosTableWidget.TableData.Row[] nodes) {
-        _nodes = nodes;
-    }
-
-    /**
-     * This constructor should be used when dragging a set of objects
-     * that currently exists in a tree.
-     */
-    TelescopePosTableDragDropObject(TelescopePosTableWidget.TableData.Row[] nodes, TelescopePosTableWidget tree) {
-        this(nodes);
-        _currentOwner = tree;
-    }
-
-    /** Get the first TelescopePosTableWidget.TableData.Row. */
+    /** Get the TelescopePosTableWidget.TableData.Row. */
     TelescopePosTableWidget.TableData.Row getNode() {
-        return getNode(0);
-    }
-
-    /** Get the nth TelescopePosTableWidget.TableData.Row. */
-    TelescopePosTableWidget.TableData.Row getNode(int i) {
-        return _nodes[i];
-    }
-
-    /** Get the set of TelescopePosTableWidget.TableData.Rows. */
-    TelescopePosTableWidget.TableData.Row[] getNodes() {
-        return _nodes;
+        return _node;
     }
 
     /** Get the owner, the SPTree that contains the items being dragged. */
@@ -81,7 +45,6 @@ final class TelescopePosTableDragDropObject implements Transferable {
         return _currentOwner;
     }
 
-    // Implementation of the Transferable interface
 
     public DataFlavor[] getTransferDataFlavors() {
         return _transferDataFlavors;
@@ -95,7 +58,6 @@ final class TelescopePosTableDragDropObject implements Transferable {
         if (!isDataFlavorSupported(fl)) {
             return null;
         }
-
         return this;
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableDragSource.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableDragSource.java
@@ -7,12 +7,9 @@ import java.awt.*;
 import java.awt.dnd.*;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
+import java.util.Objects;
 
-/**
- * Drag&Drop source for the position table widget.
- *
- * @author Allan Brighton
- */
+// Drag & drop source for the position table widget.
 class TelescopePosTableDragSource implements DragGestureListener, DragSourceListener {
 
     /** The pos table widget */
@@ -26,67 +23,60 @@ class TelescopePosTableDragSource implements DragGestureListener, DragSourceList
     /**
      * Constructor
      */
-    public TelescopePosTableDragSource(TelescopePosTableWidget tree) {
-        _tree = tree;
+    public TelescopePosTableDragSource(final TelescopePosTableWidget tree) {
+        _tree = Objects.requireNonNull(tree);
 
-        // Create a DragGestureRecognizer and register as the listener
-        final DragSource _dragSource = DragSource.getDefaultDragSource();
-        _dragSource.createDefaultDragGestureRecognizer(_tree, DnDConstants.ACTION_COPY_OR_MOVE, this);
+        // Create a DragGestureRecognizer and register as the listener.
+        DragSource.getDefaultDragSource().createDefaultDragGestureRecognizer(_tree, DnDConstants.ACTION_COPY_OR_MOVE, this);
     }
 
-    void setEditable(boolean editable) { this.editable = editable; }
+    void setEditable(boolean editable) {
+        this.editable = editable;
+    }
 
-    /** Implementation of DragGestureListener interface. */
-    public void dragGestureRecognized(DragGestureEvent dge) {
+    public void dragGestureRecognized(final DragGestureEvent dge) {
         if (!editable) return;
 
-        // don't conflict with popup menus
+        // don't conflict with popup menus.
         final InputEvent e = dge.getTriggerEvent();
         if (e instanceof MouseEvent && ((MouseEvent) e).isPopupTrigger())
             return;
 
-
-        // Get the mouse location and convert it to
-        // a location within the tree.
+        // Get the mouse location and convert it to a location within the tree.
         final Point location = dge.getDragOrigin();
         final TreePath dragPath = _tree.getPathForLocation(location.x, location.y);
         if (dragPath != null && _tree.isPathSelected(dragPath)) {
-            // Get the list of selected nodes and create a Transferable
-            final TelescopePosTableWidget.TableData.Row[] nodes = _tree.getSelectedNodes();
-            if (nodes != null && nodes.length > 0) {
-                _dragObject = new TelescopePosTableDragDropObject(nodes, _tree);
+            // Get the selected node and create a Transferable.
+            _tree.getSelectedNode().ifPresent(node -> {
+                _dragObject = new TelescopePosTableDragDropObject(node, _tree);
                 try {
                     dge.startDrag(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR), _dragObject, this);
-                } catch (Exception ex) {
+                } catch (final Exception ex) {
                     DnDUtils.debugPrintln("SPTreeDragSource.dragGestureRecognized: " + ex);
                 }
-            }
+            });
         }
     }
 
     // Implementation of DragSourceListener interface
-    public void dragEnter(DragSourceDragEvent dsde) {
-        DnDUtils.debugPrintln("Drag Source: dragEnter, drop action = "
-                              + DnDUtils.showActions(dsde.getDropAction()));
+    public void dragEnter(final DragSourceDragEvent dsde) {
+        DnDUtils.debugPrintln("Drag Source: dragEnter, drop action = " + DnDUtils.showActions(dsde.getDropAction()));
     }
 
-    public void dragOver(DragSourceDragEvent dsde) {
-        DnDUtils.debugPrintln("Drag Source: dragOver, drop action = "
-                              + DnDUtils.showActions(dsde.getDropAction()));
+    public void dragOver(final DragSourceDragEvent dsde) {
+        DnDUtils.debugPrintln("Drag Source: dragOver, drop action = " + DnDUtils.showActions(dsde.getDropAction()));
     }
 
-    public void dragExit(DragSourceEvent dse) {
+    public void dragExit(final DragSourceEvent dse) {
         DnDUtils.debugPrintln("Drag Source: dragExit");
     }
 
-    public void dropActionChanged(DragSourceDragEvent dsde) {
-        DnDUtils.debugPrintln("Drag Source: dropActionChanged, drop action = "
-                              + DnDUtils.showActions(dsde.getDropAction()));
+    public void dropActionChanged(final DragSourceDragEvent dsde) {
+        DnDUtils.debugPrintln("Drag Source: dropActionChanged, drop action = " + DnDUtils.showActions(dsde.getDropAction()));
     }
 
-    public void dragDropEnd(DragSourceDropEvent dsde) {
+    public void dragDropEnd(final DragSourceDropEvent dsde) {
         DnDUtils.debugPrintln("Drag Source: drop completed, drop action = "
-                              + DnDUtils.showActions(dsde.getDropAction())
-                              + ", success: " + dsde.getDropSuccess());
+                              + DnDUtils.showActions(dsde.getDropAction()) + ", success: " + dsde.getDropSuccess());
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableDropTarget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableDropTarget.java
@@ -94,20 +94,12 @@ class TelescopePosTableDropTarget implements DropTargetListener {
 
             try {
                 _tree.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-
-                // Save the user's selections
-                //saveTreeSelection();
-
                 dropSucceeded = dropNodes(dtde.getDropAction(), transferable, dtde.getLocation());
                 DnDUtils.debugPrintln("Drop completed, success: " + dropSucceeded);
             } catch (Exception e) {
                 DnDUtils.debugPrintln("Exception while handling drop " + e);
             } finally {
                 _tree.setCursor(Cursor.getDefaultCursor());
-
-                // Restore the user's selections
-                //restoreTreeSelection();
-
                 dtde.dropComplete(dropSucceeded);
             }
         } else {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -156,7 +156,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                 final Option<Coordinates> coords = getCoordinates(target, when);
                 distance = baseCoords.flatMap(bc ->
                         coords.map(c ->
-                                Coordinates.difference(bc, c).distance().toArcmins()
+                                bc.angularDistance(c).toArcmins()
                         )
                 );
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -708,7 +708,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
             _resetTable(newEnv);
 
             // Update the selection.
-            if ((rmTargets.size() == 0) && (addTargets.size() == 1)) {
+            if (rmTargets.isEmpty() && (addTargets.size() == 1)) {
                 // A single position was added, so just select it.
                 selectPos(addTargets.iterator().next());
                 return;
@@ -873,7 +873,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
         if (srcGrp == null) return;
 
         final ImList<GuideProbeTargets> targetList = srcGrp.getAllContaining(target);
-        if (targetList.size() == 0) return;
+        if (targetList.isEmpty()) return;
         final GuideProbeTargets src = targetList.get(0);
 
         final GuideProbe guideprobe = src.getGuider();
@@ -1005,7 +1005,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
     // the operation.
     boolean confirmGroupChange(final GuideGroup oldPrimary, final GuideGroup newPrimary) {
         final List<OffsetPosList<OffsetPosBase>> posLists = OffsetUtil.allOffsetPosLists(owner.getNode());
-        if (posLists.size() > 0) {
+        if (!posLists.isEmpty()) {
             final SortedSet<GuideProbe> oldGuideProbes = oldPrimary.getReferencedGuiders();
             final SortedSet<GuideProbe> newGuideProbes = newPrimary.getReferencedGuiders();
             final Set<String> warnSet = new TreeSet<>();
@@ -1022,7 +1022,7 @@ public final class TelescopePosTableWidget extends JXTreeTable implements Telesc
                     }
                 }
             }
-            if (warnSet.size() != 0) {
+            if (!warnSet.isEmpty()) {
                 return confirmGroupChangeDialog(warnSet);
             }
         }


### PR DESCRIPTION
This is a major cleanup with some changes to the target editor in preparation for BAGS.
The decision was made that the use of GuideGroups will now be mandatory and more explicit, so that BAGS acquired target(s) can all be placed in an explicit guide group.

In preparation for this, I overhauled the target editor to always display guide groups whenever any guide probe targets are listed, and prevented the collapsing of guide group nodes in the target editor tree.

In the past, when a single grouping of guide probe targets was provided, while in the data model, they belonged to a guide group, the guide group was not explicitly shown in the target editor:
![old - one group](https://cloud.githubusercontent.com/assets/8795653/11846803/f8b32c1c-a3f8-11e5-9568-7e35ebb66a01.png)

Now, as you can see, the guide group is always shown:
![new - one group](https://cloud.githubusercontent.com/assets/8795653/11846813/04ea0154-a3f9-11e5-9f0c-690ebdf8844b.png)

Additionally, here is an image showing the old target editor with multiple guide groups.
You can see that the guide groups are collapsible (with one being collapsed):
![old - collapsed groups](https://cloud.githubusercontent.com/assets/8795653/11846824/1f975786-a3f9-11e5-853e-24d56a53ee86.png)

Now, collapsing is no longer permissible, and all guide groups will always be displayed, along with icons identifying them as guide groups (the folders):
![new - multiple groups](https://cloud.githubusercontent.com/assets/8795653/11846840/35a247e8-a3f9-11e5-98c9-987325264afc.png)

In addition to these changes, there was a general mish-mash of code for drag and dropping of targets where in a few places, the code used arrays to try to allow for drag and drop of multiple targets. Then, since we only allow (in the UI and in the actual drop logic) ONE target to be dragged and dropped at a time, I simplified the code to no longer be a hybrid managing the possibility of multiple targets while in reality only handling one target by moving everything to only handling one target.

The rest of the changes are essentially a cleanup. I am sorry for the horrible diff that you'll see between the versions of `EdCompTargetList`, but in the old code, internal classes and listener members were littered throughout the class without rhyme and reason, making the code (at least, for me) hideously unpleasant to navigate. I have tried to conglomerate all of the methods together with some refactoring and rewriting, and then placed all the listener members and classes at the end of the file. Due to the major reordering, though, this will invariably look awful here in github.

Also note that the documentation for the `JXTreeTable` that is used (an external custom provided Swing widget) is horrible, and due to forcing the guide groups to always be open required substantial modification to the existing code in `TelescopePosTableWidget`.