### PR TITLE
REL-2522: Implement backend monitors for hbfphase1-lv1

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -36,7 +36,7 @@ def common(pv: Version) = AppConfig(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",
     "org.osgi.framework.startlevel.beginning" -> "100",
     "org.osgi.framework.bootdelegation"       -> "*",
-    "edu.gemini.pit.test"                     -> "true",
+    //"edu.gemini.pit.test"                     -> "true",
     "edu.gemini.ags.host"                     -> "gnodb.gemini.edu",
     "edu.gemini.ags.port"                     -> "8443"
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization in Global := "edu.gemini.ocs"
 
 ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2016B", true, 2, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2016B", false, 2, 1, 0)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.p1monitor/build.sbt
+++ b/bundle/edu.gemini.p1monitor/build.sbt
@@ -11,13 +11,6 @@ unmanagedJars in Compile ++= Seq(
   new File(baseDirectory.value, "../../lib/bundle/osgi.cmpn-4.3.1.jar"),
   new File(baseDirectory.value, "../../lib/bundle/osgi.core-4.3.1.jar"))
 
-libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-actors" % "2.11.7",
-  "org.scalaz" %% "scalaz-core" % "7.1.6",
-  "org.scalaz" %% "scalaz-concurrent" % "7.1.6",
-  "org.scalaz" %% "scalaz-effect" % "7.1.6")
-
-
 ocsBundleSettings // defined in top-level project/ folder
 
 osgiSettings // from the sbt-osgi plugin

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2016A.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2016A.xml
@@ -1,0 +1,56 @@
+<conf>
+    <smtp>localhost</smtp>
+
+    <bcc>swalker@gemini.edu</bcc>
+    <bcc>cquiroz@gemini.edu</bcc>
+
+    <type name="DirectorTime">
+        <dir>/home/software/proposals/directors_time/proposals/2016A</dir>
+        <to>pitdd@gemini.edu</to>
+    </type>
+
+    <type name="PoorWeather">
+        <dir>/home/software/proposals/poor_weather/proposals/2016A</dir>
+        <to>pitpw@gemini.edu</to>
+    </type>
+
+    <type name="DemoScience">
+        <dir>/home/software/proposals/demo_science/proposals/2016A</dir>
+        <to>pitds@gemini.edu</to>
+    </type>
+
+    <type name="SystemVerification">
+        <dir>/home/software/proposals/system_verification/proposals/2016A</dir>
+        <to>pitsv@gemini.edu</to>
+    </type>
+
+    <type name="FastTurnaround">
+        <dir>/home/software/proposals/fast_turnaround/proposals/2016A</dir>
+        <to>pitft@gemini.edu</to>
+    </type>
+
+    <filetranslation>
+        <translation>
+            <from>System Verification</from>
+            <to>SV</to>
+        </translation>
+        <translation>
+            <from>Poor Weather</from>
+            <to>PW</to>
+        </translation>
+        <translation>
+            <from>Directors Time</from>
+            <to>DT</to>
+        </translation>
+        <translation>
+            <from>Demo Science</from>
+            <to>DS</to>
+        </translation>
+        <translation>
+            <from>ft</from>
+            <to>FT</to>
+        </translation>
+
+    </filetranslation>
+
+</conf>

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2016B.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2016B.xml
@@ -3,81 +3,82 @@
 
     <bcc>swalker@gemini.edu</bcc>
     <bcc>cquiroz@gemini.edu</bcc>
-    <bcc>bmiller@gemini.edu</bcc>
-    <bcc>astephens@gemini.edu</bcc>
 
     <type name="DirectorTime">
-        <dir>/home/software/test_proposals/directors_time/proposals/2016B</dir>
+        <dir>/home/software/proposals/directors_time/proposals/2016B</dir>
         <to>pitdd@gemini.edu</to>
     </type>
 
     <type name="PoorWeather">
-        <dir>/home/software/test_proposals/poor_weather/proposals/2016B</dir>
+        <dir>/home/software/proposals/poor_weather/proposals/2016B</dir>
         <to>pitpw@gemini.edu</to>
     </type>
 
     <type name="DemoScience">
-        <dir>/home/software/test_proposals/demo_science/proposals/2016B</dir>
+        <dir>/home/software/proposals/demo_science/proposals/2016B</dir>
         <to>pitds@gemini.edu</to>
     </type>
 
     <type name="SystemVerification">
-        <dir>/home/software/test_proposals/system_verification/proposals/2016B</dir>
+        <dir>/home/software/proposals/system_verification/proposals/2016B</dir>
         <to>pitsv@gemini.edu</to>
     </type>
 
     <type name="FastTurnaround">
-        <dir>/home/software/test_proposals/fast_turnaround/proposals/2016B</dir>
+        <dir>/home/software/proposals/fast_turnaround/proposals/2016B</dir>
         <to>pitft@gemini.edu</to>
     </type>
 
     <type name="LargeProgram">
-        <dir>/home/software/test_proposals/large_program/proposals/2016B</dir>
+        <dir>/home/software/proposals/large_program/proposals/2016B</dir>
         <to>pitlp@gemini.edu</to>
     </type>
 
     <type name="ar">
-        <dir>/home/software/test_proposals/ar/proposals/2016B</dir>
+        <dir>/home/software/proposals/ar/proposals/2016B</dir>
         <to>pit.ar@gemini.edu</to>
     </type>
 
     <type name="au">
-        <dir>/home/software/test_proposals/au/proposals/2016B</dir>
+        <dir>/home/software/proposals/au/proposals/2016B</dir>
         <to>pit.au@gemini.edu</to>
+        <template>au</template>
     </type>
 
     <type name="br">
-        <dir>/home/software/test_proposals/br/proposals/2016B</dir>
+        <dir>/home/software/proposals/br/proposals/2016B</dir>
         <to>pit.br@gemini.edu</to>
     </type>
 
     <type name="ca">
-        <dir>/home/software/test_proposals/ca/proposals/2016B</dir>
+        <dir>/home/software/proposals/ca/proposals/2016B</dir>
         <to>pit.ca@gemini.edu</to>
     </type>
 
     <type name="cl">
-        <dir>/home/software/test_proposals/cl/proposals/2016B</dir>
+        <dir>/home/software/proposals/cl/proposals/2016B</dir>
         <to>pit.cl@gemini.edu</to>
+        <template>cl</template>
     </type>
 
     <type name="kr">
-        <dir>/home/software/test_proposals/kr/proposals/2016B</dir>
+        <dir>/home/software/proposals/kr/proposals/2016B</dir>
         <to>pit.kr@gemini.edu</to>
     </type>
 
     <type name="uh">
-        <dir>/home/software/test_proposals/uh/proposals/2016B</dir>
+        <dir>/home/software/proposals/uh/proposals/2016B</dir>
         <to>pit.uh@gemini.edu</to>
     </type>
 
     <type name="us">
-        <dir>/home/software/test_proposals/us/proposals/2016B</dir>
+        <dir>/home/software/proposals/us/proposals/2016B</dir>
         <to>pit.us@gemini.edu</to>
+        <template>us</template>
     </type>
 
     <type name="subaru">
-        <dir>/home/software/test_proposals/subaru/proposals/2016B</dir>
+        <dir>/home/software/proposals/subaru/proposals/2016B</dir>
         <to>pit.subaru@gemini.edu</to>
     </type>
 

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.test.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.test.xml
@@ -9,8 +9,9 @@
     </type>
 
     <type name="PoorWeather">
-        <dir>/tmp</dir>
+        <dir>/tmp/pw</dir>
         <to>cquiroz@gemini.edu</to>
+        <template>au</template>
     </type>
 
     <type name="DemoScience">
@@ -21,6 +22,7 @@
     <type name="SystemVerification">
         <dir>/tmp</dir>
         <to>cquiroz@gemini.edu</to>
+        <template>au</template>
     </type>
 
     <filetranslation>

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.test.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.test.xml
@@ -4,22 +4,22 @@
     <bcc>cquiroz@gemini.edu</bcc>
 
     <type name="DirectorTime">
-        <dir>/home/software/phase1/test/directors_time/proposals/2014B</dir>
+        <dir>/tmp</dir>
         <to>cquiroz@gemini.edu</to>
     </type>
 
     <type name="PoorWeather">
-        <dir>/home/software/phase1/test/poor_weather/proposals/2014B</dir>
+        <dir>/tmp</dir>
         <to>cquiroz@gemini.edu</to>
     </type>
 
     <type name="DemoScience">
-        <dir>/home/software/phase1/test/demo_science/proposals/2014B</dir>
+        <dir>/tmp</dir>
         <to>cquiroz@gemini.edu</to>
     </type>
 
     <type name="SystemVerification">
-        <dir>/home/software/phase1/test/system_verification/proposals/2014B</dir>
+        <dir>/tmp</dir>
         <to>cquiroz@gemini.edu</to>
     </type>
 

--- a/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/P1MonitorDirMonitor.scala
+++ b/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/P1MonitorDirMonitor.scala
@@ -19,14 +19,12 @@ class P1MonitorDirMonitor(cfg: P1MonitorConfig) extends DirListener {
     dirScanner.foreach {
       _.startMonitoring(this)
     }
-
   }
 
   def stopMonitoring() {
     dirScanner.foreach {
       _.stopMonitoring()
     }
-
   }
 
   def dirChanged(evt: DirEvent) {
@@ -74,7 +72,7 @@ class P1MonitorDirMonitor(cfg: P1MonitorConfig) extends DirListener {
 
             val r:Option[ProposalFileGroup] = try {
               val summaryFile = new File(f.getAbsolutePath.substring(0, f.getAbsolutePath.length - 4) + "_summary.pdf")
-              LOG.info("Build summary report of %s at %s".format(f, summaryFile))
+              LOG.info(s"Build summary report of $f at $summaryFile")
               P1PDF.createFromFile(f, P1PDF.DEFAULT, summaryFile)
               Some(new ProposalFileGroup(Some(f), newPDFile, Some(summaryFile)))
             } catch {

--- a/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/fetch/FetchRequest.scala
+++ b/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/fetch/FetchRequest.scala
@@ -1,7 +1,6 @@
 package edu.gemini.p1monitor.fetch
 
 import javax.servlet.http.HttpServletRequest
-import edu.gemini.model.p1.immutable.SpecialProposalType
 
 /**
  * A servlet request wrapper that makes it convenient to obtain the request


### PR DESCRIPTION
This PR contains updates to the phase1 monitor including:

- Remove the use of the legacy actors library
- Support that PDF templates can be assigned on a per monitor basis
- Setup final configuration of the PIT and P1-monitor for the final release