### PR TITLE
REL-2622: Data Manager Discovered Dataset Bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 2)
+ocsVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 3)
 
 pitVersion in ThisBuild := OcsVersion("2016A", false, 1, 1, 0)
 

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsLogActions.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsLogActions.scala
@@ -26,7 +26,6 @@ import ObsLogActions._
   * @param odb observing database in which to find the observations
   */
 final class ObsLogActions(odb: IDBDatabaseService) {
-
   /** Returns an action that will record the user's desire to edit the QA state
     * of the given datasets.
     */
@@ -51,7 +50,13 @@ final class ObsLogActions(odb: IDBDatabaseService) {
     // (i.e., via seq exec events in the WDBA).
     val cons: DatasetLabel => Option[Dataset] = (lab) => {
       val dsetOpt = fMap.get(lab).map { f =>
-        new Dataset(lab, f.filename, System.currentTimeMillis)
+        // Strip the trailing ".fits" suffix, if any, to be comptabile with how
+        // the WDBA adds new dataset filenames..
+        val filename = f.filename match {
+          case FitsFile(n) => n
+          case n           => n
+        }
+        new Dataset(lab, filename, System.currentTimeMillis)
       }
 
       dsetOpt.foreach { ds =>
@@ -255,6 +260,8 @@ final class ObsLogActions(odb: IDBDatabaseService) {
 
 object ObsLogActions {
   val Log = Logger.getLogger(ObsLogActions.getClass.getName)
+
+  val FitsFile = """(.*?)(?:\.fits)?$""".r
 
   val EmptyUpdates = (List.empty[DatasetQaRecord], List.empty[DatasetExecRecord])
 

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsLogActionsSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsLogActionsSpec.scala
@@ -7,8 +7,9 @@ import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances
 import edu.gemini.spModel.config2.ItemKey
-import edu.gemini.spModel.dataset.{DatasetMd5, DatasetQaState, DatasetGsaState, DatasetLabel}
+import edu.gemini.spModel.dataset.{DatasetExecRecord, DatasetMd5, DatasetQaState, DatasetGsaState, DatasetLabel}
 import edu.gemini.spModel.obslog.ObsLog
+import org.scalacheck.Prop
 
 import java.time.Instant
 
@@ -20,34 +21,35 @@ import scalaz.{\/-, -\/}
 object ObsLogActionsSpec extends TestSupport {
 
   "FitsFile regex" should {
-    "match all strings ending with .fits suffix" in
+    "match the prefix of all strings that don't contain vertical whitespace" in
       forAll { (s: String) =>
         s"$s.fits" match {
           case FitsFile(n) => s == n
-          case _           => false
+          case _           => s.exists(_.isWhitespace)
         }
       }
-
-    "match all strings not ending with .fits suffix" in
+    "match any strings not ending with .fits suffix and not containing vertical whitespace" in
       forAll { (s: String) =>
         s.endsWith(".fits") || (s match {
           case FitsFile(n) => s == n
-          case _           => false
+          case _           => s.exists(_.isWhitespace)
         })
       }
 
-    "ignore intermediate .fits sub-strings" in
+    "ignore intermediate .fits sub-strings in all strings not containing vertical whitespace" in
       forAll { (s: String) =>
         val fn = s".fits$s.fits"
         s"$fn.fits" match {
           case FitsFile(n) => fn == n
-          case _           => false
+          case _           => s.exists(_.isWhitespace)
         }
       }
   }
 
 
-  val DatasetLabelKey = new ItemKey("observe:dataLabel")
+  val FilenamePrefix   = "GN20160207S"
+  val DatasetLabelKey  = new ItemKey("observe:dataLabel")
+  val ObservationIdKey = new ItemKey("ocs:observationId")
 
   // All missing dataset labels in the given programs.
   def missingLabels(progs: List[ISPProgram]): List[DatasetLabel] =
@@ -64,28 +66,47 @@ object ObsLogActionsSpec extends TestSupport {
       }
     }
 
-  "ObsLogActions" should {
-    "strip .fits from discovered datasets" ! forAllPrograms { (odb, progs) =>
-
-      val prefix = "GN20160207S"
+  def test(p: (List[ISPProgram], List[GsaRecord], List[DatasetExecRecord]) => Boolean): Prop =
+    forAllPrograms { (odb, progs) =>
 
       val labs = missingLabels(progs).sorted
       val recs = labs.zipWithIndex.map { case (lab, index) =>
-          GsaRecord(Some(lab), f"$prefix%s${index+1}%03d.fits", DatasetGsaState(DatasetQaState.UNDEFINED, Instant.now(), DatasetMd5.empty))
+        GsaRecord(Some(lab), f"$FilenamePrefix%s${index+1}%03d.fits", DatasetGsaState(DatasetQaState.UNDEFINED, Instant.now(), DatasetMd5.empty))
       }
 
-      val act  = new ObsLogActions(odb).updateSummit(recs)
-
-      act.unsafeRun match {
+      new ObsLogActions(odb).updateSummit(recs).unsafeRun match {
         case -\/(f) =>
           failure(f.explain)
           false
         case \/-((_, exs)) =>
-          exs.sortBy(_.dataset.getLabel).zipWithIndex.forall { case (ex, index) =>
-            ex.dataset.getDhsFilename == f"$prefix%s${index+1}%03d"
+          p(progs, recs, exs)
+      }
+    }
+
+  "ObsLogActions" should {
+    "strip .fits from discovered datasets" ! test { (progs, gsaRecs, execRecs) =>
+      execRecs.sortBy(_.dataset.getLabel).zipWithIndex.forall { case (ex, index) =>
+        ex.dataset.getDhsFilename == f"$FilenamePrefix%s${index+1}%03d"
+      }
+    }
+
+    "add a config for missing datasets" ! test { (progs, gsaRecs, execRecs) =>
+      gsaRecs.forall { gsaRec =>
+        gsaRec.label.forall { label =>
+          val oid = label.getObservationId
+          val pid = oid.getProgramID
+
+          progs.find(_.getProgramID == pid).exists { p =>
+            p.getAllObservations.asScala.find(_.getObservationID == oid).exists { o =>
+              Option(ObsLog.getIfExists(o)).exists { log =>
+                Option(log.getExecRecord.getConfigForDataset(label)).exists { config =>
+                  config.getItemValue(ObservationIdKey) == oid.stringValue
+                }
+              }
+            }
           }
+        }
       }
     }
   }
-
 }

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsLogActionsSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsLogActionsSpec.scala
@@ -1,0 +1,91 @@
+package edu.gemini.dataman.app
+
+import edu.gemini.dataman.app.ObsLogActions.FitsFile
+
+import edu.gemini.dataman.core.GsaRecord
+import edu.gemini.pot.sp.ISPProgram
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances
+import edu.gemini.spModel.config2.ItemKey
+import edu.gemini.spModel.dataset.{DatasetMd5, DatasetQaState, DatasetGsaState, DatasetLabel}
+import edu.gemini.spModel.obslog.ObsLog
+
+import java.time.Instant
+
+import org.scalacheck.Prop._
+import scala.collection.JavaConverters._
+import scalaz.{\/-, -\/}
+
+
+object ObsLogActionsSpec extends TestSupport {
+
+  "FitsFile regex" should {
+    "match all strings ending with .fits suffix" in
+      forAll { (s: String) =>
+        s"$s.fits" match {
+          case FitsFile(n) => s == n
+          case _           => false
+        }
+      }
+
+    "match all strings not ending with .fits suffix" in
+      forAll { (s: String) =>
+        s.endsWith(".fits") || (s match {
+          case FitsFile(n) => s == n
+          case _           => false
+        })
+      }
+
+    "ignore intermediate .fits sub-strings" in
+      forAll { (s: String) =>
+        val fn = s".fits$s.fits"
+        s"$fn.fits" match {
+          case FitsFile(n) => fn == n
+          case _           => false
+        }
+      }
+  }
+
+
+  val DatasetLabelKey = new ItemKey("observe:dataLabel")
+
+  // All missing dataset labels in the given programs.
+  def missingLabels(progs: List[ISPProgram]): List[DatasetLabel] =
+    progs.flatMap { p =>
+      p.getObservations.asScala.flatMap { o =>
+        Option(ObsLog.getIfExists(o)).toList.flatMap { log =>
+          val cs  = ConfigBridge.extractSequence(o, null, ConfigValMapInstances.IDENTITY_MAP)
+          val all = cs.getDistinctItemValues(DatasetLabelKey).collect {
+            case lab: DatasetLabel => lab
+            case s: String         => new DatasetLabel(s)
+          }
+          (all.toSet -- log.getDatasetLabels.asScala).toList
+        }
+      }
+    }
+
+  "ObsLogActions" should {
+    "strip .fits from discovered datasets" ! forAllPrograms { (odb, progs) =>
+
+      val prefix = "GN20160207S"
+
+      val labs = missingLabels(progs).sorted
+      val recs = labs.zipWithIndex.map { case (lab, index) =>
+          GsaRecord(Some(lab), f"$prefix%s${index+1}%03d.fits", DatasetGsaState(DatasetQaState.UNDEFINED, Instant.now(), DatasetMd5.empty))
+      }
+
+      val act  = new ObsLogActions(odb).updateSummit(recs)
+
+      act.unsafeRun match {
+        case -\/(f) =>
+          failure(f.explain)
+          false
+        case \/-((_, exs)) =>
+          exs.sortBy(_.dataset.getLabel).zipWithIndex.forall { case (ex, index) =>
+            ex.dataset.getDhsFilename == f"$prefix%s${index+1}%03d"
+          }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This grim little PR fixes a fault report (FR-36116) that was triggered by the Data Manager update for 2016A.  Usually new datasets are recorded in the ODB via events from the seqexec.  Sometimes however the seqexec event is never generated and yet the dataset is created by the instrument and added to the archive.  When the Data Manager discovers a new dataset via archive poll results, it adds a new record to the corresponding Observing Log in the ODB.

The behavior change in 2016A was to no longer attempt to compute the sequence step configuration corresponding to the dataset.  Unfortunately though this information is needed by the Observing Log webapp, particularly for exporting the observing log to a text file.  When expected sequence step information is not available, it blows up.

This PR restores the pre-2016A behavior of adding a sequence step configuration for newly discovered datasets.  It also changes the dataset filename to strip off the ".fits" extension to be consistent with the WDBA and allow the Observing Log webapp to parse out the file number.