### PR TITLE
Don't import p1 mutable classes

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaProject.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/idea/IdeaProject.scala
@@ -43,6 +43,11 @@ object IdeaProject {
     <component name="EntryPointsManager">
       <entry_points version="2.0" />
     </component>
+    <component name="JavaProjectCodeInsightSettings">
+      <excluded-names>
+        <name>edu.gemini.model.p1.mutable</name>
+      </excluded-names>
+    </component>
     <component name="InspectionProjectProfileManager">
       <profiles>
         <profile version="1.0" is_locked="false">


### PR DESCRIPTION
Mini improvement to the IDEAproject generation logic. With this PR the generated IDEA project won't attempt to import the classes on the mutable p1 model by default. They are still available and the project compiles fine but avoids a common mistake I make when letting IDEA do the imports