### PR TITLE
REL-2463B: Add site options to all visitor instruments

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
@@ -215,6 +215,7 @@
     <!-- Creates a nice name for the instrument names used in the xml blueprints -->
     <xsl:template name="get-inst-name">
         <xsl:param name="inst"/>
+        <xsl:param name="site"/>
         <xsl:choose>
             <xsl:when test="$inst = 'flamingos2'">Flamingos2</xsl:when>
             <xsl:when test="$inst = 'gmosN'">GMOS North</xsl:when>
@@ -227,9 +228,9 @@
             <xsl:when test="$inst = 'nici'">NICI</xsl:when>
             <xsl:when test="$inst = 'nifs'">NIFS</xsl:when>
             <xsl:when test="$inst = 'niri'">NIRI</xsl:when>
-            <xsl:when test="$inst = 'phoenix'">Phoenix</xsl:when>
-            <xsl:when test="$inst = 'dssi'">DSSI</xsl:when>
-            <xsl:when test="$inst = 'texes'">Texes</xsl:when>
+            <xsl:when test="$inst = 'phoenix'">Phoenix - <xsl:value-of select="$site"/></xsl:when>
+            <xsl:when test="$inst = 'dssi'">DSSI - <xsl:value-of select="$site"/></xsl:when>
+            <xsl:when test="$inst = 'texes'">Texes - <xsl:value-of select="$site"/></xsl:when>
             <xsl:when test="$inst = 'trecs'">TReCS</xsl:when>
             <xsl:otherwise>?<xsl:value-of select="$inst"/>?</xsl:otherwise>
         </xsl:choose>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -104,6 +104,9 @@
                                         <xsl:with-param name="inst">
                                             <xsl:value-of select="name(.)"/>
                                         </xsl:with-param>
+                                        <xsl:with-param name="site">
+                                            <xsl:value-of select=".//site"/>
+                                        </xsl:with-param>
                                     </xsl:call-template>
                                 </xsl:otherwise>
                             </xsl:choose>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_dssi.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_dssi.xml
@@ -50,6 +50,7 @@
         <dssi>
             <Dssi id="blueprint-0">
                 <name>DSSI</name>
+                <site>Gemini North</site>
                 <visitor>true</visitor>
             </Dssi>
         </dssi>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_phoenix.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_phoenix.xml
@@ -50,6 +50,7 @@
         <phoenix>
             <Phoenix id="blueprint-0">
                 <name>Phoenix 0.17 arcsec slit H6073</name>
+                <site>Gemini South</site>
                 <visitor>false</visitor>
                 <fpu>0.17 arcsec slit</fpu>
                 <filter>H6073</filter>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_texes.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_texes.xml
@@ -50,6 +50,7 @@
         <texes>
             <Texes id="blueprint-0">
                 <name>Texes 32 l/mm echelle</name>
+                <site>Gemini North</site>
                 <disperser>32 l/mm echelle</disperser>
             </Texes>
         </texes>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
@@ -74,7 +74,7 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       // Check there is a table
       XML.loadString(result) must \\("block") \ "inline" \>~ """\s*TAC information\s*"""
       // Check there is one accepted
-      accepted must be size (1)
+      accepted must be size 1
       // And none rejected
       rejected must beEmpty
     }
@@ -105,7 +105,7 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       // Check there is a scheduling element
       XML.loadString(result) must (\\("block") \ "inline" \>~ """\s*Scheduling Constraints\s*""")
       // Check there is a scheduling text
-      foundMatches must be size (1)
+      foundMatches must be size 1
     }
     "use new text for observations with guiding between 50% and less than 100%, REL-640" in {
       val result = transformProposal("proposal_guiding_caution.xml")
@@ -130,12 +130,12 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     "present the correct name when using Texes, REL-1062" in {
       val result = transformProposal("proposal_with_texes.xml")
       // Check that we use the proper public name of Texes
-      XML.loadString(result) must (\\("table-cell") \ "block" \> "Texes")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Texes - Gemini North")
     }
     "present the correct name when using Dssi, REL-1061" in {
       val result = transformProposal("proposal_with_dssi.xml")
       // Check that we use the proper public name of DSSI
-      XML.loadString(result) must (\\("table-cell") \ "block" \> "DSSI")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "DSSI - Gemini North")
     }
     "present the correct name when using Visitor GN, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gn.xml")
@@ -146,6 +146,21 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       val result = transformProposal("proposal_with_visitor_gs.xml")
       // Check that we use the proper public name of a south visitor
       XML.loadString(result) must (\\("table-cell") \ "block" \> "Visitor - Gemini South - Super Camera")
+    }
+    "present Phoenix's Site, REL-2463" in {
+      val result = transformProposal("proposal_with_phoenix.xml")
+      // Check that we use the proper public name of a south visitor
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Phoenix - Gemini South")
+    }
+    "present Texes' Site, REL-2463" in {
+      val result = transformProposal("proposal_with_texes.xml")
+      // Check that we use the proper public name of a south visitor
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Texes - Gemini North")
+    }
+    "present DSSI' Site, REL-2463" in {
+      val result = transformProposal("proposal_with_dssi.xml")
+      // Check that we use the proper public name of a south visitor
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "DSSI - Gemini North")
     }
     "show an ITAC information section if the proposal contains a comment, REL-1165" in {
       val result = transformProposal("proposal_with_itac_comment.xml")
@@ -183,7 +198,7 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     "present the correct instrument name when using Phoenix, REL-2356" in {
       val result = transformProposal("proposal_with_phoenix.xml")
       // Check that we use the proper public name of Phoenix
-      XML.loadString(result) must (\\("table-cell") \ "block" \> "Phoenix")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Phoenix - Gemini South")
     }
     "Supports Large Programs, REL-1614" in {
       val result = transformProposal("large_program.xml")
@@ -250,7 +265,7 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
       // Check there is a scheduling element
       XML.loadString(result) must (\\("block") \ "inline" \>~ """\s*Scheduling Constraints:\s*""")
       // Check there is a scheduling text
-      foundMatches must be size (1)
+      foundMatches must be size 1
     }
     "include TAC partner ranking, REL-677" in {
       val result = transformProposal("proposal_submitted_to_tac_all_approved.xml", P1PDF.NOAO)
@@ -287,6 +302,11 @@ class P1TemplatesSpec extends SpecificationWithJUnit {
     "show that a GS visitor is in Gemini North, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gs.xml", P1PDF.NOAO)
       // Check that Speckle is shown in Gemini North
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini South")
+    }
+    "show that a Phoenix site is displayed, REL-1090" in {
+      val result = transformProposal("proposal_with_phoenix.xml", P1PDF.NOAO)
+      // Check that Phoenix is shown in Gemini South
       XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini South")
     }
     "show an ITAC information section if the proposal contains a comment, REL-1165" in {


### PR DESCRIPTION
This PR adds the site option selected for Phoenix, Texes and DSSI to the PDF output. Tests are included