### PR TITLE
FIX: Added missing dependencies to ITC standalone app.

### DIFF
--- a/app/itc/build.sbt
+++ b/app/itc/build.sbt
@@ -61,10 +61,14 @@ def common(version: Version) = AppConfig(
     BundleSpec("org.ops4j.pax.web.pax-web-spi",          Version(1, 1, 13)),
     BundleSpec("org.scala-lang.scala-reflect",           Version(2, 10, 5)),
     BundleSpec("org.scalaz.concurrent",                  Version(7, 1, 6)),
+    BundleSpec("org.scala-lang.scala-reflect",           Version(2, 10, 5)),
+    BundleSpec("org.scala-lang.scala-actors",            Version(2, 10, 5)),
+    BundleSpec("org.scala-lang.scala-compiler",          Version(2, 10, 5)),
     BundleSpec("slf4j.api",                              Version(1, 6, 4)),
     BundleSpec("slf4j.jdk14",                            Version(1, 6, 4)),
     BundleSpec("squants",                                Version(0, 5, 3)),
-    BundleSpec("org.apache.commons.logging",             Version(1, 1, 0))
+    BundleSpec("org.apache.commons.logging",             Version(1, 1, 0)),
+    BundleSpec("com.chuusai.shapeless.core",             Version(2, 2, 5))
   )
 ) extending List(common_credentials(version))
 


### PR DESCRIPTION
Dependencies that were introduced with `doobie` were missing in the ITC standalone server app.

(This is a stripped down server app that only runs the ITC and is currently used by science for development and is also what is running on itc.gemini.edu to provide the ITC calculation web pages to the outside world.)