### PR TITLE
Phoenix and DSSI should display a single site where it is installed

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
@@ -10,7 +10,7 @@ object Dssi {
   class SiteNode extends SingleSelectNode[Unit, VisitorSite, DssiBlueprint](()) {
     val title       = "Site"
     val description = "Select the site."
-    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
+    def choices     = GNVisitorSite :: Nil
 
     def apply(fs: VisitorSite) = Right(DssiBlueprint(fs))
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Phoenix.scala
@@ -9,7 +9,7 @@ object Phoenix {
   class SiteNode extends SingleSelectNode[Unit, VisitorSite, Site](()) {
     val title       = "Site"
     val description = "Select the site."
-    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
+    def choices     = GSVisitorSite :: Nil
 
     def apply(s: VisitorSite) = Left(new FocalPlaneUnitNode(s.site))
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/PhoenixSpec.scala
@@ -9,7 +9,7 @@ class PhoenixSpec extends Specification {
     "includes a Site" in {
       val phoenix = Phoenix()
       phoenix.title must beEqualTo("Site")
-      phoenix.choices must have size 2
+      phoenix.choices must have size 1
       // Check no default site
       phoenix.default must beNone
     }


### PR DESCRIPTION
Last minute request to change the PIT UI, displaying only the sites where a visitor instrument is really installed