### PR TITLE
Enable sbt cached resolution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ version in ThisBuild := ocsVersion.value.toOsgiVersion
 
 scalaVersion in ThisBuild := "2.10.4"
 
+updateOptions := updateOptions.value.withCachedResolution(true)
+
 // Note that this is not a standard setting; it's used for building IDEA modules.
 javaVersion in ThisBuild := {
   val expected = "1.8" 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7


### PR DESCRIPTION
I found this little gem, With sbt 0.13.7 you can enable cached resolution, now when I change the project and reload instead of 30 mins it takes 30seconds

http://www.scala-sbt.org/0.13/docs/Cached-Resolution.html

I don't know about side effects of moving to 0.13.7 but I'm able to e.g. build the PIT without any problems with this patch