### PR TITLE
REL-2621: Fix for erratic behaviour of Guide Group Name text widget

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -479,7 +479,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
                     // N.B. don't trim, otherwise user can't include space in group name
                     final String name = _curGroup.getName().getOrElse("");
-                    _w.guideGroupName.setValue(name);
+                    if (!_w.guideGroupName.getValue().equals(name))
+                        _w.guideGroupName.setValue(name);
 
                     final boolean editable = OTOptions.areRootAndCurrentObsIfAnyEditable(getProgram(), getContextObservation());
                     _w.removeButton.setEnabled(editable);


### PR DESCRIPTION
In previous versions of the OT, the target editor widget that allowed one to specify a name for a guide group was broken in that if edits were attempted to be made to the name, the caret would jump to the end of the text widget.

This can be seen if one goes to the target editor, adds a guide probe target, creates a guide group, and then enters a name for the group and tries to edit the name in the middle of group name field.
(I would include a screenshot, but there is nothing visible to be seen, really.)

This small fix simply checks to see if the guide group text widget requires updating, i.e. if the text in the widget differs from the name of the currently selected group, and only updates the guide group text widget contents require it.