### PR TITLE
REL-2644: fix confirm group change bug

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -908,7 +908,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
     // Returns true if the new primary guide group should be set, false to cancel
     // the operation.
     boolean confirmGroupChange(final GuideGroup oldPrimary, final GuideGroup newPrimary) {
-        final List<OffsetPosList<OffsetPosBase>> posLists = OffsetUtil.allOffsetPosLists(owner.getNode());
+        final List<OffsetPosList<OffsetPosBase>> posLists = OffsetUtil.allOffsetPosLists(owner.getContextObservation());
         if (!posLists.isEmpty()) {
             final SortedSet<GuideProbe> oldGuideProbes = oldPrimary.getReferencedGuiders();
             final SortedSet<GuideProbe> newGuideProbes = newPrimary.getReferencedGuiders();


### PR DESCRIPTION
In an offset position list, you can configure custom guiding options for specific guide probes.  For example, you can specify that PWFS2 be parked at a particular offset position.  Over in the target component, you can specify multiple guide groups, some of which may have a PWFS2 guide star while others do not.  When you have custom guide configuration for a guide probe and then switch guide groups to one that doesn't include the probe for which there is custom configuration, the OT should display a confirmation dialog informing you of the consequences and allowing you to reconsider.

This is a small bug fix that takes longer to explain than fix.  The upshot is that we were calling `OffsetUtil.allOffsetPosLists` with a target component node instead of with its "context" observation.  That results in an empty list of offset position lists instead of all the offset position lists in the observation.