### PR TITLE
REL-1806: Implement PIT validation checks of conditions and configurations

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -678,11 +678,11 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
     def fixConditions(c: Condition) {
       model.foreach { m =>
         m.elems.find {
-          case g @ ConditionGroup(_, _, _) =>
+          case g @ ConditionGroup(Some(gc), _, _) if c == gc =>
             viewer.edit(g, p => ConditionEditor.open(Some(c), canEdit, panel), Observation.condition)
             viewer.selection = Some(g)
             true
-          case _                                         => false
+          case _                                             => false
         }
       }
     }


### PR DESCRIPTION
This PR fixes a bug when clicking on the problems table with a conditions-related issue. The PIT would open the conditions editor but apply the updated conditions to the first condition on the plan. This is visible if you have many condition groups on your proposal