### PR TITLE
Horizons Service for Ephemeris Lookup

### DIFF
--- a/bundle/edu.gemini.horizons.server/build.sbt
+++ b/bundle/edu.gemini.horizons.server/build.sbt
@@ -24,4 +24,9 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.horizons.server.backend"
 )
 
-        
+initialCommands :=
+  """
+    |import edu.gemini.spModel.core._
+    |import edu.gemini.horizons.api._
+    |import edu.gemini.horizons.server.backend._
+  """.stripMargin

--- a/bundle/edu.gemini.horizons.server/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
+++ b/bundle/edu.gemini.horizons.server/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
@@ -132,6 +132,9 @@ public class CgiReplyBuilder {
         HorizonsReply reply = new HorizonsReply();
         try {
             StringBuffer responseBuffer = _readFully(new InputStreamReader(stream, charset));
+
+            System.out.println(responseBuffer);
+
             //parse the buffer to get the real data...
             _processHeader(responseBuffer, reply);
             switch (reply.getReplyType()) {

--- a/bundle/edu.gemini.horizons.server/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
+++ b/bundle/edu.gemini.horizons.server/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
@@ -132,9 +132,6 @@ public class CgiReplyBuilder {
         HorizonsReply reply = new HorizonsReply();
         try {
             StringBuffer responseBuffer = _readFully(new InputStreamReader(stream, charset));
-
-            System.out.println(responseBuffer);
-
             //parse the buffer to get the real data...
             _processHeader(responseBuffer, reply);
             switch (reply.getReplyType()) {

--- a/bundle/edu.gemini.horizons.server/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.server/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -15,155 +15,37 @@ import java.text.SimpleDateFormat
 import scala.collection.JavaConverters._
 import scala.util.matching.Regex
 import scala.io.Source
-import scalaz._, Scalaz._, scalaz.effect.IO
+import scalaz._, Scalaz._, scalaz.effect.{ IO, Resource }
 
-object HS2 {
+// work-in-progress; this will get a better name and will probably move elsewhere
+object HorizonsService2 {
 
-  case class InternalError(input: List[String], message: String)
+  /** The type of programs that talk to HORIZONS */
+  type HS2[A] = EitherT[IO, HS2Error, A]
+  object HS2 {
+    def fromDisjunction[A](a: HS2Error \/ A): HS2[A] = EitherT(IO(a))
+    def delay[A](a: => A): HS2[A] = EitherT(IO(a.right))
+  }
+
+  /** The type of failures that might arise when talking to HORIZONS. */
+  sealed trait HS2Error
+  case class HorizonsError(e: HorizonsException) extends HS2Error
+  case class ParseError(input: List[String], message: String) extends HS2Error
+
+  /** A value annotated with a name. Used when multiple results are returned. */
   case class Row[A](a: A, name: String)
 
-  sealed abstract class Search[A](val queryString: String) extends Product with Serializable {
-    def parseResponse(lines: List[String]): String \/ List[HS2.Row[A]]
-  }
+  /** A partial-name search specification for HORIZONS. */
+  sealed abstract class Search[A](val queryString: String) extends Product with Serializable
   object Search {
-
-    // Representation of column offsets as (start, end) pairs, as deduced from --- -------- --- -----
-    private type Offsets = List[(Int, Int)]
-
-    // Parse many results based on an expected header pattern. This will read through the tail until
-    // headers are found, then parse the remaining lines (until a blank line is encountered) using
-    // the function constructed by `f`, if any (otherwise it is assumed that there were not enough
-    // columns found). Returns a list of values or an error message.
-    private def parseMany[A](header: String, tail: List[String], headerPattern: Regex)(f: Offsets => Option[String => A] ): String \/ List[A] =
-      (headerPattern.findFirstMatchIn(header) \/> ("Header pattern not found: " + headerPattern)) *>
-      (tail.dropWhile(s => !s.trim.startsWith("---")) match {
-        case Nil                => Nil.right // no column headers means no results!
-        case colHeaders :: rows =>           // we have a header row with data rows following
-          val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
-          try {
-            f(offsets).map(g => rows.takeWhile(_.trim.nonEmpty).map(g)) \/> "Not enough columns."
-          } catch {
-            case    nfe: NumberFormatException           =>  ("Number format exception: " + nfe.getMessage).left
-            case sioobe: StringIndexOutOfBoundsException =>   "Column value(s) not found.".left
-          }
-      })
-
-    // Split into header/tail, parse
-    private def parseHeader[A](lines: List[String])(f: (String, List[String]) => String \/ List[A]): String \/ List[A] =
-      lines match {
-        case _ :: h :: t => f(h, t)
-        case _           => "Fewer than 2 lines!".left
-      }
-
-    // Comet
-    final case class Comet(partial: String) extends Search[HorizonsDesignation.Comet](s"COMNAM=$partial*;CAP") {
-      def parseResponse(lines: List[String]): String \/ List[HS2.Row[HorizonsDesignation.Comet]] =
-        parseHeader[HS2.Row[HorizonsDesignation.Comet]](lines) { case (header, tail) => 
-
-          // Common case is that we have many results, or none.
-          lazy val case0 =
-            parseMany[HS2.Row[HorizonsDesignation.Comet]](header, tail, """  +Small-body Search Results  """.r) { os =>
-              (os.lift(2) |@| os.lift(3)).tupled.map {
-                case ((ods, ode), (ons, one)) => { row =>
-                  val desig = row.substring(ods, ode).trim
-                  val name  = row.substring(ons, one).trim
-                  HS2.Row(HorizonsDesignation.Comet(desig), name)
-                }
-              }
-            }
-
-          // Single result with form: JPL/HORIZONS      Hubble (C/1937 P1)     2015-Dec-31 11:40:21
-          lazy val case1 =
-            """  +([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
-              List(HS2.Row(HorizonsDesignation.Comet(m.group(2)), m.group(1)))
-            } \/> "Could not match 'Hubble (C/1937 P1)' header pattern."
-
-          // Single result with form: JPL/HORIZONS         1P/Halley           2015-Dec-31 11:40:21
-          lazy val case2 =
-            """  +([^/]+)/(.+?)  """.r.findFirstMatchIn(header).map { m =>
-              List(HS2.Row(HorizonsDesignation.Comet(m.group(1)), m.group(2)))
-            } \/> "Could not match '1P/Halley' header pattern."
-
-          // First one that works!
-          case0 orElse
-          case1 orElse
-          case2 orElse "Could not parse the header line.".left
-        }
-    }
-
-    // Asteroid
-    final case class Asteroid(partial: String) extends Search[HorizonsDesignation.Asteroid](s"ASTNAM=$partial*") {
-      def parseResponse(lines: List[String]): \/[String, List[Row[HorizonsDesignation.Asteroid]]] =
-        parseHeader[Row[HorizonsDesignation.Asteroid]](lines) { case (header, tail) =>
-
-          // Common case is that we have many results, or none.
-          lazy val case0 =
-            parseMany[HS2.Row[HorizonsDesignation.Asteroid]](header, tail, """  +Small-body Index Search Results  """.r) { os =>
-              (os.lift(0) |@| os.lift(1) |@| os.lift(2)).tupled.map {
-                case ((ors, ore), (ods, ode), (ons, one)) => { row =>
-                  val rec   = row.substring(ors, ore).trim.toInt
-                  val desig = row.substring(ods, ode).trim
-                  val name  = row.substring(ons     ).trim // last column
-                  desig match {
-                    case "(undefined)" => HS2.Row(HorizonsDesignation.AsteroidOldStyle(rec): HorizonsDesignation.Asteroid, name)
-                    case des           => HS2.Row(HorizonsDesignation.AsteroidNewStyle(des): HorizonsDesignation.Asteroid, name)
-                  }
-                }
-              }
-            }
-
-          // Single result with form: JPL/HORIZONS      90377 Sedna (2003 VB12)     2015-Dec-31 11:40:21
-          lazy val case1 =
-            """  +\d+ ([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
-              List(HS2.Row(HorizonsDesignation.AsteroidNewStyle(m.group(2)) : HorizonsDesignation.Asteroid, m.group(1)))
-            } \/> "Could not match '90377 Sedna (2003 VB12)' header pattern."
-
-          // Single result with form: JPL/HORIZONS      4 Vesta     2015-Dec-31 11:40:21
-          lazy val case2 =
-            """  +(\d+) ([^(]+?)  """.r.findFirstMatchIn(header).map { m =>
-              List(HS2.Row(HorizonsDesignation.AsteroidOldStyle(m.group(1).toInt) : HorizonsDesignation.Asteroid, m.group(2)))
-            } \/> "Could not match '4 Vesta' header pattern."
-
-          // First one that works!
-          case0 orElse
-          case1 orElse
-          case2 orElse "Could not parse the header line.".left
-
-        }
-    }
-
-
-    final case class MajorBody(partial: String) extends Search[HorizonsDesignation.MajorBody](s"$partial") {
-      def parseResponse(lines: List[String]): \/[String, List[Row[HorizonsDesignation.MajorBody]]] =
-        parseHeader[Row[HorizonsDesignation.MajorBody]](lines) { case (header, tail) =>
-
-          // Common case is that we have many results, or none.
-          lazy val case0 = 
-            parseMany[HS2.Row[HorizonsDesignation.MajorBody]](header, tail, """Multiple major-bodies match string""".r) { os =>
-              (os.lift(0) |@| os.lift(1)).tupled.map {
-                case ((ors, ore), (ons, one)) => { row =>
-                  val rec  = row.substring(ors, ore).trim.toInt
-                  val name = row.substring(ons, one).trim
-                  HS2.Row(HorizonsDesignation.MajorBody(rec.toInt), name)
-                }
-              }
-            } .map(_.filterNot(_.a.num < 0)) // filter out spacecraft
-
-          // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
-          lazy val case1 =
-            """  +(.*?)  +(\d+) $""".r.findFirstMatchIn(header).map { m =>
-              List(HS2.Row(HorizonsDesignation.MajorBody(m.group(2).toInt), m.group(1)))
-            } \/> "Could not match 'Charon / (Pluto)     901' header pattern."
-
-          // First one that works, otherwise Nil because it falls through to small-body search
-          case0 orElse 
-          case1 orElse Nil.right
-        }
-    }
-
+    final case class Comet(partial: String)     extends Search[HorizonsDesignation.Comet](s"COMNAM=$partial*;CAP")
+    final case class Asteroid(partial: String)  extends Search[HorizonsDesignation.Asteroid](s"ASTNAM=$partial*")
+    final case class MajorBody(partial: String) extends Search[HorizonsDesignation.MajorBody](s"$partial")
   }
 
-  def search[A](search: Search[A]): EitherT[IO, InternalError, List[Row[A]]] = {
+  /** Construct a program that performs a partial-name search. */
+  def search[A](search: Search[A]): HS2[List[Row[A]]] = {
+
     val queryParams: Map[String, String] =
       Map(
         BATCH      -> "1",
@@ -172,52 +54,31 @@ object HS2 {
         EPHEMERIS  -> NO,
         COMMAND    -> s"'${search.queryString}'"
       )
-    EitherT(fetch(queryParams).map(ss => search.parseResponse(ss).leftMap(HS2.InternalError(ss, _))))
+
+    // Lift our pure String \/ List[Row[A]] into HS2
+    def parseLines(lines: List[String]): HS2[List[Row[A]]] =
+      HS2.fromDisjunction(parseResponse(search, lines).leftMap(ParseError(lines, _)))
+
+    // And finally
+    horizonsRequestLines2(queryParams) >>= parseLines
+
   }
 
-  def lookup(d: HorizonsDesignation, site: Site, start: Long, duration: Long, steps: Int): Throwable \/ Ephemeris =
-    ???
+  /** Convenience method; looks up ephemeris for the current semester. */
+  def lookupEphemeris(target: HorizonsDesignation, site: Site, elems: Int): HS2[Ephemeris] =
+    HS2.delay(new Semester(site)).flatMap(lookupEphemeris(target, site, elems, _))
 
+  /** Convenience method; looks up ephemeris for the given semester. */
+  def lookupEphemeris(target: HorizonsDesignation, site: Site, elems: Int, sem: Semester): HS2[Ephemeris] =
+    lookupEphemeris(target, site, sem.getStartDate(site), sem.getEndDate(site), elems)
 
-  def fetch(params: Map[String, String]): IO[List[String]] =
-    genFetch(params) { method =>
-      val s = Source.fromInputStream(method.getResponseBodyAsStream, method.getRequestCharSet)
-      try     s.getLines.toList
-      finally s.close()
-    }
-
-  def genFetch[A](params: Map[String, String])(f: GetMethod => A): IO[A] =
-    IO {
-      // HORIZONS allows only one request at a time for a given host :-/
-      HS2.synchronized {
-        val method = new GetMethod(CgiHorizonsConstants.HORIZONS_URL)
-        try {
-          method.setQueryString(params.map { case (k, v) => new NameValuePair(k, v) } .toArray)
-          (new HttpClient).executeMethod(method)
-          f(method)
-        } catch {
-          case ex: HorizonsException => throw ex
-          case ex: HttpException     => throw HorizonsException.create(ex)
-          case ex: IOException       => throw HorizonsException.create(ex)
-        } finally {
-          method.releaseConnection
-        }
-      }
-    }
-
-}
-
-
-
-object Executor {
-
-  def execute(query: HorizonsDesignation, site: Site, elements: Int): IO[Ephemeris] =
-    execute(query, site, elements, new Semester(site))
-
-  def execute(query: HorizonsDesignation, site: Site, elements: Int, sem: Semester): IO[Ephemeris] =
-    execute(query, site, sem.getStartDate(site), sem.getEndDate(site), elements)
-
-  def execute(query: HorizonsDesignation, site: Site, start: Date, stop: Date, elements: Int): IO[Ephemeris] = {
+  /** 
+   * Look up the ephemeris for the given target when viewed from the given site, requesting `elems`
+   * total elements spread uniformly over the over the given time period. The computed ephemeris may
+   * contain slightly more or fewer entries than requested due to rounding, or many fewer for very
+   * short timespans (no more than one entry will be returned per minute).
+   */
+  def lookupEphemeris(target: HorizonsDesignation, site: Site, start: Date, stop: Date, elems: Int): HS2[Ephemeris] = {
 
     def formatDate(date: Date): String = {
       val df = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss")
@@ -240,7 +101,7 @@ object Executor {
 
     // The step size in minutes, such that the total number of elements will be roughly what was
     // requested, or fewer for very short timespans (no more than 1/min)
-    val stepSize = 1L max (stop.getTime - start.getTime) / (1000L * 60 * elements)
+    val stepSize = 1L max (stop.getTime - start.getTime) / (1000L * 60 * elems)
 
     val queryParams: Map[String, String] =
       Map(
@@ -251,16 +112,186 @@ object Executor {
         TABLE_FIELDS_ARG -> TABLE_FIELDS,
         CENTER           -> CENTER_COORD,
         COORD_TYPE       -> COORD_TYPE_GEO,
-        COMMAND          -> s"'${query.queryString}'",
+        COMMAND          -> s"'${target.queryString}'",
         SITE_COORD       -> siteCoord(site),
         START_TIME       -> formatDate(start),
         STOP_TIME        -> formatDate(stop),
         STEP_SIZE        -> s"${stepSize}m"
       )
 
-    HS2.genFetch(queryParams)(m => CgiReplyBuilder.buildResponse(m.getResponseBodyAsStream, m.getRequestCharSet)).map(toEphemeris)
+    def buildEphemeris(m: GetMethod): IO[Ephemeris]  =
+      IO(CgiReplyBuilder.buildResponse(m.getResponseBodyAsStream, m.getRequestCharSet)).map(toEphemeris)
+
+    // And finally      
+    horizonsRequest2(queryParams)(buildEphemeris)
 
   }
+
+  ///
+  /// INTERNALS
+  ///
+
+  // Representation of column offsets as (start, end) pairs, as deduced from --- -------- --- -----
+  private type Offsets = List[(Int, Int)]
+
+  // Parse many results based on an expected header pattern. This will read through the tail until
+  // headers are found, then parse the remaining lines (until a blank line is encountered) using
+  // the function constructed by `f`, if any (otherwise it is assumed that there were not enough
+  // columns found). Returns a list of values or an error message.
+  private def parseMany[A](header: String, tail: List[String], headerPattern: Regex)(f: Offsets => Option[String => A] ): String \/ List[A] =
+    (headerPattern.findFirstMatchIn(header) \/> ("Header pattern not found: " + headerPattern)) *>
+    (tail.dropWhile(s => !s.trim.startsWith("---")) match {
+      case Nil                => Nil.right // no column headers means no results!
+      case colHeaders :: rows =>           // we have a header row with data rows following
+        val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
+        try {
+          f(offsets).map(g => rows.takeWhile(_.trim.nonEmpty).map(g)) \/> "Not enough columns."
+        } catch {
+          case    nfe: NumberFormatException           =>  ("Number format exception: " + nfe.getMessage).left
+          case sioobe: StringIndexOutOfBoundsException =>   "Column value(s) not found.".left
+        }
+    })
+
+  // Split into header/tail, parse
+  private def parseHeader[A](lines: List[String])(f: (String, List[String]) => String \/ List[A]): String \/ List[A] =
+    lines match {
+      case _ :: h :: t => f(h, t)
+      case _           => "Fewer than 2 lines!".left
+    }
+
+  // Parse the result of the given search
+  private def parseResponse[A](s: Search[A], lines: List[String]): \/[String, List[Row[A]]] =
+    parseHeader[Row[A]](lines) { case (header, tail) => 
+      s match {
+
+        case Search.Comet(_) => 
+
+          // Common case is that we have many results, or none.
+          lazy val case0 =
+            parseMany[Row[HorizonsDesignation.Comet]](header, tail, """  +Small-body Search Results  """.r) { os =>
+              (os.lift(2) |@| os.lift(3)).tupled.map {
+                case ((ods, ode), (ons, one)) => { row =>
+                  val desig = row.substring(ods, ode).trim
+                  val name  = row.substring(ons, one).trim
+                  Row(HorizonsDesignation.Comet(desig), name)
+                }
+              }
+            }
+
+          // Single result with form: JPL/HORIZONS      Hubble (C/1937 P1)     2015-Dec-31 11:40:21
+          lazy val case1 =
+            """  +([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.Comet(m.group(2)), m.group(1)))
+            } \/> "Could not match 'Hubble (C/1937 P1)' header pattern."
+
+          // Single result with form: JPL/HORIZONS         1P/Halley           2015-Dec-31 11:40:21
+          lazy val case2 =
+            """  +([^/]+)/(.+?)  """.r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.Comet(m.group(1)), m.group(2)))
+            } \/> "Could not match '1P/Halley' header pattern."
+
+          // First one that works!
+          case0 orElse
+          case1 orElse
+          case2 orElse "Could not parse the header line.".left
+
+       case Search.Asteroid(_) =>
+
+          // Common case is that we have many results, or none.
+          lazy val case0 =
+            parseMany[Row[HorizonsDesignation.Asteroid]](header, tail, """  +Small-body Index Search Results  """.r) { os =>
+              (os.lift(0) |@| os.lift(1) |@| os.lift(2)).tupled.map {
+                case ((ors, ore), (ods, ode), (ons, one)) => { row =>
+                  val rec   = row.substring(ors, ore).trim.toInt
+                  val desig = row.substring(ods, ode).trim
+                  val name  = row.substring(ons     ).trim // last column, so no end index because rows are ragged
+                  desig match {
+                    case "(undefined)" => Row(HorizonsDesignation.AsteroidOldStyle(rec): HorizonsDesignation.Asteroid, name)
+                    case des           => Row(HorizonsDesignation.AsteroidNewStyle(des): HorizonsDesignation.Asteroid, name)
+                  }
+                }
+              }
+            }
+
+          // Single result with form: JPL/HORIZONS      90377 Sedna (2003 VB12)     2015-Dec-31 11:40:21
+          lazy val case1 =
+            """  +\d+ ([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.AsteroidNewStyle(m.group(2)) : HorizonsDesignation.Asteroid, m.group(1)))
+            } \/> "Could not match '90377 Sedna (2003 VB12)' header pattern."
+
+          // Single result with form: JPL/HORIZONS      4 Vesta     2015-Dec-31 11:40:21
+          lazy val case2 =
+            """  +(\d+) ([^(]+?)  """.r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.AsteroidOldStyle(m.group(1).toInt) : HorizonsDesignation.Asteroid, m.group(2)))
+            } \/> "Could not match '4 Vesta' header pattern."
+
+          // First one that works!
+          case0 orElse
+          case1 orElse
+          case2 orElse "Could not parse the header line.".left
+
+
+        case Search.MajorBody(_) =>
+
+          // Common case is that we have many results, or none.
+          lazy val case0 = 
+            parseMany[Row[HorizonsDesignation.MajorBody]](header, tail, """Multiple major-bodies match string""".r) { os =>
+              (os.lift(0) |@| os.lift(1)).tupled.map {
+                case ((ors, ore), (ons, one)) => { row =>
+                  val rec  = row.substring(ors, ore).trim.toInt
+                  val name = row.substring(ons, one).trim
+                  Row(HorizonsDesignation.MajorBody(rec.toInt), name)
+                }
+              }
+            } .map(_.filterNot(_.a.num < 0)) // filter out spacecraft
+
+          // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
+          lazy val case1 =
+            """  +(.*?)  +(\d+) $""".r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.MajorBody(m.group(2).toInt), m.group(1)))
+            } \/> "Could not match 'Charon / (Pluto)     901' header pattern."
+
+          // First one that works, otherwise Nil because it falls through to small-body search
+          case0 orElse 
+          case1 orElse Nil.right
+      
+      }
+  }
+
+  // Construct a program thet performs a HORIZONS request and yields the response as lines of text.
+  private def horizonsRequestLines2(params: Map[String, String]): HS2[List[String]] =
+    horizonsRequest2(params) { method =>
+      IO {
+        val s = Source.fromInputStream(method.getResponseBodyAsStream, method.getRequestCharSet)
+        try     s.getLines.toList
+        finally s.close()
+      }
+    }
+
+  implicit def GetMethodResource: Resource[GetMethod] =
+    new Resource[GetMethod] {
+      def close(m: GetMethod): IO[Unit] =
+        IO(m.releaseConnection)
+    }
+
+  // Construct a program thet performs a HORIZONS request and transforms the respons with the
+  // provided function.
+  private def horizonsRequest2[A](params: Map[String, String])(f: GetMethod => IO[A]): HS2[A] =
+    EitherT {
+      IO(new GetMethod(CgiHorizonsConstants.HORIZONS_URL)).using { (method: GetMethod) =>
+        IO {
+          HorizonsService2.synchronized {
+            method.setQueryString(params.map { case (k, v) => new NameValuePair(k, v) } .toArray)
+            (new HttpClient).executeMethod(method)
+            method
+          }
+        } .flatMap(f).catchSomeLeft {
+          case ex: HorizonsException => HorizonsError(ex).some
+          case ex: HttpException     => HorizonsError(HorizonsException.create(ex)).some
+          case ex: IOException       => HorizonsError(HorizonsException.create(ex)).some
+        }
+      }
+    }
 
 }
 

--- a/bundle/edu.gemini.horizons.server/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.server/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -1,0 +1,319 @@
+package edu.gemini.horizons.server.backend
+
+import edu.gemini.spModel.core._
+import org.apache.commons.httpclient.HttpClient
+import org.apache.commons.httpclient.HttpException
+import org.apache.commons.httpclient.NameValuePair
+import org.apache.commons.httpclient.methods.GetMethod
+import edu.gemini.horizons.api.HorizonsException
+import java.io.IOException
+import CgiHorizonsConstants._
+import scalaz._, Scalaz._, scalaz.effect.IO
+
+object HS2 {
+
+  case class InternalError(input: List[String], message: String)
+
+  sealed abstract class Search[A](val queryString: String) extends Product with Serializable {
+    def parseResponse(lines: List[String]): InternalError \/ List[HS2.Row[A]]
+  }
+  object Search {
+
+    final case class Comet(partial: String) extends Search[HorizonsDesignation.Comet](s"COMNAM=$partial*;CAP") {
+      def parseResponse(lines: List[String]): InternalError \/ List[HS2.Row[HorizonsDesignation.Comet]] =
+        lines match {
+          case _ :: header :: tail =>
+
+            // Common case is that we have many results, or none.
+            lazy val case0: InternalError \/ List[HS2.Row[HorizonsDesignation.Comet]] =
+              ("""  +Small-body Search Results  """.r.findFirstMatchIn(header) \/>
+                InternalError(lines, "'Small-body Search Results' header not found")).flatMap { _ =>
+                lines.dropWhile(s => !s.trim.startsWith("---")) match {
+                  case Nil => Nil.right // no column headers means no results!
+                  case colHeaders :: rows => // designation and name at column offsets 2 and 3
+                    val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
+                    try {
+                      (offsets.lift(2) |@| offsets.lift(3)).tupled.map {
+                        case ((ods, ode), (ons, one)) =>
+                          rows.takeWhile(_.trim.nonEmpty).map { row =>
+                            val desig = row.substring(ods, ode).trim
+                            val name  = row.substring(ons, one).trim
+                            HS2.Row(HorizonsDesignation.Comet(desig), name)
+                          }
+                      } \/> InternalError(lines, "Not enough columns.")
+                    } catch {
+                      case sioobe: StringIndexOutOfBoundsException =>
+                        InternalError(lines, "Column value(s) not found.").left
+                    }
+                }
+              }
+
+            // Single result with form: JPL/HORIZONS      Hubble (C/1937 P1)     2015-Dec-31 11:40:21
+            lazy val case1 =
+              """  +([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+                List(HS2.Row(HorizonsDesignation.Comet(m.group(2)), m.group(1)))
+              } \/> InternalError(lines, "Could not match 'Hubble (C/1937 P1)' header pattern.")
+
+            // Single result with form: JPL/HORIZONS         1P/Halley           2015-Dec-31 11:40:21
+            lazy val case2 =
+              """  +([^/]+)/(.+?)  """.r.findFirstMatchIn(header).map { m =>
+                List(HS2.Row(HorizonsDesignation.Comet(m.group(1)), m.group(2)))
+              } \/> InternalError(lines, "Could not match '1P/Halley' header pattern.")
+
+            // First one that works!
+            case0 orElse
+              case1 orElse
+              case2 orElse InternalError(lines, "Could not parse the header line.").left
+
+          case _ => InternalError(lines, "Fewer than 2 lines!").left
+
+        }
+    }
+
+
+    final case class Asteroid(partial: String) extends Search[HorizonsDesignation.Asteroid](s"ASTNAM=$partial*") {
+      def parseResponse(lines: List[String]): \/[InternalError, List[Row[HorizonsDesignation.Asteroid]]] =
+        lines match {
+          case _ :: header :: tail =>
+
+            // Common case is that we have many results, or none.
+            lazy val case0: InternalError \/ List[HS2.Row[HorizonsDesignation.Asteroid]] =
+              ("""  +Small-body Index Search Results  """.r.findFirstMatchIn(header) \/>
+                InternalError(lines, "'Small-body Index Search Results' header not found")).flatMap { _ =>
+                lines.dropWhile(s => !s.trim.startsWith("---")) match {
+                  case Nil => Nil.right // no column headers means no results!
+                  case colHeaders :: rows => // designation and name at column offsets 2 and 3
+                    val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
+                    try {
+                      (offsets.lift(0) |@| offsets.lift(1) |@| offsets.lift(2)).tupled.map {
+                        case ((ors, ore), (ods, ode), (ons, one)) =>
+                          rows.takeWhile(_.trim.nonEmpty).map { row =>
+                            val rec = row.substring(ors, ore).trim.toInt
+                            val desig = row.substring(ods, ode).trim
+                            val name = row.substring(ons).trim // last column
+                            if (desig == "(undefined)") {
+                              HS2.Row(HorizonsDesignation.AsteroidOldStyle(rec): HorizonsDesignation.Asteroid, name)
+                            } else {
+                              HS2.Row(HorizonsDesignation.AsteroidNewStyle(desig): HorizonsDesignation.Asteroid, name)
+                            }
+                          }
+                      } \/> InternalError(lines, "Not enough columns.")
+                    } catch {
+                      case nfe: NumberFormatException =>
+                        InternalError(lines, "Old-style identifier not an integer.").left
+                      case sioobe: StringIndexOutOfBoundsException =>
+                        InternalError(lines, "Column value(s) not found.").left
+                    }
+                }
+              }
+
+            // Single result with form: JPL/HORIZONS      90377 Sedna (2003 VB12)     2015-Dec-31 11:40:21
+            lazy val case1 =
+              """  +\d+ ([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+                List(HS2.Row(HorizonsDesignation.AsteroidNewStyle(m.group(2)) : HorizonsDesignation.Asteroid, m.group(1)))
+              } \/> InternalError(lines, "Could not match '90377 Sedna (2003 VB12)' header pattern.")
+
+            // Single result with form: JPL/HORIZONS      4 Vesta     2015-Dec-31 11:40:21
+            lazy val case2 =
+              """  +(\d+) ([^(]+)  """.r.findFirstMatchIn(header).map { m =>
+                List(HS2.Row(HorizonsDesignation.AsteroidOldStyle(m.group(1).toInt) : HorizonsDesignation.Asteroid, m.group(2)))
+              } \/> InternalError(lines, "Could not match '4 Vesta' header pattern.")
+
+            // First one that works!
+            case0 orElse
+            case1 orElse
+            case2 orElse InternalError(lines, "Could not parse the header line.").left
+
+          case _ => InternalError(lines, "Fewer than 2 lines!").left
+
+        }
+
+    }
+
+
+    final case class MajorBody(partial: String) extends Search[HorizonsDesignation.MajorBody](s"$partial") {
+      def parseResponse(lines: List[String]): \/[InternalError, List[Row[HorizonsDesignation.MajorBody]]] =
+        lines match {
+          case _ :: header :: tail =>
+
+            // Common case is that we have many results, or none.
+            lazy val case0: InternalError \/ List[HS2.Row[HorizonsDesignation.MajorBody]] =
+              ("""Multiple major-bodies match string""".r.findFirstMatchIn(header) \/>
+                InternalError(lines, "'Multiple major-bodies match string' header not found")).flatMap { _ =>
+                lines.dropWhile(s => !s.trim.startsWith("---")) match {
+                  case Nil => Nil.right // no column headers means no results!
+                  case colHeaders :: rows => // designation and name at column offsets 2 and 3
+                    val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
+                    try {
+                      (offsets.lift(0) |@| offsets.lift(1)).tupled.map {
+                        case ((ors, ore), (ons, one)) =>
+                          rows.takeWhile(_.trim.nonEmpty).map { row =>
+                            val rec = row.substring(ors, ore).trim.toInt
+                            val name = row.substring(ons, one).trim
+                            HS2.Row(HorizonsDesignation.MajorBody(rec.toInt), name)
+                          }.filterNot(_.a.num < 0) // filter out spacecraft
+                      } \/> InternalError(lines, "Not enough columns.")
+                    } catch {
+                      case nfe: NumberFormatException =>
+                        InternalError(lines, "Old-style identifier not an integer.").left
+                      case sioobe: StringIndexOutOfBoundsException =>
+                        InternalError(lines, "Column value(s) not found.").left
+                    }
+                }
+              }
+
+            // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
+            lazy val case1 =
+              """  +(.*?)  +(\d+)""".r.findFirstMatchIn(header).map { m =>
+                List(HS2.Row(HorizonsDesignation.MajorBody(m.group(2).toInt), m.group(1)))
+              } \/> InternalError(lines, "Could not match 'Charon / (Pluto)     901' header pattern.")
+
+            // First one that works!
+            case0 orElse case1 orElse InternalError(lines, "Could not parse the header line.").left
+
+          case _ => InternalError(lines, "Fewer than 2 lines!").left
+
+        }
+    }
+
+  }
+
+  case class Row[A](a: A, name: String)
+
+  def search[A](s: Search[A]): Throwable \/ List[Row[A]] =
+    ???
+
+  def lookup(d: HorizonsDesignation, site: Site, start: Long, duration: Long, steps: Int): Throwable \/ Ephemeris =
+    ???
+
+}
+
+
+object Searcher {
+
+  def search[A](search: HS2.Search[A]): HS2.InternalError \/ List[HS2.Row[A]] = {
+
+    val queryParams: Map[String, String] =
+      Map(
+        BATCH      -> "1",
+        TABLE_TYPE -> OBSERVER_TABLE,
+        CSV_FORMAT -> NO,
+        EPHEMERIS  -> NO,
+        COMMAND    -> s"'${search.queryString}'"
+      )
+
+    val lines = fetch(queryParams).unsafePerformIO()
+    lines.foreach(println)
+    search.parseResponse(lines)
+  }
+
+
+  def fetch(params: Map[String, String]): IO[List[String]] =
+    IO {
+      val method = new GetMethod(CgiHorizonsConstants.HORIZONS_URL)
+      try {
+        method.setQueryString(params.map { case (k, v) => new NameValuePair(k, v) } .toArray)
+        (new HttpClient).executeMethod(method)
+        val s = scala.io.Source.fromInputStream(method.getResponseBodyAsStream, method.getRequestCharSet)
+        try {
+          s.getLines.toList
+        } finally s.close()
+      } catch {
+        case ex: HorizonsException => throw ex
+        case ex: HttpException     => throw HorizonsException.create(ex)
+        case ex: IOException       => throw HorizonsException.create(ex)
+      } finally {
+        method.releaseConnection
+      }
+    }
+
+}
+
+//
+//
+//object Executor {
+//
+//  val initialParams: Map[String, String] =
+//    Map(
+//      BATCH            -> "1",
+//      TABLE_TYPE       -> OBSERVER_TABLE,
+//      CSV_FORMAT       -> NO,
+//      EPHEMERIS        -> YES,
+//      TABLE_FIELDS_ARG -> TABLE_FIELDS,
+//      CENTER           -> CENTER_COORD,
+//      COORD_TYPE       -> COORD_TYPE_GEO
+//    )
+//
+//  def siteParams(site: Site): Map[String, String] =
+//    site match {
+//      case Site.GN => Map(SITE_COORD -> SITE_COORD_GN)
+//      case Site.GS => Map(SITE_COORD -> SITE_COORD_GS)
+//    }
+//
+//  def dateParams(startDate: Date, endDate: Date): Map[String, String] = {
+//    def formatDate(date: Date): String = {
+//      val formatter: DateFormat = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss")
+//      val sb: StringBuilder = new StringBuilder("'")
+//      sb.append(formatter.format(date))
+//      sb.append("'")
+//      return sb.toString
+//    }
+//    Map(
+//      START_TIME -> formatDate(startDate),
+//      STOP_TIME  -> formatDate(endDate)
+//    )
+//  }
+//
+//  def commandParam(id: String): Map[String, String] =
+//    Map(COMMAND -> id)
+//
+//  def stepParams(stepSize: Int, stepUnits: StepUnits): Map[String, String] =
+//    if (stepSize > 0) Map(STEP_SIZE -> (stepSize + stepUnits.suffix))
+//    else Map.empty
+//
+//  def execute(query: HorizonsQuery): HorizonsReply = {
+//
+//    var objectId: String = query.getObjectId.trim
+//    if (query.getObjectType eq HorizonsQuery.ObjectType.MINOR_BODY) {
+//      objectId += ";"
+//    }
+//    if (objectId.contains(" ")) {
+//      val sb: StringBuffer = new StringBuffer
+//      sb.append("'")
+//      sb.append(objectId)
+//      sb.append("'")
+//      objectId = sb.toString
+//    }
+//
+//    val queryParams: Map[String, String] =
+//      initialParams ++
+//      siteParams(query.getSite) ++
+//      dateParams(query.getStartDate, query.getEndDate) ++
+//      commandParam(objectId) ++
+//      stepParams(query.getStepSize, query.getStepUnits)
+//
+//    val method: GetMethod = new GetMethod(CgiHorizonsConstants.HORIZONS_URL)
+//    method.setQueryString(queryParams.map { case (k, v) => new NameValuePair(k, v) } .toArray)
+//    var reply: HorizonsReply = null
+//    val client: HttpClient = new HttpClient
+//    try {
+//      client.executeMethod(method)
+//      reply = CgiReplyBuilder.buildResponse(method.getResponseBodyAsStream, method.getRequestCharSet)
+//      method.releaseConnection
+//    } catch {
+//      case ex: HorizonsException => {
+//        throw ex
+//      }
+//      case ex: HttpException => {
+//        throw HorizonsException.create(ex)
+//      }
+//      case ex: IOException => {
+//        throw HorizonsException.create(ex)
+//      }
+//    }
+//    return reply
+//  }
+//
+//}
+
+

--- a/bundle/edu.gemini.horizons.server/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.server/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -8,191 +8,157 @@ import org.apache.commons.httpclient.methods.GetMethod
 import edu.gemini.horizons.api.HorizonsException
 import java.io.IOException
 import CgiHorizonsConstants._
+
+import scala.util.matching.Regex
 import scalaz._, Scalaz._, scalaz.effect.IO
 
 object HS2 {
 
   case class InternalError(input: List[String], message: String)
+  case class Row[A](a: A, name: String)
 
   sealed abstract class Search[A](val queryString: String) extends Product with Serializable {
-    def parseResponse(lines: List[String]): InternalError \/ List[HS2.Row[A]]
+    def parseResponse(lines: List[String]): String \/ List[HS2.Row[A]]
   }
   object Search {
 
-    final case class Comet(partial: String) extends Search[HorizonsDesignation.Comet](s"COMNAM=$partial*;CAP") {
-      def parseResponse(lines: List[String]): InternalError \/ List[HS2.Row[HorizonsDesignation.Comet]] =
-        lines match {
-          case _ :: header :: tail =>
+    // Representation of column offsets as (start, end) pairs, as deduced from --- -------- --- -----
+    private type Offsets = List[(Int, Int)]
 
-            // Common case is that we have many results, or none.
-            lazy val case0: InternalError \/ List[HS2.Row[HorizonsDesignation.Comet]] =
-              ("""  +Small-body Search Results  """.r.findFirstMatchIn(header) \/>
-                InternalError(lines, "'Small-body Search Results' header not found")).flatMap { _ =>
-                lines.dropWhile(s => !s.trim.startsWith("---")) match {
-                  case Nil => Nil.right // no column headers means no results!
-                  case colHeaders :: rows => // designation and name at column offsets 2 and 3
-                    val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
-                    try {
-                      (offsets.lift(2) |@| offsets.lift(3)).tupled.map {
-                        case ((ods, ode), (ons, one)) =>
-                          rows.takeWhile(_.trim.nonEmpty).map { row =>
-                            val desig = row.substring(ods, ode).trim
-                            val name  = row.substring(ons, one).trim
-                            HS2.Row(HorizonsDesignation.Comet(desig), name)
-                          }
-                      } \/> InternalError(lines, "Not enough columns.")
-                    } catch {
-                      case sioobe: StringIndexOutOfBoundsException =>
-                        InternalError(lines, "Column value(s) not found.").left
-                    }
+    // Parse many results based on an expected header pattern. This will read through the tail until
+    // headers are found, then parse the remaining lines (until a blank line is encountered) using
+    // the function constructed by `f`, if any (otherwise it is assumed that there were not enough
+    // columns found). Returns a list of values or an error message.
+    private def parseMany[A](header: String, tail: List[String], headerPattern: Regex)(f: Offsets => Option[String => A] ): String \/ List[A] =
+      (headerPattern.findFirstMatchIn(header) \/> ("Header pattern not found: " + headerPattern)) *>
+      (tail.dropWhile(s => !s.trim.startsWith("---")) match {
+        case Nil                => Nil.right // no column headers means no results!
+        case colHeaders :: rows =>           // we have a header row with data rows following
+          val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
+          try {
+            f(offsets).map(g => rows.takeWhile(_.trim.nonEmpty).map(g)) \/> "Not enough columns."
+          } catch {
+            case    nfe: NumberFormatException           =>  ("Number format exception: " + nfe.getMessage).left
+            case sioobe: StringIndexOutOfBoundsException =>   "Column value(s) not found.".left
+          }
+      })
+
+    // Split into header/tail, parse
+    private def parseHeader[A](lines: List[String])(f: (String, List[String]) => String \/ List[A]): String \/ List[A] =
+      lines match {
+        case _ :: h :: t => f(h, t)
+        case _           => "Fewer than 2 lines!".left
+      }
+
+    // Comet
+    final case class Comet(partial: String) extends Search[HorizonsDesignation.Comet](s"COMNAM=$partial*;CAP") {
+      def parseResponse(lines: List[String]): String \/ List[HS2.Row[HorizonsDesignation.Comet]] =
+        parseHeader[HS2.Row[HorizonsDesignation.Comet]](lines) { case (header, tail) => 
+
+          // Common case is that we have many results, or none.
+          lazy val case0 =
+            parseMany[HS2.Row[HorizonsDesignation.Comet]](header, tail, """  +Small-body Search Results  """.r) { os =>
+              (os.lift(2) |@| os.lift(3)).tupled.map {
+                case ((ods, ode), (ons, one)) => { row =>
+                  val desig = row.substring(ods, ode).trim
+                  val name  = row.substring(ons, one).trim
+                  HS2.Row(HorizonsDesignation.Comet(desig), name)
                 }
               }
+            }
 
-            // Single result with form: JPL/HORIZONS      Hubble (C/1937 P1)     2015-Dec-31 11:40:21
-            lazy val case1 =
-              """  +([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
-                List(HS2.Row(HorizonsDesignation.Comet(m.group(2)), m.group(1)))
-              } \/> InternalError(lines, "Could not match 'Hubble (C/1937 P1)' header pattern.")
+          // Single result with form: JPL/HORIZONS      Hubble (C/1937 P1)     2015-Dec-31 11:40:21
+          lazy val case1 =
+            """  +([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+              List(HS2.Row(HorizonsDesignation.Comet(m.group(2)), m.group(1)))
+            } \/> "Could not match 'Hubble (C/1937 P1)' header pattern."
 
-            // Single result with form: JPL/HORIZONS         1P/Halley           2015-Dec-31 11:40:21
-            lazy val case2 =
-              """  +([^/]+)/(.+?)  """.r.findFirstMatchIn(header).map { m =>
-                List(HS2.Row(HorizonsDesignation.Comet(m.group(1)), m.group(2)))
-              } \/> InternalError(lines, "Could not match '1P/Halley' header pattern.")
+          // Single result with form: JPL/HORIZONS         1P/Halley           2015-Dec-31 11:40:21
+          lazy val case2 =
+            """  +([^/]+)/(.+?)  """.r.findFirstMatchIn(header).map { m =>
+              List(HS2.Row(HorizonsDesignation.Comet(m.group(1)), m.group(2)))
+            } \/> "Could not match '1P/Halley' header pattern."
 
-            // First one that works!
-            case0 orElse
-              case1 orElse
-              case2 orElse InternalError(lines, "Could not parse the header line.").left
-
-          case _ => InternalError(lines, "Fewer than 2 lines!").left
-
+          // First one that works!
+          case0 orElse
+          case1 orElse
+          case2 orElse "Could not parse the header line.".left
         }
     }
 
-
+    // Asteroid
     final case class Asteroid(partial: String) extends Search[HorizonsDesignation.Asteroid](s"ASTNAM=$partial*") {
-      def parseResponse(lines: List[String]): \/[InternalError, List[Row[HorizonsDesignation.Asteroid]]] =
-        lines match {
-          case _ :: header :: tail =>
+      def parseResponse(lines: List[String]): \/[String, List[Row[HorizonsDesignation.Asteroid]]] =
+        parseHeader[Row[HorizonsDesignation.Asteroid]](lines) { case (header, tail) =>
 
-            // Common case is that we have many results, or none.
-            lazy val case0: InternalError \/ List[HS2.Row[HorizonsDesignation.Asteroid]] =
-              ("""  +Small-body Index Search Results  """.r.findFirstMatchIn(header) \/>
-                InternalError(lines, "'Small-body Index Search Results' header not found")).flatMap { _ =>
-                lines.dropWhile(s => !s.trim.startsWith("---")) match {
-                  case Nil => Nil.right // no column headers means no results!
-                  case colHeaders :: rows => // designation and name at column offsets 2 and 3
-                    val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
-                    try {
-                      (offsets.lift(0) |@| offsets.lift(1) |@| offsets.lift(2)).tupled.map {
-                        case ((ors, ore), (ods, ode), (ons, one)) =>
-                          rows.takeWhile(_.trim.nonEmpty).map { row =>
-                            val rec = row.substring(ors, ore).trim.toInt
-                            val desig = row.substring(ods, ode).trim
-                            val name = row.substring(ons).trim // last column
-                            if (desig == "(undefined)") {
-                              HS2.Row(HorizonsDesignation.AsteroidOldStyle(rec): HorizonsDesignation.Asteroid, name)
-                            } else {
-                              HS2.Row(HorizonsDesignation.AsteroidNewStyle(desig): HorizonsDesignation.Asteroid, name)
-                            }
-                          }
-                      } \/> InternalError(lines, "Not enough columns.")
-                    } catch {
-                      case nfe: NumberFormatException =>
-                        InternalError(lines, "Old-style identifier not an integer.").left
-                      case sioobe: StringIndexOutOfBoundsException =>
-                        InternalError(lines, "Column value(s) not found.").left
-                    }
+          // Common case is that we have many results, or none.
+          lazy val case0 =
+            parseMany[HS2.Row[HorizonsDesignation.Asteroid]](header, tail, """  +Small-body Index Search Results  """.r) { os =>
+              (os.lift(0) |@| os.lift(1) |@| os.lift(2)).tupled.map {
+                case ((ors, ore), (ods, ode), (ons, one)) => { row =>
+                  val rec   = row.substring(ors, ore).trim.toInt
+                  val desig = row.substring(ods, ode).trim
+                  val name  = row.substring(ons     ).trim // last column
+                  desig match {
+                    case "(undefined)" => HS2.Row(HorizonsDesignation.AsteroidOldStyle(rec): HorizonsDesignation.Asteroid, name)
+                    case des           => HS2.Row(HorizonsDesignation.AsteroidNewStyle(des): HorizonsDesignation.Asteroid, name)
+                  }
                 }
               }
+            }
 
-            // Single result with form: JPL/HORIZONS      90377 Sedna (2003 VB12)     2015-Dec-31 11:40:21
-            lazy val case1 =
-              """  +\d+ ([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
-                List(HS2.Row(HorizonsDesignation.AsteroidNewStyle(m.group(2)) : HorizonsDesignation.Asteroid, m.group(1)))
-              } \/> InternalError(lines, "Could not match '90377 Sedna (2003 VB12)' header pattern.")
+          // Single result with form: JPL/HORIZONS      90377 Sedna (2003 VB12)     2015-Dec-31 11:40:21
+          lazy val case1 =
+            """  +\d+ ([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+              List(HS2.Row(HorizonsDesignation.AsteroidNewStyle(m.group(2)) : HorizonsDesignation.Asteroid, m.group(1)))
+            } \/> "Could not match '90377 Sedna (2003 VB12)' header pattern."
 
-            // Single result with form: JPL/HORIZONS      4 Vesta     2015-Dec-31 11:40:21
-            lazy val case2 =
-              """  +(\d+) ([^(]+?)  """.r.findFirstMatchIn(header).map { m =>
-                List(HS2.Row(HorizonsDesignation.AsteroidOldStyle(m.group(1).toInt) : HorizonsDesignation.Asteroid, m.group(2)))
-              } \/> InternalError(lines, "Could not match '4 Vesta' header pattern.")
+          // Single result with form: JPL/HORIZONS      4 Vesta     2015-Dec-31 11:40:21
+          lazy val case2 =
+            """  +(\d+) ([^(]+?)  """.r.findFirstMatchIn(header).map { m =>
+              List(HS2.Row(HorizonsDesignation.AsteroidOldStyle(m.group(1).toInt) : HorizonsDesignation.Asteroid, m.group(2)))
+            } \/> "Could not match '4 Vesta' header pattern."
 
-            // First one that works!
-            case0 orElse
-            case1 orElse
-            case2 orElse InternalError(lines, "Could not parse the header line.").left
-
-          case _ => InternalError(lines, "Fewer than 2 lines!").left
+          // First one that works!
+          case0 orElse
+          case1 orElse
+          case2 orElse "Could not parse the header line.".left
 
         }
-
     }
 
 
     final case class MajorBody(partial: String) extends Search[HorizonsDesignation.MajorBody](s"$partial") {
-      def parseResponse(lines: List[String]): \/[InternalError, List[Row[HorizonsDesignation.MajorBody]]] =
-        lines match {
-          case _ :: header :: tail =>
+      def parseResponse(lines: List[String]): \/[String, List[Row[HorizonsDesignation.MajorBody]]] =
+        parseHeader[Row[HorizonsDesignation.MajorBody]](lines) { case (header, tail) =>
 
-            // Common case is that we have many results, or none.
-            lazy val case0: InternalError \/ List[HS2.Row[HorizonsDesignation.MajorBody]] =
-              ("""Multiple major-bodies match string""".r.findFirstMatchIn(header) \/>
-                InternalError(lines, "'Multiple major-bodies match string' header not found")).flatMap { _ =>
-                lines.dropWhile(s => !s.trim.startsWith("---")) match {
-                  case Nil => Nil.right // no column headers means no results!
-                  case colHeaders :: rows => // designation and name at column offsets 2 and 3
-                    val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
-                    try {
-                      (offsets.lift(0) |@| offsets.lift(1)).tupled.map {
-                        case ((ors, ore), (ons, one)) =>
-                          rows.takeWhile(_.trim.nonEmpty).map { row =>
-                            val rec = row.substring(ors, ore).trim.toInt
-                            val name = row.substring(ons, one).trim
-                            HS2.Row(HorizonsDesignation.MajorBody(rec.toInt), name)
-                          }.filterNot(_.a.num < 0) // filter out spacecraft
-                      } \/> InternalError(lines, "Not enough columns.")
-                    } catch {
-                      case nfe: NumberFormatException =>
-                        InternalError(lines, "Old-style identifier not an integer.").left
-                      case sioobe: StringIndexOutOfBoundsException =>
-                        InternalError(lines, "Column value(s) not found.").left
-                    }
+          // Common case is that we have many results, or none.
+          lazy val case0 = 
+            parseMany[HS2.Row[HorizonsDesignation.MajorBody]](header, tail, """Multiple major-bodies match string""".r) { os =>
+              (os.lift(0) |@| os.lift(1)).tupled.map {
+                case ((ors, ore), (ons, one)) => { row =>
+                  val rec  = row.substring(ors, ore).trim.toInt
+                  val name = row.substring(ons, one).trim
+                  HS2.Row(HorizonsDesignation.MajorBody(rec.toInt), name)
                 }
               }
+            } .map(_.filterNot(_.a.num < 0)) // filter out spacecraft
 
-            // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
-            lazy val case1 =
-              """  +(.*?)  +(\d+) $""".r.findFirstMatchIn(header).map { m =>
-                List(HS2.Row(HorizonsDesignation.MajorBody(m.group(2).toInt), m.group(1)))
-              } \/> InternalError(lines, "Could not match 'Charon / (Pluto)     901' header pattern.")
+          // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
+          lazy val case1 =
+            """  +(.*?)  +(\d+) $""".r.findFirstMatchIn(header).map { m =>
+              List(HS2.Row(HorizonsDesignation.MajorBody(m.group(2).toInt), m.group(1)))
+            } \/> "Could not match 'Charon / (Pluto)     901' header pattern."
 
-            // First one that works, otherwise Nil because it falls through to small-body search
-            case0 orElse case1 orElse Nil.right
-
-          case _ => InternalError(lines, "Fewer than 2 lines!").left
-
+          // First one that works, otherwise Nil because it falls through to small-body search
+          case0 orElse 
+          case1 orElse Nil.right
         }
     }
 
   }
 
-  case class Row[A](a: A, name: String)
-
-  def search[A](s: Search[A]): Throwable \/ List[Row[A]] =
-    ???
-
-  def lookup(d: HorizonsDesignation, site: Site, start: Long, duration: Long, steps: Int): Throwable \/ Ephemeris =
-    ???
-
-}
-
-
-object Searcher {
-
-  def search[A](search: HS2.Search[A]): HS2.InternalError \/ List[HS2.Row[A]] = {
-
+  def search[A](search: Search[A]): EitherT[IO, InternalError, List[Row[A]]] = {
     val queryParams: Map[String, String] =
       Map(
         BATCH      -> "1",
@@ -201,17 +167,17 @@ object Searcher {
         EPHEMERIS  -> NO,
         COMMAND    -> s"'${search.queryString}'"
       )
-
-    val lines = fetch(queryParams).unsafePerformIO()
-    // lines.foreach(println)
-    search.parseResponse(lines)
+    EitherT(fetch(queryParams).map(ss => search.parseResponse(ss).leftMap(HS2.InternalError(ss, _))))
   }
 
+  def lookup(d: HorizonsDesignation, site: Site, start: Long, duration: Long, steps: Int): Throwable \/ Ephemeris =
+    ???
 
-  def fetch(params: Map[String, String]): IO[List[String]] =
+
+  private def fetch(params: Map[String, String]): IO[List[String]] =
     IO {
-      // HORIZONS allows only one request at a time for a given host
-      Searcher.synchronized {
+      // HORIZONS allows only one request at a time for a given host :-/
+      HS2.synchronized {
         val method = new GetMethod(CgiHorizonsConstants.HORIZONS_URL)
         try {
           method.setQueryString(params.map { case (k, v) => new NameValuePair(k, v) } .toArray)
@@ -231,6 +197,8 @@ object Searcher {
     }
 
 }
+
+
 
 //
 //

--- a/bundle/edu.gemini.horizons.server/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.server/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -11,20 +11,20 @@ import org.specs2.mutable.Specification
 
 object HS2Spec extends Specification with ScalaCheck {
 
-  import HS2.{ Search, Row }
-  import Searcher.search
-
+  import HS2.{ InternalError, Row, Search }
   import edu.gemini.spModel.core.{ HorizonsDesignation => HD }
 
+  def runSearch[A](s: Search[A]): InternalError \/ List[Row[A]] =
+    HS2.search(s).run.unsafePerformIO
 
   "comet search" should {
 
     "handle empty results" in {
-      search(Search.Comet("kjhdwekuq")) must_== \/-(Nil)
+      runSearch(Search.Comet("kjhdwekuq")) must_== \/-(Nil)
     }
 
     "handle multiple results" in {
-      search(Search.Comet("hu")).map(_.take(5)) must_== \/-(List(      
+      runSearch(Search.Comet("hu")).map(_.take(5)) must_== \/-(List(      
         Row(HD.Comet("67P"), "Churyumov-Gerasimenko"), 
         Row(HD.Comet("106P"), "Schuster"), 
         Row(HD.Comet("130P"), "McNaught-Hughes"), 
@@ -34,13 +34,13 @@ object HS2Spec extends Specification with ScalaCheck {
     }
 
     "handle single result (Format 1) Hubble (C/1937 P1)" in {
-      search(Search.Comet("hubble")) must_== \/-(List(
+      runSearch(Search.Comet("hubble")) must_== \/-(List(
         Row(HD.Comet("C/1937 P1"), "Hubble")
       ))
     }   
 
     "handle single result (Format 2) 1P/Halley pattern" in {
-      search(Search.Comet("halley")) must_== \/-(List(
+      runSearch(Search.Comet("halley")) must_== \/-(List(
         Row(HD.Comet("1P"), "Halley")
       ))
     }   
@@ -50,11 +50,11 @@ object HS2Spec extends Specification with ScalaCheck {
   "asteroid search" should {
 
     "handle empty results" in {
-      search(Search.Asteroid("kjhdwekuq")) must_== \/-(Nil)
+      runSearch(Search.Asteroid("kjhdwekuq")) must_== \/-(Nil)
     }
 
     "handle multiple results" in {
-      search(Search.Asteroid("her")).map(_.take(5)) must_== \/-(List(
+      runSearch(Search.Asteroid("her")).map(_.take(5)) must_== \/-(List(
         Row(HD.AsteroidOldStyle(103), "Hera"),
         Row(HD.AsteroidOldStyle(121), "Hermione"),
         Row(HD.AsteroidOldStyle(135), "Hertha"),
@@ -64,13 +64,13 @@ object HS2Spec extends Specification with ScalaCheck {
     }
 
     "handle single result (Format 1) 90377 Sedna (2003 VB12)" in {
-      search(Search.Asteroid("sedna")) must_== \/-(List(
+      runSearch(Search.Asteroid("sedna")) must_== \/-(List(
         Row(HD.AsteroidNewStyle("2003 VB12"), "Sedna")
       ))
     }   
 
     "handle single result (Format 2) 29 Amphitrite" in {
-      search(Search.Asteroid("amphitrite")) must_== \/-(List(
+      runSearch(Search.Asteroid("amphitrite")) must_== \/-(List(
         Row(HD.AsteroidOldStyle(29), "Amphitrite")
       ))
     }   
@@ -80,19 +80,19 @@ object HS2Spec extends Specification with ScalaCheck {
   "major body search" should {
 
     "handle empty results" in {
-      search(Search.MajorBody("kjhdwekuq")) must_== \/-(Nil)
+      runSearch(Search.MajorBody("kjhdwekuq")) must_== \/-(Nil)
     }
 
     "handle empty results with small-body fallthrough (many)" in {
-      search(Search.MajorBody("hu")) must_== \/-(Nil)
+      runSearch(Search.MajorBody("hu")) must_== \/-(Nil)
     }
 
     "handle empty results with small-body fallthrough (single)" in {
-      search(Search.MajorBody("hermione")) must_== \/-(Nil)
+      runSearch(Search.MajorBody("hermione")) must_== \/-(Nil)
     }
 
     "handle multiple results" in {
-      search(Search.MajorBody("mar")).map(_.take(5)) must_== \/-(List(
+      runSearch(Search.MajorBody("mar")).map(_.take(5)) must_== \/-(List(
         Row(HD.MajorBody(4), "Mars Barycenter"),
         Row(HD.MajorBody(499), "Mars"),
         Row(HD.MajorBody(723), "Margaret")
@@ -100,7 +100,7 @@ object HS2Spec extends Specification with ScalaCheck {
     }
 
     "handle single result" in {
-      search(Search.MajorBody("charon")) must_== \/-(List(
+      runSearch(Search.MajorBody("charon")) must_== \/-(List(
         Row(HD.MajorBody(901), "Charon / (Pluto)")
       ))
     }   

--- a/bundle/edu.gemini.horizons.server/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.server/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -11,10 +11,10 @@ import org.specs2.mutable.Specification
 
 object HS2Spec extends Specification with ScalaCheck {
 
-  import HS2.{ InternalError, Row, Search }
+  import HS2.{ HS2Error, Row, Search }
   import edu.gemini.spModel.core.{ HorizonsDesignation => HD }
 
-  def runSearch[A](s: Search[A]): InternalError \/ List[Row[A]] =
+  def runSearch[A](s: Search[A]): HS2Error \/ List[Row[A]] =
     HS2.search(s).run.unsafePerformIO
 
   "comet search" should {

--- a/bundle/edu.gemini.horizons.server/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.server/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -1,0 +1,109 @@
+package edu.gemini.horizons.server.backend
+
+import scalaz._
+import Scalaz._
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop._
+import org.scalacheck.Gen
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object HS2Spec extends Specification with ScalaCheck {
+
+  import HS2.{ Search, Row }
+  import Searcher.search
+
+  import edu.gemini.spModel.core.{ HorizonsDesignation => HD }
+
+
+  "comet search" should {
+
+    "handle empty results" in {
+      search(Search.Comet("kjhdwekuq")) must_== \/-(Nil)
+    }
+
+    "handle multiple results" in {
+      search(Search.Comet("hu")).map(_.take(5)) must_== \/-(List(      
+        Row(HD.Comet("67P"), "Churyumov-Gerasimenko"), 
+        Row(HD.Comet("106P"), "Schuster"), 
+        Row(HD.Comet("130P"), "McNaught-Hughes"), 
+        Row(HD.Comet("178P"), "Hug-Bell"), 
+        Row(HD.Comet("C/1880 Y1"), "Pechule")
+      ))
+    }
+
+    "handle single result (Format 1) Hubble (C/1937 P1)" in {
+      search(Search.Comet("hubble")) must_== \/-(List(
+        Row(HD.Comet("C/1937 P1"), "Hubble")
+      ))
+    }   
+
+    "handle single result (Format 2) 1P/Halley pattern" in {
+      search(Search.Comet("halley")) must_== \/-(List(
+        Row(HD.Comet("1P"), "Halley")
+      ))
+    }   
+
+  }
+
+  "asteroid search" should {
+
+    "handle empty results" in {
+      search(Search.Asteroid("kjhdwekuq")) must_== \/-(Nil)
+    }
+
+    "handle multiple results" in {
+      search(Search.Asteroid("her")).map(_.take(5)) must_== \/-(List(
+        Row(HD.AsteroidOldStyle(103), "Hera"),
+        Row(HD.AsteroidOldStyle(121), "Hermione"),
+        Row(HD.AsteroidOldStyle(135), "Hertha"),
+        Row(HD.AsteroidOldStyle(206), "Hersilia"),
+        Row(HD.AsteroidOldStyle(214), "Aschera")
+      ))
+    }
+
+    "handle single result (Format 1) 90377 Sedna (2003 VB12)" in {
+      search(Search.Asteroid("sedna")) must_== \/-(List(
+        Row(HD.AsteroidNewStyle("2003 VB12"), "Sedna")
+      ))
+    }   
+
+    "handle single result (Format 2) 29 Amphitrite" in {
+      search(Search.Asteroid("amphitrite")) must_== \/-(List(
+        Row(HD.AsteroidOldStyle(29), "Amphitrite")
+      ))
+    }   
+
+  }
+
+  "major body search" should {
+
+    "handle empty results" in {
+      search(Search.MajorBody("kjhdwekuq")) must_== \/-(Nil)
+    }
+
+    "handle empty results with small-body fallthrough (many)" in {
+      search(Search.MajorBody("hu")) must_== \/-(Nil)
+    }
+
+    "handle empty results with small-body fallthrough (single)" in {
+      search(Search.MajorBody("hermione")) must_== \/-(Nil)
+    }
+
+    "handle multiple results" in {
+      search(Search.MajorBody("mar")).map(_.take(5)) must_== \/-(List(
+        Row(HD.MajorBody(4), "Mars Barycenter"),
+        Row(HD.MajorBody(499), "Mars"),
+        Row(HD.MajorBody(723), "Margaret")
+      ))
+    }
+
+    "handle single result" in {
+      search(Search.MajorBody("charon")) must_== \/-(List(
+        Row(HD.MajorBody(901), "Charon / (Pluto)")
+      ))
+    }   
+
+  }
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
@@ -71,9 +71,9 @@ object TargetParamSetCodecs {
     ParamSetCodec.initial(HorizonsDesignation.Comet(""))
       .withParam("des", HorizonsDesignation.Comet.des)
       
-  implicit val AsteroidParamSetCodec: ParamSetCodec[HorizonsDesignation.Asteroid] =
-    ParamSetCodec.initial(HorizonsDesignation.Asteroid(""))
-      .withParam("des", HorizonsDesignation.Asteroid.des)
+  implicit val AsteroidParamSetCodec: ParamSetCodec[HorizonsDesignation.AsteroidNewStyle] =
+    ParamSetCodec.initial(HorizonsDesignation.AsteroidNewStyle(""))
+      .withParam("des", HorizonsDesignation.AsteroidNewStyle.des)
       
   implicit val AsteroidOldStyleParamSetCodec: ParamSetCodec[HorizonsDesignation.AsteroidOldStyle] =
     ParamSetCodec.initial(HorizonsDesignation.AsteroidOldStyle(0))
@@ -89,7 +89,7 @@ object TargetParamSetCodecs {
       def encode(key: String, a: HorizonsDesignation): ParamSet = {
         val (tag, ps) = a match {
           case d: HorizonsDesignation.Comet            => ("comet", CometParamSetCodec.encode(key, d))
-          case d: HorizonsDesignation.Asteroid         => ("asteroid", AsteroidParamSetCodec.encode(key, d))
+          case d: HorizonsDesignation.AsteroidNewStyle         => ("asteroid", AsteroidParamSetCodec.encode(key, d))
           case d: HorizonsDesignation.AsteroidOldStyle => ("asteroid-old-style", AsteroidOldStyleParamSetCodec.encode(key, d))
           case d: HorizonsDesignation.MajorBody        => ("major-body", MajorBodyParamSetCodec.encode(key, d))
         }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/HorizonsDesignation.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/HorizonsDesignation.scala
@@ -7,7 +7,7 @@ import scalaz._, Scalaz._
  * values passed to the constructors are extracted correctly from search results. See `horizons.md`
  * in the bundle source for more information.
  */
-sealed abstract class HorizonsDesignation(val queryString: String) 
+sealed abstract class HorizonsDesignation(val queryString: String)
   extends Product with Serializable
 
 object HorizonsDesignation {
@@ -21,20 +21,22 @@ object HorizonsDesignation {
     val des: Comet @> String = Lens.lensu((a, b) => a.copy(des = b), _.des)
   }
 
+  sealed abstract class Asteroid(s: String) extends HorizonsDesignation(s)
+
   /**
    * Designation for an asteroid under modern naming conventions. Example: `1971 UC1` for
    * 1896 Beer, yielding a query string `DES=1971 UC1`.
    */
-  final case class Asteroid(des: String) extends HorizonsDesignation(s"DES=$des")
-  object Asteroid {
-    val des: Asteroid @> String = Lens.lensu((a, b) => a.copy(des = b), _.des)
+  final case class AsteroidNewStyle(des: String) extends Asteroid(s"DES=$des")
+  object AsteroidNewStyle {
+    val des: AsteroidNewStyle @> String = Lens.lensu((a, b) => a.copy(des = b), _.des)
   }
 
   /**
    * Designation for an asteroid under "old" naming conventions. These are small numbers. Example:
    * `4` for Vesta, yielding a query string `4;`
    */
-  final case class AsteroidOldStyle(num: Int) extends HorizonsDesignation(s"$num;")
+  final case class AsteroidOldStyle(num: Int) extends Asteroid(s"$num;")
   object AsteroidOldStyle {
     val num: AsteroidOldStyle @> Int = Lens.lensu((a, b) => a.copy(num = b), _.num)
   }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
@@ -118,7 +118,7 @@ trait Arbitraries {
       for {
         obj <- arbitrary[Int]
         des <- oneOf(
-          HorizonsDesignation.Asteroid(obj.toString),
+          HorizonsDesignation.AsteroidNewStyle(obj.toString),
           HorizonsDesignation.AsteroidOldStyle(obj),
           HorizonsDesignation.Comet(obj.toString),
           HorizonsDesignation.MajorBody(obj)


### PR DESCRIPTION
This PR adds yet another version of the Horizons service, which provides support for automated ephemeris lookup.

- `search` fetches a list of `HorizonsDesignation` (with a text name for display, as needed) given a partial name. There are three cases for the user to consider (comet, asteroid, major body) and eight cases internally, for differing output formats.
- `lookupEphemeris` takes a `HorizonsDesignation` and a few other details and looks up an `Ephemeris`. This lookup should never fail or be ambiguous (it's an error condition if this happens).

The API will likely change, and will probably move from server to client. For now it's just basic library support proving that it works (or at least seems to).