### PR TITLE
Idea project generation update.

### DIFF
--- a/project/OcsBundleSettings.scala
+++ b/project/OcsBundleSettings.scala
@@ -57,21 +57,17 @@ trait OcsBundleSettings { this: OcsKey =>
 
     ocsBundleIdeaModule := {
       val iml = ocsBundleIdeaModuleAbstractPath.value
-      if (iml.exists && iml.lastModified >= ocsBootTime.value) {
-        streams.value.log.debug("IDEA module up to date: " + iml)
-      } else {
-        val modules: Seq[String] = {
-          val s = state.value
-          val extracted = Project.extract(s)      
-          ocsDependencies.value.map(p => extracted.get(ocsBundleIdeaModuleName in p))
-        }      
-        val classpath = ((managedClasspath in Compile).value ++ (unmanagedJars in Compile).value).map(_.data)
-        val testClasspath= ((managedClasspath in Test).value ++ (unmanagedJars in Test).value).map(_.data) filterNot (classpath.contains)
-        IO.createDirectory(iml.getParentFile)
-        val mod = new IdeaModule(iml.getParentFile, modules, classpath, testClasspath)
-        IO.writeLines(iml, List(new PrettyPrinter(132, 2).format(mod.module)), IO.utf8)
-        streams.value.log.info("IDEA module: " + iml)
-      }
+      val modules: Seq[String] = {
+        val s = state.value
+        val extracted = Project.extract(s)      
+        ocsDependencies.value.map(p => extracted.get(ocsBundleIdeaModuleName in p))
+      }      
+      val classpath = ((managedClasspath in Compile).value ++ (unmanagedJars in Compile).value).map(_.data)
+      val testClasspath= ((managedClasspath in Test).value ++ (unmanagedJars in Test).value).map(_.data) filterNot (classpath.contains)
+      IO.createDirectory(iml.getParentFile)
+      val mod = new IdeaModule(iml.getParentFile, modules, classpath, testClasspath)
+      IO.writeLines(iml, List(new PrettyPrinter(132, 2).format(mod.module)), IO.utf8)
+      streams.value.log.info("IDEA module: " + iml)
       iml
     },
 

--- a/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaModule.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaModule.scala
@@ -22,15 +22,7 @@ class IdeaModule(
     </module>
 
   def scalaComponent: xml.Elem =
-    <component name="FacetManager">
-      <facet type="scala" name="Scala">
-        <configuration>
-          <option name="compilerLibraryLevel" value="Project" />
-          <option name="compilerLibraryName" value={"scala-compiler"} />
-          <option name="languageLevel" value="Scala 2.10" />
-        </configuration>
-      </facet>
-    </component>
+    <component name="FacetManager" />
 
   def rootComponent: xml.Elem =
     <component name="NewModuleRootManager" inherit-compiler-output="true">
@@ -45,7 +37,7 @@ class IdeaModule(
       {depMods.map(bv => bundleDependency(bv))}
       {depJars.map(j => libraryDependency(j))}
       {testJars.map(j => libraryDependency(j, isTest = true))}
-      {/*testScopeDependencies(imlFile)*/}
+      <orderEntry type="library" name="scala-sdk" level="project" />
     </component>
 
   def srcDirs(isTest: Boolean): List[File]= {
@@ -87,14 +79,6 @@ class IdeaModule(
         </CLASSES>
       </library>
     </orderEntry>
-
-  /**
-   * Keep any already defined test-scoped deps.  If none, add given deps.
-  def testLibraryDependencies(iml: File): xml.NodeSeq = {
-    val existing = testScopeDependencies(iml)
-    if (existing.isEmpty) testJars.map(j => libraryDependency(j, true)) else existing
-  }
-   */
 }
 
 object IdeaModule {

--- a/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaProject.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaProject.scala
@@ -164,6 +164,7 @@ class IdeaProject(idea: Idea, scalaInstance: ScalaInstance, imls: List[File]) {
       </component>
       <component name="VcsDirectoryMappings"/>
       {libraryTable}
+      <component name="ScalaCompilerConfiguration" />
     </project>
 
   private def initialProject(javaVersion: String): xml.Elem =
@@ -318,19 +319,20 @@ def project: xml.Elem =
 
   private def libraryTable: xml.Elem =
     <component name="libraryTable">
-      <library name="scala-compiler">
-        <CLASSES>
-          {scalaInstance.allJars.map(jarUrl)}
-        </CLASSES>
-      </library>
-      <library name="scala-library">
-        <CLASSES>
-          {scalaInstance.allJars.map(jarUrl)}
-        </CLASSES>
+      <library name="scala-sdk" type="Scala">
+        <properties>
+          <option name="languageLevel" value="Scala_2_11" />
+          <compiler-classpath>
+            {scalaInstance.allJars.map(jarUrl)}
+          </compiler-classpath>
+        </properties>
+        <CLASSES />
+        <JAVADOC />
+        <SOURCES />
       </library>
     </component>
 
   private def jarUrl(jarFile: File): xml.Elem =
-    <root url={"jar://%s!/".format(projRelativePath(jarFile)) } />
+    <root url={s"jar://${projRelativePath(jarFile)}"} />
 }
 

--- a/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaProject.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaProject.scala
@@ -317,11 +317,14 @@ def project: xml.Elem =
 
   private def artifactName(bl: BundleLoc): String = "%s_%s".format(bl.name, bl.version)
 
+  private def languageLevel: String =
+    scala.util.Properties.versionNumberString.split('.').take(2).mkString("Scala_", "_", "")
+
   private def libraryTable: xml.Elem =
     <component name="libraryTable">
       <library name="scala-sdk" type="Scala">
         <properties>
-          <option name="languageLevel" value="Scala_2_11" />
+          <option name="languageLevel" value={languageLevel} />
           <compiler-classpath>
             {scalaInstance.allJars.map(jarUrl)}
           </compiler-classpath>


### PR DESCRIPTION
A couple of minor updates to Idea project generation.

1) Update project and module XML files so that a conversion and backup is not performed on startup. (At least for Idea 14.  Further updates might be needed for Idea 15.)

2) Always replace module files when the project is generated regardless of whether they have been edited.  In practice not touching existing updated modules just meant having to delete all `.iml` files before regenerating the project file anyway.

