### PR TITLE
REL-2569: Removed 'Last update' line in ITC output for all instruments

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -421,10 +421,6 @@
   </center></div>
 
 </form>
-
-<hr align="left" size="3">
-
-<p><i>Last update May 24, 2007; Brian Walls</i> </p>
 </div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -476,11 +476,6 @@
 	</center>
 	</div>
 </form>
-<hr align="left" size="3" />
-<p>
-<br />
-<i>Last update June 12, 2014; Sabrina Pakzad</i>
-</p>
 </div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -611,11 +611,6 @@
 	</div>
 
 </form>
-<hr align="left" size="3" />
-<p>
-<br />
-<i>Last update February 19, 2011 by Matt Dillman</i>
-</p>
 </div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -530,11 +530,6 @@
 	</center>
 	</div>
 </form>
-<hr align="left" size="3" />
-<p>
-<br />
-<i>Last update December 21, 2011; Allan Brighton</i>
-</p>
 </div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -450,9 +450,6 @@
 	</div>
 
 </form>
-<p>
-<i>Last update February 19; Matt Dillman</i> 
-</p>
 </div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -544,10 +544,6 @@
 	</center>
 	</div>
 </form>
-<hr align="left" size="3" />
-<p>
-<i>Last update February 19, 2011; Matt Dillman</i> 
-</p>
 </div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -571,11 +571,6 @@
 	</center>
 	</div>
 </form>
-<hr align="left" size="3" />
-<p>
-<br />
-<i>Last update February 19, 2011; Matt Dillman</i> 
-</p>
 </div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -469,10 +469,6 @@
 	</div>
 
 </form>
-<hr align="left" size="3" />
-<p>
-<i>Last update February 19, 2011; Matt Dillman</i> 
-</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Note: the changes for GNIRS have been applied in REL-552