### PR TITLE
REL-2632: Small TableUtil bug

### DIFF
--- a/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TableUtil.java
+++ b/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TableUtil.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: TableUtil.java 18053 2009-02-20 20:16:23Z swalker $
- */
-
 package jsky.util.gui;
 
 import javax.swing.*;
@@ -92,9 +85,9 @@ public class TableUtil {
 
             if (!show.isPresent() || show.get()[colIdx]) {
                 final TableCellRenderer cellRenderer = getColumnRenderer(table, colIdx);
-                final TableCellRenderer headerRenderer = Optional.ofNullable(column.getHeaderRenderer()).orElse(cellRenderer);
+                final TableCellRenderer headerRenderer = Optional.ofNullable(column.getHeaderRenderer()).orElse(getHeaderRenderer(table));
 
-                // check the header width
+                // Check the header width if we can.
                 final Component headerComponent = headerRenderer.getTableCellRendererComponent(table, column.getHeaderValue(), false, false, -1, colIdx);
                 final int headerWidth           = headerComponent.getPreferredSize().width;
 

--- a/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TableUtil.java
+++ b/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TableUtil.java
@@ -87,7 +87,7 @@ public class TableUtil {
                 final TableCellRenderer cellRenderer = getColumnRenderer(table, colIdx);
                 final TableCellRenderer headerRenderer = Optional.ofNullable(column.getHeaderRenderer()).orElse(getHeaderRenderer(table));
 
-                // Check the header width if we can.
+                // check the header width
                 final Component headerComponent = headerRenderer.getTableCellRendererComponent(table, column.getHeaderValue(), false, false, -1, colIdx);
                 final int headerWidth           = headerComponent.getPreferredSize().width;
 


### PR DESCRIPTION
The former `TableUtil` was not calculating column widths correctly as it was using the wrong renderers, so I made an attempt to fix this properly.

However, I made a small error in doing so, which used the wrong renderer to calculate header widths if a header renderer was not explicitly defined, and resulted in an exception in terms of the data contained in the data.

This can be seen by creating a new GSAOI observation and attempting to do a GeMS manual guide star search: a table will pop open and a complaint will be issued about String vs. Boolean types.

This PR simply changes the header renderer to be the correct one, i.e. a default, instead of using the cell renderer if the header renderer is not explicitly defined.