### PR TITLE
REL-2412: PIT duplication check with the in-house archive

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -49,7 +49,9 @@ def common(pv: Version) = AppConfig(
     BundleSpec("org.scala-lang.scala-actors",  Version(2, 10, 1)),
     BundleSpec("org.scala-lang.scala-reflect", Version(2, 10, 1)),
     BundleSpec("org.scala-lang.scala-swing",   Version(2, 0, 0)),
-    BundleSpec("org.apache.commons.logging",   Version(1, 1, 0))
+    BundleSpec("org.apache.commons.logging",   Version(1, 1, 0)),
+    BundleSpec("monocle.core",                 Version(1, 1, 0)),
+    BundleSpec("monocle.macro",                Version(1, 1, 0))
   )
 ) extending List()
 

--- a/bundle/edu.gemini.ui.workspace/src/main/java/edu/gemini/ui/workspace/osgi/Activator.java
+++ b/bundle/edu.gemini.ui.workspace/src/main/java/edu/gemini/ui/workspace/osgi/Activator.java
@@ -12,6 +12,8 @@ import edu.gemini.ui.workspace.IShellAdvisor;
 import edu.gemini.ui.workspace.impl.Shell;
 import edu.gemini.ui.workspace.impl.Workspace;
 
+import javax.swing.SwingUtilities;
+
 public class Activator implements BundleActivator, ServiceTrackerCustomizer<IShellAdvisor, Shell> {
 
     private static final Logger LOGGER = Logger.getLogger(Activator.class.getName());
@@ -38,10 +40,12 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<IShe
 
         // Close everything, in opposite order.
         tracker.close();
-        workspace.close();
+        SwingUtilities.invokeLater(() -> {
+            workspace.close();
+            workspace = null;
+        });
 
         // And let everything be GC'd
-        workspace = null;
         tracker = null;
         this.context = null;
 


### PR DESCRIPTION
The PIT breaks when doing GSA queries because monocle jars were not included after the scalaz migration.
I include a small bug fix removing an exception that appears when the PIT is closed from the felix console