### PR TITLE
REL-2202: Apple developer signature for PIT Mac app

### DIFF
--- a/project/src/main/resources/edu/gemini/osgi/tools/app/Info.plist
+++ b/project/src/main/resources/edu/gemini/osgi/tools/app/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>English</string>
+        <key>CFBundleExecutable</key>
+        <string>libjli.dylib</string>
+        <key>CFBundleGetInfoString</key>
+        <string>Java SE 1.8.0_40</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.oracle.java.8u40.jdk</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>7.0</string>
+        <key>CFBundleName</key>
+        <string>Java SE 8</string>
+        <key>CFBundlePackageType</key>
+        <string>BNDL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>1.8.0_40</string>
+        <key>JavaVM</key>
+        <dict>
+                <key>JVMCapabilities</key>
+                <array>
+                        <string>CommandLine</string>
+                </array>
+                <key>JVMMinimumFrameworkVersion</key>
+                <string>13.2.9</string>
+                <key>JVMMinimumSystemVersion</key>
+                <string>10.6.0</string>
+                <key>JVMPlatformVersion</key>
+                <string>1.8</string>
+                <key>JVMVendor</key>
+                <string>Oracle Corporation</string>
+                <key>JVMVersion</key>
+                <string>1.8.0_40</string>
+        </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This PR updates the build to support signing Mac Applications thus becoming acceptable to GateKeeper. So far it has been tested only for the PIT
The code will check if the certificate exists on the system and only then do the signing, Several steps of signing must be done before the file is acceptable.
The signature can be verified running the command below on the app:

    spctl -v -a <path.to>\Gemini...app

The certificate itself is not included as it cannot be made public but it must be installed in each system where the application is built. Note that in the code the SHA hash of the certificate and certificate id are included. That information is of no use to a potential attacker