### PR TITLE
Revert "Enable sbt cached resolution"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,6 @@ version in ThisBuild := ocsVersion.value.toOsgiVersion
 
 scalaVersion in ThisBuild := "2.10.4"
 
-updateOptions := updateOptions.value.withCachedResolution(true)
-
 // Note that this is not a standard setting; it's used for building IDEA modules.
 javaVersion in ThisBuild := {
   val expected = "1.8" 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.5


### PR DESCRIPTION
This reverts commit b4bd9f51e0fe9ed74e9a4130a34c4ab4b553c6ca.

@cquiroz I was getting compiler crashes during a compile phase that sbt introduces, so I had to revert this commit locally to get my world to compile again. Can you see if a clean full sbt build works for you?