### PR TITLE
REL-2617: Remove H_STAR and H_LIWA observing modes from PIT

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Gpi.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Gpi.scala
@@ -10,7 +10,7 @@ object Gpi {
     val title = "Observing Mode"
     val description = "Select an observing mode for your configuration."
 
-    def choices: List[GpiObservingMode] = GpiObservingMode.values.toList
+    def choices: List[GpiObservingMode] = GpiObservingMode.values.toList.filterNot(m => m == GpiObservingMode.HStar || m == GpiObservingMode.HLiwa)
 
     def apply(om: GpiObservingMode) = Left(new DisperserNode(om))
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -237,6 +237,10 @@ package object immutable {
 
   type GpiObservingMode = M.GpiObservingMode
   object GpiObservingMode extends EnumObject[M.GpiObservingMode] {
+    val HStar   = M.GpiObservingMode.H_STAR
+    val HLiwa   = M.GpiObservingMode.H_LIWA
+    val HDirect = M.GpiObservingMode.DIRECT_H_BAND
+    
     def isCoronographMode(mode: GpiObservingMode):Boolean = mode.value.startsWith("Coronograph")
     def isDirectMode(mode: GpiObservingMode):Boolean = mode.value.endsWith("direct")
     def scienceBand(mode: GpiObservingMode):Option[String] = {

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_gpi_hstar.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_gpi_hstar.xml
@@ -1,0 +1,39 @@
+<proposal schemaVersion="2014.1.1">
+    <meta band3optionChosen="false"/>
+    <semester year="2014" half="A"/>
+    <title/>
+    <abstract/>
+    <scheduling/>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email/>
+            <address>
+                <institution/>
+                <address/>
+                <country/>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <gpi>
+            <Gpi id="blueprint-0">
+                <name>GPI H_STAR Prism</name>
+                <visitor>false</visitor>
+                <observingMode>H_STAR</observingMode>
+                <disperser>Prism</disperser>
+            </Gpi>
+        </gpi>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-0"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/GpiSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/GpiSpec.scala
@@ -8,7 +8,7 @@ class GpiSpec extends SpecificationWithJUnit {
     "includes Gpi observing modes" in {
       val gpi = Gpi()
       gpi.title must beEqualTo("Observing Mode")
-      gpi.choices must have size (17)
+      gpi.choices must have size (15)
     }
     "includes Gpi disperser modes" in {
       val gpi = Gpi()

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -697,6 +697,17 @@ class UpConverterSpec extends SpecificationWithJUnit with SemesterProperties {
           result \\ "niri" must \\("name") \> "NIRI Altair Laser Guidestar f/32 (0.02\"/pix, 22\" FoV) HeI (1.083 um)"
       }
     }
+    "proposal with GPI and HStar and HLiwa modes should become H direct, REL-2671" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gpi_hstar.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 4
+          result \\ "gpi" must \\("observingMode") \>~ "H.direct"
+          result \\ "gpi" must \\("name") \> "GPI H direct Prism"
+      }
+    }
   }
 
   def testF2R3KYConversion(xml: Elem) = {


### PR DESCRIPTION
This PR hides the GPI modes H_Star and H_Liwa on the UI and adds upconversion code to convert existing proposal with those modes and convert them to H Direct