### PR TITLE
Compilation error fixes

### DIFF
--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
@@ -3,6 +3,7 @@ package edu.gemini.sp.vcs2
 import edu.gemini.pot.sp._
 import edu.gemini.pot.sp.version._
 import edu.gemini.shared.util._
+import edu.gemini.shared.util.IntegerIsIntegral._
 import edu.gemini.sp.vcs2.NodeDetail.Obs
 import edu.gemini.sp.vcs2.VcsFailure._
 import edu.gemini.spModel.rich.pot.sp._

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -9,7 +9,7 @@ import edu.gemini.pot.sp.Conflict.Moved
 import edu.gemini.pot.sp.validator.Validator
 import edu.gemini.pot.sp.version.VersionMap
 import edu.gemini.pot.sp.{DataObjectBlob => DOB, _}
-import edu.gemini.shared.util.IntegerIsIntegral
+import edu.gemini.shared.util.IntegerIsIntegral._
 import edu.gemini.shared.util.VersionComparison
 import edu.gemini.shared.util.VersionComparison.{Conflicting, Same, Newer}
 import edu.gemini.shared.util.immutable.ScalaConverters._
@@ -27,7 +27,6 @@ import scala.collection.JavaConverters._
 
 import scalaz._
 import scalaz.syntax.functor._  // idea marks as unused but required for "as"
-
 
 class MergeTest extends JUnitSuite {
   import edu.gemini.sp.vcs2.MergePropertyTest.NamedProperty

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/VersionVectorPio.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/VersionVectorPio.scala
@@ -3,6 +3,7 @@ package edu.gemini.spModel.io.impl
 import edu.gemini.pot.sp.SPNodeKey
 import edu.gemini.pot.sp.version._
 import edu.gemini.shared.util._
+import edu.gemini.shared.util.IntegerIsIntegral._
 import edu.gemini.spModel.pio._
 
 import scala.collection.JavaConverters._
@@ -49,7 +50,7 @@ object VersionVectorPio {
 
     // Fold and empty version map over the Node, converting each Node into a
     // SPNodeKey -> DbVersions tuple to add it to the version map.
-    (EmptyVersionMap/:nodes) { (vm, node) => vm + node.toTuple(ids) }.toMap
+    (EmptyVersionMap/:nodes) { (vm, node) => vm + node.toTuple(ids) }
   }
 
   private object Node {


### PR DESCRIPTION
Compilation breaks in a few places as `IntegerIsIntegral` was moved to another package. This was tested with a full project compilation