### PR TITLE
 REL-2463: Add site options to all visitor instruments

### DIFF
--- a/bundle/edu.gemini.ags.client.impl/src/test/scala/edu/gemini/ags/client/impl/QueryArgsSpec.scala
+++ b/bundle/edu.gemini.ags.client.impl/src/test/scala/edu/gemini/ags/client/impl/QueryArgsSpec.scala
@@ -7,7 +7,7 @@ import edu.gemini.model.p1.mutable.TexesDisperser
 class QueryArgsSpec extends SpecificationWithJUnit {
   "The QueryArgs" should {
     "should map texes to Nifs. REL-1062" in {
-      QueryArgs.instId(new TexesBlueprint(TexesDisperser.D_32_LMM)) must beRight.like {
+      QueryArgs.instId(new TexesBlueprint(Site.GN, TexesDisperser.D_32_LMM)) must beRight.like {
         case i => i must beEqualTo(Instrument.Nifs.id)
       }
     }

--- a/bundle/edu.gemini.ags.client.impl/src/test/scala/edu/gemini/ags/client/impl/QueryArgsSpec.scala
+++ b/bundle/edu.gemini.ags.client.impl/src/test/scala/edu/gemini/ags/client/impl/QueryArgsSpec.scala
@@ -12,7 +12,7 @@ class QueryArgsSpec extends SpecificationWithJUnit {
       }
     }
     "should map Speckle to Nifs. REL-1061" in {
-      QueryArgs.instId(new DssiBlueprint()) must beRight.like {
+      QueryArgs.instId(new DssiBlueprint(Site.GN)) must beRight.like {
         case i => i must beEqualTo(Instrument.Nifs.id)
       }
     }
@@ -20,7 +20,7 @@ class QueryArgsSpec extends SpecificationWithJUnit {
       QueryArgs.instId(new VisitorBlueprint(Site.GN, "name")) must beRight.like {
         case i => i must beEqualTo(Instrument.Niri.id)
       }
-      QueryArgs.instSpecificArgs(new VisitorBlueprint(Site.GN, "name")) must contain(("niriCamera" -> "F6"))
+      QueryArgs.instSpecificArgs(new VisitorBlueprint(Site.GN, "name")) must contain("niriCamera" -> "F6")
     }
   }
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -23,7 +23,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
     case Nifs       => Left(inst.Nifs())
     case Niri       => Left(inst.Niri())
     case Phoenix    => Left(inst.Phoenix())
-    case Dssi       => Right(DssiBlueprint())
+    case Dssi       => Left(inst.Dssi())
     case Texes      => Left(inst.Texes())
     case Trecs      => Left(inst.Trecs())
     case Visitor    => Left(inst.Visitor())

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
@@ -1,0 +1,22 @@
+package edu.gemini.model.p1.dtree.inst
+
+import edu.gemini.model.p1.dtree._
+import edu.gemini.model.p1.immutable._
+
+object Dssi {
+
+  def apply() = new SiteNode
+
+  class SiteNode extends SingleSelectNode[Unit, VisitorSite, DssiBlueprint](()) {
+    val title       = "Site"
+    val description = "Select the site."
+    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
+
+    def apply(fs: VisitorSite) = Right(DssiBlueprint(fs))
+
+    def unapply = {
+      case b: DssiBlueprint => b.site
+    }
+  }
+
+}

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
@@ -18,7 +18,6 @@ object Phoenix {
     }
   }
 
-
   class FocalPlaneUnitNode(s: Site) extends SingleSelectNode[Site, PhoenixFocalPlaneUnit, PhoenixFocalPlaneUnit](s) {
     val title = "Focal Plane Unit"
     val description = "Select a focal plane unit for your configuration."

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
@@ -4,15 +4,28 @@ import edu.gemini.model.p1.dtree._
 import edu.gemini.model.p1.immutable._
 
 object Phoenix {
-  def apply() = new FocalPlaneUnitNode
+  def apply() = new SiteNode
 
-  class FocalPlaneUnitNode extends SingleSelectNode[Unit, PhoenixFocalPlaneUnit, PhoenixFocalPlaneUnit](()) {
+  class SiteNode extends SingleSelectNode[Unit, VisitorSite, Site](()) {
+    val title       = "Site"
+    val description = "Select the site."
+    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
+
+    def apply(s: VisitorSite) = Left(new FocalPlaneUnitNode(s.site))
+
+    def unapply = {
+      case b: PhoenixBlueprint => b.site
+    }
+  }
+
+
+  class FocalPlaneUnitNode(s: Site) extends SingleSelectNode[Site, PhoenixFocalPlaneUnit, PhoenixFocalPlaneUnit](s) {
     val title = "Focal Plane Unit"
     val description = "Select a focal plane unit for your configuration."
 
     def choices: List[PhoenixFocalPlaneUnit] = PhoenixFocalPlaneUnit.values.toList
 
-    def apply(om: PhoenixFocalPlaneUnit) = Left(new FilterNode(om))
+    def apply(om: PhoenixFocalPlaneUnit) = Left(new FilterNode(s, om))
 
     override def default = Some(PhoenixFocalPlaneUnit.forName("MASK_3"))
 
@@ -21,11 +34,11 @@ object Phoenix {
     }
   }
 
-  class FilterNode(fpu: PhoenixFocalPlaneUnit) extends SingleSelectNode[PhoenixFocalPlaneUnit, PhoenixFilter, PhoenixBlueprint](fpu){
+  class FilterNode(s: Site, fpu: PhoenixFocalPlaneUnit) extends SingleSelectNode[PhoenixFocalPlaneUnit, PhoenixFilter, PhoenixBlueprint](fpu){
     def title = "Filter"
     def description = "Select a filter for your configuration."
 
-    def apply(f: PhoenixFilter) = Right(PhoenixBlueprint(fpu, f))
+    def apply(f: PhoenixFilter) = Right(PhoenixBlueprint(s, fpu, f))
 
     override def default = Some(PhoenixFilter.forName("K4396"))
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Texes.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Texes.scala
@@ -5,14 +5,26 @@ import edu.gemini.model.p1.immutable._
 
 object Texes {
 
-  def apply() = new DisperserNode
+  def apply() = new SiteNode
 
-  class DisperserNode extends SingleSelectNode[Unit, TexesDisperser, TexesBlueprint](()) {
+  class SiteNode extends SingleSelectNode[Unit, VisitorSite, Site](()) {
+    val title       = "Site"
+    val description = "Select the site."
+    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
+
+    def apply(s: VisitorSite) = Left(new DisperserNode(s.site))
+
+    def unapply = {
+      case b: PhoenixBlueprint => b.site
+    }
+  }
+
+  class DisperserNode(s: Site) extends SingleSelectNode[Site, TexesDisperser, TexesBlueprint](s) {
     val title       = "Disperser"
     val description = "Select the disperser to use."
     def choices     = TexesDisperser.values.toList
 
-    def apply(ds: TexesDisperser) = Right(new TexesBlueprint(ds))
+    def apply(ds: TexesDisperser) = Right(new TexesBlueprint(s, ds))
 
     def unapply = {
       case b: TexesBlueprint => b.disperser

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/DssiBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/DssiBlueprint.scala
@@ -3,14 +3,15 @@ package edu.gemini.model.p1.immutable
 import edu.gemini.model.p1.{mutable => M}
 
 object DssiBlueprint {
-  def apply(m: M.DssiBlueprint): DssiBlueprint = new DssiBlueprint()
+  def apply(m: M.DssiBlueprint): DssiBlueprint = new DssiBlueprint(Site.fromMutable(m.getSite))
 }
 
-case class DssiBlueprint() extends GeminiBlueprintBase {
+case class DssiBlueprint(site0: Site) extends GeminiBlueprintBase {
   def name: String = "DSSI"
+  override def site = site0
   override val visitor = true
 
-  def this(m: M.DssiBlueprint) = this()
+  def this(m: M.DssiBlueprint) = this(Site.GN)
 
   override def instrument: Instrument = Instrument.Dssi
 
@@ -19,6 +20,7 @@ case class DssiBlueprint() extends GeminiBlueprintBase {
     m.setId(n.nameOf(this))
     m.setName(name)
     m.setVisitor(visitor)
+    m.setSite(Site.toMutable(site))
     m
   }
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/DssiBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/DssiBlueprint.scala
@@ -6,9 +6,8 @@ object DssiBlueprint {
   def apply(m: M.DssiBlueprint): DssiBlueprint = new DssiBlueprint(Site.fromMutable(m.getSite))
 }
 
-case class DssiBlueprint(site0: Site) extends GeminiBlueprintBase {
+case class DssiBlueprint(override val site: Site) extends GeminiBlueprintBase {
   def name: String = s"DSSI ${site.name}"
-  override def site = site0
   override val visitor = true
 
   def this(m: M.DssiBlueprint) = this(Site.GN)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/DssiBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/DssiBlueprint.scala
@@ -7,7 +7,7 @@ object DssiBlueprint {
 }
 
 case class DssiBlueprint(site0: Site) extends GeminiBlueprintBase {
-  def name: String = "DSSI"
+  def name: String = s"DSSI ${site.name}"
   override def site = site0
   override val visitor = true
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
@@ -13,7 +13,7 @@ object Instrument {
   case object Michelle   extends Instrument(GN, "Michelle", "Michelle", "michelle")
   case object Nifs       extends Instrument(GN, "NIFS")
   case object Niri       extends Instrument(GN, "NIRI")
-  case object Dssi       extends Instrument(GN, "DSSI", "DSSI North", "DSSI")
+  case object Dssi       extends Instrument(GN, "DSSI", "DSSI", "DSSI")
   case object Texes      extends Instrument(GN, "Texes", "Texes", "TEXES")
 
   case object Flamingos2 extends Instrument(GS, "Flamingos2", "Flamingos2", "FLAMINGOS")

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
@@ -6,10 +6,12 @@ object PhoenixBlueprint {
   def apply(m: M.PhoenixBlueprint): PhoenixBlueprint = new PhoenixBlueprint(m)
 }
 
-case class PhoenixBlueprint(fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) extends GeminiBlueprintBase {
-  def name: String = s"Phoenix ${fpu.value} ${filter.value}"
+case class PhoenixBlueprint(site0: Site, fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) extends GeminiBlueprintBase {
+  def name: String = s"Phoenix ${site.name} ${fpu.value} ${filter.value}"
+  override def site = site0
 
   def this(m: M.PhoenixBlueprint) = this(
+    Site.fromMutable(m.getSite),
     m.getFpu,
     m.getFilter
   )
@@ -23,6 +25,7 @@ case class PhoenixBlueprint(fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) e
     m.setName(name)
     m.setFpu(fpu)
     m.setFilter(filter)
+    m.setSite(Site.toMutable(site))
     m
   }
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/PhoenixBlueprint.scala
@@ -6,9 +6,8 @@ object PhoenixBlueprint {
   def apply(m: M.PhoenixBlueprint): PhoenixBlueprint = new PhoenixBlueprint(m)
 }
 
-case class PhoenixBlueprint(site0: Site, fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) extends GeminiBlueprintBase {
+case class PhoenixBlueprint(override val site: Site, fpu: PhoenixFocalPlaneUnit, filter: PhoenixFilter) extends GeminiBlueprintBase {
   def name: String = s"Phoenix ${site.name} ${fpu.value} ${filter.value}"
-  override def site = site0
 
   def this(m: M.PhoenixBlueprint) = this(
     Site.fromMutable(m.getSite),

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TexesBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TexesBlueprint.scala
@@ -6,11 +6,12 @@ object TexesBlueprint {
   def apply(m: M.TexesBlueprint): TexesBlueprint = new TexesBlueprint(m)
 }
 
-case class TexesBlueprint(disperser: TexesDisperser) extends GeminiBlueprintBase {
-  def name: String = s"Texes ${disperser.value}"
+case class TexesBlueprint(override val site: Site, disperser: TexesDisperser) extends GeminiBlueprintBase {
+  def name: String = s"Texes ${site.name} ${disperser.value}"
   override val visitor = true
 
   def this(m: M.TexesBlueprint) = this(
+    Site.fromMutable(m.getSite),
     m.getDisperser
   )
 
@@ -22,6 +23,7 @@ case class TexesBlueprint(disperser: TexesDisperser) extends GeminiBlueprintBase
     m.setName(name)
     m.setDisperser(disperser)
     m.setVisitor(visitor)
+    m.setSite(Site.toMutable(site))
     m
   }
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/VisitorBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/VisitorBlueprint.scala
@@ -6,9 +6,8 @@ object VisitorBlueprint {
   def apply(m: M.VisitorBlueprint): VisitorBlueprint = new VisitorBlueprint(Site.fromMutable(m.getSite), m.getCustomName)
 }
 
-case class VisitorBlueprint(site0: Site, customName: String) extends GeminiBlueprintBase {
+case class VisitorBlueprint(override val site: Site, customName: String) extends GeminiBlueprintBase {
   def name: String = s"Visitor - ${site.name} - $customName"
-  override def site = site0
   override val visitor = true
 
   def this(m: M.VisitorBlueprint) = this(Site.fromMutable(m.getSite), m.getCustomName)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -160,8 +160,9 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
       }
       StepResult("Dssi proposal has been assigned to Gemini North.", <dssi>{DssiSiteTransformer.transform(ns)}</dssi>).successNel
   }
+
   val phoenixNameRegex = "(Phoenix) (.*)".r
-  def transformPhoneixName(name: String) = name match {
+  def transformPhoenixName(name: String) = name match {
     case phoenixNameRegex(a, b) => s"$a ${Site.GS.name} $b"
     case _                      => name
   }
@@ -170,14 +171,32 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
       object PhoenixSiteTransformer extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
             case p @ <Phoenix>{q @ _*}</Phoenix> => <Phoenix id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GS.name}</site>}</Phoenix>
-            case <name>{name}</name>             => <name>{transformPhoneixName(name.text)}</name>
+            case <name>{name}</name>             => <name>{transformPhoenixName(name.text)}</name>
             case elem: xml.Elem                  => elem.copy(child = elem.child.flatMap(transform))
             case _                               => n
           }
       }
       StepResult("Phoenix proposal has been assigned to Gemini South.", <phoenix>{PhoenixSiteTransformer.transform(ns)}</phoenix>).successNel
   }
-  val transformers = List(replaceKLongFilter, dssSite, phoenixSite)
+
+  val texesNameRegex = "(Texes) (.*)".r
+  def transformTexesName(name: String) = name match {
+    case texesNameRegex(a, b) => s"$a ${Site.GN.name} $b"
+    case _                      => name
+  }
+  val texesSite: TransformFunction = {
+    case <texes>{ns @ _*}</texes> =>
+      object TexesSiteTransformer extends BasicTransformer {
+        override def transform(n: xml.Node): xml.NodeSeq = n match {
+            case p @ <Texes>{q @ _*}</Texes> => <Texes id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GN.name}</site>}</Texes>
+            case <name>{name}</name>         => <name>{transformTexesName(name.text)}</name>
+            case elem: xml.Elem              => elem.copy(child = elem.child.flatMap(transform))
+            case _                           => n
+          }
+      }
+      StepResult("Texes proposal has been assigned to Gemini North.", <texes>{TexesSiteTransformer.transform(ns)}</texes>).successNel
+  }
+  val transformers = List(replaceKLongFilter, dssSite, phoenixSite, texesSite)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -152,7 +152,8 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
     case p @ <dssi>{ns @ _*}</dssi> =>
       object DssiSiteTransformer extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
-            case <Dssi>{q @ _*}</Dssi> => <Dssi>{q +: <site>{Site.GN.name}</site>}</Dssi>
+            case <Dssi>{q @ _*}</Dssi> => <Dssi>{q.map(transform) +: <site>{Site.GN.name}</site>}</Dssi>
+            case <name>{name}</name>   => <name>DSSI {Site.GN.name}</name>
             case elem: xml.Elem        => elem.copy(child = elem.child.flatMap(transform))
             case _                     => n
           }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -148,6 +148,7 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
         }
         StepResult("The Flamingos2 filter K-long (2.00 um) has been converted to K-long (2.20 um).", <flamingos2>{KLongFilterTransformer.transform(ns)}</flamingos2>).successNel
     }
+
   val dssSite: TransformFunction = {
     case <dssi>{ns @ _*}</dssi> =>
       object DssiSiteTransformer extends BasicTransformer {
@@ -184,6 +185,7 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
     case texesNameRegex(a, b) => s"$a ${Site.GN.name} $b"
     case _                      => name
   }
+
   val texesSite: TransformFunction = {
     case <texes>{ns @ _*}</texes> =>
       object TexesSiteTransformer extends BasicTransformer {

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -152,10 +152,10 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
     case <dssi>{ns @ _*}</dssi> =>
       object DssiSiteTransformer extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
-            case <Dssi>{q @ _*}</Dssi> => <Dssi>{q.map(transform) +: <site>{Site.GN.name}</site>}</Dssi>
-            case <name>{name}</name>   => <name>DSSI {Site.GN.name}</name>
-            case elem: xml.Elem        => elem.copy(child = elem.child.flatMap(transform))
-            case _                     => n
+            case p @ <Dssi>{q @ _*}</Dssi> => <Dssi id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GN.name}</site>}</Dssi>
+            case <name>{name}</name>       => <name>DSSI {Site.GN.name}</name>
+            case elem: xml.Elem            => elem.copy(child = elem.child.flatMap(transform))
+            case _                         => n
           }
       }
       StepResult("Dssi proposal has been assigned to Gemini North.", <dssi>{DssiSiteTransformer.transform(ns)}</dssi>).successNel
@@ -167,15 +167,15 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
   }
   val phoenixSite: TransformFunction = {
     case <phoenix>{ns @ _*}</phoenix> =>
-      object PhoneixSiteTransformer extends BasicTransformer {
+      object PhoenixSiteTransformer extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
-            case <Phoenix>{q @ _*}</Phoenix> => <Phoenix>{q.map(transform) +: <site>{Site.GS.name}</site>}</Phoenix>
-            case <name>{name}</name>         => <name>{transformPhoneixName(name.text)}</name>
-            case elem: xml.Elem              => elem.copy(child = elem.child.flatMap(transform))
-            case _                           => n
+            case p @ <Phoenix>{q @ _*}</Phoenix> => <Phoenix id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GS.name}</site>}</Phoenix>
+            case <name>{name}</name>             => <name>{transformPhoneixName(name.text)}</name>
+            case elem: xml.Elem                  => elem.copy(child = elem.child.flatMap(transform))
+            case _                               => n
           }
       }
-      StepResult("Phoenix proposal has been assigned to Gemini South.", <phoenix>{PhoneixSiteTransformer.transform(ns)}</phoenix>).successNel
+      StepResult("Phoenix proposal has been assigned to Gemini South.", <phoenix>{PhoenixSiteTransformer.transform(ns)}</phoenix>).successNel
   }
   val transformers = List(replaceKLongFilter, dssSite, phoenixSite)
 }

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -5,6 +5,7 @@ Gemini Phase I Schema Changes
 
 * Rename Flamingos-2 K-long from 'K-long (2.20 um)' to 'K-long (2.00um)'
 * Add site to DSSI
+* Add site to Phoenix
 
 # Version 2016.1.1 - 2016A
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -6,6 +6,7 @@ Gemini Phase I Schema Changes
 * Rename Flamingos-2 K-long from 'K-long (2.20 um)' to 'K-long (2.00um)'
 * Add site to DSSI
 * Add site to Phoenix
+* Add site to Texes
 
 # Version 2016.1.1 - 2016A
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -3,6 +3,12 @@ Gemini Phase I Schema Changes
 # Version 2016.1.1 - 2016A
 ##########################
 
+* Rename Flamingos-2 K-long from 'K-long (2.20 um)' to 'K-long (2.00um)'
+* Add site to DSSI
+
+# Version 2016.1.1 - 2016A
+##########################
+
 * Offer Flamingos-2 K-long filter
 * Added keyword 'Star formation'
 * Offer Phoenix instrument

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Dssi.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Dssi.xsd
@@ -3,6 +3,7 @@
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:include schemaLocation="Instrument.xsd"/>
+    <xsd:include schemaLocation="Site.xsd"/>
 
     <!-- Options for Speckle Blueprint. -->
     <xsd:complexType name="DssiBlueprintChoice">
@@ -23,6 +24,9 @@
     <xsd:complexType name="DssiBlueprint">
         <xsd:complexContent>
             <xsd:extension base="BlueprintBase">
+                <xsd:sequence>
+                    <xsd:element name="site"        type="Site" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Dssi.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Dssi.xsd
@@ -25,7 +25,7 @@
         <xsd:complexContent>
             <xsd:extension base="BlueprintBase">
                 <xsd:sequence>
-                    <xsd:element name="site"        type="Site" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="site" type="Site" minOccurs="1" maxOccurs="1"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Phoenix.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Phoenix.xsd
@@ -3,6 +3,7 @@
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:include schemaLocation="Instrument.xsd"/>
+    <xsd:include schemaLocation="Site.xsd"/>
 
     <!-- Options for Phoenix Blueprint. -->
     <xsd:complexType name="PhoenixBlueprintChoice">
@@ -24,6 +25,7 @@
         <xsd:complexContent>
             <xsd:extension base="BlueprintBase">
                 <xsd:sequence>
+                    <xsd:element name="site"   type="Site" minOccurs="1" maxOccurs="1"/>
                     <xsd:element name="fpu"    type="PhoenixFocalPlaneUnit" maxOccurs="1" minOccurs="0"/>
                     <xsd:element name="filter" type="PhoenixFilter"         maxOccurs="1" minOccurs="0"/>
                 </xsd:sequence>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Texes.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Texes.xsd
@@ -3,6 +3,7 @@
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:include schemaLocation="Instrument.xsd"/>
+    <xsd:include schemaLocation="Site.xsd"/>
 
     <!-- Options for Texes Blueprint. -->
     <xsd:complexType name="TexesBlueprintChoice">
@@ -24,7 +25,8 @@
         <xsd:complexContent>
             <xsd:extension base="BlueprintBase">
                 <xsd:sequence>
-                    <xsd:element name="disperser"  type="TexesDisperser"/>
+                    <xsd:element name="site"      type="Site" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="disperser" type="TexesDisperser"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_dssi.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_dssi.xml
@@ -25,6 +25,7 @@
         <dssi>
             <Dssi id="blueprint-0">
                 <name>Dssi</name>
+                <site>Gemini North</site>
                 <visitor>true</visitor>
             </Dssi>
         </dssi>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_phoenix.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_phoenix.xml
@@ -23,7 +23,8 @@
     <blueprints>
         <phoenix>
             <Phoenix id="blueprint-0">
-                <name>Phoenix 0.17 arcsec slit H6073</name>
+                <name>Phoenix Gemini South 0.17 arcsec slit H6073</name>
+                <site>Gemini South</site>
                 <visitor>false</visitor>
                 <fpu>0.17 arcsec slit</fpu>
                 <filter>H6073</filter>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_texes.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_texes.xml
@@ -24,7 +24,8 @@
     <blueprints>
         <texes>
             <Texes id="blueprint-0">
-                <name>Texes LM_32_echelle</name>
+                <name>Texes Gemini North LM_32_echelle</name>
+                <site>Gemini North</site>
                 <disperser>32 l/mm echelle</disperser>
             </Texes>
         </texes>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_texes_as_non_visitor.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_texes_as_non_visitor.xml
@@ -24,7 +24,8 @@
     <blueprints>
         <texes>
             <Texes id="blueprint-0">
-                <name>Texes LM_32_echelle</name>
+                <name>Texes Gemini North LM_32_echelle</name>
+                <site>Gemini North</site>
                 <disperser>32 l/mm echelle</disperser>
                 <visitor>false</visitor>
             </Texes>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_dssi_no_site.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_dssi_no_site.xml
@@ -25,8 +25,7 @@
         <dssi>
             <Dssi id="blueprint-0">
                 <name>Dssi</name>
-                <site>Gemini North</site>
-                <visitor>false</visitor>
+                <visitor>true</visitor>
             </Dssi>
         </dssi>
     </blueprints>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_phoenix_no_site.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_phoenix_no_site.xml
@@ -1,0 +1,39 @@
+<proposal schemaVersion="2016.1.1">
+    <meta band3optionChosen="false"/>
+    <semester half="A" year="2016"/>
+    <title/>
+    <abstract/>
+    <scheduling/>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email/>
+            <address>
+                <institution/>
+                <address/>
+                <country/>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <phoenix>
+            <Phoenix id="blueprint-0">
+                <name>Phoenix 0.17 arcsec slit H6073</name>
+                <visitor>false</visitor>
+                <fpu>0.17 arcsec slit</fpu>
+                <filter>H6073</filter>
+            </Phoenix>
+        </phoenix>
+    </blueprints>
+    <observations>
+        <observation blueprint="blueprint-0" enabled="true" band="Band 1/2"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_texes_no_site.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_texes_no_site.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2013.2.1">
+    <meta band3optionChosen="false"/>
+    <semester year="2013" half="B"/>
+    <title/>
+    <abstract/>
+    <scheduling/>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email/>
+            <address>
+                <institution/>
+                <address/>
+                <country/>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <texes>
+            <Texes id="blueprint-0">
+                <name>Texes LM_32_echelle</name>
+                <disperser>32 l/mm echelle</disperser>
+            </Texes>
+        </texes>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-0"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
@@ -1,20 +1,30 @@
 package edu.gemini.model.p1.dtree.inst
 
+import edu.gemini.model.p1.immutable.Site
 import edu.gemini.model.p1.mutable.{PhoenixFocalPlaneUnit, PhoenixFilter}
 import org.specs2.mutable.SpecificationWithJUnit
 
 class PhoenixSpec extends SpecificationWithJUnit {
   "The Phoenix decision tree" should {
-    "includes Phoenix GPU" in {
+    "includes a Site" in {
       val phoenix = Phoenix()
-      phoenix.title must beEqualTo("Focal Plane Unit")
-      phoenix.choices must have size 3
+      phoenix.title must beEqualTo("Site")
+      phoenix.choices must have size 2
+      // Check no default site
+      phoenix.default must beNone
+    }
+    "includes Phoenix FPU" in {
+      val phoenix = Phoenix()
+      val fpuNode = phoenix.apply(Site.GN).a
+      fpuNode.title must beEqualTo("Focal Plane Unit")
+      fpuNode.choices must have size 3
       // Check the default
-      phoenix.default should beSome(PhoenixFocalPlaneUnit.MASK_3)
+      fpuNode.default should beSome(PhoenixFocalPlaneUnit.MASK_3)
     }
     "includes Phoenix filter modes" in {
       val phoenix = Phoenix()
-      val filterNode = phoenix.apply(PhoenixFocalPlaneUnit.MASK_1).a
+      val fpuNode = phoenix.apply(Site.GN).a
+      val filterNode = fpuNode.apply(PhoenixFocalPlaneUnit.MASK_1).a
       filterNode.title must beEqualTo("Filter")
       filterNode.choices must have size 21
       // Check the default filter

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/TexesSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/TexesSpec.scala
@@ -1,13 +1,20 @@
 package edu.gemini.model.p1.dtree.inst
 
+import edu.gemini.model.p1.immutable.Site
 import org.specs2.mutable.SpecificationWithJUnit
 
 class TexesSpec extends SpecificationWithJUnit {
   "The Texes decision tree" should {
+      "includes a site choice" in {
+        val texes = Texes()
+        texes.title must beEqualTo("Site")
+        texes.choices must have size 2
+      }
       "includes a disperser choice" in {
         val texes = Texes()
-        texes.title must beEqualTo("Disperser")
-        texes.choices must have size(4)
+        val disperserNode = texes.apply(VisitorSite.fromSite(Site.GN)).a
+        disperserNode.title must beEqualTo("Disperser")
+        disperserNode.choices must have size 4
       }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/DssiBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/DssiBlueprintSpec.scala
@@ -13,7 +13,7 @@ class DssiBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
     }
     "have an appropriate public name" in {
       val blueprint = DssiBlueprint(Site.GN)
-      blueprint.name must beEqualTo("DSSI")
+      blueprint.name must beEqualTo("DSSI Gemini North")
     }
     "is a visitor instrument" in {
       val blueprint = DssiBlueprint(Site.GN)
@@ -33,7 +33,7 @@ class DssiBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
       // verify the exported value
       xml must \\("dssi")
       xml must \\("dssi") \\ "Dssi"
-      xml must \\("Dssi") \\ "name" \> "DSSI"
+      xml must \\("Dssi") \\ "name" \> "DSSI Gemini North"
       xml must \\("Dssi") \\ "site" \> "Gemini North"
       xml must \\("Dssi") \ "visitor" \> "true"
     }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/DssiBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/DssiBlueprintSpec.scala
@@ -8,19 +8,23 @@ class DssiBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
 
   "The Dssi Blueprint" should {
     "not use Ao" in {
-      val blueprint = DssiBlueprint()
+      val blueprint = DssiBlueprint(Site.GN)
       blueprint.ao must beEqualTo(AoNone)
     }
     "have an appropriate public name" in {
-      val blueprint = DssiBlueprint()
+      val blueprint = DssiBlueprint(Site.GN)
       blueprint.name must beEqualTo("DSSI")
     }
     "is a visitor instrument" in {
-      val blueprint = DssiBlueprint()
+      val blueprint = DssiBlueprint(Site.GN)
       blueprint.visitor must beTrue
     }
+    "has a site" in {
+      DssiBlueprint(Site.GS).site must beEqualTo(Site.GS)
+      DssiBlueprint(Site.GN).site must beEqualTo(Site.GN)
+    }
     "export Dssi to XML" in {
-      val blueprint = DssiBlueprint()
+      val blueprint = DssiBlueprint(Site.GN)
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
       val proposal = Proposal.empty.copy(observations = observation :: Nil)
@@ -28,24 +32,25 @@ class DssiBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
 
       // verify the exported value
       xml must \\("dssi")
-      xml must \\("dssi") \\("Dssi")
-      xml must \\("Dssi") \\("name") \> ("DSSI")
-      xml must \\("Dssi") \("visitor") \> "true"
+      xml must \\("dssi") \\ "Dssi"
+      xml must \\("Dssi") \\ "name" \> "DSSI"
+      xml must \\("Dssi") \\ "site" \> "Gemini North"
+      xml must \\("Dssi") \ "visitor" \> "true"
     }
     "be possible to deserialize" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi.xml")))
 
-      proposal.blueprints(0) must beEqualTo(DssiBlueprint())
+      proposal.blueprints.head must beEqualTo(DssiBlueprint(Site.GN))
     }
     "overwrite visitor as false" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi_as_non_visitor.xml")))
 
       // Even though it is false in the xml it becomes true in the logic
-      proposal.blueprints(0).visitor must beTrue
+      proposal.blueprints.head.visitor must beTrue
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
       // verify the blueprint has a true attribute
-      xml must \\("Dssi") \("visitor") \> "true"
+      xml must \\("Dssi") \ "visitor" \> "true"
     }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PhoenixBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PhoenixBlueprintSpec.scala
@@ -12,20 +12,20 @@ class PhoenixBlueprintSpec extends SpecificationWithJUnit with SemesterPropertie
   "The Phoenix Blueprint" should {
     "has an FPU and a filter" in {
       // trivial sanity tests
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(Site.GS, M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
       blueprint.fpu must beEqualTo(M.PhoenixFocalPlaneUnit.MASK_1)
       blueprint.filter must beEqualTo(M.PhoenixFilter.H6073)
     }
     "never uses Lgs" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(Site.GS, M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
       blueprint.ao must beEqualTo(AoNone)
     }
     "has an appropriate public name" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
-      blueprint.name must beEqualTo("Phoenix 0.17 arcsec slit H6073")
+      val blueprint = PhoenixBlueprint(Site.GS, M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      blueprint.name must beEqualTo("Phoenix Gemini South 0.17 arcsec slit H6073")
     }
     "is not a visitor" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(Site.GS, M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
       blueprint.visitor must beFalse
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
@@ -36,7 +36,7 @@ class PhoenixBlueprintSpec extends SpecificationWithJUnit with SemesterPropertie
       xml must \\("Phoenix") \ "visitor" \> "false"
     }
     "export fpu and filter to XML" in {
-      val blueprint = PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
+      val blueprint = PhoenixBlueprint(Site.GS, M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073)
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
       val proposal = Proposal.empty.copy(observations = observation :: Nil)
@@ -50,7 +50,7 @@ class PhoenixBlueprintSpec extends SpecificationWithJUnit with SemesterPropertie
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix.xml")))
 
       proposal.blueprints.head.visitor must beFalse
-      proposal.blueprints must beEqualTo(PhoenixBlueprint(M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073) :: Nil)
+      proposal.blueprints must beEqualTo(PhoenixBlueprint(Site.GS, M.PhoenixFocalPlaneUnit.MASK_1, M.PhoenixFilter.H6073) :: Nil)
     }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/TexesBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/TexesBlueprintSpec.scala
@@ -4,39 +4,36 @@ import edu.gemini.model.p1.{mutable => M}
 import java.io.InputStreamReader
 import org.specs2.mutable._
 import scala.xml.XML
-import org.specs2.scalaz.ValidationMatchers._
-import scala.Some
-
 
 class TexesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
 
   "The Texes Blueprint" should {
     "be able to have a disperser" in {
       // trivial sanity test
-      val blueprint = TexesBlueprint(M.TexesDisperser.D_32_LMM)
+      val blueprint = TexesBlueprint(Site.GN, M.TexesDisperser.D_32_LMM)
       blueprint.disperser must beEqualTo(M.TexesDisperser.D_32_LMM)
     }
     "does not use Ao" in {
-      val blueprint = TexesBlueprint(M.TexesDisperser.D_32_LMM)
+      val blueprint = TexesBlueprint(Site.GN, M.TexesDisperser.D_32_LMM)
       blueprint.ao must beEqualTo(AoNone)
     }
     "has an appropriate public name" in {
-      val blueprint = TexesBlueprint(M.TexesDisperser.D_32_LMM)
-      blueprint.name must beEqualTo("Texes 32 l/mm echelle")
+      val blueprint = TexesBlueprint(Site.GN, M.TexesDisperser.D_32_LMM)
+      blueprint.name must beEqualTo("Texes Gemini North 32 l/mm echelle")
     }
     "includes the dispersers 'Echelon + 32 l/mm echelle' and 'Echelon + 75 l/mm grating'" in {
-      val blueprint32 = TexesBlueprint(M.TexesDisperser.E_D_32_LMM)
-      blueprint32.name must beEqualTo("Texes Echelon + 32 l/mm echelle")
+      val blueprint32 = TexesBlueprint(Site.GN, M.TexesDisperser.E_D_32_LMM)
+      blueprint32.name must beEqualTo("Texes Gemini North Echelon + 32 l/mm echelle")
 
-      val blueprint75 = TexesBlueprint(M.TexesDisperser.E_D_75_LMM)
-      blueprint75.name must beEqualTo("Texes Echelon + 75 l/mm grating")
+      val blueprint75 = TexesBlueprint(Site.GN, M.TexesDisperser.E_D_75_LMM)
+      blueprint75.name must beEqualTo("Texes Gemini North Echelon + 75 l/mm grating")
     }
     "is a visitor instrument" in {
-      val blueprint = TexesBlueprint(M.TexesDisperser.D_32_LMM)
+      val blueprint = TexesBlueprint(Site.GN, M.TexesDisperser.D_32_LMM)
       blueprint.visitor must beTrue
     }
     "export Texes to XML" in {
-      val blueprint = TexesBlueprint(M.TexesDisperser.D_32_LMM)
+      val blueprint = TexesBlueprint(Site.GN, M.TexesDisperser.D_32_LMM)
       val observation = Observation(Some(blueprint), None, None, Band.BAND_1_2, None)
 
       val proposal = Proposal.empty.copy(observations = observation :: Nil)
@@ -44,24 +41,24 @@ class TexesBlueprintSpec extends SpecificationWithJUnit with SemesterProperties 
 
       // verify the exported value
       xml must \\("texes")
-      xml must \\("texes") \\("Texes")
-      xml must \\("Texes") \\("name") \> ("Texes 32 l/mm echelle")
-      xml must \\("Texes") \("visitor") \> "true"
-      xml must \\("disperser") \> ("32 l/mm echelle")
+      xml must \\("texes") \\ "Texes"
+      xml must \\("Texes") \\ "name" \> "Texes Gemini North 32 l/mm echelle"
+      xml must \\("Texes") \ "visitor" \> "true"
+      xml must \\("disperser") \> "32 l/mm echelle"
     }
     "be possible to deserialize" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_texes.xml")))
 
-      proposal.blueprints(0) must beEqualTo(TexesBlueprint(M.TexesDisperser.D_32_LMM))
+      proposal.blueprints.head must beEqualTo(TexesBlueprint(Site.GN, M.TexesDisperser.D_32_LMM))
     }
     "overwrite visitor as false" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_texes_as_non_visitor.xml")))
 
-      proposal.blueprints(0).visitor must beTrue
+      proposal.blueprints.head.visitor must beTrue
       val xml = XML.loadString(ProposalIo.writeToString(proposal  ))
 
-      // verify the blueprint has a true attribute
-      xml must \\("Texes") \("visitor") \> "true"
+      // verify the blueprint has a true visitor attribute
+      xml must \\("Texes") \ "visitor" \> "true"
     }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/VisitorBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/VisitorBlueprintSpec.scala
@@ -3,9 +3,7 @@ package edu.gemini.model.p1.immutable
 import java.io.InputStreamReader
 import org.specs2.mutable._
 import scala.xml.XML
-import org.specs2.scalaz.ValidationMatchers._
 import scala.Some
-
 
 class VisitorBlueprintSpec extends SpecificationWithJUnit with SemesterProperties {
 
@@ -35,21 +33,21 @@ class VisitorBlueprintSpec extends SpecificationWithJUnit with SemesterPropertie
 
       // verify the exported value
       xml must \\("visitor")
-      xml must \\("visitor") \\("visitor")
-      xml must \\("name") \> ("Visitor - Gemini South - Instrument name")
-      xml must \\("visitor") \("visitor") \> "true"
+      xml must \\("visitor") \\"visitor"
+      xml must \\("name") \> "Visitor - Gemini South - Instrument name"
+      xml must \\("visitor") \"visitor" \> "true"
       xml must \\("site") \> "Gemini South"
       xml must \\("custom-name") \> "Instrument name"
     }
     "can be deserialized with site GS" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_visitor_gs.xml")))
 
-      proposal.blueprints(0) must beEqualTo(VisitorBlueprint(Site.GS, "My instrument"))
+      proposal.blueprints.head must beEqualTo(VisitorBlueprint(Site.GS, "My instrument"))
     }
     "can be deserialized with site GN" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_visitor_gn.xml")))
 
-      proposal.blueprints(0) must beEqualTo(VisitorBlueprint(Site.GN, "My instrument"))
+      proposal.blueprints.head must beEqualTo(VisitorBlueprint(Site.GN, "My instrument"))
     }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -437,6 +437,19 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result must \\("Texes")
       }
     }
+    "proposal with dssi blueprints must have a site, REL-2463" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi_no_site.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 4
+          changes must contain("Dssi proposal has been assigned to Gemini North.")
+          // The dssi blueprint must remain and include a site
+          result must \\("Dssi")
+          result must \\("Dssi") \\ "site" \> "Gemini North"
+      }
+    }
     /*
     "proposal with dssi blueprints must be removed, REL-1350" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi.xml")))
@@ -626,7 +639,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2014B to view the unmodified proposal")

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -451,6 +451,20 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result must \\("Dssi") \\ "name" \> "DSSI Gemini North"
       }
     }
+    "proposal with texes blueprints must have a site, REL-2463" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix_no_site.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 4
+          changes must contain("Phoenix proposal has been assigned to Gemini South.")
+          // The phoenix blueprint must remain and include a site
+          result must \\("Phoenix")
+          result must \\("Phoenix") \\ "site" \> "Gemini South"
+          result must \\("Phoenix") \\ "name" \> "Phoenix Gemini South 0.17 arcsec slit H6073"
+      }
+    }
     "proposal with GmosN blueprints that use a 0.25 slit must be converted to a 0.5 slit, REL-1256" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gmosn_0.25_slit.xml")))
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -448,22 +448,9 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           // The dssi blueprint must remain and include a site
           result must \\("Dssi")
           result must \\("Dssi") \\ "site" \> "Gemini North"
+          result must \\("Dssi") \\ "name" \> "DSSI Gemini North"
       }
     }
-    /*
-    "proposal with dssi blueprints must be removed, REL-1350" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi.xml")))
-
-      val converted = UpConverter.convert(xml)
-      converted must beSuccessful.like {
-        case StepResult(changes, result) => {
-          changes must have length 5
-          changes must contain("The original proposal contained DSSI observations. The instrument is not available and those resources have been removed.")
-          // The texes blueprint must remain
-          result must \\("gmosN")
-        }
-      }
-    } */
     "proposal with GmosN blueprints that use a 0.25 slit must be converted to a 0.5 slit, REL-1256" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gmosn_0.25_slit.xml")))
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -446,12 +446,12 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           changes must have length 4
           changes must contain("Dssi proposal has been assigned to Gemini North.")
           // The dssi blueprint must remain and include a site
-          result must \\("Dssi")
+          result must \\("Dssi", "id")
           result must \\("Dssi") \\ "site" \> "Gemini North"
           result must \\("Dssi") \\ "name" \> "DSSI Gemini North"
       }
     }
-    "proposal with texes blueprints must have a site, REL-2463" in {
+    "proposal with phoenix blueprints must have a site, REL-2463" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix_no_site.xml")))
 
       val converted = UpConverter.convert(xml)
@@ -460,7 +460,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           changes must have length 4
           changes must contain("Phoenix proposal has been assigned to Gemini South.")
           // The phoenix blueprint must remain and include a site
-          result must \\("Phoenix")
+          result must \\("Phoenix", "id")
           result must \\("Phoenix") \\ "site" \> "Gemini South"
           result must \\("Phoenix") \\ "name" \> "Phoenix Gemini South 0.17 arcsec slit H6073"
       }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -432,7 +432,7 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           // The texes blueprint must remain
           result must \\("Texes")
       }
@@ -463,6 +463,20 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result must \\("Phoenix", "id")
           result must \\("Phoenix") \\ "site" \> "Gemini South"
           result must \\("Phoenix") \\ "name" \> "Phoenix Gemini South 0.17 arcsec slit H6073"
+      }
+    }
+    "proposal with texes blueprints must have a site, REL-2463" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_texes_no_site.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 4
+          changes must contain("Texes proposal has been assigned to Gemini North.")
+          // The texes blueprint must remain and include a site
+          result must \\("Texes", "id")
+          result must \\("Texes") \\ "site" \> "Gemini North"
+          result must \\("Texes") \\ "name" \> "Texes Gemini North LM_32_echelle"
       }
     }
     "proposal with GmosN blueprints that use a 0.25 slit must be converted to a 0.5 slit, REL-1256" in {


### PR DESCRIPTION
This PR changes the phase 1 model of  Texes, Dssi and Phoenix to request the user to indicate which site the proposal belongs to. Included are model changes, UI updates on the decision tree, upconversion logic and multiple tests.
Most of the added lines are test files