### PR TITLE
Fix for package export bug

### DIFF
--- a/bundle/edu.gemini.shared.util/src/main/scala/edu/gemini/shared/util/IntegerIsIntegral.scala
+++ b/bundle/edu.gemini.shared.util/src/main/scala/edu/gemini/shared/util/IntegerIsIntegral.scala
@@ -1,4 +1,4 @@
-package edu.gemini.shared
+package edu.gemini.shared.util
 
 import java.lang.{Integer => JInt}
 
@@ -28,7 +28,7 @@ trait IntegerIsIntegral extends Integral[JInt] with Ordering[JInt] {
   def rem(x: JInt, y: JInt)    = x.intValue() % y.intValue()
 }
 
-package object util {
+object IntegerIsIntegral {
 
-  implicit object IntegerIsIntegral extends IntegerIsIntegral
+  implicit val integerIsIntegral = new IntegerIsIntegral {}
 }

--- a/bundle/edu.gemini.shared.util/src/main/scala/edu/gemini/shared/util/VersionVector.scala
+++ b/bundle/edu.gemini.shared.util/src/main/scala/edu/gemini/shared/util/VersionVector.scala
@@ -1,5 +1,6 @@
 package edu.gemini.shared.util
 
+import IntegerIsIntegral._
 import scala.collection.immutable.ListMap
 import scala.collection.JavaConverters._
 
@@ -45,7 +46,7 @@ case class VersionVector[K, V : Integral](clocks: Map[K, V]) extends PartiallyOr
    * Returns true if there are no entries in the version vector (that is, if
    * all values are implicitly 0).
    */
-  def isEmpty = clocks.size == 0
+  def isEmpty = clocks.isEmpty
 
   /**
    * Combines this vector version with <code>that</code> one.  The vector


### PR DESCRIPTION
PR #788 introduced a bug with the exported packages as it contains a class on package `edu.gemini.shared` which likely shouldn't be exported
This PR moves the class on `package.scala` to its own file