### PR TITLE
Cleaned sequence commands

### DIFF
--- a/app/seqexec-server/build.sbt
+++ b/app/seqexec-server/build.sbt
@@ -47,6 +47,7 @@ def common(version: Version) = AppConfig(
     BundleSpec("edu.gemini.spModel.smartgcal", version),
     BundleSpec("edu.gemini.epics.acm",         version),
     BundleSpec("org.scala-lang.scala-reflect", Version(2, 10, 5)),
+    BundleSpec("org.scala-lang.scala-compiler",Version(2, 10, 5)),
     BundleSpec("org.scala-lang.scala-swing",   Version(2, 0, 0)),
     BundleSpec("slf4j.api",                    Version(1, 6, 4)),
     BundleSpec("slf4j.jdk14",                  Version(1, 6, 4)),

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
@@ -1,6 +1,6 @@
 package edu.gemini.seqexec.server
 
-import edu.gemini.epics.acm.{CaCommandListener, CaCommandSender, CaParameter}
+import edu.gemini.epics.acm.{CaService, CaCommandListener, CaCommandSender, CaParameter}
 import edu.gemini.seqexec.server.SeqexecFailure.{Timeout, SeqexecException}
 
 import scala.concurrent.TimeoutException
@@ -30,6 +30,10 @@ trait EpicsCommand {
       cs.map(_.mark().right).getOrElse(SeqexecFailure.Unexpected("Unable to mark command.").left)
     })
   )
+}
+
+trait EpicsSystem {
+  def init(service: CaService): TrySeq[Unit]
 }
 
 object EpicsCommand {

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
@@ -41,10 +41,10 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
   )
 
   def setDCConfig(dc: DCConfig): SeqAction[Unit] = for {
-    _ <- Flamingos2Epics.dcConfigCmd.setExposureTime(dc.t.toSeconds)
-    _ <- Flamingos2Epics.dcConfigCmd.setNumReads(dc.n.getCount)
-    _ <- Flamingos2Epics.dcConfigCmd.setReadoutMode(encode(dc.r))
-    _ <- Flamingos2Epics.dcConfigCmd.setBiasMode(encode(dc.b))
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setExposureTime(dc.t.toSeconds)
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setNumReads(dc.n.getCount)
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setReadoutMode(encode(dc.r))
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setBiasMode(encode(dc.b))
   } yield ()
 
   implicit val encodeWindowCoverPosition: EncodeEpicsValue[WindowCover, String] = EncodeEpicsValue((a: WindowCover)
@@ -119,13 +119,13 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
   def setCCConfig(cc: CCConfig): SeqAction[Unit] = {
     val fpu = encode(cc.fpu)
     for {
-      _ <- Flamingos2Epics.configCmd.setWindowCover(encode(cc.w))
-      _ <- Flamingos2Epics.configCmd.setDecker(encode(cc.d))
-      _ <- Flamingos2Epics.configCmd.setMOS(fpu._1)
-      _ <- Flamingos2Epics.configCmd.setMask(fpu._2)
-      _ <- Flamingos2Epics.configCmd.setFilter(encode(cc.f))
-      _ <- Flamingos2Epics.configCmd.setLyot(encode(cc.l))
-      _ <- Flamingos2Epics.configCmd.setGrism(encode(cc.g))
+      _ <- Flamingos2Epics.instance.configCmd.setWindowCover(encode(cc.w))
+      _ <- Flamingos2Epics.instance.configCmd.setDecker(encode(cc.d))
+      _ <- Flamingos2Epics.instance.configCmd.setMOS(fpu._1)
+      _ <- Flamingos2Epics.instance.configCmd.setMask(fpu._2)
+      _ <- Flamingos2Epics.instance.configCmd.setFilter(encode(cc.f))
+      _ <- Flamingos2Epics.instance.configCmd.setLyot(encode(cc.l))
+      _ <- Flamingos2Epics.instance.configCmd.setGrism(encode(cc.g))
     } yield ()
   }
 
@@ -133,14 +133,14 @@ object Flamingos2ControllerEpics extends Flamingos2Controller {
     _ <- EitherT(Task(Log.info("Start Flamingos2 configuration").right))
     _ <- setDCConfig(config.dc)
     _ <- setCCConfig(config.cc)
-    _ <- Flamingos2Epics.post
+    _ <- Flamingos2Epics.instance.post
     _ <- EitherT(Task(Log.info("Completed Flamingos2 configuration").right))
   } yield ()
 
   override def observe(obsid: ObsId): SeqAction[ObsId] = for {
     _ <- EitherT(Task(Log.info("Start Flamingos2 observation").right))
-    _ <- Flamingos2Epics.observeCmd.setLabel(obsid)
-    _ <- Flamingos2Epics.observeCmd.post
+    _ <- Flamingos2Epics.instance.observeCmd.setLabel(obsid)
+    _ <- Flamingos2Epics.instance.observeCmd.post
     _ <- EitherT(Task(Log.info("Completed Flamingos2 observation").right))
   } yield obsid
 }

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
@@ -105,15 +105,18 @@ object Flamingos2Epics extends EpicsSystem {
   val Log = Logger.getLogger(getClass.getName)
   val CA_CONFIG_FILE = "/Flamingos2.xml"
   
-  // Ugly use of null. But if it is used before initialization, then the application deserves to crash.
-  var instance: Flamingos2Epics = null
+  // Still using a var, but at least now it's hidden. Attempts to access the single instance will
+  // now result in an Exception with a meaningful message, instead of a NullPointerException
+  private var instanceInternal = Option.empty[Flamingos2Epics]
+  lazy val instance: Flamingos2Epics = instanceInternal.getOrElse(
+    throw new Exception("Attempt to reference Flamingos2Epics single instance before initialization."))
 
   override def init(service: CaService): TrySeq[Unit] = {
     try {
       (new XMLBuilder).fromStream(this.getClass.getResourceAsStream(CA_CONFIG_FILE))
         .buildAll()
 
-      instance = new Flamingos2Epics(service)
+      instanceInternal = Some(new Flamingos2Epics(service))
 
       TrySeq(())
     } catch {

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecFailure.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecFailure.scala
@@ -1,5 +1,8 @@
 package edu.gemini.seqexec.server
 
+import edu.gemini.seqexec.shared.SeqFailure
+import edu.gemini.seqexec.shared.SeqFailure._
+
 /**
  * Created by jluhrs on 5/18/15.
  */
@@ -25,6 +28,9 @@ object SeqexecFailure {
   /** Timeout */
   case class Timeout(msg: String) extends SeqexecFailure
 
+  /** Sequence loading errors */
+  case class ODBSeqError(fail: SeqFailure) extends SeqexecFailure
+
   def explain(f: SeqexecFailure): String = f match {
     case UnrecognizedInstrument(name) => s"Unrecognized instrument: $name"
     case Execution(errMsg)            => s"Sequence execution failed with error $errMsg"
@@ -32,6 +38,7 @@ object SeqexecFailure {
     case InvalidOp(msg)               => s"Invalid operation: $msg"
     case Unexpected(msg)              => s"Unexpected error: $msg"
     case Timeout(msg)                 => s"Timeout while waiting for $msg"
+    case ODBSeqError(fail)             => SeqFailure.explain(fail)
   }
 
 }

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Tcs.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Tcs.scala
@@ -55,6 +55,7 @@ final case class Tcs(tcsController: TcsController) extends System {
 
   private def configure(config: Config, tcsState: TcsConfig): SeqAction[ConfigResult] = {
     val tcsConfig = fromSequenceConfig(config)(tcsState)
+    Log.info("Applying TCS configuration " + tcsConfig)
 
     for {
       _ <- guideOff(tcsState, Requested(tcsConfig))

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
@@ -54,15 +54,15 @@ object TcsControllerEpics extends TcsController {
 
   private def getGuideConfig: TrySeq[GuideConfig] = {
     for {
-      mountGuide <- TcsEpics.absorbTipTilt.map(decode[Integer, MountGuideOption])
-      m1Source <- TcsEpics.m1GuideSource.map(decode[String, M1Source])
-      m1Guide <- TcsEpics.m1Guide.map(decodeM1Guide(_, m1Source))
-      m2p1Guide <- TcsEpics.m2p1Guide.map(decodeGuideSourceOption)
-      m2p2Guide <- TcsEpics.m2p2Guide.map(decodeGuideSourceOption)
-      m2oiGuide <- TcsEpics.m2oiGuide.map(decodeGuideSourceOption)
-      m2aoGuide <- TcsEpics.m2aoGuide.map(decodeGuideSourceOption)
-      m2Coma <- TcsEpics.comaCorrect.map(decode[String, ComaOption])
-      m2Guide <- TcsEpics.m2GuideState.map(decodeM2Guide(_, m2Coma, List((m2p1Guide, TipTiltSource.PWFS1),
+      mountGuide <- TcsEpics.instance.absorbTipTilt.map(decode[Integer, MountGuideOption])
+      m1Source <- TcsEpics.instance.m1GuideSource.map(decode[String, M1Source])
+      m1Guide <- TcsEpics.instance.m1Guide.map(decodeM1Guide(_, m1Source))
+      m2p1Guide <- TcsEpics.instance.m2p1Guide.map(decodeGuideSourceOption)
+      m2p2Guide <- TcsEpics.instance.m2p2Guide.map(decodeGuideSourceOption)
+      m2oiGuide <- TcsEpics.instance.m2oiGuide.map(decodeGuideSourceOption)
+      m2aoGuide <- TcsEpics.instance.m2aoGuide.map(decodeGuideSourceOption)
+      m2Coma <- TcsEpics.instance.comaCorrect.map(decode[String, ComaOption])
+      m2Guide <- TcsEpics.instance.m2GuideState.map(decodeM2Guide(_, m2Coma, List((m2p1Guide, TipTiltSource.PWFS1),
         (m2p2Guide, TipTiltSource.PWFS2), (m2oiGuide, TipTiltSource.OIWFS),
         (m2aoGuide, TipTiltSource.GAOS)).foldLeft(Set[TipTiltSource]())((s: Set[TipTiltSource], v: (Boolean, TipTiltSource)) => if (v._1) s + v._2 else s)))
     } yield TrySeq(GuideConfig(mountGuide, m1Guide, m2Guide))
@@ -79,16 +79,16 @@ object TcsControllerEpics extends TcsController {
 
   private def getTelescopeConfig: TrySeq[TelescopeConfig] = {
     for {
-      xOffsetA <- TcsEpics.xoffsetPoA1
-      yOffsetA <- TcsEpics.yoffsetPoA1
-      xOffsetB <- TcsEpics.xoffsetPoB1
-      yOffsetB <- TcsEpics.yoffsetPoB1
-      xOffsetC <- TcsEpics.xoffsetPoC1
-      yOffsetC <- TcsEpics.yoffsetPoC1
-      wavelengthA <- TcsEpics.sourceAWavelength
-      wavelengthB <- TcsEpics.sourceBWavelength
-      wavelengthC <- TcsEpics.sourceCWavelength
-      m2Beam <- TcsEpics.chopBeam.map(decode[String, Beam])
+      xOffsetA <- TcsEpics.instance.xoffsetPoA1
+      yOffsetA <- TcsEpics.instance.yoffsetPoA1
+      xOffsetB <- TcsEpics.instance.xoffsetPoB1
+      yOffsetB <- TcsEpics.instance.yoffsetPoB1
+      xOffsetC <- TcsEpics.instance.xoffsetPoC1
+      yOffsetC <- TcsEpics.instance.yoffsetPoC1
+      wavelengthA <- TcsEpics.instance.sourceAWavelength
+      wavelengthB <- TcsEpics.instance.sourceBWavelength
+      wavelengthC <- TcsEpics.instance.sourceCWavelength
+      m2Beam <- TcsEpics.instance.chopBeam.map(decode[String, Beam])
     } yield TrySeq(TelescopeConfig(
       OffsetA(FocalPlaneOffset(OffsetX(Millimeters[Double](xOffsetA)), OffsetY(Millimeters[Double](yOffsetA)))),
       OffsetB(FocalPlaneOffset(OffsetX(Millimeters[Double](xOffsetB)), OffsetY(Millimeters[Double](yOffsetB)))),
@@ -146,12 +146,12 @@ object TcsControllerEpics extends TcsController {
 
   private def getGuidersTrackingConfig: TrySeq[GuidersTrackingConfig] = {
     for {
-      p1 <- getNodChopTrackingConfig(TcsEpics.pwfs1ProbeGuideConfig)
-      p2 <- getNodChopTrackingConfig(TcsEpics.pwfs2ProbeGuideConfig)
-      oi <- getNodChopTrackingConfig(TcsEpics.oiwfsProbeGuideConfig)
-      p1Follow <- TcsEpics.p1FollowS.map(decode[String, FollowOption])
-      p2Follow <- TcsEpics.p2FollowS.map(decode[String, FollowOption])
-      oiFollow <- TcsEpics.oiFollowS.map(decode[String, FollowOption])
+      p1 <- getNodChopTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideConfig)
+      p2 <- getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig)
+      oi <- getNodChopTrackingConfig(TcsEpics.instance.oiwfsProbeGuideConfig)
+      p1Follow <- TcsEpics.instance.p1FollowS.map(decode[String, FollowOption])
+      p2Follow <- TcsEpics.instance.p2FollowS.map(decode[String, FollowOption])
+      oiFollow <- TcsEpics.instance.oiFollowS.map(decode[String, FollowOption])
     } yield TrySeq(GuidersTrackingConfig(ProbeTrackingConfigP1(calcProbeTrackingConfig(p1Follow, p1)),
       ProbeTrackingConfigP2(calcProbeTrackingConfig(p2Follow, p2)),
       ProbeTrackingConfigOI(calcProbeTrackingConfig(oiFollow, oi)),
@@ -165,10 +165,10 @@ object TcsControllerEpics extends TcsController {
 
   private def getGuidersEnabled: TrySeq[GuidersEnabled] = {
     for {
-      p1On <- TcsEpics.pwfs1On.map(decode[BinaryYesNo, GuiderSensorOption])
-      p2On <- TcsEpics.pwfs2On.map(decode[BinaryYesNo, GuiderSensorOption])
-      oiOn <- TcsEpics.oiwfsOn.map(decode[BinaryYesNo, GuiderSensorOption])
-      aoOn <- TcsEpics.aowfsOn.map(decode[Double, GuiderSensorOption])
+      p1On <- TcsEpics.instance.pwfs1On.map(decode[BinaryYesNo, GuiderSensorOption])
+      p2On <- TcsEpics.instance.pwfs2On.map(decode[BinaryYesNo, GuiderSensorOption])
+      oiOn <- TcsEpics.instance.oiwfsOn.map(decode[BinaryYesNo, GuiderSensorOption])
+      aoOn <- TcsEpics.instance.aowfsOn.map(decode[Double, GuiderSensorOption])
     } yield TrySeq(GuidersEnabled(GuiderSensorOptionP1(p1On), GuiderSensorOptionP2(p2On), GuiderSensorOptionOI(oiOn),
       GuiderSensorOptionAO(aoOn)))
   }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read guider detectors state from TCS.")))
@@ -204,8 +204,8 @@ object TcsControllerEpics extends TcsController {
   import CodexScienceFoldPosition._
 
   private def getScienceFoldPosition: Option[ScienceFoldPosition] = for {
-    sfPos <- TcsEpics.sfName.map(decode[String, ScienceFoldPosition.Position])
-    sfParked <- TcsEpics.sfParked.map {
+    sfPos <- TcsEpics.instance.sfName.map(decode[String, ScienceFoldPosition.Position])
+    sfParked <- TcsEpics.instance.sfParked.map {
       _ != 0
     }
   } yield if (sfParked) ScienceFoldPosition.Parked
@@ -216,8 +216,8 @@ object TcsControllerEpics extends TcsController {
     else HrwfsPickupPosition.OUT)
 
   private def getHrwfsPickupPosition: Option[HrwfsPickupPosition] = for {
-    hwPos <- TcsEpics.agHwName.map(decode[String, HrwfsPickupPosition])
-    hwParked <- TcsEpics.agHwParked.map {
+    hwPos <- TcsEpics.instance.agHwName.map(decode[String, HrwfsPickupPosition])
+    hwParked <- TcsEpics.instance.agHwParked.map {
       _ != 0
     }
   } yield if (hwParked) HrwfsPickupPosition.Parked
@@ -232,7 +232,7 @@ object TcsControllerEpics extends TcsController {
 
   private def getIAA: TrySeq[InstrumentAlignAngle] = {
     for {
-      iaa <- TcsEpics.instrAA
+      iaa <- TcsEpics.instance.instrAA
     } yield TrySeq(InstrumentAlignAngle(Degrees[Double](iaa)))
   }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read IAA from TCS.")))
 
@@ -256,16 +256,16 @@ object TcsControllerEpics extends TcsController {
     })
 
   private def setTelescopeConfig(c: TelescopeConfig): SeqAction[Unit] = for {
-    _ <- TcsEpics.offsetACmd.setX(c.offsetA.self.x.self.toMillimeters)
-    _ <- TcsEpics.offsetACmd.setY(c.offsetA.self.y.self.toMillimeters)
-    _ <- TcsEpics.offsetBCmd.setX(c.offsetB.self.x.self.toMillimeters)
-    _ <- TcsEpics.offsetBCmd.setY(c.offsetB.self.y.self.toMillimeters)
-    _ <- TcsEpics.offsetCCmd.setX(c.offsetC.self.x.self.toMillimeters)
-    _ <- TcsEpics.offsetCCmd.setY(c.offsetC.self.y.self.toMillimeters)
-    _ <- TcsEpics.wavelSourceA.setWavel(c.wavelA.self.toMicrons)
-    _ <- TcsEpics.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
-    _ <- TcsEpics.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
-    _ <- TcsEpics.m2Beam.setBeam(encode(c.m2beam))
+    _ <- TcsEpics.instance.offsetACmd.setX(c.offsetA.self.x.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetACmd.setY(c.offsetA.self.y.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetBCmd.setX(c.offsetB.self.x.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetBCmd.setY(c.offsetB.self.y.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetCCmd.setX(c.offsetC.self.x.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetCCmd.setY(c.offsetC.self.y.self.toMillimeters)
+    _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelA.self.toMicrons)
+    _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
+    _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
+    _ <- TcsEpics.instance.m2Beam.setBeam(encode(c.m2beam))
   } yield TrySeq(())
 
   implicit private val encodeNodChopOption: EncodeEpicsValue[NodChopTrackingOption, String] = 
@@ -295,20 +295,20 @@ object TcsControllerEpics extends TcsController {
     }
 
   private def setGuidersWfs(c: GuidersEnabled): SeqAction[Unit] = for {
-    _ <- setGuiderWfs(TcsEpics.pwfs1ObserveCmd, TcsEpics.pwfs1StopObserveCmd, c.pwfs1.self)
-    _ <- setGuiderWfs(TcsEpics.pwfs2ObserveCmd, TcsEpics.pwfs2StopObserveCmd, c.pwfs2.self)
-    _ <- setGuiderWfs(TcsEpics.oiwfsObserveCmd, TcsEpics.oiwfsStopObserveCmd, c.oiwfs.self)
+    _ <- setGuiderWfs(TcsEpics.instance.pwfs1ObserveCmd, TcsEpics.instance.pwfs1StopObserveCmd, c.pwfs1.self)
+    _ <- setGuiderWfs(TcsEpics.instance.pwfs2ObserveCmd, TcsEpics.instance.pwfs2StopObserveCmd, c.pwfs2.self)
+    _ <- setGuiderWfs(TcsEpics.instance.oiwfsObserveCmd, TcsEpics.instance.oiwfsStopObserveCmd, c.oiwfs.self)
   } yield TrySeq(())
 
   private def setProbesTrackingConfig(c: GuidersTrackingConfig): SeqAction[Unit] = for {
-    _ <- setProbeTrackingConfig(TcsEpics.pwfs1ProbeGuideCmd, c.pwfs1.self)
-    _ <- setProbeTrackingConfig(TcsEpics.pwfs2ProbeGuideCmd, c.pwfs2.self)
-    _ <- setProbeTrackingConfig(TcsEpics.oiwfsProbeGuideCmd, c.oiwfs.self)
+    _ <- setProbeTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideCmd, c.pwfs1.self)
+    _ <- setProbeTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideCmd, c.pwfs2.self)
+    _ <- setProbeTrackingConfig(TcsEpics.instance.oiwfsProbeGuideCmd, c.oiwfs.self)
   } yield TrySeq(())
 
   def setScienceFoldConfig(sfPos: ScienceFoldPosition): SeqAction[Unit] = sfPos match {
-    case ScienceFoldPosition.Parked => TcsEpics.scienceFoldParkCmd.mark
-    case p: ScienceFoldPosition.Position => TcsEpics.scienceFoldPosCmd.setScfold(encode(p))
+    case ScienceFoldPosition.Parked => TcsEpics.instance.scienceFoldParkCmd.mark
+    case p: ScienceFoldPosition.Position => TcsEpics.instance.scienceFoldPosCmd.setScfold(encode(p))
   }
 
   implicit private val encodeHrwfsPickupPosition: EncodeEpicsValue[HrwfsPickupPosition, String] = EncodeEpicsValue((op: HrwfsPickupPosition)
@@ -319,8 +319,8 @@ object TcsControllerEpics extends TcsController {
     })
 
   def setHRPickupConfig(hrwfsPos: HrwfsPickupPosition): SeqAction[Unit] = hrwfsPos match {
-    case HrwfsPickupPosition.Parked => TcsEpics.hrwfsParkCmd.mark
-    case _ => TcsEpics.hrwfsPosCmd.setHrwfsPos(encode(hrwfsPos))
+    case HrwfsPickupPosition.Parked => TcsEpics.instance.hrwfsParkCmd.mark
+    case _ => TcsEpics.instance.hrwfsPosCmd.setHrwfsPos(encode(hrwfsPos))
   }
 
   private def setAGConfig(c: AGConfig): SeqAction[Unit] = for {
@@ -335,7 +335,7 @@ object TcsControllerEpics extends TcsController {
       case MountGuideOff => "off"
     })
 
-  private def setMountGuide(c: MountGuideOption): SeqAction[Unit] = TcsEpics.mountGuideCmd.setMode(encode(c))
+  private def setMountGuide(c: MountGuideOption): SeqAction[Unit] = TcsEpics.instance.mountGuideCmd.setMode(encode(c))
 
   implicit private val encodeM1GuideConfig: EncodeEpicsValue[M1GuideConfig, String] = EncodeEpicsValue((op: M1GuideConfig)
   => op match {
@@ -343,7 +343,7 @@ object TcsControllerEpics extends TcsController {
       case M1GuideOff => "off"
     })
 
-  private def setM1Guide(c: M1GuideConfig): SeqAction[Unit] = TcsEpics.m1GuideCmd.setState(encode(c))
+  private def setM1Guide(c: M1GuideConfig): SeqAction[Unit] = TcsEpics.instance.m1GuideCmd.setState(encode(c))
 
   implicit private val encodeM2GuideConfig: EncodeEpicsValue[M2GuideConfig, String] = EncodeEpicsValue((op: M2GuideConfig)
   => op match {
@@ -351,7 +351,7 @@ object TcsControllerEpics extends TcsController {
       case M2GuideOff => "off"
     })
 
-  private def setM2Guide(c: M2GuideConfig): SeqAction[Unit] = TcsEpics.m2GuideCmd.setState(encode(c))
+  private def setM2Guide(c: M2GuideConfig): SeqAction[Unit] = TcsEpics.instance.m2GuideCmd.setState(encode(c))
 
   implicit private val decodeInPosition: DecodeEpicsValue[String, Boolean] = DecodeEpicsValue(x => x.trim == "TRUE")
 
@@ -361,9 +361,9 @@ object TcsControllerEpics extends TcsController {
       _ <- setProbesTrackingConfig(gtc)
       _ <- setGuidersWfs(ge)
       _ <- setAGConfig(agc)
-      _ <- TcsEpics.post
+      _ <- TcsEpics.instance.post
       _ <- EitherT(Task(Log.info("TCS configuration command post").right))
-      _ <- TcsEpics.waitInPosition(Seconds(30))
+      _ <- TcsEpics.instance.waitInPosition(Seconds(30))
       _ <- EitherT(Task(Log.info("TCS inposition").right))
     } yield TrySeq(())
 
@@ -371,7 +371,7 @@ object TcsControllerEpics extends TcsController {
     _ <- setMountGuide(gc.mountGuide)
     _ <- setM1Guide(gc.m1Guide)
     _ <- setM2Guide(gc.m2Guide)
-    _ <- TcsEpics.post
+    _ <- TcsEpics.instance.post
   } yield TrySeq(())
 
 }

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
@@ -350,8 +350,12 @@ object TcsEpics extends EpicsSystem {
   val CA_CONFIG_FILE = "/Tcs.xml"
   val TCS_TOP = "tc1:"
 
-  // Ugly use of null. But if it is used before initialization, then the application deserves to crash.
-  var instance: TcsEpics = null
+
+  // Still using a var, but at least now it's hidden. Attempts to access the single instance will
+  // now result in an Exception with a meaningful message, instead of a NullPointerExecption
+  private var instanceInternal = Option.empty[TcsEpics]
+  lazy val instance: TcsEpics = instanceInternal.getOrElse(
+    throw new Exception("Attempt to reference TcsEpics single instance before initialization."))
 
   override def init(service: CaService): TrySeq[Unit] = {
     try {
@@ -364,7 +368,7 @@ object TcsEpics extends EpicsSystem {
         .withTop("oiwfs", "toiwfs:")
         .buildAll()
 
-        instance = new TcsEpics(service)
+        instanceInternal = Some(new TcsEpics(service))
 
         TrySeq(())
 

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 import java.util.{Timer, TimerTask}
 import java.util.logging.Logger
-import edu.gemini.seqexec.server.TcsEpics._
+import edu.gemini.seqexec.server.EpicsCommand._
 import edu.gemini.seqexec.server.tcs.{BinaryYesNo, BinaryOnOff}
 
 import collection.JavaConversions._
@@ -25,205 +25,266 @@ import scalaz.concurrent.Task
  * Created by jluhrs on 10/1/15.
  */
 
-object TcsEpics {
+final class TcsEpics(epicsService: CaService) {
+
   import TcsEpics._
   import EpicsCommand.setParameter
-
 
   // This is a bit ugly. Commands are triggered from the main apply record, so I just choose an arbitrary command here.
   // Triggering that command will trigger all the marked commands.
   def post: SeqAction[Unit] = m1GuideCmd.post
 
   object m1GuideCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("m1Guide"))
+    override val cs = Option(epicsService.getCommandSender("m1Guide"))
     val state = cs.map(_.getString("state"))
+
     def setState(v: String): SeqAction[Unit] = setParameter(state, v)
   }
 
   object m2GuideCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("m2Guide"))
+    override val cs = Option(epicsService.getCommandSender("m2Guide"))
     val state = cs.map(_.getString("state"))
+
     def setState(v: String): SeqAction[Unit] = setParameter[String](state, v)
   }
 
   object mountGuideCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("mountGuide"))
+    override val cs = Option(epicsService.getCommandSender("mountGuide"))
 
     val source = cs.map(_.getString("source"))
+
     def setSource(v: String): SeqAction[Unit] = setParameter(source, v)
 
     val p1weight = cs.map(_.getDouble("p1weight"))
+
     def setP1Weight(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](p1weight, v)
 
     val p2weight = cs.map(_.getDouble("p2weight"))
+
     def setP2Weight(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](p2weight, v)
 
     val mode = cs.map(_.getString("mode"))
+
     def setMode(v: String): SeqAction[Unit] = setParameter(mode, v)
   }
 
   object offsetACmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("offsetPoA1"))
+    override val cs = Option(epicsService.getCommandSender("offsetPoA1"))
 
     val x = cs.map(_.getDouble("x"))
+
     def setX(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](x, v)
 
     val y = cs.map(_.getDouble("y"))
+
     def setY(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](y, v)
   }
 
   object offsetBCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("offsetPoB1"))
+    override val cs = Option(epicsService.getCommandSender("offsetPoB1"))
 
     val x = cs.map(_.getDouble("x"))
+
     def setX(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](x, v)
 
     val y = cs.map(_.getDouble("y"))
+
     def setY(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](y, v)
   }
 
   object offsetCCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("offsetPoC1"))
+    override val cs = Option(epicsService.getCommandSender("offsetPoC1"))
 
     val x = cs.map(_.getDouble("x"))
+
     def setX(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](x, v)
 
     val y = cs.map(_.getDouble("y"))
+
     def setY(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](y, v)
   }
 
   object wavelSourceA extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("wavelSourceA"))
+    override val cs = Option(epicsService.getCommandSender("wavelSourceA"))
 
     val wavel = cs.map(_.getDouble("wavel"))
+
     def setWavel(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](wavel, v)
   }
 
   object wavelSourceB extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("wavelSourceB"))
+    override val cs = Option(epicsService.getCommandSender("wavelSourceB"))
 
     val wavel = cs.map(_.getDouble("wavel"))
+
     def setWavel(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](wavel, v)
   }
 
   object wavelSourceC extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("wavelSourceC"))
+    override val cs = Option(epicsService.getCommandSender("wavelSourceC"))
 
     val wavel = cs.map(_.getDouble("wavel"))
+
     def setWavel(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](wavel, v)
   }
 
   object m2Beam extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("m2Beam"))
+    override val cs = Option(epicsService.getCommandSender("m2Beam"))
 
     val beam = cs.map(_.getString("beam"))
+
     def setBeam(v: String): SeqAction[Unit] = setParameter(beam, v)
   }
 
-  object pwfs1ProbeGuideCmd extends ProbeGuideCmd("pwfs1Guide")
-  object pwfs2ProbeGuideCmd extends ProbeGuideCmd("pwfs2Guide")
-  object oiwfsProbeGuideCmd extends ProbeGuideCmd("oiwfsGuide")
+  object pwfs1ProbeGuideCmd extends ProbeGuideCmd("pwfs1Guide", epicsService)
+
+  object pwfs2ProbeGuideCmd extends ProbeGuideCmd("pwfs2Guide", epicsService)
+
+  object oiwfsProbeGuideCmd extends ProbeGuideCmd("oiwfsGuide", epicsService)
 
   object pwfs1Park extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("pwfs1Park"))
+    override val cs = Option(epicsService.getCommandSender("pwfs1Park"))
   }
 
   object pwfs2Park extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("pwfs2Park"))
+    override val cs = Option(epicsService.getCommandSender("pwfs2Park"))
   }
 
   object oiwfsPark extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("oiwfsPark"))
+    override val cs = Option(epicsService.getCommandSender("oiwfsPark"))
   }
 
   object pwfs1StopObserveCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("pwfs1StopObserve"))
+    override val cs = Option(epicsService.getCommandSender("pwfs1StopObserve"))
   }
 
   object pwfs2StopObserveCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("pwfs2StopObserve"))
+    override val cs = Option(epicsService.getCommandSender("pwfs2StopObserve"))
   }
 
   object oiwfsStopObserveCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("oiwfsStopObserve"))
+    override val cs = Option(epicsService.getCommandSender("oiwfsStopObserve"))
   }
 
-  object pwfs1ObserveCmd extends WfsObserveCmd("pwfs1Observe")
-  object pwfs2ObserveCmd extends WfsObserveCmd("pwfs2Observe")
-  object oiwfsObserveCmd extends WfsObserveCmd("oiwfsObserve")
+  object pwfs1ObserveCmd extends WfsObserveCmd("pwfs1Observe", epicsService)
+
+  object pwfs2ObserveCmd extends WfsObserveCmd("pwfs2Observe", epicsService)
+
+  object oiwfsObserveCmd extends WfsObserveCmd("oiwfsObserve", epicsService)
 
   object hrwfsParkCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("hrwfsPark"))
+    override val cs = Option(epicsService.getCommandSender("hrwfsPark"))
   }
 
   object hrwfsPosCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("hrwfs"))
+    override val cs = Option(epicsService.getCommandSender("hrwfs"))
 
     val hrwfsPos = cs.map(_.getString("hrwfsPos"))
+
     def setHrwfsPos(v: String): SeqAction[Unit] = setParameter(hrwfsPos, v)
   }
 
   object scienceFoldParkCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("scienceFoldPark"))
+    override val cs = Option(epicsService.getCommandSender("scienceFoldPark"))
   }
 
   object scienceFoldPosCmd extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender("scienceFold"))
+    override val cs = Option(epicsService.getCommandSender("scienceFold"))
 
     val scfold = cs.map(_.getString("scfold"))
+
     def setScfold(v: String): SeqAction[Unit] = setParameter(scfold, v)
   }
 
-  val tcsState = CaService.getInstance().getStatusAcceptor("tcsstate")
+  val tcsState = epicsService.getStatusAcceptor("tcsstate")
 
   def absorbTipTilt: Option[Integer] = Option(tcsState.getIntegerAttribute("absorbTipTilt").value)
+
   def m1GuideSource: Option[String] = Option(tcsState.getStringAttribute("m1GuideSource").value)
+
   private val m1GuideAttr: Option[CaAttribute[BinaryOnOff]] = Option(tcsState.addEnum("m1Guide",
     TCS_TOP + "im:m1GuideOn", classOf[BinaryOnOff], "M1 guide"))
+
   def m1Guide: Option[BinaryOnOff] = m1GuideAttr.flatMap(v => Option(v.value))
+
   def m2p1Guide: Option[String] = Option(tcsState.getStringAttribute("m2p1Guide").value)
+
   def m2p2Guide: Option[String] = Option(tcsState.getStringAttribute("m2p2Guide").value)
+
   def m2oiGuide: Option[String] = Option(tcsState.getStringAttribute("m2oiGuide").value)
+
   def m2aoGuide: Option[String] = Option(tcsState.getStringAttribute("m2aoGuide").value)
+
   def comaCorrect: Option[String] = Option(tcsState.getStringAttribute("comaCorrect").value)
+
   private val m2GuideStateAttr: Option[CaAttribute[BinaryOnOff]] = Option(tcsState.addEnum("m2GuideState",
     TCS_TOP + "om:m2GuideState", classOf[BinaryOnOff], "M2 guiding state"))
+
   def m2GuideState: Option[BinaryOnOff] = m2GuideStateAttr.flatMap(v => Option(v.value))
+
   def xoffsetPoA1: Option[Double] = Option(tcsState.getDoubleAttribute("xoffsetPoA1").value).map(_.doubleValue)
+
   def yoffsetPoA1: Option[Double] = Option(tcsState.getDoubleAttribute("yoffsetPoA1").value).map(_.doubleValue)
+
   def xoffsetPoB1: Option[Double] = Option(tcsState.getDoubleAttribute("xoffsetPoB1").value).map(_.doubleValue)
+
   def yoffsetPoB1: Option[Double] = Option(tcsState.getDoubleAttribute("yoffsetPoB1").value).map(_.doubleValue)
+
   def xoffsetPoC1: Option[Double] = Option(tcsState.getDoubleAttribute("xoffsetPoC1").value).map(_.doubleValue)
+
   def yoffsetPoC1: Option[Double] = Option(tcsState.getDoubleAttribute("yoffsetPoC1").value).map(_.doubleValue)
+
   def sourceAWavelength: Option[Double] = Option(tcsState.getDoubleAttribute("sourceAWavelength").value).map(_.doubleValue)
+
   def sourceBWavelength: Option[Double] = Option(tcsState.getDoubleAttribute("sourceBWavelength").value).map(_.doubleValue)
+
   def sourceCWavelength: Option[Double] = Option(tcsState.getDoubleAttribute("sourceCWavelength").value).map(_.doubleValue)
+
   def chopBeam: Option[String] = Option(tcsState.getStringAttribute("chopBeam").value)
+
   def p1FollowS: Option[String] = Option(tcsState.getStringAttribute("p1FollowS").value)
+
   def p2FollowS: Option[String] = Option(tcsState.getStringAttribute("p2FollowS").value)
+
   def oiFollowS: Option[String] = Option(tcsState.getStringAttribute("oiFollowS").value)
+
   private val pwfs1OnAttr: Option[CaAttribute[BinaryYesNo]] = Option(tcsState.addEnum("pwfs1On",
     TCS_TOP + "drives:p1Integrating", classOf[BinaryYesNo], "P1 integrating"))
+
   def pwfs1On: Option[BinaryYesNo] = pwfs1OnAttr.flatMap(v => Option(v.value))
+
   private val pwfs2OnAttr: Option[CaAttribute[BinaryYesNo]] = Option(tcsState.addEnum("pwfs2On",
     TCS_TOP + "drives:p2Integrating", classOf[BinaryYesNo], "P2 integrating"))
+
   def pwfs2On: Option[BinaryYesNo] = pwfs2OnAttr.flatMap(v => Option(v.value))
+
   private val oiwfsOnAttr: Option[CaAttribute[BinaryYesNo]] = Option(tcsState.addEnum("oiwfsOn",
     TCS_TOP + "drives:oiIntegrating", classOf[BinaryYesNo], "P2 integrating"))
+
   def oiwfsOn: Option[BinaryYesNo] = oiwfsOnAttr.flatMap(v => Option(v.value))
+
   def aowfsOn: Option[Double] = Option(tcsState.getDoubleAttribute("aowfsOn").value).map(_.doubleValue)
+
   def sfName: Option[String] = Option(tcsState.getStringAttribute("sfName").value)
+
   //def sfParked: Option[Integer] = Option(tcsState.getIntegerAttribute("sfParked").value)
   def sfParked: Option[Integer] = Some(0)
+
   def agHwName: Option[String] = Option(tcsState.getStringAttribute("agHwName").value)
-//  def agHwParked: Option[Integer] = Option(tcsState.getIntegerAttribute("agHwParked").value)
+
+  //  def agHwParked: Option[Integer] = Option(tcsState.getIntegerAttribute("agHwParked").value)
   def agHwParked: Option[Integer] = Some(1)
+
   def instrAA: Option[Double] = Option(tcsState.getDoubleAttribute("instrAA").value).map(_.doubleValue)
+
   private val inPositionAttr: CaAttribute[String] = tcsState.getStringAttribute("inPosition")
+
   def inPosition: Option[String] = Option(inPositionAttr.value)
 
   object pwfs1ProbeGuideConfig extends ProbeGuideConfig("p1", tcsState)
+
   object pwfs2ProbeGuideConfig extends ProbeGuideConfig("p2", tcsState)
+
   object oiwfsProbeGuideConfig extends ProbeGuideConfig("oi", tcsState)
 
   def waitInPosition(timeout: Time): SeqAction[Unit] =
@@ -233,14 +294,14 @@ object TcsEpics {
       val lock = new ReentrantLock()
       def locked(f: => Unit): Unit = {
         lock.lock()
-        try{
+        try {
           f
-        }finally {
-         lock.unlock()
+        } finally {
+          lock.unlock()
         }
       }
 
-      if(!inPositionAttr.values().isEmpty && inPositionAttr.value == "TRUE") {
+      if (!inPositionAttr.values().isEmpty && inPositionAttr.value == "TRUE") {
         f(TrySeq(()).right)
       } else {
 
@@ -277,13 +338,46 @@ object TcsEpics {
           inPositionAttr.addListener(statusListener)
         }
       }
-    } ) ) )
+    })))
 
 
+
+}
+
+object TcsEpics extends EpicsSystem {
+
+  val Log = Logger.getLogger(getClass.getName)
+  val CA_CONFIG_FILE = "/Tcs.xml"
   val TCS_TOP = "tc1:"
 
-  sealed class ProbeGuideCmd(csName: String) extends EpicsCommand {
-    override val cs = Option(CaService.getInstance().getCommandSender(csName))
+  // Ugly use of null. But if it is used before initialization, then the application deserves to crash.
+  var instance: TcsEpics = null
+
+  override def init(service: CaService): TrySeq[Unit] = {
+    try {
+      (new XMLBuilder).fromStream(this.getClass.getResourceAsStream(CA_CONFIG_FILE))
+        .withCaService(service)
+        .withTop("tcs", TcsEpics.TCS_TOP)
+        .withTop("ag", "tag:")
+        .withTop("m2", "tc1:m2:")
+        .withTop("ao", "tc1:ao:")
+        .withTop("oiwfs", "toiwfs:")
+        .buildAll()
+
+        instance = new TcsEpics(service)
+
+        TrySeq(())
+
+    } catch {
+      case c: Throwable =>
+        Log.warning("TcsEpics: Problem initializing EPICS service: " + c.getMessage + "\n"
+          + c.getStackTrace.mkString("\n"))
+        TrySeq.fail(SeqexecFailure.SeqexecException(c))
+    }
+  }
+
+  sealed class ProbeGuideCmd(csName: String, epicsService: CaService) extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender(csName))
 
     val nodachopa = cs.map(_.getString("nodachopa"))
     def setNodachopa(v: String): SeqAction[Unit] = setParameter(nodachopa, v)
@@ -313,8 +407,8 @@ object TcsEpics {
     def setNodcchopc(v: String): SeqAction[Unit] = setParameter(nodcchopc, v)
   }
 
-  sealed class WfsObserveCmd(csName: String) extends EpicsCommand {
-    override val cs= Option(CaService.getInstance().getCommandSender(csName))
+  sealed class WfsObserveCmd(csName: String, epicsService: CaService) extends EpicsCommand {
+    override val cs= Option(epicsService.getCommandSender(csName))
 
     val noexp = cs.map(_.getInteger("noexp"))
     def setNoexp(v: Integer): SeqAction[Unit] = setParameter(noexp, v)
@@ -350,33 +444,4 @@ object TcsEpics {
     def nodcchopc: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodcchopc").value)
   }
 
-}
-
-object TcsEpicsInitializer {
-  val Log = Logger.getLogger(getClass.getName)
-  val CA_CONFIG_FILE = "/Tcs.xml"
-
-  def init: TrySeq[Unit] = {
-    try {
-      (new XMLBuilder).fromStream(this.getClass.getResourceAsStream(CA_CONFIG_FILE))
-        .withTop("tcs", TcsEpics.TCS_TOP)
-        .withTop("ag", "tag:")
-        .withTop("m2", "tc1:m2:")
-        .withTop("ao", "tc1:ao:")
-        .withTop("oiwfs", "toiwfs:")
-        .buildAll()
-
-      val tcsState = CaService.getInstance().getStatusAcceptor("ẗcsstate")
-
-      TrySeq(())
-    } catch {
-      case c: Throwable =>
-        Log.warning("TcsEpics: Problem initializing EPICS service: " + c.getMessage)
-        SeqexecFailure.SeqexecException(c).left
-    }
-  }
-
-  def cleanup(): Unit = {
-    CaService.getInstance().unbind()
-  }
 }


### PR DESCRIPTION
The main goal of this task was to clean the sequence commands. In the initial prototype, commands could only be triggered from the console. The code that implemented the console commands had details that should have been in the sequence command themselves, so I fixed that. Also, I modified some commands to provide an immediate response in case of an error. For example, the method to run a sequence would have returned a Task, that has to be run to know if the sequence could actually be run. But if there was no problem, running that Task would actually run the sequence. So now the command is more like a "start sequence", that return a value that tells if the sequence started or there was a problem.

A secondary issue that I tried to fix is that a previous modification that changed some singletons to be objects exposed an initialization problem.