### PR TITLE
Immutable library cleanup and functional interfaces

### DIFF
--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ApplyOp.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ApplyOp.java
@@ -1,12 +1,9 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**
  * A generic operation applied to all members of an immutable collection.
  */
+@FunctionalInterface
 public interface ApplyOp<T> {
     void apply(T t);
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 import java.io.Serializable;
@@ -14,26 +10,26 @@ import java.util.*;
  * more traditional immutable list implementation.
  */
 public final class DefaultImList<T> implements ImList<T>, Serializable {
-    private static final long serialVersionUID = 1l;
+    private static final long serialVersionUID = 1L;
 
-    public static <T> ImList<T> create(T... elements) {
+    public static <T> ImList<T> create(final T... elements) {
         if ((elements == null) || (elements.length == 0)) {
             return ImCollections.emptyList();
         }
 
-        List<T> copy = new ArrayList<T>(elements.length);
+        final List<T> copy = new ArrayList<>(elements.length);
         copy.addAll(Arrays.asList(elements));
 
-        return new DefaultImList<T>(copy);
+        return new DefaultImList<>(copy);
     }
 
-    public static <T> ImList<T> create(Collection<? extends T> list) {
+    public static <T> ImList<T> create(final Collection<? extends T> list) {
         if (list == null) return ImCollections.emptyList();
 
-        List<T> copy = new ArrayList<T>(list.size());
+        final List<T> copy = new ArrayList<>(list.size());
         copy.addAll(list);
 
-        return new DefaultImList<T>(copy);
+        return new DefaultImList<>(copy);
     }
 
     // Quickly implemented with a backing java.util.List, though it would be
@@ -46,63 +42,63 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
      * implementation.  This is private constructor because it would be an
      * error should the <code>backingList</code> be modified.
      */
-    DefaultImList(List<T> backingList) {
+    DefaultImList(final List<T> backingList) {
         this.backingList = Collections.unmodifiableList(backingList);
     }
 
     @Override
-    public ImList<T> cons(T t) {
+    public ImList<T> cons(final T t) {
         // ... list copying would be avoided with a proper implementation ...
-        List<T> tmp = new ArrayList<T>(backingList.size() + 1);
+        final List<T> tmp = new ArrayList<>(backingList.size() + 1);
         tmp.add(t);
         tmp.addAll(backingList);
-        return new DefaultImList<T>(tmp);
+        return new DefaultImList<>(tmp);
     }
 
     @Override
-    public ImList<T> append(ImList<? extends T> tail) {
+    public ImList<T> append(final ImList<? extends T> tail) {
         // ... list copying would be avoided with a proper implementation ...
-        List<T> tmp = new ArrayList<T>(backingList.size() + tail.size());
+        final List<T> tmp = new ArrayList<>(backingList.size() + tail.size());
         tmp.addAll(backingList);
         tmp.addAll(tail.toList());
-        return new DefaultImList<T>(tmp);
+        return new DefaultImList<>(tmp);
     }
 
     @Override
-    public ImList<T> append(T t) {
-        List<T> tmp = new ArrayList<T>(backingList.size() + 1);
+    public ImList<T> append(final T t) {
+        final List<T> tmp = new ArrayList<>(backingList.size() + 1);
         tmp.addAll(backingList);
         tmp.add(t);
-        return new DefaultImList<T>(tmp);
+        return new DefaultImList<>(tmp);
     }
 
     @Override
-    public ImList<T> remove(T t) {
+    public ImList<T> remove(final T t) {
         int index = backingList.indexOf(t);
         if (index < 0) return this;
 
-        List<T> tmp = new ArrayList<T>(backingList.size()-1);
+        final List<T> tmp = new ArrayList<>(backingList.size()-1);
         tmp.addAll(backingList.subList(0, index));
         tmp.addAll(backingList.subList(index+1, backingList.size()));
-        return new DefaultImList<T>(tmp);
+        return new DefaultImList<>(tmp);
     }
 
     @Override
-    public ImList<T> remove(Function1<? super T, Boolean> op) {
-        ArrayList<T> res = new ArrayList<T>(backingList.size());
-        for (T t : backingList) {
+    public ImList<T> remove(final Function1<? super T, Boolean> op) {
+        final ArrayList<T> res = new ArrayList<>(backingList.size());
+        backingList.forEach(t -> {
             if (!op.apply(t)) res.add(t);
-        }
+        });
         res.trimToSize();
-        return new DefaultImList<T>(res);
+        return new DefaultImList<>(res);
     }
 
     @Override
-    public ImList<T> updated(int index, T t) {
-        ArrayList<T> res = new ArrayList<T>(backingList.size());
+    public ImList<T> updated(final int index, final T t) {
+        final ArrayList<T> res = new ArrayList<>(backingList.size());
         res.addAll(backingList);
         res.set(index, t);
-        return new DefaultImList<T>(res);
+        return new DefaultImList<>(res);
     }
 
     @Override
@@ -113,8 +109,8 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
 
     @Override
     public Option<T> headOption() {
-        if (backingList.size() == 0) return None.INSTANCE;
-        return new Some<T>(backingList.get(0));
+        if (backingList.size() == 0) return None.instance();
+        return new Some<>(backingList.get(0));
     }
 
     @Override
@@ -126,32 +122,32 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
     @Override
     public ImList<T> tail() {
         if (backingList.size() <= 1) return ImCollections.emptyList();
-        return new DefaultImList<T>(backingList.subList(1, backingList.size()));
+        return new DefaultImList<>(backingList.subList(1, backingList.size()));
     }
 
     @Override
     public ImList<T> initial() {
         if (backingList.size() <= 1) return ImCollections.emptyList();
-        return new DefaultImList<T>(backingList.subList(0, backingList.size()-1));
+        return new DefaultImList<>(backingList.subList(0, backingList.size()-1));
     }
 
     @Override
-    public boolean contains(T t) {
+    public boolean contains(final T t) {
         return backingList.contains(t);
     }
 
     @Override
-    public boolean containsAll(ImList<?> c) {
+    public boolean containsAll(final ImList<?> c) {
         return backingList.containsAll(c.toList());
     }
 
     @Override
-    public T get(int index) {
+    public T get(final int index) {
         return backingList.get(index);
     }
 
     @Override
-    public int indexOf(T t) {
+    public int indexOf(final T t) {
         return backingList.indexOf(t);
     }
 
@@ -181,69 +177,69 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
     }
 
     @Override
-    public <U> ImList<U> map(Function1<? super T, U> op) {
-        List<U> res = new ArrayList<U>();
-        for (T t : this) res.add(op.apply(t));
-        return new DefaultImList<U>(res);
+    public <U> ImList<U> map(final Function1<? super T, U> op) {
+        final List<U> res = new ArrayList<>();
+        backingList.forEach(t -> res.add(op.apply(t)));
+        return new DefaultImList<>(res);
     }
 
     @Override
-    public <U> ImList<U> flatMap(Function1<? super T, ImList<U>> op) {
-        List<U> res = new ArrayList<U>();
-        for (T t : this) res.addAll(op.apply(t).toList());
-        return new DefaultImList<U>(res);
+    public <U> ImList<U> flatMap(final Function1<? super T, ImList<U>> op) {
+        final List<U> res = new ArrayList<>();
+        backingList.forEach(t -> res.addAll(op.apply(t).toList()));
+        return new DefaultImList<>(res);
     }
 
     @Override
-    public void foreach(ApplyOp<? super T> op) {
-        for (T t : this) op.apply(t);
+    public void foreach(final ApplyOp<? super T> op) {
+        backingList.forEach(op::apply);
     }
 
     @Override
-    public ImList<T> filter(Function1<? super T, Boolean> op) {
-        List<T> res = new ArrayList<T>();
-        for (T t : this) if (op.apply(t)) res.add(t);
-        return new DefaultImList<T>(res);
+    public ImList<T> filter(final Function1<? super T, Boolean> op) {
+        final List<T> res = new ArrayList<>();
+        backingList.forEach(t -> { if (op.apply(t)) res.add(t); });
+        return new DefaultImList<>(res);
     }
 
     @Override
     public Option<T> find(Function1<? super T, Boolean> op) {
-        for (T t : this) if (op.apply(t)) return new Some<T>(t);
+        for (final T t : this) if (op.apply(t)) return new Some<>(t);
         return None.instance();
     }
 
     @Override
-    public Tuple2<ImList<T>, ImList<T>> partition(Function1<? super T, Boolean> op) {
-        List<T> lst1 = new ArrayList<T>();
-        List<T> lst2 = new ArrayList<T>();
+    public Tuple2<ImList<T>, ImList<T>> partition(final Function1<? super T, Boolean> op) {
+        final List<T> lst1 = new ArrayList<>();
+        final List<T> lst2 = new ArrayList<>();
 
-        for (T t : this) {
+        backingList.forEach(t -> {
             if (op.apply(t)) {
                 lst1.add(t);
             } else {
                 lst2.add(t);
             }
-        }
+        });
 
-        return new Pair<ImList<T>, ImList<T>>(new DefaultImList<T>(lst1), new DefaultImList<T>(lst2));
+        return new Pair<>(new DefaultImList<>(lst1), new DefaultImList<>(lst2));
     }
 
     @Override
-    public boolean forall(Function1<? super T, Boolean> op) {
-        for (T t : this) if (!op.apply(t)) return false;
+    public boolean forall(final Function1<? super T, Boolean> op) {
+        for (final T t : this) if (!op.apply(t)) return false;
         return true;
     }
 
     @Override
-    public boolean exists(Function1<? super T, Boolean> op) {
-        for (T t : this) if (op.apply(t)) return true;
+    public boolean exists(final Function1<? super T, Boolean> op) {
+        for (final T t : this) if (op.apply(t)) return true;
         return false;
     }
 
     @Override
-    public String mkString(String prefix, String separator, String suffix) {
-        StringBuilder buf = new StringBuilder(prefix);
-        Iterator<T> it = iterator();
+    public String mkString(final String prefix, final String separator, final String suffix) {
+        final StringBuilder buf = new StringBuilder(prefix);
+        final Iterator<T> it = iterator();
         if (it.hasNext()) {
             buf.append(it.next());
             while (it.hasNext()) {
@@ -255,56 +251,55 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
     }
 
     @Override
-    public <U> ImList<Tuple2<T, U>> zip(ImList<U> list) {
-        List<Tuple2<T, U>> res = new ArrayList<Tuple2<T, U>>();
+    public <U> ImList<Tuple2<T, U>> zip(final ImList<U> list) {
+        final List<Tuple2<T, U>> res = new ArrayList<>();
 
-        int limit = Math.min(backingList.size(), list.size());
+        final int limit = Math.min(backingList.size(), list.size());
         for (int i=0; i<limit; ++i) {
-            res.add(new Pair<T, U>(
-                    backingList.get(i), list.get(i)));
+            res.add(new Pair<>(backingList.get(i), list.get(i)));
         }
 
-        return new DefaultImList<Tuple2<T, U>>(res);
+        return new DefaultImList<>(res);
     }
 
     @Override
     public ImList<Tuple2<T, Integer>> zipWithIndex() {
-        List<Tuple2<T, Integer>> res = new ArrayList<Tuple2<T, Integer>>(backingList.size());
+        final List<Tuple2<T, Integer>> res = new ArrayList<>(backingList.size());
 
         int index = 0;
-        for (T t : backingList) {
-            res.add(new Pair<T, Integer>(t, index++));
+        for (final T t : backingList) {
+            res.add(new Pair<>(t, index++));
         }
-        return new DefaultImList<Tuple2<T, Integer>>(res);
+        return new DefaultImList<>(res);
     }
 
     @Override
-    public ImList<T> sort(Comparator<? super T> c) {
+    public ImList<T> sort(final Comparator<? super T> c) {
         if (backingList.size() < 2) return this;
 
-        List<T> sortedList = new ArrayList<T>(backingList.size());
+        final List<T> sortedList = new ArrayList<>(backingList.size());
         sortedList.addAll(backingList);
         Collections.sort(sortedList, c);
-        return new DefaultImList<T>(sortedList);
+        return new DefaultImList<>(sortedList);
     }
 
     @Override
-    public T min(Comparator<? super T> c) {
+    public T min(final Comparator<? super T> c) {
         if (backingList.size() == 1) return backingList.get(0);
 
         T minElement = backingList.get(0);
-        for (T cur : backingList.subList(1, backingList.size())) {
+        for (final T cur : backingList.subList(1, backingList.size())) {
             if (c.compare(minElement, cur) > 0) minElement = cur;
         }
         return minElement;
     }
 
     @Override
-    public T max(Comparator<? super T> c) {
+    public T max(final Comparator<? super T> c) {
         if (backingList.size() == 1) return backingList.get(0);
 
         T maxElement = backingList.get(0);
-        for (T cur : backingList.subList(1, backingList.size())) {
+        for (final T cur : backingList.subList(1, backingList.size())) {
             if (c.compare(maxElement, cur) < 0) maxElement = cur;
         }
         return maxElement;
@@ -314,24 +309,24 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
     public ImList<T> reverse() {
         if (backingList.size() < 2) return this;
 
-        List<T> revList = new ArrayList<T>(backingList.size());
+        final List<T> revList = new ArrayList<>(backingList.size());
         revList.addAll(backingList);
         Collections.reverse(revList);
-        return new DefaultImList<T>(revList);
+        return new DefaultImList<>(revList);
     }
 
     @Override
-    public <U> U foldLeft(U start, Function2<U, ? super T, U> op) {
+    public <U> U foldLeft(final U start, final Function2<U, ? super T, U> op) {
         U cur = start;
-        for (T t : backingList) cur = op.apply(cur, t);
+        for (final T t : backingList) cur = op.apply(cur, t);
         return cur;
     }
 
     @Override
-    public <U> U foldRight(U start, Function2<? super T, U, U> op) {
+    public <U> U foldRight(final U start, final Function2<? super T, U, U> op) {
         U cur = start;
         for (int i=backingList.size()-1; i >= 0; --i) {
-            T elem = backingList.get(i);
+            final T elem = backingList.get(i);
             cur = op.apply(elem, cur);
         }
         return cur;
@@ -352,11 +347,11 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
         if (o == this) return true;
         if (!(o instanceof ImList)) return false;
 
-        ImList that = (ImList) o;
+        final ImList that = (ImList) o;
         if (this.size() != that.size()) return false;
 
-        Iterator thatIt = that.iterator();
-        for (T t : this) {
+        final Iterator thatIt = that.iterator();
+        for (final T t : this) {
             if (t == null) {
                 if (thatIt.next() != null) return false;
             } else {
@@ -370,7 +365,7 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
     @Override
     public int hashCode() {
         int res = 1;
-        for (T t : this) {
+        for (final T t : this) {
             res = 31*res + ((t == null) ? 0 : t.hashCode());
         }
         return res;

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Function1.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Function1.java
@@ -1,13 +1,10 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**
  * A function wrapper object for a function that accepts a single argument of
  * type T and returns a result of type R.
  */
+@FunctionalInterface
 public interface Function1<T, R> {
     R apply(T t);
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Function2.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Function2.java
@@ -1,13 +1,10 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**
  * A function wrapper object for a function that accepts two arguments of
  * type T1 and T2 and returns a result of type R.
  */
+@FunctionalInterface
 public interface Function2<T1, T2, R> {
     R apply(T1 t1, T2 t2);
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 import java.io.Serializable;
@@ -18,34 +14,34 @@ public class ImCollections {
     private static class EmptyList implements ImList<Object>, Serializable {
 
         @Override
-        public ImList<Object> cons(Object o) {
-            List<Object> lst = new ArrayList<Object>();
+        public ImList<Object> cons(final Object o) {
+            final List<Object> lst = new ArrayList<>();
             lst.add(o);
-            return new DefaultImList<Object>(lst);
+            return new DefaultImList<>(lst);
         }
 
         @Override
-        public ImList<Object> append(ImList<?> tail) {
+        public ImList<Object> append(final ImList<?> tail) {
             return (ImList<Object>) tail;
         }
 
         @Override
-        public ImList<Object> append(Object o) {
+        public ImList<Object> append(final Object o) {
             return cons(o);
         }
 
         @Override
-        public ImList<Object> remove(Object o) {
+        public ImList<Object> remove(final Object o) {
             return this;
         }
 
         @Override
-        public ImList<Object> remove(Function1<? super Object, Boolean> f) {
+        public ImList<Object> remove(final Function1<? super Object, Boolean> f) {
             return this;
         }
 
         @Override
-        public ImList<Object> updated(int index, Object o) {
+        public ImList<Object> updated(final int index, final Object o) {
             throw new IndexOutOfBoundsException(String.valueOf(index));
         }
 
@@ -56,7 +52,7 @@ public class ImCollections {
 
         @Override
         public Option<Object> headOption() {
-            return None.INSTANCE;
+            return None.instance();
         }
 
         @Override
@@ -75,22 +71,22 @@ public class ImCollections {
         }
 
         @Override
-        public boolean contains(Object o) {
+        public boolean contains(final Object o) {
             return false;
         }
 
         @Override
-        public boolean containsAll(ImList<?> c) {
+        public boolean containsAll(final ImList<?> c) {
             return c.size() == 0;
         }
 
         @Override
-        public Object get(int index) {
+        public Object get(final int index) {
             throw new IndexOutOfBoundsException(String.valueOf(index));
         }
 
         @Override
-        public int indexOf(Object o) {
+        public int indexOf(final Object o) {
             return -1;
         }
 
@@ -115,51 +111,51 @@ public class ImCollections {
         }
 
         @Override
-        public <U> ImList<U> map(Function1<? super Object, U> op) {
+        public <U> ImList<U> map(final Function1<? super Object, U> op) {
             return (ImList<U>) this;
         }
 
         @Override
-        public <U> ImList<U> flatMap(Function1<? super Object, ImList<U>> op) {
+        public <U> ImList<U> flatMap(final Function1<? super Object, ImList<U>> op) {
             return (ImList<U>) this;
         }
 
         @Override
-        public void foreach(ApplyOp<? super Object> op) {
+        public void foreach(final ApplyOp<? super Object> op) {
         }
 
         @Override
-        public Option<Object> find(Function1<? super Object, Boolean> op) {
+        public Option<Object> find(final Function1<? super Object, Boolean> op) {
             return None.instance();
         }
 
         @Override
-        public ImList<Object> filter(Function1<? super Object, Boolean> op) {
+        public ImList<Object> filter(final Function1<? super Object, Boolean> op) {
             return this;
         }
 
         @Override
-        public Tuple2<ImList<Object>, ImList<Object>> partition(Function1<? super Object, Boolean> op) {
+        public Tuple2<ImList<Object>, ImList<Object>> partition(final Function1<? super Object, Boolean> op) {
             return new Pair(this, this);
         }
 
         @Override
-        public boolean forall(Function1<? super Object, Boolean> op) {
+        public boolean forall(final Function1<? super Object, Boolean> op) {
             return true;
         }
 
         @Override
-        public boolean exists(Function1<? super Object, Boolean> op) {
+        public boolean exists(final Function1<? super Object, Boolean> op) {
             return false;
         }
 
         @Override
-        public String mkString(String prefix, String separator, String suffix) {
+        public String mkString(final String prefix, final String separator, final String suffix) {
             return prefix + suffix;
         }
 
         @Override
-        public <U> ImList<Tuple2<Object, U>> zip(ImList<U> list) {
+        public <U> ImList<Tuple2<Object, U>> zip(final ImList<U> list) {
             return emptyList();
         }
 
@@ -169,17 +165,17 @@ public class ImCollections {
         }
 
         @Override
-        public ImList<Object> sort(Comparator<? super Object> c) {
+        public ImList<Object> sort(final Comparator<? super Object> c) {
             return this;
         }
 
         @Override
-        public Object min(Comparator<? super Object> c) {
+        public Object min(final Comparator<? super Object> c) {
             throw new NoSuchElementException();
         }
 
         @Override
-        public Object max(Comparator<? super Object> c) {
+        public Object max(final Comparator<? super Object> c) {
             throw new NoSuchElementException();
         }
 
@@ -193,7 +189,7 @@ public class ImCollections {
          * combine it with
          */
         @Override
-        public <U> U foldLeft(U start, Function2<U, ? super Object, U> op) {
+        public <U> U foldLeft(final U start, final Function2<U, ? super Object, U> op) {
             return start;
         }
 
@@ -202,7 +198,7 @@ public class ImCollections {
          * combine it with
          */
         @Override
-        public <U> U foldRight(U start, Function2<? super Object, U, U> op) {
+        public <U> U foldRight(final U start, final Function2<? super Object, U, U> op) {
             return start;
         }
 
@@ -216,11 +212,11 @@ public class ImCollections {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (o == this) return true;
             if (!(o instanceof ImList)) return false;
 
-            ImList that = (ImList) o;
+            final ImList that = (ImList) o;
             return (that.size() == 0);
         }
 
@@ -251,7 +247,7 @@ public class ImCollections {
      *
      * @return a list consisting of a single element
      */
-    public static <T> ImList<T> singletonList(T item) {
+    public static <T> ImList<T> singletonList(final T item) {
         return DefaultImList.create(Collections.singletonList(item));
     }
 
@@ -267,15 +263,11 @@ public class ImCollections {
      * @return a tuple containing two lists, one for each element of the
      * tuples contained in the input list
      */
-    public static <T, U> Tuple2<ImList<T>, ImList<U>> unzip(ImList<Tuple2<T, U>> list) {
+    public static <T, U> Tuple2<ImList<T>, ImList<U>> unzip(final ImList<Tuple2<T, U>> list) {
 
         // Kind of inefficient to go through the list twice ...
-        ImList<T> uz1 = list.map(new MapOp<Tuple2<T, U>, T>() {
-            @Override public T apply(Tuple2<T, U> tup) { return tup._1(); }
-        });
-        ImList<U> uz2 = list.map(new MapOp<Tuple2<T, U>, U>() {
-            @Override public U apply(Tuple2<T, U> tup) { return tup._2(); }
-        });
-        return new Pair<ImList<T>, ImList<U>>(uz1, uz2);
+        final ImList<T> uz1 = list.map(Tuple2::_1);
+        final ImList<U> uz2 = list.map(Tuple2::_2);
+        return new Pair<>(uz1, uz2);
     }
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 import java.util.Comparator;
@@ -193,7 +189,7 @@ public interface ImList<T> extends Iterable<T> {
      * the provided <code>op</code>, and the resulting objects are collected
      * and returned in an immutable list.
      *
-     * <p>For example, a {@link Function1<String, Integer>} that maps a string
+     * <p>For example, a {@link Function1}<String,Integer> that maps a string
      * to its corresponding integer could map a list
      * <code>{"1", "2", "3"}</code> to <code>{1, 2, 3}</code>.
      *

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
@@ -1,17 +1,11 @@
 package edu.gemini.shared.util.immutable;
 
-/**
- * Class ImOption
- *
- * @author Nicolas A. Barriga
- *         Date: 5/3/12
- */
 public class ImOption {
-    public static <T> Option<T> apply(T value) {
+    public static <T> Option<T> apply(final T value) {
         if (value == null) {
             return None.instance();
         } else {
-            return new Some(value);
+            return new Some<>(value);
         }
     }
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/MapOp.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/MapOp.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**
@@ -10,6 +6,7 @@ package edu.gemini.shared.util.immutable;
  *
  * <p>This is just a renaming of Function1 and may be removed.
  */
+@FunctionalInterface
 public interface MapOp<T, U> extends Function1<T, U> {
 //    U apply(T t);
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/None.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/None.java
@@ -63,12 +63,12 @@ public final class None<T> implements Option<T>, Serializable {
     }
 
     @Override
-    public T getOrElse(T defaultValue) {
+    public T getOrElse(final T defaultValue) {
         return defaultValue;
     }
 
     @Override
-    public Option<T> orElse(Option<T> that) {
+    public Option<T> orElse(final Option<T> that) {
         return that;
     }
 
@@ -93,28 +93,28 @@ public final class None<T> implements Option<T>, Serializable {
     }
 
     @Override
-    public Option<T> filter(Function1<? super T, Boolean> p) {
+    public Option<T> filter(final Function1<? super T, Boolean> p) {
         return instance();
     }
 
     @Override
-    public void foreach(ApplyOp<? super T> tApplyOp) {
+    public void foreach(final ApplyOp<? super T> tApplyOp) {
         // do nothing
     }
 
     @Override
-    public boolean exists(Function1<? super T, Boolean> op) { return false; }
+    public boolean exists(final Function1<? super T, Boolean> op) { return false; }
 
     @Override
-    public boolean forall(Function1<? super T, Boolean> op) { return true; }
+    public boolean forall(final Function1<? super T, Boolean> op) { return true; }
 
     @Override
-    public <U> Option<U> map(Function1<? super T, U> tuMapOp) {
+    public <U> Option<U> map(final Function1<? super T, U> tuMapOp) {
         return instance();
     }
 
     @Override
-    public <U> Option<U> flatMap(Function1<? super T, Option<U>> tOptionMapOp) {
+    public <U> Option<U> flatMap(final Function1<? super T, Option<U>> tOptionMapOp) {
         return instance();
     }
 
@@ -128,7 +128,7 @@ public final class None<T> implements Option<T>, Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         return (o instanceof None);
     }
 

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Option.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Option.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 import java.util.NoSuchElementException;

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Pair.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Pair.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 import java.io.Serializable;
@@ -14,7 +10,7 @@ public final class Pair<T, U> implements Tuple2<T, U>, Serializable {
     private final T _1;
     private final U _2;
 
-    public Pair(T left, U right) {
+    public Pair(final T left, final U right) {
         _1 = left;
         _2 = right;
     }
@@ -28,15 +24,14 @@ public final class Pair<T, U> implements Tuple2<T, U>, Serializable {
     }
 
     public Pair<U, T> swap() {
-        //noinspection unchecked
-        return new Pair<U, T>(_2, _1);
+        return new Pair<>(_2, _1);
     }
 
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof Tuple2)) return false;
 
-        Tuple2 that = (Tuple2) o;
+        final Tuple2 that = (Tuple2) o;
         if (_1 == null) {
             if (that._1() != null) return false;
         } else {
@@ -59,13 +54,8 @@ public final class Pair<T, U> implements Tuple2<T, U>, Serializable {
         return res;
     }
 
-    public String mkString(String prefix, String sep, String suffix) {
-        StringBuilder buf = new StringBuilder(prefix);
-        buf.append(_1);
-        buf.append(sep);
-        buf.append(_2);
-        buf.append(suffix);
-        return buf.toString();
+    public String mkString(final String prefix, final String sep, final String suffix) {
+        return prefix + _1 + sep + _2 + suffix;
     }
 
     public String toString() {

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/PredicateOp.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/PredicateOp.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**
@@ -11,5 +7,6 @@ package edu.gemini.shared.util.immutable;
  *
  * <p>PredicateOp simply pins the return type of a {@link Function1} to Boolean.
  */
+@FunctionalInterface
 public interface PredicateOp<T> extends Function1<T, Boolean> {
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Some.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Some.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 import java.util.Iterator;
@@ -13,7 +9,7 @@ import java.util.NoSuchElementException;
 public final class Some<T> implements Option<T> {
     private final T val;
 
-    public Some(T val) {
+    public Some(final T val) {
         this.val = val;
     }
 
@@ -23,12 +19,12 @@ public final class Some<T> implements Option<T> {
     }
 
     @Override
-    public T getOrElse(T defaultValue) {
+    public T getOrElse(final T defaultValue) {
         return val;
     }
 
     @Override
-    public Option<T> orElse(Option<T> that) {
+    public Option<T> orElse(final Option<T> that) {
         return this;
     }
 
@@ -53,34 +49,34 @@ public final class Some<T> implements Option<T> {
     }
 
     @Override
-    public Option<T> filter(Function1<? super T, Boolean> p) {
+    public Option<T> filter(final Function1<? super T, Boolean> p) {
         if (p.apply(val)) return this;
         return None.instance();
     }
 
     @Override
-    public void foreach(ApplyOp<? super T> op) {
+    public void foreach(final ApplyOp<? super T> op) {
         op.apply(val);
     }
 
     @Override
-    public boolean exists(Function1<? super T, Boolean> op) {
+    public boolean exists(final Function1<? super T, Boolean> op) {
         return op.apply(val);
     }
 
     @Override
-    public boolean forall(Function1<? super T, Boolean> op) {
+    public boolean forall(final Function1<? super T, Boolean> op) {
         return op.apply(val);
     }
 
     @Override
-    public <U> Option<U> map(Function1<? super T, U> op) {
-        U res = op.apply(val);
-        return new Some<U>(res);
+    public <U> Option<U> map(final Function1<? super T, U> op) {
+        final U res = op.apply(val);
+        return new Some<>(res);
     }
 
     @Override
-    public <U> Option<U> flatMap(Function1<? super T, Option<U>> op) {
+    public <U> Option<U> flatMap(final Function1<? super T, Option<U>> op) {
         return op.apply(val);
     }
 
@@ -109,7 +105,7 @@ public final class Some<T> implements Option<T> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (!(o instanceof Some)) return false;
         return val.equals(((Some) o).val);
     }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Trio.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Trio.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 import java.io.Serializable;
@@ -15,7 +11,7 @@ public final class Trio<T, U, V> implements Tuple3<T, U, V>, Serializable {
     private final U _2;
     private final V _3;
 
-    public Trio(T left, U middle, V right) {
+    public Trio(final T left, final U middle, final V right) {
         _1 = left;
         _2 = middle;
         _3 = right;
@@ -34,11 +30,11 @@ public final class Trio<T, U, V> implements Tuple3<T, U, V>, Serializable {
     }
 
 
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof Tuple3)) return false;
 
-        Tuple3 that = (Tuple3) o;
+        final Tuple3 that = (Tuple3) o;
         if (_1 == null) {
             if (that._1() != null) return false;
         } else {
@@ -66,15 +62,8 @@ public final class Trio<T, U, V> implements Tuple3<T, U, V>, Serializable {
         return res;
     }
 
-    public String mkString(String prefix, String sep, String suffix) {
-        StringBuilder buf = new StringBuilder(prefix);
-        buf.append(_1);
-        buf.append(sep);
-        buf.append(_2);
-        buf.append(sep);
-        buf.append(_3);
-        buf.append(suffix);
-        return buf.toString();
+    public String mkString(final String prefix, final String sep, final String suffix) {
+        return prefix + _1 + sep + _2 + sep + _3 + suffix;
     }
 
     public String toString() {

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Tuple2.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Tuple2.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Tuple3.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Tuple3.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/UpdateOp.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/UpdateOp.java
@@ -1,12 +1,9 @@
-//
-// $
-//
-
 package edu.gemini.shared.util.immutable;
 
 /**
  * A shorthand definition for a map function that takes and returns a value of
  * the same type.
  */
+@FunctionalInterface
 public interface UpdateOp<T> extends Function1<T, T> {
 }


### PR DESCRIPTION
I was feeling inspired by @cquiroz and his herculean efforts, so last night I tried to do some cleaning up of the edu.gemini.shared.util.immutable classes to get rid of template parameter warnings, exploit backing lists better for our `ImList`s, remove unnecessary comments, and add `@FunctionalInterface` annotations where it made sense to do so.

All test cases still pass and I don't think this will break anything (e.g. serializability), but please let me know if you see any issues.