### PR TITLE
prep for target model swap

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -88,7 +88,7 @@ object AgsStrategy {
     def applyTo(env: TargetEnvironment): TargetEnvironment = {
       def findMatching(gpt: GuideProbeTargets, target: SPTarget): Option[SPTarget] = {
         def name(t: SPTarget): Option[String] =
-          Option(t.getTarget.getName).map(_.trim)
+          Option(t.getName).map(_.trim)
 
         name(target).flatMap(n => gpt.getTargets.asScalaList.find(name(_).exists(_ == n)))
       }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsGuideStars.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsGuideStars.scala
@@ -133,7 +133,7 @@ case class GemsGuideStars(pa: Angle, tiptiltGroup: GemsGuideProbeGroup, strehl: 
 
     val guiders = guideGroup.getReferencedGuiders.asScala.map { gp =>
       val target = guideGroup.get(gp).getValue.getPrimary.getValue
-      s"$gp[${target.getTarget.getRaString(NoTime)},${target.getTarget.getRaString(NoTime)}]"
+      s"$gp[${target.getRaString(NoTime)},${target.getRaString(NoTime)}]"
     }
     s"GemsGuideStars{pa=$pa, tiptilt=${tiptiltGroup.getKey}, avg Strehl=${strehl.avg * 100}, guiders=${guiders.mkString(" ")}}"
   }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -13,7 +13,7 @@ import edu.gemini.spModel.guide.{GuideProbe, GuideProbeUtil}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe
-import edu.gemini.spModel.target.system.NonSiderealTarget
+import edu.gemini.spModel.target.system.{ITarget, NonSiderealTarget}
 
 import scala.Function.const
 
@@ -72,7 +72,7 @@ object Strategy {
   }
 
   def isSidereal(ctx: ObsContext): Boolean =
-    !ctx.getTargets.getBase.getTarget.isInstanceOf[NonSiderealTarget]
+    ctx.getTargets.getBase.isSidereal
 
   val InstMap = Map[SPComponentType, ObsContext => List[AgsStrategy]](
     SPComponentType.INSTRUMENT_ACQCAM     -> const(List(Pwfs1North, Pwfs2North, Pwfs1South, Pwfs2South)),

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -235,7 +235,7 @@ object ConfigExtractor {
     def extractGuideStar(targets: GuideProbeTargets) =
       targets.getPrimary.asScalaOpt.fold("No guide star selected".left[SPTarget])(_.right)
 
-    def extractMagnitude(guideStar: ITarget) = {
+    def extractMagnitude(guideStar: SPTarget) = {
       val r  = guideStar.getMagnitude(Band.r)
       val R  = guideStar.getMagnitude(Band.R)
       val UC = guideStar.getMagnitude(Band.UC)
@@ -249,7 +249,7 @@ object ConfigExtractor {
       for {
         group     <- extractGroup
         guideStar <- extractGuideStar(group)
-        magnitude <- extractMagnitude(guideStar.getTarget)
+        magnitude <- extractMagnitude(guideStar)
         fieldLens <- extract[FieldLens]     (c, AoFieldLensKey)
         wfsMode   <- extract[GuideStarType] (c, AoGuideStarTypeKey)
       } yield {

--- a/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/java/edu/gemini/lchquery/servlet/LchQueryFunctor.java
@@ -359,7 +359,7 @@ public class LchQueryFunctor extends DBAbstractQueryFunctor implements IDBParall
     private Serializable _makeTargetNode(SPTarget target, TargetEnvironment targetEnvironment) {
         if (target.getTarget() instanceof NonSiderealTarget) {
             NonSidereal nonSidereal = new NonSidereal();
-            nonSidereal.setName(target.getTarget().getName());
+            nonSidereal.setName(target.getName());
             nonSidereal.setType(_getTargetType(target, targetEnvironment));
             Long id = ((NonSiderealTarget) target.getTarget()).getHorizonsObjectId();
             if (id != null) {
@@ -368,7 +368,7 @@ public class LchQueryFunctor extends DBAbstractQueryFunctor implements IDBParall
             return nonSidereal;
         } else {
             Sidereal sidereal = new Sidereal();
-            sidereal.setName(target.getTarget().getName());
+            sidereal.setName(target.getName());
             sidereal.setType(_getTargetType(target, targetEnvironment));
             Coordinates coords = target.getTarget().getSkycalcCoordinates();
             HmsDms hmsDms = new HmsDms();

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
@@ -268,7 +268,7 @@ public final class AltairRule implements IRule {
             Magnitude.Band[] bands = new Magnitude.Band[]{Magnitude.Band.R, Magnitude.Band.V};
             for (SPTarget spTarget : guideGroup.getTargets()) {
                 for (Magnitude.Band band : bands) {
-                    Magnitude m = spTarget.getTarget().getMagnitude(band).getOrNull();
+                    Magnitude m = spTarget.getMagnitude(band).getOrNull();
                     if (m != null) {
                         double b = m.getBrightness();
                         if (minMag == null || b < minMag) minMag = b;

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -442,10 +442,10 @@ public class GeneralRule implements IRule {
 
         final Option<Long> when = elems.getSchedulingBlock().map(SchedulingBlock::start);
 
-        Option<Double> spRA = target.getTarget().getRaHours(when);
+        Option<Double> spRA = target.getRaHours(when);
         Option<Double> spDec = target.getTarget().getDecDegrees(when);
 
-        Option<Double> p1RA = p1Target.getTarget().getRaHours(when);
+        Option<Double> p1RA = p1Target.getRaHours(when);
         Option<Double> p1Dec = p1Target.getTarget().getDecDegrees(when);
 
         double minDistance = _getMinDistance(elems);

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -212,7 +212,7 @@ public class GeneralRule implements IRule {
                 final Set<String> errorSet = new TreeSet<>();
                 for (final SPTarget target : guideTargets) {
                     //Check for empty name
-                    if ("".equals(target.getTarget().getName().trim())) {
+                    if ("".equals(target.getName().trim())) {
                         errorSet.add(String.format(WFS_EMPTY_NAME_TEMPLATE, guider.getKey()));
                     }
 
@@ -385,7 +385,7 @@ public class GeneralRule implements IRule {
             if (scienceTarget == null) { //really unlikely
                 problems.addError(PREFIX+"NO_SCIENCE_TARGET_MSG", NO_SCIENCE_TARGET_MSG, elements.getTargetObsComponentNode().getValue());
             } else {
-                if ("".equals(scienceTarget.getTarget().getName().trim())) {
+                if ("".equals(scienceTarget.getName().trim())) {
                     problems.addError(PREFIX+"EMPTY_TARGET_NAME_MSG", EMPTY_TARGET_NAME_MSG, elements.getTargetObsComponentNode().getValue());
                 }
             }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -662,7 +662,7 @@ public class GeneralRule implements IRule {
                 ObsClass obsClass = ObsClassService.lookupObsClass(elements.getObservationNode());
                 if (obsClass == ObsClass.SCIENCE) {
                     SPTarget target = targetEnv.getBase();
-                    if (!(target.getTarget() instanceof NonSiderealTarget))
+                    if (target.isSidereal())
                         return target;
                 }
             }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -443,10 +443,10 @@ public class GeneralRule implements IRule {
         final Option<Long> when = elems.getSchedulingBlock().map(SchedulingBlock::start);
 
         Option<Double> spRA = target.getRaHours(when);
-        Option<Double> spDec = target.getTarget().getDecDegrees(when);
+        Option<Double> spDec = target.getDecDegrees(when);
 
         Option<Double> p1RA = p1Target.getRaHours(when);
-        Option<Double> p1Dec = p1Target.getTarget().getDecDegrees(when);
+        Option<Double> p1Dec = p1Target.getDecDegrees(when);
 
         double minDistance = _getMinDistance(elems);
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gpi/GpiRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gpi/GpiRule.java
@@ -165,8 +165,8 @@ public class GpiRule implements IRule {
                 P2Problems problems = new P2Problems();
                 TargetEnvironment env = obsComp.getTargetEnvironment();
                 SPTarget base = env.getBase();
-                Option<Magnitude> imag = base.getTarget().getMagnitude(Magnitude.Band.I);
-                Option<Magnitude> hmag = base.getTarget().getMagnitude(Magnitude.Band.H);
+                Option<Magnitude> imag = base.getMagnitude(Magnitude.Band.I);
+                Option<Magnitude> hmag = base.getMagnitude(Magnitude.Band.H);
                 // OT-74
                 if (imag.isEmpty() || imag.getValue().getBrightness() == Magnitude.UNDEFINED_MAG) {
                     problems.addError(PREFIX + "MAG_BAND_MESSAGE", MAG_BAND_MESSAGE + "I-band.", elements.getTargetObsComponentNode().getValue());
@@ -181,7 +181,7 @@ public class GpiRule implements IRule {
                     if (!inst.getObservingMode().isEmpty()) {
                         Gpi.ObservingMode obsMode = inst.getObservingMode().getValue();
                         Magnitude.Band band = inst.getFilter().getBand(); // OT-102: obsMode could be NONSTANDARD
-                        Option<Magnitude> mag = base.getTarget().getMagnitude(band);
+                        Option<Magnitude> mag = base.getMagnitude(band);
                         if (mag.isEmpty() || mag.getValue().getBrightness() == Magnitude.UNDEFINED_MAG) {
                             // OT-99
                             problems.addError(PREFIX + "MAG_BAND_MESSAGE", MAG_BAND_MESSAGE + band + "-band",

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
@@ -196,13 +196,13 @@ public final class NifsRule implements IRule {
                 final Option<Long> when = elements.getSchedulingBlock().map(SchedulingBlock::start);
 
                 baseTarget.getRaHours(when).foreach(baseC1 ->
-                baseTarget.getTarget().getDecDegrees(when).foreach(baseC2 ->
+                baseTarget.getDecDegrees(when).foreach(baseC2 ->
 
                 oiTarget.getValue().getRaHours(when).foreach(oiC1 ->
-                oiTarget.getValue().getTarget().getDecDegrees(when).foreach(oiC2 ->
+                oiTarget.getValue().getDecDegrees(when).foreach(oiC2 ->
 
                 aoTarget.getValue().getRaHours(when).foreach(aoC1 ->
-                aoTarget.getValue().getTarget().getDecDegrees(when).foreach(aoC2 -> {
+                aoTarget.getValue().getDecDegrees(when).foreach(aoC2 -> {
                     if (Double.compare(baseC1, oiC1) == 0
                             &&
                             Double.compare(baseC2, oiC2) == 0

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
@@ -195,13 +195,13 @@ public final class NifsRule implements IRule {
 
                 final Option<Long> when = elements.getSchedulingBlock().map(SchedulingBlock::start);
 
-                baseTarget.getTarget().getRaHours(when).foreach(baseC1 ->
+                baseTarget.getRaHours(when).foreach(baseC1 ->
                 baseTarget.getTarget().getDecDegrees(when).foreach(baseC2 ->
 
-                oiTarget.getValue().getTarget().getRaHours(when).foreach(oiC1 ->
+                oiTarget.getValue().getRaHours(when).foreach(oiC1 ->
                 oiTarget.getValue().getTarget().getDecDegrees(when).foreach(oiC2 ->
 
-                aoTarget.getValue().getTarget().getRaHours(when).foreach(aoC1 ->
+                aoTarget.getValue().getRaHours(when).foreach(aoC1 ->
                 aoTarget.getValue().getTarget().getDecDegrees(when).foreach(aoC2 -> {
                     if (Double.compare(baseC1, oiC1) == 0
                             &&

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
@@ -363,9 +363,8 @@ public class TrecsRule implements IRule {
 
         // Return the world coordinates for the give target
         private Option<WorldCoords> _getWorldCoords(SPTarget tp, Option<Long> time) {
-            ITarget target = tp.getTarget();
-            return target.getRaDegrees(time).flatMap( ra ->
-                   target.getDecDegrees(time).map(dec ->
+            return tp.getRaDegrees(time).flatMap( ra ->
+                   tp.getDecDegrees(time).map(dec ->
                      new WorldCoords(ra, dec, 2000.)));
         }
     };

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/WfsRuleSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/WfsRuleSpec.scala
@@ -37,7 +37,7 @@ class WfsRuleSpec extends Specification {
     // Rename base to "Foo" and add a guidestar that's mod(base.clone())
     t.setTargetEnvironment {
       val te  = t.getTargetEnvironment <| (_.getBase.setName("Foo"))
-      val g   = te.getBase.clone() <| (g => g.setTarget(mod(g.getTarget.asInstanceOf[HmsDegTarget])))
+      val g   = te.getBase.clone() <| (g => g.setTarget(mod(g.getHmsDegTarget.get)))
       val p   = GmosOiwfsGuideProbe.instance
       val gpt = GuideProbeTargets.create(p, g)
       val gg  = te.getOrCreatePrimaryGuideGroup.setAll(List(gpt).asImList)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -122,7 +122,7 @@ trait Partitioner {
 
 object GnirsSpectroscopyPartitioner extends Partitioner {
   import edu.gemini.shared.skyobject.Magnitude.Band.H
-  def bucket(t:SPTarget):Int = Option(t.getTarget.getMagnitude(H).getOrNull).map(_.getBrightness).map {H =>
+  def bucket(t:SPTarget):Int = Option(t.getMagnitude(H).getOrNull).map(_.getBrightness).map {H =>
     if (H < 11.5) 1
     else if (H < 16) 2
     else if (H < 20) 3
@@ -139,7 +139,7 @@ object GnirsSpectroscopyPartitioner extends Partitioner {
 
 object NifsPartitioner extends Partitioner {
   import edu.gemini.shared.skyobject.Magnitude.Band.K
-  def bucket(t:SPTarget):Int = Option(t.getTarget.getMagnitude(K).getOrNull).map(_.getBrightness).map { K =>
+  def bucket(t:SPTarget):Int = Option(t.getMagnitude(K).getOrNull).map(_.getBrightness).map { K =>
          if (K <= 9) 1
     else if (K <= 13) 2
     else if (K <= 20) 3
@@ -153,7 +153,7 @@ object NifsPartitioner extends Partitioner {
 
 object F2LongslitPartitioner extends Partitioner {
   import edu.gemini.shared.skyobject.Magnitude.Band.H
-  def bucket(t: SPTarget): Int = (Option(t.getTarget.getMagnitude(H).getOrNull).map(_.getBrightness) map { h =>
+  def bucket(t: SPTarget): Int = (Option(t.getMagnitude(H).getOrNull).map(_.getBrightness) map { h =>
     if (h <= 12.0) 1 else 2
   }).getOrElse(3)
 }
@@ -166,8 +166,8 @@ object F2LongslitPartitioner extends Partitioner {
 object GracesPartitioner extends Partitioner {
   import edu.gemini.shared.skyobject.Magnitude.Band.{ R, V }
   def bucket(t:SPTarget):Int =
-    (t.getTarget.getMagnitude(R).asScalaOpt orElse
-     t.getTarget.getMagnitude(V).asScalaOpt).map(_.getBrightness).map { mag =>
+    (t.getMagnitude(R).asScalaOpt orElse
+     t.getMagnitude(V).asScalaOpt).map(_.getBrightness).map { mag =>
          if (mag > 10) 1 else 2
      }.getOrElse(3) // no R/V-mag is treated differently
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
@@ -33,7 +33,7 @@ case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTa
 //              Put FILTERS from PI into F2 ITERATOR
 //
 
-  val acq = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
+  val acq = exampleTarget.flatMap(t => Option(t.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
     case Some(h) if h <= 12 => Seq(13)
     case Some(h) if h >  12 => Seq(14)
     case _                  => Seq(13, 14)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsSpectroscopy.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsSpectroscopy.scala
@@ -98,7 +98,7 @@ case class GnirsSpectroscopy(blueprint:SpGnirsBlueprintSpectroscopy, exampleTarg
   // IF TARGET H-MAGNITUDE >= 20 INCLUDE {10}        #Blind offset target
   // ELSE INCLUDE {7} - {11}, {22}   # No H-magnitude provided for target, so put all of them
 
-  val otherAcq = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
+  val otherAcq = exampleTarget.flatMap(t => Option(t.getMagnitude(H).getOrNull)).map(_.getBrightness) match {
     case Some(h) =>
       if (h < 7) Seq(22)
       else if (h < 11.5) Seq(7)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/graces/Graces.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/graces/Graces.scala
@@ -34,8 +34,8 @@ case class Graces(blueprint: SpGracesBlueprint, exampleTarget: Option[SPTarget])
   val rMag: Option[Double] =
     for {
       t <- exampleTarget
-      m <- t.getTarget.getMagnitude(Band.R).asScalaOpt orElse
-           t.getTarget.getMagnitude(Band.V).asScalaOpt
+      m <- t.getMagnitude(Band.R).asScalaOpt orElse
+           t.getMagnitude(Band.V).asScalaOpt
     } yield m.getBrightness
 
   //  IF FIBER-MODE == 1 AND (READ-MODE == Normal OR READ-MODE == Fast):

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/Nifs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/Nifs.scala
@@ -12,7 +12,7 @@ case class Nifs(blueprint:SpNifsBlueprint, exampleTarget: Option[SPTarget]) exte
 
   // N.B. This is the same as NifsAo but without altair or occulting disk
 
-  val tb = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(Band.K).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
+  val tb = exampleTarget.flatMap(t => Option(t.getMagnitude(Band.K).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
 
   // These two notes should be included at the top of every NIFS program
   addNote("Phase II Requirements: General Information", "Phase II  \"BEFORE Submission\" Checklist") in TopLevel

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/NifsAo.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/NifsAo.scala
@@ -16,7 +16,7 @@ import edu.gemini.spModel.rich.pot.sp._
 case class NifsAo(blueprint: SpNifsBlueprintAo, exampleTarget: Option[SPTarget]) extends NifsBase[SpNifsBlueprintAo] {
   import blueprint._
 
-  val tb = exampleTarget.flatMap(t => Option(t.getTarget.getMagnitude(Band.K).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
+  val tb = exampleTarget.flatMap(t => Option(t.getMagnitude(Band.K).getOrNull)).map(_.getBrightness).map(TargetBrightness(_))
 
   // These two notes should be included at the top of every NIFS program
   addNote("Phase II Requirements: General Information", "Phase II  \"BEFORE Submission\" Checklist") in TopLevel

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/REL_2429_Test.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/REL_2429_Test.scala
@@ -21,8 +21,8 @@ class REL_2429_Test extends TemplateSpec("GRACES_BP.xml") with SpecificationLike
   object Bucket {
     def all = List(A, B)
     def fromTarget(t: SPTarget): Option[Bucket] =
-      (t.getTarget.getMagnitude(Band.R).asScalaOpt orElse
-       t.getTarget.getMagnitude(Band.V).asScalaOpt).map(_.getBrightness).map {
+      (t.getMagnitude(Band.R).asScalaOpt orElse
+       t.getMagnitude(Band.V).asScalaOpt).map(_.getBrightness).map {
         m => if (m > 10) A else B
       }
   }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
@@ -117,7 +117,7 @@ abstract class TemplateSpec(xmlName: String) { this: SpecificationLike =>
 
   /** Retrieve the phase-2 magnitude in the given band, if any, from the given target. */
   def p2mag(t: SPTarget, b: Band): Option[Double] =
-    Option(t.getTarget.getMagnitude(b).getOrNull).map(_.getBrightness)
+    Option(t.getMagnitude(b).getOrNull).map(_.getBrightness)
 
   /** True if a note with the given title exists at the root of the given template group. */
   def existsNote(tg: ISPTemplateGroup, title: String) =

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
@@ -59,14 +59,12 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     @Override
     public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
         if (ctx.getInstrument() instanceof InstNIFS) {
-            return ctx.getAOComponent().flatMap(new MapOp<AbstractDataObject, Option<PatrolField>>() {
-                @Override public Option<PatrolField> apply(AbstractDataObject ado) {
-                    if (ado instanceof InstAltair) {
-                        final InstAltair altair = (InstAltair) ado;
-                        return new Some<>((altair.getFieldLens() == IN) ? fieldLensPatrolField : noFieldLensPatrolField);
-                    } else {
-                        return None.instance();
-                    }
+            return ctx.getAOComponent().flatMap(ado -> {
+                if (ado instanceof InstAltair) {
+                    final InstAltair altair = (InstAltair) ado;
+                    return new Some<>((altair.getFieldLens() == IN) ? fieldLensPatrolField : noFieldLensPatrolField);
+                } else {
+                    return None.instance();
                 }
             }).orElse(new Some<>(noFieldLensPatrolField));
         } else {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
@@ -134,7 +134,7 @@ public final class ObsSchedulingReport implements Serializable {
 
         return
             target.getTarget().getRaDegrees(when).flatMap(ra ->
-            target.getTarget().getDecDegrees(when).map(dec ->
+            target.getDecDegrees(when).map(dec ->
                 new WorldCoords(ra, dec))).getOrNull();
         }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
@@ -133,7 +133,7 @@ public final class ObsSchedulingReport implements Serializable {
         if (target == null) return null;
 
         return
-            target.getTarget().getRaDegrees(when).flatMap(ra ->
+            target.getRaDegrees(when).flatMap(ra ->
             target.getDecDegrees(when).map(dec ->
                 new WorldCoords(ra, dec))).getOrNull();
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -267,7 +267,7 @@ public final class ObsContext {
         SPTarget target = targets.getBase();
         return
             target.getTarget().getRaDegrees(when).flatMap(raDeg ->
-            target.getTarget().getDecDegrees(when).map(decDeg ->
+            target.getDecDegrees(when).map(decDeg ->
                 new Coordinates(raDeg, decDeg)
             ));
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -266,7 +266,7 @@ public final class ObsContext {
         final Option<Long> when = getSchedulingBlock().map(SchedulingBlock::start);
         SPTarget target = targets.getBase();
         return
-            target.getTarget().getRaDegrees(when).flatMap(raDeg ->
+            target.getRaDegrees(when).flatMap(raDeg ->
             target.getDecDegrees(when).map(decDeg ->
                 new Coordinates(raDeg, decDeg)
             ));

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
@@ -68,7 +68,7 @@ public class ObsTargetDesc extends TargetDesc {
                 new WorldCoords(x, y, 2000.)
             ));
 
-                 String targetName = basePos.getTarget().getName();
+                 String targetName = basePos.getName();
 
         String obsId = "";
         SPObservationID spObsId = obs.getObservationID();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/ObsTargetDesc.java
@@ -60,11 +60,10 @@ public class ObsTargetDesc extends TargetDesc {
         if (targetEnv == null) return null;
 
         SPTarget basePos = targetEnv.getBase();
-        ITarget target = basePos.getTarget();
 
         Function<Option<Long>, Option<WorldCoords>> pos = op ->
-            target.getRaDegrees(op).flatMap(x ->
-            target.getDecDegrees(op).map(y ->
+            basePos.getRaDegrees(op).flatMap(x ->
+            basePos.getDecDegrees(op).map(y ->
                 new WorldCoords(x, y, 2000.)
             ));
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
@@ -50,7 +50,7 @@ public class TargetObsCompCB extends AbstractObsComponentCB {
 
         // Patch for a problem in 2009B.1.1.1.  The "telescope:Base:name" param
         // was missing, which caused the FITS OBJECT keyword to be incorrect.
-        String baseName = env.getBase().getTarget().getName();
+        String baseName = env.getBase().getName();
         if ((baseName != null) && !"".equals(baseName)) {
             DefaultConfigParameter cp = DefaultConfigParameter.getInstance("Base");
             ISysConfig sc = (ISysConfig) cp.getValue();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -6,6 +6,7 @@ import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SpatialProfile;
 import edu.gemini.spModel.core.SpectralDistribution;
 import edu.gemini.spModel.target.WatchablePos;
+import scala.None$;
 
 // transitional; will go away
 public abstract class TransitionalSPTarget extends WatchablePos {
@@ -58,6 +59,10 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         return getTarget().getDecDegrees(time);
     }
 
+    public Option<String> getDecString(Option<Long> time) {
+        return getTarget().getDecString(time);
+    }
+
     public void setRaString(String value) {
         getTarget().setRaString(value);
         _notifyOfUpdate();
@@ -103,6 +108,34 @@ public abstract class TransitionalSPTarget extends WatchablePos {
     @Deprecated
     public void notifyOfGenericUpdate() {
         super._notifyOfUpdate();
+    }
+
+    public scala.Option<HmsDegTarget> getHmsDegTarget() {
+        ITarget t = getTarget();
+        return (t instanceof  HmsDegTarget) ? new scala.Some<>((HmsDegTarget) t) : scala.Option.empty();
+    }
+
+    public scala.Option<NonSiderealTarget> getNonSiderealTarget() {
+        ITarget t = getTarget();
+        return (t instanceof NonSiderealTarget) ? new scala.Some<>((NonSiderealTarget) t) : scala.Option.empty();
+    }
+
+    public scala.Option<ConicTarget> getConicTarget() {
+        ITarget t = getTarget();
+        return (t instanceof ConicTarget) ? new scala.Some<>((ConicTarget) t) : scala.Option.empty();
+    }
+
+    public scala.Option<NamedTarget> getNamedTarget() {
+        ITarget t = getTarget();
+        return (t instanceof NamedTarget) ? new scala.Some<>((NamedTarget) t) : scala.Option.empty();
+    }
+
+    public boolean isSidereal() {
+        return getTarget() instanceof HmsDegTarget;
+    }
+
+    public boolean isNonSidereal() {
+        return !isSidereal();
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -31,9 +31,14 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         _notifyOfUpdate();
     }
 
+
     public void setRaHours(double value) {
         getTarget().setRaHours(value);
         _notifyOfUpdate();
+    }
+
+    public Option<Double> getRaHours(Option<Long> time) {
+        return getTarget().getRaHours(time);
     }
 
     public void setDecDegrees(double value) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -17,6 +17,10 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         _notifyOfUpdate();
     }
 
+    public String getName() {
+        return getTarget().getName();
+    }
+
     public void setName(String name) {
         getTarget().setName(name);
         _notifyOfUpdate();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -46,6 +46,10 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         _notifyOfUpdate();
     }
 
+    public Option<Double> getDecDegrees(Option<Long> time) {
+        return getTarget().getDecDegrees(time);
+    }
+
     public void setRaString(String value) {
         getTarget().setRaString(value);
         _notifyOfUpdate();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -92,6 +92,14 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         _notifyOfUpdate();
     }
 
+    public scala.Option<SpectralDistribution> getSpectralDistribution() {
+        return getTarget().getSpectralDistribution();
+    }
+
+    public scala.Option<SpatialProfile> getSpatialProfile() {
+        return getTarget().getSpatialProfile();
+    }
+
     @Deprecated
     public void notifyOfGenericUpdate() {
         super._notifyOfUpdate();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -2,6 +2,7 @@ package edu.gemini.spModel.target.system;
 
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.ImList;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SpatialProfile;
 import edu.gemini.spModel.core.SpectralDistribution;
 import edu.gemini.spModel.target.WatchablePos;
@@ -49,6 +50,10 @@ public abstract class TransitionalSPTarget extends WatchablePos {
     public void putMagnitude(final Magnitude mag) {
         getTarget().putMagnitude(mag);
         _notifyOfUpdate();
+    }
+
+    public Option<Magnitude> getMagnitude(final Magnitude.Band band) {
+        return getTarget().getMagnitude(band);
     }
 
     public void setMagnitudes(final ImList<Magnitude> magnitudes) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -6,7 +6,6 @@ import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SpatialProfile;
 import edu.gemini.spModel.core.SpectralDistribution;
 import edu.gemini.spModel.target.WatchablePos;
-import scala.None$;
 
 // transitional; will go away
 public abstract class TransitionalSPTarget extends WatchablePos {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -41,6 +41,10 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         return getTarget().getRaHours(time);
     }
 
+    public Option<String> getRaString(Option<Long> time) {
+        return getTarget().getRaString(time);
+    }
+
     public void setDecDegrees(double value) {
         getTarget().setDecDegrees(value);
         _notifyOfUpdate();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -45,6 +45,10 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         return getTarget().getRaString(time);
     }
 
+    public Option<Double> getRaDegrees(Option<Long> time) {
+        return getTarget().getRaDegrees(time);
+    }
+
     public void setDecDegrees(double value) {
         getTarget().setDecDegrees(value);
         _notifyOfUpdate();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
@@ -146,7 +146,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
     // Get a group name from the given config, conditions, target triple
     private static String createGroupTitle(TemplateGroup templateGroupData, SPTarget targetData) {
         return String.format("%s - [%s] %s",
-                targetData.getTarget().getName(),
+                targetData.getName(),
                 templateGroupData.getVersionToken(),
                 templateGroupData.getTitle());
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/util/ReadableNodeName.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/util/ReadableNodeName.java
@@ -23,7 +23,7 @@ public final class ReadableNodeName {
 
         private String formatTarget(ISPObsComponent oc) {
             final TargetObsComp toc = (TargetObsComp) oc.getDataObject();
-            return String.format("Target Environment '%s'", toc.getBase().getTarget().getName());
+            return String.format("Target Environment '%s'", toc.getBase().getName());
         }
 
         private String formatInstrument(ISPObsComponent oc) {
@@ -116,7 +116,7 @@ public final class ReadableNodeName {
             final SPSiteQuality c = tp.getSiteQuality();
             final TimeValue     v = tp.getTime();
             if ((t != null) && (c != null) && (v != null)) {
-                final String ts = t.getTarget().getName();
+                final String ts = t.getName();
                 final String cs = c.conditions().toString();
                 final String vs = v.toString(2);
                 if (ts != null) {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -186,7 +186,7 @@ object ModelConverters {
 
   implicit class SPTarget2SiderealTarget(val sp:SPTarget) extends AnyVal {
     def toNewModel:SiderealTarget = {
-      val name        = sp.getTarget.getName
+      val name        = sp.getName
       val coords      = sp.getTarget.getSkycalcCoordinates
       val mags        = sp.getTarget.getMagnitudes.asScalaList.map(_.toNewModel)
       val ra          = Angle.fromDegrees(coords.getRaDeg)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -213,8 +213,8 @@ object ModelConverters {
         redshift             = z,
         parallax             = px,
         magnitudes           = mags,
-        spectralDistribution = sp.getTarget.getSpectralDistribution,
-        spatialProfile       = sp.getTarget.getSpatialProfile
+        spectralDistribution = sp.getSpectralDistribution,
+        spatialProfile       = sp.getSpatialProfile
       )
     }
   }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -194,17 +194,14 @@ object ModelConverters {
       val coordinates = Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))
 
       // Only HmsDegTargets have a proper motion, radial velocity, etc
-      val pm          = sp.getTarget match {
-        case t:HmsDegTarget => Some(ProperMotion(RightAscensionAngularVelocity(AngularVelocity(t.getPropMotionRA)), DeclinationAngularVelocity(AngularVelocity(t.getPropMotionDec))))
-        case _              => None
+      val pm = sp.getHmsDegTarget map { t =>
+        ProperMotion(RightAscensionAngularVelocity(AngularVelocity(t.getPropMotionRA)), DeclinationAngularVelocity(AngularVelocity(t.getPropMotionDec)))
       }
-      val px          = sp.getTarget match {
-        case t:HmsDegTarget => Some(Parallax(t.getParallax.mas()))
-        case _              => None
+      val px = sp.getHmsDegTarget map { t =>
+        Parallax(t.getParallax.mas())
       }
-      val z           = sp.getTarget match {
-        case t:HmsDegTarget => Some(t.getRedshift)
-        case _              => None
+      val z = sp.getHmsDegTarget map { t =>
+        t.getRedshift
       }
       SiderealTarget( // full ctor here, so we're forced to handle changes
         name                 = name,

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -64,7 +64,7 @@ public final class SPTargetSkyObjectTest {
 
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
-            assertEquals("xyz", target.getTarget().getName());
+            assertEquals("xyz", target.getName());
             assertEquals(15.0, target.getTarget().getRaDegrees(None.instance()).getValue(), 0.000001);
             assertEquals(20.0, target.getTarget().getDecDegrees(None.instance()).getValue(), 0.000001);
             assertEquals(1.0, hmsDeg.getPM1().getValue(), 0.000001);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -65,7 +65,7 @@ public final class SPTargetSkyObjectTest {
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
             assertEquals("xyz", target.getName());
-            assertEquals(15.0, target.getTarget().getRaDegrees(None.instance()).getValue(), 0.000001);
+            assertEquals(15.0, target.getRaDegrees(None.instance()).getValue(), 0.000001);
             assertEquals(20.0, target.getDecDegrees(None.instance()).getValue(), 0.000001);
             assertEquals(1.0, hmsDeg.getPM1().getValue(), 0.000001);
             assertEquals(2.0, hmsDeg.getPM2().getValue(), 0.000001);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -66,7 +66,7 @@ public final class SPTargetSkyObjectTest {
 
             assertEquals("xyz", target.getName());
             assertEquals(15.0, target.getTarget().getRaDegrees(None.instance()).getValue(), 0.000001);
-            assertEquals(20.0, target.getTarget().getDecDegrees(None.instance()).getValue(), 0.000001);
+            assertEquals(20.0, target.getDecDegrees(None.instance()).getValue(), 0.000001);
             assertEquals(1.0, hmsDeg.getPM1().getValue(), 0.000001);
             assertEquals(2.0, hmsDeg.getPM2().getValue(), 0.000001);
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -93,12 +93,12 @@ public final class SPTargetSkyObjectTest {
         expected.foreach(new ApplyOp<Magnitude>() {
             @Override public void apply(Magnitude magnitude) {
                 assertTrue(bands.contains(magnitude.getBand()));
-                assertEquals(magnitude, target.getTarget().getMagnitude(magnitude.getBand()).getValue());
+                assertEquals(magnitude, target.getMagnitude(magnitude.getBand()).getValue());
             }
         });
 
         // okay don't call this method with "M" in the list of expected or input
-        assertTrue(target.getTarget().getMagnitude(Magnitude.Band.M).isEmpty());
+        assertTrue(target.getMagnitude(Magnitude.Band.M).isEmpty());
     }
 
     @Test
@@ -124,15 +124,15 @@ public final class SPTargetSkyObjectTest {
         ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());
-        assertEquals(magJ1, target.getTarget().getMagnitude(Magnitude.Band.J).getValue());
-        assertEquals(magK2, target.getTarget().getMagnitude(Magnitude.Band.K).getValue());
+        assertEquals(magJ1, target.getMagnitude(Magnitude.Band.J).getValue());
+        assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
 
         // Replace the existing J band mag with a new one.
         target.putMagnitude(magJ3);
         magList = target.getTarget().getMagnitudes();
         assertEquals(2, magList.size());
-        assertEquals(magJ3, target.getTarget().getMagnitude(Magnitude.Band.J).getValue());
-        assertEquals(magK2, target.getTarget().getMagnitude(Magnitude.Band.K).getValue());
+        assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());
+        assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
     }
 
     @Test
@@ -145,7 +145,7 @@ public final class SPTargetSkyObjectTest {
         ImList<Magnitude> magList = target.getTarget().getMagnitudes();
 
         assertEquals(2, magList.size());
-        assertEquals(magJ3, target.getTarget().getMagnitude(Magnitude.Band.J).getValue());
-        assertEquals(magK2, target.getTarget().getMagnitude(Magnitude.Band.K).getValue());
+        assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());
+        assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
     }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
@@ -107,7 +107,7 @@ final class Fixture {
             // same for the purposes of testing GuideProbeTargets.
 
             assertOptEquals(t1.getTarget().getRaDegrees(when), t2.getTarget().getRaDegrees(when), 0.000001);
-            assertOptEquals(t1.getTarget().getDecDegrees(when), t2.getTarget().getDecDegrees(when), 0.000001);
+            assertOptEquals(t1.getDecDegrees(when), t2.getDecDegrees(when), 0.000001);
         });
     }
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Fixture.java
@@ -106,7 +106,7 @@ final class Fixture {
             // the coordinates and get enough of an idea that they are the
             // same for the purposes of testing GuideProbeTargets.
 
-            assertOptEquals(t1.getTarget().getRaDegrees(when), t2.getTarget().getRaDegrees(when), 0.000001);
+            assertOptEquals(t1.getRaDegrees(when), t2.getRaDegrees(when), 0.000001);
             assertOptEquals(t1.getDecDegrees(when), t2.getDecDegrees(when), 0.000001);
         });
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
@@ -32,7 +32,7 @@ public class Pre2010BTargetEnvironmentIoTest {
     // We're not trying to verify the entire SPTarget parsing code.  It's
     // enough to know that the name is what we expected.
     private static void verifyTarget(String name, SPTarget target) throws Exception {
-        assertEquals(name, target.getTarget().getName());
+        assertEquals(name, target.getName());
     }
 
     private enum Case {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -32,8 +32,8 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
           val pset = SPTargetPio.getParamSet(spt, factory)
           val spt2 = SPTargetPio.fromParamSet(pset)
 
-          assert(spt.getTarget.getSpatialProfile === spt2.getTarget.getSpatialProfile)
-          assert(spt.getTarget.getSpectralDistribution === spt2.getTarget.getSpectralDistribution)
+          assert(spt.getSpatialProfile === spt2.getSpatialProfile)
+          assert(spt.getSpectralDistribution === spt2.getSpectralDistribution)
         }
     }
     "SPTargetPio" should {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -71,7 +71,7 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
 
     def expect(ps: ParamSet, era: Double, edec: Double): MatchResult[Double] = {
       val spt = SPTargetPio.fromParamSet(ps)
-      val ra  = spt.getTarget.getRaDegrees(JNone.instance[java.lang.Long]).asScalaOpt.map(_.doubleValue).get
+      val ra  = spt.getRaDegrees(JNone.instance[java.lang.Long]).asScalaOpt.map(_.doubleValue).get
       val dec = spt.getDecDegrees(JNone.instance[java.lang.Long]).asScalaOpt.map(_.doubleValue).get
 
       val raCheck = ra  must beCloseTo(era,  0.000001)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -49,9 +49,9 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
           val pset = SPTargetPio.getParamSet(spt, factory)
           val spt2 = SPTargetPio.fromParamSet(pset)
 
-          (spt.getTarget, spt2.getTarget) match {
-            case (t1: HmsDegTarget, t2: HmsDegTarget) => assert(t1.getRedshift === t2.getRedshift)
-            case _                                    => assert(false)
+          (spt.getHmsDegTarget, spt2.getHmsDegTarget) match {
+            case (Some(t1), Some(t2)) => assert(t1.getRedshift === t2.getRedshift)
+            case _                    => assert(false)
           }
         }
       }
@@ -124,7 +124,7 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
       Pio.addParam(fact, ps, "rv", "295000")
       ps.removeChild("z")
       val spt = SPTargetPio.fromParamSet(ps)
-      spt.getTarget.asInstanceOf[HmsDegTarget].getRedshift must beEqualTo(Redshift.fromRadialVelocity(KilometersPerSecond(295000)))
+      spt.getHmsDegTarget.map(_.getRedshift) must beEqualTo(Some(Redshift.fromRadialVelocity(KilometersPerSecond(295000))))
     }
   }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -72,7 +72,7 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
     def expect(ps: ParamSet, era: Double, edec: Double): MatchResult[Double] = {
       val spt = SPTargetPio.fromParamSet(ps)
       val ra  = spt.getTarget.getRaDegrees(JNone.instance[java.lang.Long]).asScalaOpt.map(_.doubleValue).get
-      val dec = spt.getTarget.getDecDegrees(JNone.instance[java.lang.Long]).asScalaOpt.map(_.doubleValue).get
+      val dec = spt.getDecDegrees(JNone.instance[java.lang.Long]).asScalaOpt.map(_.doubleValue).get
 
       val raCheck = ra  must beCloseTo(era,  0.000001)
       val decCheck = dec must beCloseTo(edec, 0.000001)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
@@ -168,7 +168,7 @@ class InstantiationFunctorTest extends SpModelTestBase {
         case o :: Nil =>
           // Science site quality is copied, but not the science target
           assertTrue(siteQuality(o).exists(_.getCloudCover == ScienceTargetCC) &&
-                     target(o).exists(_.getBase.getTarget.getName == ScienceTargetName))
+                     target(o).exists(_.getBase.getName == ScienceTargetName))
         case _       =>
           fail("Expected a single observation")
       }
@@ -184,7 +184,7 @@ class InstantiationFunctorTest extends SpModelTestBase {
         case o :: Nil =>
           // CC, target, and PA changes are kept.
           assertTrue(siteQuality(o).exists(_.getCloudCover == EditTargetCC) &&
-                     target(o).exists(_.getBase.getTarget.getName == EditTargetName) &&
+                     target(o).exists(_.getBase.getName == EditTargetName) &&
                      getPositionAngle(o) == EditPA)
         case _       =>
           fail("Expected a single observation")

--- a/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/TargetEnvironmentListener.scala
+++ b/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/TargetEnvironmentListener.scala
@@ -57,7 +57,7 @@ class TargetEnvironmentListener extends MarkerModelListener[Variant] {
       }
 
       // Check for non-sidereal targets.
-      if (targetEnvironment.getBase.getTarget.isInstanceOf[NonSiderealTarget]) {
+      if (targetEnvironment.getBase.isNonSidereal) {
         markerManager.addMarker(false, this, Marker.Severity.Warning, "Observation has a non-sidereal target.", variant, a)
       }
 

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -575,9 +575,9 @@ public final class Obs implements Serializable, Comparable<Obs> {
         return obsNumber;
     }
 
-    public double getRa() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getRaDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
-    }
+	public double getRa() {
+        return (targetEnvironment != null ? targetEnvironment.getBase().getRaDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
+	}
 
 	public double getDec() {
         return (targetEnvironment != null ? targetEnvironment.getBase().getDecDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -771,7 +771,8 @@ public final class Obs implements Serializable, Comparable<Obs> {
      * Call this only if you know there is a target environment.
      */
     public boolean isSidereal() {
-        return !isNonSidereal();
+        assert targetEnvironment != null;
+        return targetEnvironment.getBase().isSidereal();
     }
 
     /**
@@ -780,7 +781,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
      */
     public boolean isNonSidereal() {
         assert targetEnvironment != null;
-        return targetEnvironment.getBase().getTarget() instanceof NonSiderealTarget;
+        return targetEnvironment.getBase().isNonSidereal();
     }
 
     public Object getConstraintsString() {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -579,9 +579,9 @@ public final class Obs implements Serializable, Comparable<Obs> {
         return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getRaDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
     }
 
-    public double getDec() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getDecDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
-    }
+	public double getDec() {
+        return (targetEnvironment != null ? targetEnvironment.getBase().getDecDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
+	}
 
     public Conds getConditions() {
         return conditions;

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/NonSiderealCache.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/NonSiderealCache.scala
@@ -46,10 +46,7 @@ object NonSiderealCache {
    */
   def isHorizonsTarget(obs: Obs): Boolean =
     // QV only deals with "valid" observations, i.e. target environment, base and target all have to be set
-    obs.getTargetEnvironment.getBase.getTarget match {
-      case t: NST => true
-      case _ => false
-    }
+    obs.getTargetEnvironment.getBase.isNonSidereal
 
   def get(nights: Seq[Night], obs: Obs): NonSiderealTarget = {
     require(isHorizonsTarget(obs))
@@ -81,13 +78,13 @@ object NonSiderealCache {
    * @return
    */
   def horizonsNameFor(obs: Obs): Option[String] =
-    obs.getTargetEnvironment.getBase.getTarget match {
+    obs.getTargetEnvironment.getBase.getNonSiderealTarget match {
 
-      case t: NST =>
+      case Some(t) =>
         if (t.getName == null || t.getName.isEmpty) None
         else Option(t.getName)
 
-      case _ =>
+      case None =>
         LOG.warning(s"Don't know how to get Horizons name for this target ${obs.getObsId}.")
         None
     }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015A/TemplateConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015A/TemplateConversionTest.scala
@@ -54,7 +54,7 @@ class TemplateConversionTest extends MigrationTest {
       assertTrue(tpList.forall(_.getSiteQuality.conditions() == sq.conditions()))
 
       // Different targets
-      assertEquals(List("target_D", "target_C", "target_B", "target_A"), tpList.map(_.getTarget.getTarget.getName))
+      assertEquals(List("target_D", "target_C", "target_B", "target_A"), tpList.map(_.getTarget.getName))
     }
 
     def validateFolder(f: ISPTemplateFolder): Unit = {

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
@@ -57,10 +57,10 @@ class TargetConversionTest extends MigrationTest {
       tpList.map(_.getTarget) match {
         case List(tSidereal, tNonSidereal) =>
           assertTrue(tSidereal.getTarget.isInstanceOf[HmsDegTarget])
-          assertEquals("Some Sidereal", tSidereal.getTarget.getName)
+          assertEquals("Some Sidereal", tSidereal.getName)
 
           assertTrue(tNonSidereal.getTarget.isInstanceOf[NonSiderealTarget])
-          assertEquals("S123456", tNonSidereal.getTarget.getName)
+          assertEquals("S123456", tNonSidereal.getName)
 
         case _ =>
           fail("expecting Sidereal, NonSidereal")

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetConversionTest.scala
@@ -56,10 +56,10 @@ class TargetConversionTest extends MigrationTest {
       // A sidereal and a non-sidereal target
       tpList.map(_.getTarget) match {
         case List(tSidereal, tNonSidereal) =>
-          assertTrue(tSidereal.getTarget.isInstanceOf[HmsDegTarget])
+          assertTrue(tSidereal.isSidereal)
           assertEquals("Some Sidereal", tSidereal.getName)
 
-          assertTrue(tNonSidereal.getTarget.isInstanceOf[NonSiderealTarget])
+          assertTrue(tNonSidereal.isNonSidereal)
           assertEquals("S123456", tNonSidereal.getName)
 
         case _ =>
@@ -86,7 +86,7 @@ class TargetConversionTest extends MigrationTest {
     // unsafe extravaganza!
     val targetComp = obs.getObsComponents.asScala.find(_.getType == SPComponentType.TELESCOPE_TARGETENV).get
     val toc        = targetComp.getDataObject.asInstanceOf[TargetObsComp]
-    val rigel      = toc.getBase.getTarget.asInstanceOf[HmsDegTarget]
+    val rigel      = toc.getBase.getHmsDegTarget.get
 
     val when  = JNone.instance[java.lang.Long]
 

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
@@ -27,9 +27,9 @@ class PlutoDemotionTest extends MigrationTest {
 
       case sp: SPTarget =>
 
-        sp.getTarget match {
+        sp.getConicTarget match {
 
-          case ct: ConicTarget => // we know system is correct
+          case Some(ct) => // we know system is correct
 
             // These are preserved from the fixture
             Assert.assertEquals("Name", "Pluto", ct.getName)
@@ -48,7 +48,7 @@ class PlutoDemotionTest extends MigrationTest {
             Assert.assertEquals("Perihelion", 114.2248220688449, ct.getPerihelion.getValue, 0.00001)
             Assert.assertEquals("Epoch of Perihelion", 2447885.60548777, ct.getEpochOfPeri.getValue, 0.00001)
 
-          case t => Assert.fail("Expected ConicTarget, found " + t)
+          case None => Assert.fail("Expected ConicTarget, found " + sp.getTarget)
 
         }
     }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/UnitsAdditionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/UnitsAdditionTest.scala
@@ -26,7 +26,7 @@ class UnitsAdditionTest extends MigrationTest {
     val targetComp = obs.getObsComponents.asScala.find(_.getType == SPComponentType.TELESCOPE_TARGETENV).get
     val toc        = targetComp.getDataObject.asInstanceOf[TargetObsComp]
 
-    toc.getBase.getTarget.getSpectralDistribution match {
+    toc.getBase.getSpectralDistribution match {
       // Check that units have been properly added during migration;
       // without migration we wouldn't get the right values here
       case Some(EmissionLine(_, width, flux, continuum)) =>

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -136,7 +136,7 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.TEMPLATE_ID, templateId);
         row.put(Columns.TARGET_NAME, target.getName());
         row.put(Columns.RA, target.getRaString(None.instance()).getOrElse(""));
-        row.put(Columns.DEC, target.getTarget().getDecString(None.instance()).getOrElse(""));
+        row.put(Columns.DEC, target.getDecString(None.instance()).getOrElse(""));
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));
         row.put(Columns.INST_CONFIG, instConfig);
         row.put(Columns.PHASE1_TIME, String.format("%.2f hrs", time.getTimeAmount()));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -134,7 +134,7 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.BAND, band);
         row.put(Columns.PROG_TOO_STATUS, tooType.getDisplayValue());
         row.put(Columns.TEMPLATE_ID, templateId);
-        row.put(Columns.TARGET_NAME, target.getTarget().getName());
+        row.put(Columns.TARGET_NAME, target.getName());
         row.put(Columns.RA, target.getTarget().getRaString(None.instance()).getOrElse(""));
         row.put(Columns.DEC, target.getTarget().getDecString(None.instance()).getOrElse(""));
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -135,7 +135,7 @@ public class TemplateSummaryTable extends AbstractTable {
         row.put(Columns.PROG_TOO_STATUS, tooType.getDisplayValue());
         row.put(Columns.TEMPLATE_ID, templateId);
         row.put(Columns.TARGET_NAME, target.getName());
-        row.put(Columns.RA, target.getTarget().getRaString(None.instance()).getOrElse(""));
+        row.put(Columns.RA, target.getRaString(None.instance()).getOrElse(""));
         row.put(Columns.DEC, target.getTarget().getDecString(None.instance()).getOrElse(""));
         row.put(Columns.COND_CONSTRAINTS, conditions.toString().replaceAll(",", ""));
         row.put(Columns.INST_CONFIG, instConfig);

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
@@ -422,7 +422,7 @@ public class ReportUtils {
         }
 
         return
-            target.getTarget().getRaDegrees(when).flatMap(r ->
+            target.getRaDegrees(when).flatMap(r ->
             target.getDecDegrees(when).flatMap(d ->
                 (r == 0.0 && d == 0.0) ?  None.instance() : new Some<>(((int) Math.round(r / 15.0)) % 24)
             ));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
@@ -423,7 +423,7 @@ public class ReportUtils {
 
         return
             target.getTarget().getRaDegrees(when).flatMap(r ->
-            target.getTarget().getDecDegrees(when).flatMap(d ->
+            target.getDecDegrees(when).flatMap(d ->
                 (r == 0.0 && d == 0.0) ?  None.instance() : new Some<>(((int) Math.round(r / 15.0)) % 24)
             ));
     }

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
@@ -417,9 +417,6 @@ public class ReportUtils {
         if (target == null) {
             return None.instance();
         }
-        if (!(target.getTarget() instanceof HmsDegTarget)) {
-            return None.instance();
-        }
 
         return
             target.getRaDegrees(when).flatMap(r ->

--- a/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
+++ b/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
@@ -62,7 +62,7 @@ object RolloverObservation {
 
       // Coordinates may or may not be known
       val coords = for {
-        ra  <- science.getTarget.getRaDegrees(when).asScalaOpt
+        ra  <- science.getRaDegrees(when).asScalaOpt
         dec <- science.getDecDegrees(when).asScalaOpt
       } yield Coords(new Angle(ra, Angle.Unit.DEGREES), new Angle(dec, Angle.Unit.DEGREES))
 

--- a/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
+++ b/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
@@ -63,7 +63,7 @@ object RolloverObservation {
       // Coordinates may or may not be known
       val coords = for {
         ra  <- science.getTarget.getRaDegrees(when).asScalaOpt
-        dec <- science.getTarget.getDecDegrees(when).asScalaOpt
+        dec <- science.getDecDegrees(when).asScalaOpt
       } yield Coords(new Angle(ra, Angle.Unit.DEGREES), new Angle(dec, Angle.Unit.DEGREES))
 
       RolloverTarget(name, coords)

--- a/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
+++ b/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
@@ -49,7 +49,7 @@ object RolloverObservation {
       dataObj    <- Option(targetComp.getDataObject.asInstanceOf[TargetObsComp])
       targetEnv  <- Option(dataObj.getTargetEnvironment)
       science    <- Option(targetEnv.getBase)
-      name       <- Option(science.getTarget.getName)
+      name       <- Option(science.getName)
     } yield {
 
       // Amazingly this is easier in Java

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -131,7 +131,7 @@ public final class ObservationEnvironment {
     }
 
     public String getBasePositionName() {
-        return _targetEnv.getBase().getTarget().getName();
+        return _targetEnv.getBase().getName();
     }
 
     public boolean isNorth() {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -94,14 +94,14 @@ public final class TargetConfig extends ParamSet {
      */
     private void _buildHmsDegTarget(SPTarget target) {
 
-        HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
+        HmsDegTarget hmsDeg = target.getHmsDegTarget().get();
         putParameter(TccNames.C1, hmsDeg.getRa().toString());
         putParameter(TccNames.C2, hmsDeg.getDec().toString());
         add(_addProperMotion(hmsDeg));
     }
 
     private void _buildConicTarget(SPTarget spTarget) {
-        ConicTarget target = (ConicTarget) spTarget.getTarget();
+        ConicTarget target = spTarget.getConicTarget().get();
 
         ITarget.Tag option = target.getTag();
         putParameter(TccNames.FORMAT, option.tccName);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -53,9 +53,9 @@ public final class TargetConfig extends ParamSet {
      * Note that only the hmsDegTarget is supported at this time.
      */
     public TargetConfig(SPTarget spTarget) throws WdbaGlueException {
-        super(spTarget.getTarget().getName());
+        super(spTarget.getName());
 
-        putParameter(TccNames.OBJNAME, spTarget.getTarget().getName());
+        putParameter(TccNames.OBJNAME, spTarget.getName());
 
         putParameter(TccNames.BRIGHTNESS, ""); // TODO: can we elide this altogether?
         putParameter(TccNames.TAG, ""); // ugh

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
@@ -39,11 +39,11 @@ public final class TargetGroupConfig extends ParamSet {
 
         addAttribute(TYPE, TYPE_VALUE);
 
-        primaryTarget.map(t -> t.getTarget().getName())
+        primaryTarget.map(t -> t.getName())
                 .filter(n -> !"".equals(n))
                 .foreach(n -> putParameter(TccNames.PRIMARY, n));
 
-        final List<String> targetNames = targets.toList().stream().map(t -> t.getTarget().getName()).collect(Collectors.toList());
+        final List<String> targetNames = targets.toList().stream().map(t -> t.getName()).collect(Collectors.toList());
         putParameter(TccNames.TARGETS, targetNames);
     }
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -104,7 +104,7 @@ public class TccFieldConfig extends ParamSet {
     private void addBaseGroup(TargetEnvironment env) throws WdbaGlueException {
         // Add the target itself.
         SPTarget base = env.getBase();
-        if (isEmpty(base.getTarget().getName())) {
+        if (isEmpty(base.getName())) {
             base.setName(TccNames.BASE);
         }
         add(new TargetConfig(base));
@@ -112,7 +112,7 @@ public class TccFieldConfig extends ParamSet {
         // Add the user targets.
         int pos = 1;
         for (SPTarget user : env.getUserTargets()) {
-            if (isEmpty(user.getTarget().getName())) {
+            if (isEmpty(user.getName())) {
                 user.setName(TargetConfig.formatName("User", pos));
             }
             ++pos;
@@ -136,7 +136,7 @@ public class TccFieldConfig extends ParamSet {
 
         int pos = 1;
         for (SPTarget target : targets) {
-            if (isEmpty(target.getTarget().getName())) {
+            if (isEmpty(target.getName())) {
                 target.setName(TargetConfig.formatName(tag, pos));
             }
             add(new TargetConfig(target));

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -316,7 +316,7 @@ public final class TargetGroupTest extends TestBase {
 
         public String getTargetName(SPTarget target) {
             String name = targetNameMap.get(target);
-            return (name == null) ? target.getTarget().getName() : name;
+            return (name == null) ? target.getName() : name;
         }
 
         public void putTargetName(SPTarget target, String name) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -79,7 +79,7 @@ public final class TargetMagnitudeTest extends TestBase {
             final String name = targetElement.attributeValue(ParamSet.NAME);
             assertNotNull(name);
 
-            final Option<SPTarget> target = env.getTargets().find(spTarget -> name.equals(spTarget.getTarget().getName()));
+            final Option<SPTarget> target = env.getTargets().find(spTarget -> name.equals(spTarget.getName()));
             assertFalse(target.isEmpty());
 
             // Check the magnitude information for each target

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
@@ -443,7 +443,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
             final SPTarget target = targetEnv.getBase();
             if (target == null)
                 return null;
-            return target.getTarget().getName();
+            return target.getName();
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
@@ -526,11 +526,10 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
             return false;
         final TargetObsComp targetEnv = (TargetObsComp) targetObsComp.getDataObject();
         final SPTarget tp = targetEnv.getBase();
-        final ITarget target = tp.getTarget();
 
         final Option<Long> when = ((SPObservation) o.getDataObject()).getSchedulingBlock().map(SchedulingBlock::start);
-        final Option<Double> raOp  = target.getRaDegrees(when).map(x -> x / 15.);
-        final Option<Double> decOp = target.getDecDegrees(when);
+        final Option<Double> raOp  = tp.getRaDegrees(when).map(x -> x / 15.);
+        final Option<Double> decOp = tp.getDecDegrees(when);
 
         final double ra0  = (minRA != null)  ? new HMS(minRA, true).getVal() :   0.;
         final double ra1  = (maxRA != null)  ? new HMS(maxRA, true).getVal() :  24.;
@@ -623,10 +622,9 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
         if (targetObsComp != null) {
             final TargetObsComp targetEnv = (TargetObsComp) targetObsComp.getDataObject();
             final SPTarget tp = targetEnv.getBase();
-            final ITarget target = tp.getTarget();
             final Option<Long> when = obs.getSchedulingBlock().map(SchedulingBlock::start);
-            ra = target.getRaDegrees(when).getOrNull();
-            dec = target.getDecDegrees(when).getOrNull();
+            ra = tp.getRaDegrees(when).getOrNull();
+            dec = tp.getDecDegrees(when).getOrNull();
         }
 
         // Figure out the planned time for all observations.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
@@ -287,7 +287,7 @@ class ParamsListTableCellRenderer extends DefaultTableCellRenderer {
             label.setText(target.getName());
 
             // Two possible icons
-            if (target.getTarget() instanceof NonSiderealTarget) {
+            if (target.isNonSidereal()) {
                 label.setIcon(ICON_NONSIDEREAL);
             } else {
                 label.setIcon(ICON_SIDEREAL);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
@@ -284,7 +284,7 @@ class ParamsListTableCellRenderer extends DefaultTableCellRenderer {
 
             // Cell for a target
             final SPTarget target = (SPTarget) value;
-            label.setText(target.getTarget().getName());
+            label.setText(target.getName());
 
             // Two possible icons
             if (target.getTarget() instanceof NonSiderealTarget) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/InstantiationDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/InstantiationDialog.java
@@ -95,8 +95,7 @@ class InstantiationDialogRenderer extends TemplateDialogRenderer {
             // Icon
             final TemplateParameters tps = (TemplateParameters) nd.getDataObject();
             final SPTarget spTarget = tps.getTarget();
-            final ITarget target = spTarget.getTarget();
-            final Icon targetIcon = (target instanceof NonSiderealTarget) ? ICON_NONSIDEREAL : ICON_SIDEREAL;
+            final Icon targetIcon = spTarget.isNonSidereal() ? ICON_NONSIDEREAL : ICON_SIDEREAL;
             setIcon(new DualIcon(targetIcon, ICON_CONDS));
 
             // Text

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/InstantiationDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/InstantiationDialog.java
@@ -101,7 +101,7 @@ class InstantiationDialogRenderer extends TemplateDialogRenderer {
 
             // Text
             final SPSiteQuality.Conditions conds = tps.getSiteQuality().conditions();
-            setText(spTarget.getTarget().getName() + " - " + conds);
+            setText(spTarget.getName() + " - " + conds);
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -165,7 +165,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
 
         public void setTarget(SPTarget target, Mode mode) {
             Option<Magnitude> magOpt = None.instance();
-            if (target != null) magOpt = target.getTarget().getMagnitude(band);
+            if (target != null) magOpt = target.getMagnitude(band);
 
             // Update visibility based upon whether the target has a
             // corresponding magnitude value for this band.
@@ -477,7 +477,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void addBand(Magnitude.Band b) {
-        final Option<Magnitude> magOpt = target.getTarget().getMagnitude(b);
+        final Option<Magnitude> magOpt = target.getMagnitude(b);
         if (!magOpt.isEmpty()) return; // shouldn't happen ...
 
         final Magnitude newMag = new Magnitude(b, Magnitude.UNDEFINED_MAG, 0, b.defaultSystem);
@@ -491,7 +491,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void changeBand(Magnitude.Band from, Magnitude.Band to) {
-        final Option<Magnitude> oldMagOpt = target.getTarget().getMagnitude(from);
+        final Option<Magnitude> oldMagOpt = target.getMagnitude(from);
         if (oldMagOpt.isEmpty()) return; // shouldn't happen ...
         final Magnitude oldMag = oldMagOpt.getValue();
         final Magnitude newMag = new Magnitude(to, oldMag.getBrightness(), oldMag.getError(), oldMag.getSystem());
@@ -503,7 +503,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void changeSystem(Magnitude.Band band, MagnitudeSystem system) {
-        final Option<Magnitude> oldMagOpt = target.getTarget().getMagnitude(band);
+        final Option<Magnitude> oldMagOpt = target.getMagnitude(band);
         if (oldMagOpt.isEmpty()) return; // shouldn't happen ...
         final Magnitude oldMag = oldMagOpt.getValue();
         if (system == oldMag.getSystem()) return;
@@ -516,7 +516,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
     }
 
     void updateMagnitudeValue(Magnitude.Band b, double d) {
-        final Option<Magnitude> oldMagOpt = target.getTarget().getMagnitude(b);
+        final Option<Magnitude> oldMagOpt = target.getMagnitude(b);
         if (oldMagOpt.isEmpty()) return;
         final Magnitude oldMag = oldMagOpt.getValue();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -67,7 +67,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
 
             DEC("Dec") {
                 public String getValue(final Row row) {
-                    return row.target().flatMap(t -> t.getTarget().getDecString(row.when())).getOrElse("");
+                    return row.target().flatMap(t -> t.getDecString(row.when())).getOrElse("");
                 }
             },
 
@@ -415,9 +415,8 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
 
     // Return the world coordinates for the given target
     private static Option<Coordinates> getCoordinates(final SPTarget tp, final Option<Long> when) {
-        final ITarget target = tp.getTarget();
-        return target.getRaDegrees(when).flatMap(ra ->
-                target.getDecDegrees(when).flatMap(dec ->
+        return tp.getRaDegrees(when).flatMap(ra ->
+                tp.getDecDegrees(when).flatMap(dec ->
                     ImOption.apply(Coordinates.fromDegrees(ra, dec).getOrElse(null))
                 )
         );

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -61,7 +61,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
 
             RA("RA") {
                 public String getValue(final Row row) {
-                    return row.target().flatMap(t -> t.getTarget().getRaString(row.when())).getOrElse("");
+                    return row.target().flatMap(t -> t.getRaString(row.when())).getOrElse("");
                 }
             },
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -137,7 +137,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
 
         static final class BaseTargetRow extends AbstractRow {
             BaseTargetRow(final SPTarget target, final Option<Long> when) {
-                super(true, TargetEnvironment.BASE_NAME, target.getTarget().getName(), new Some<>(target), when);
+                super(true, TargetEnvironment.BASE_NAME, target.getName(), new Some<>(target), when);
             }
         }
 
@@ -146,7 +146,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
 
             NonBaseTargetRow(final boolean enabled, final String tag, final SPTarget target,
                              final Option<Coordinates> baseCoords, final Option<Long> when) {
-                super(enabled, tag, target.getTarget().getName(), new Some<>(target), when);
+                super(enabled, tag, target.getName(), new Some<>(target), when);
 
                 final Option<Coordinates> coords = getCoordinates(target, when);
                 distance = baseCoords.flatMap(bc ->

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -127,7 +127,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
             @Override public Option<Long> when()        { return when; }
 
             public Option<Magnitude> getMagnitude(final Magnitude.Band band) {
-                return target.flatMap(t -> t.getTarget().getMagnitude(band));
+                return target.flatMap(t -> t.getMagnitude(band));
             }
 
             @Override public String formatMagnitude(final Magnitude.Band band) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -417,7 +417,7 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
                 final SPTarget spt = targetList.get(i);
                 final Option<Star> op = targetToStar(spt);
                 if (op.isEmpty()) {
-                    throw new RuntimeException("No coordinates for " + spt.getTarget().getName());
+                    throw new RuntimeException("No coordinates for " + spt.getName());
                 }
                 starList[i] = op.getValue();
             }
@@ -431,7 +431,7 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
         return
             target.getTarget().getRaDegrees(when).flatMap(ra ->
             target.getTarget().getDecDegrees(when).map(dec -> {
-                String name = target.getTarget().getName();
+                String name = target.getName();
                 double baseX = _tii.getBasePos().getRaDeg();
                 double baseY = _tii.getBasePos().getDecDeg();
                 Magnitude undef = new Magnitude(Magnitude.Band.J, MascotConf.invalidMag());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -429,7 +429,7 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
     private Option<Star> targetToStar(SPTarget target) {
         final Option<Long> when = _iw.getContext().schedulingBlockJava().map(SchedulingBlock::start);
         return
-            target.getTarget().getRaDegrees(when).flatMap(ra ->
+            target.getRaDegrees(when).flatMap(ra ->
             target.getDecDegrees(when).map(dec -> {
                 String name = target.getName();
                 double baseX = _tii.getBasePos().getRaDeg();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -435,12 +435,12 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
                 double baseX = _tii.getBasePos().getRaDeg();
                 double baseY = _tii.getBasePos().getDecDeg();
                 Magnitude undef = new Magnitude(Magnitude.Band.J, MascotConf.invalidMag());
-                double bmag = target.getTarget().getMagnitude(Magnitude.Band.B).getOrElse(undef).getBrightness();
-                double vmag = target.getTarget().getMagnitude(Magnitude.Band.V).getOrElse(undef).getBrightness();
-                double rmag = target.getTarget().getMagnitude(Magnitude.Band.R).getOrElse(undef).getBrightness();
-                double jmag = target.getTarget().getMagnitude(Magnitude.Band.J).getOrElse(undef).getBrightness();
-                double hmag = target.getTarget().getMagnitude(Magnitude.Band.H).getOrElse(undef).getBrightness();
-                double kmag = target.getTarget().getMagnitude(Magnitude.Band.K).getOrElse(undef).getBrightness();
+                double bmag = target.getMagnitude(Magnitude.Band.B).getOrElse(undef).getBrightness();
+                double vmag = target.getMagnitude(Magnitude.Band.V).getOrElse(undef).getBrightness();
+                double rmag = target.getMagnitude(Magnitude.Band.R).getOrElse(undef).getBrightness();
+                double jmag = target.getMagnitude(Magnitude.Band.J).getOrElse(undef).getBrightness();
+                double hmag = target.getMagnitude(Magnitude.Band.H).getOrElse(undef).getBrightness();
+                double kmag = target.getMagnitude(Magnitude.Band.K).getOrElse(undef).getBrightness();
                 return Star.makeStar(name, baseX, baseY, bmag, vmag, rmag, jmag, hmag, kmag, ra, dec);
             }));
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -430,7 +430,7 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
         final Option<Long> when = _iw.getContext().schedulingBlockJava().map(SchedulingBlock::start);
         return
             target.getTarget().getRaDegrees(when).flatMap(ra ->
-            target.getTarget().getDecDegrees(when).map(dec -> {
+            target.getDecDegrees(when).map(dec -> {
                 String name = target.getName();
                 double baseX = _tii.getBasePos().getRaDeg();
                 double baseY = _tii.getBasePos().getDecDeg();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -344,7 +344,7 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         final Option<Long> when = ctx.schedulingBlockJava().map(SchedulingBlock::start);
 
         _baseTarget.getTarget().getRaDegrees(when).flatMap(ra ->
-            _baseTarget.getTarget().getDecDegrees(when).flatMap( dec -> {
+            _baseTarget.getDecDegrees(when).flatMap( dec -> {
                 final HmsDegCoordinates hmsDegCoordinates = new HmsDegCoordinates.Builder(new Angle(ra, Angle.Unit.DEGREES), new Angle(dec, Angle.Unit.DEGREES)).build();
                 final Coordinates coordinates = ModelConverters.toCoordinates(hmsDegCoordinates);
                 final URL queryUrl = imageCatalog.queryUrl(coordinates);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -236,10 +236,9 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         SPTarget tp = _ctx.targets().baseOrNull();
         if (tp != null) {
             // Get the RA and Dec from the pos list.
-            final ITarget target = tp.getTarget();
             final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
-            ra = target.getRaDegrees(when).getOrElse(0.0);
-            dec = target.getDecDegrees(when).getOrElse(0.0);
+            ra = tp.getRaDegrees(when).getOrElse(0.0);
+            dec = tp.getDecDegrees(when).getOrElse(0.0);
         } else {
             ra  = 0.0;
             dec = 0.0;
@@ -254,14 +253,11 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         if (newBasePos == null) return oldBasePos != null;
         if (oldBasePos == null) return true;
 
-        final ITarget oldBase = oldBasePos.getTarget();
-        final ITarget newBase = newBasePos.getTarget();
-
         final Option<Long> oldWhen = oldCtx.schedulingBlockJava().map(SchedulingBlock::start);
         final Option<Long> newWhen = newCtx.schedulingBlockJava().map(SchedulingBlock::start);
 
-        return !(oldBase.getRaDegrees(oldWhen).equals(newBase.getRaDegrees(newWhen)) &&
-                 oldBase.getDecDegrees(oldWhen).equals(newBase.getDecDegrees(newWhen)));
+        return !(oldBasePos.getRaDegrees(oldWhen).equals(newBasePos.getRaDegrees(newWhen)) &&
+                oldBasePos.getDecDegrees(oldWhen).equals(newBasePos.getDecDegrees(newWhen)));
     }
 
     private final PropertyChangeListener obsListener = evt -> {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -343,7 +343,7 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
 
         final Option<Long> when = ctx.schedulingBlockJava().map(SchedulingBlock::start);
 
-        _baseTarget.getTarget().getRaDegrees(when).flatMap(ra ->
+        _baseTarget.getRaDegrees(when).flatMap(ra ->
             _baseTarget.getDecDegrees(when).flatMap( dec -> {
                 final HmsDegCoordinates hmsDegCoordinates = new HmsDegCoordinates.Builder(new Angle(ra, Angle.Unit.DEGREES), new Angle(dec, Angle.Unit.DEGREES)).build();
                 final Coordinates coordinates = ModelConverters.toCoordinates(hmsDegCoordinates);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -483,7 +483,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
         }
 
         // Get the equinox assumed by the coordinate conversion methods (depends on current image)
-        final ITarget target = ((SPTarget) tp).getTarget();
+        final SPTarget target = (SPTarget) tp;
         final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
         final double x = target.getRaDegrees(when).getOrElse(0.0);
         final double y = target.getDecDegrees(when).getOrElse(0.0);
@@ -660,7 +660,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
         if (_ctx.targets().base().isDefined()) {
             final SPTarget base = _ctx.targets().base().get();
             base.addWatcher(this);
-            basePosUpdate(base.getTarget());
+            basePosUpdate(base);
         }
 
         _autoGuideStarAction.setEnabled(GuideStarSupport.supportsAutoGuideStarSelection(_ctx));
@@ -813,13 +813,13 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
 
     @Override
     public void telescopePosUpdate(final WatchablePos tp) {
-        basePosUpdate(((SPTarget) tp).getTarget());
+        basePosUpdate((SPTarget) tp);
     }
 
     /**
      * The Base position has been updated.
      */
-    public void basePosUpdate(final ITarget target) {
+    public void basePosUpdate(final SPTarget target) {
         final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
         final double x = target.getRaDegrees(when).getOrElse(0.0);
         final double y = target.getDecDegrees(when).getOrElse(0.0);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -200,7 +200,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         String getRA() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().getRaString(_when).getOrNull();
+                return getTarget().getRaString(_when).getOrNull();
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.strehl();
                 if (strehl != null) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -212,7 +212,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         Object getDec() {
             if (_guideProbeTargets != null) {
-                return getTarget().getTarget().getDecString(_when).getOrNull();
+                return getTarget().getDecString(_when).getOrNull();
             }
             return null;
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -165,7 +165,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         String getId() {
             if (_guideProbeTargets != null) {
                 if (_guideProbeTargets.getPrimary().isDefined()) {
-                    return _guideProbeTargets.getPrimary().getValue().getTarget().getName();
+                    return _guideProbeTargets.getPrimary().getValue().getName();
                 }
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.strehl();

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -158,7 +158,7 @@ object ObservationInfo {
 
   def apply(ctx: ObsContext, mt: MagnitudeTable):ObservationInfo = ObservationInfo(
     ctx.some,
-    Option(ctx.getTargets.getBase).map(_.getTarget.getName),
+    Option(ctx.getTargets.getBase).map(_.getName),
     Option(ctx.getTargets.getBase).map(_.getTarget.getSkycalcCoordinates.toNewModel),
     Option(ctx.getInstrument.getType),
     AgsRegistrar.currentStrategy(ctx).map(toSupportedStrategy(ctx, _, mt)),

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
@@ -50,13 +50,13 @@ object ItcParametersProvider {
     def spatialProfile: String \/ SpatialProfile =
       for {
         tEnv <- targetEnvironment
-        sp   <- tEnv.getBase.getTarget.getSpatialProfile.fold("Spatial profile not available".left[SpatialProfile])(_.right)
+        sp   <- tEnv.getBase.getSpatialProfile.fold("Spatial profile not available".left[SpatialProfile])(_.right)
       } yield sp
 
     def spectralDistribution: String \/ SpectralDistribution =
       for {
         tEnv <- targetEnvironment
-        sd   <- tEnv.getBase.getTarget.getSpectralDistribution.fold("Spectral distribution not available".left[SpectralDistribution])(_.right)
+        sd   <- tEnv.getBase.getSpectralDistribution.fold("Spectral distribution not available".left[SpectralDistribution])(_.right)
       } yield sd
 
     def instrumentPort: String \/ IssPort =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
@@ -68,18 +68,11 @@ object ItcParametersProvider {
     def redshift: String \/ Redshift =
       for {
         tEnv <- targetEnvironment
-      } yield {
-        tEnv.getBase.getTarget match {
-          case t: HmsDegTarget  => t.getRedshift // get z-shift for this target
-          case _                => Redshift(0.0) // non-sidereal targets are assumed to have z-shift 0
-        }
-      }
+      } yield tEnv.getBase.getHmsDegTarget.fold(Redshift(0.0))(_.getRedshift)
 
     def sequence: ConfigSequence = Option(owner.getContextObservation).fold(new ConfigSequence) {
       ConfigBridge.extractSequence(_, null, ConfigValMapInstances.IDENTITY_MAP, true)
     }
-
-
 
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -234,7 +234,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
     }
 
     def targetType(t: SPTarget): TargetType =
-      if (t.getTarget.isInstanceOf[NonSiderealTarget]) NonSidereal else Sidereal
+      t.getHmsDegTarget.map(_ => Sidereal).getOrElse(NonSidereal)
 
     object CoordinatesPanel extends ColumnPanel {
       val nameField = new BoundTextField[String](10)(
@@ -280,12 +280,12 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         new BoundTextField[Double](10)(
           read = _.toDouble,
           show = d => f"$d%.3f",
-          get  = tp => Option(tp.getTarget.getTarget).collect { case t: HmsDegTarget => getPM(t) } .getOrElse(0.0),
+          get  = tp => tp.getTarget.getHmsDegTarget.fold(0.0)(getPM),
           set  = (tp, pm) => {
             val newTarget = tp.getTarget
-            newTarget.getTarget match {
-              case t: HmsDegTarget => setPM(t, pm); newTarget.notifyOfGenericUpdate()
-              case _               => () // do nothing
+            newTarget.getHmsDegTarget.foreach {t =>
+              setPM(t, pm)
+              newTarget.notifyOfGenericUpdate()
             }
             tp.copy(newTarget)
           }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -314,14 +314,14 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         lazy val zero = new Magnitude(band, 0.0, band.defaultSystem)
 
         def mag(tp: TemplateParameters): Option[Magnitude] =
-          tp.getTarget.getTarget.getMagnitude(band).asScalaOpt
+          tp.getTarget.getMagnitude(band).asScalaOpt
 
         def magOrZero(tp: TemplateParameters): Magnitude =
           mag(tp).getOrElse(zero)
 
         def setMag[A](f: (Magnitude, A) => Magnitude): (TemplateParameters, A) => TemplateParameters =
           setTarget[A]{ (t, a) =>
-            t.putMagnitude(f(t.getTarget.getMagnitude(band).getOrElse(zero), a))
+            t.putMagnitude(f(t.getMagnitude(band).getOrElse(zero), a))
           }
 
         val magCheck = new BoundCheckbox(

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -240,7 +240,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val nameField = new BoundTextField[String](10)(
         read = identity,
         show = identity,
-        get  = _.getTarget.getTarget.getName,
+        get  = _.getTarget.getName,
         set  = setTarget(_.setName(_))
       )
 
@@ -253,7 +253,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
             case NonSidereal => new ConicTarget()
           }
           target.setTarget(coords)
-          target.setName(target.getTarget.getName)
+          target.setName(target.getName)
           target.setMagnitudes(DefaultImList.create[Magnitude]())
         })}
       )

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -264,7 +264,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val raField = new BoundTextField[Double](10)(
         read = s => hms.parse(s),
         show = hms.format,
-        get  = _.getTarget.getTarget.getRaHours(JNoneLong).getOrElse(0.0),
+        get  = _.getTarget.getRaHours(JNoneLong).getOrElse(0.0),
         set  = setTarget((a, b) => a.setRaHours(b))
       )
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -272,7 +272,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val decField = new BoundTextField[Double](10)(
         read = s => dms.parse(s),
         show = dms.format,
-        get  = _.getTarget.getTarget.getDecDegrees(JNoneLong).getOrElse(0.0),
+        get  = _.getTarget.getDecDegrees(JNoneLong).getOrElse(0.0),
         set  = setTarget((a, b) => a.setDecDegrees(b))
       )
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ConicNameEditor.scala
@@ -22,7 +22,7 @@ final class ConicNameEditor(date: HorizonsIO[Date]) extends TelescopePosEditor w
 
   private[this] var spt = new SPTarget // never null
 
-  def ct: ConicTarget = spt.getTarget.asInstanceOf[ConicTarget]
+  def ct: ConicTarget = spt.getConicTarget.get
 
   /** A program to resolve the current target BY NAME and replace it. */
   val lookup: HorizonsIO[Unit] =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/JplMinorBodyDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/JplMinorBodyDetailEditor.scala
@@ -8,7 +8,7 @@ import edu.gemini.spModel.target.system.ITarget.Tag
 final class JplMinorBodyDetailEditor extends ConicDetailEditor(Tag.JPL_MINOR_BODY) {
   import NumericPropertySheet.Prop
 
-  lazy val props = NumericPropertySheet[ConicTarget](Some("Orbital Elements"), _.getTarget.asInstanceOf[ConicTarget],
+  lazy val props = NumericPropertySheet[ConicTarget](Some("Orbital Elements"), _.getConicTarget.get,
     Prop("EPOCH", "Orbital Element Epoch (JD)",        _.getEpoch.getValue, (t,d) => t.setEpoch(new Epoch(d, Units.JD))),
     Prop("IN",    "Inclination (deg)",                 _.getInclination),
     Prop("OM",    "Longitude of Ascending Node (deg)", _.getANode),

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/MpcMinorPlanetDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/MpcMinorPlanetDetailEditor.scala
@@ -7,7 +7,7 @@ import edu.gemini.spModel.target.system.{ConicTarget, ITarget}
 final class MpcMinorPlanetDetailEditor extends ConicDetailEditor(ITarget.Tag.MPC_MINOR_PLANET) {
   import NumericPropertySheet.Prop
 
-  lazy val props = NumericPropertySheet[ConicTarget](Some("Orbital Elements"), _.getTarget.asInstanceOf[ConicTarget],
+  lazy val props = NumericPropertySheet[ConicTarget](Some("Orbital Elements"), _.getConicTarget.get,
     Prop("EPOCH", "Orbital Element Epoch (JD)",        _.getEpoch.getValue, (t,d) => t.setEpoch(new Epoch(d, Units.JD))),
     Prop("IN",    "Inclination (deg)",                 _.getInclination),
     Prop("OM",    "Longitude of Ascending Node (deg)", _.getANode),

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
@@ -17,7 +17,7 @@ import scalaz._, Scalaz._
 final class NamedDetailEditor extends TargetDetailEditor(Tag.NAMED) with ReentrancyHack {
   private[this] var spt = new SPTarget // never null
 
-  private def nt: NamedTarget = spt.getTarget.asInstanceOf[NamedTarget]
+  private def nt: NamedTarget = spt.getNamedTarget.get
 
   // Editors
 
@@ -210,7 +210,7 @@ final class NamedDetailEditor extends TargetDetailEditor(Tag.NAMED) with Reentra
 
     this.spt = spTarget
     nonreentrant {
-      solarObject.setValue(spt.getTarget.asInstanceOf[NamedTarget].getSolarObject)
+      solarObject.setValue(spt.getNamedTarget.map(_.getSolarObject).get)
       name.setValue(spt.getName)
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/NamedDetailEditor.scala
@@ -211,7 +211,7 @@ final class NamedDetailEditor extends TargetDetailEditor(Tag.NAMED) with Reentra
     this.spt = spTarget
     nonreentrant {
       solarObject.setValue(spt.getTarget.asInstanceOf[NamedTarget].getSolarObject)
-      name.setValue(spt.getTarget.getName)
+      name.setValue(spt.getName)
     }
 
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealDetailEditor.scala
@@ -75,7 +75,7 @@ final class SiderealDetailEditor extends TargetDetailEditor(ITarget.Tag.SIDEREAL
     val formatter: RedshiftRepresentations => NumberFormat = (v) => v.formatter
   }
 
-  val props = NumericPropertySheet[HmsDegTarget](Some("Motion"), _.getTarget.asInstanceOf[HmsDegTarget],
+  val props = NumericPropertySheet[HmsDegTarget](Some("Motion"), _.getHmsDegTarget.get,
     Prop("µ RA",     "mas/year", _.getPM1),
     Prop("µ Dec",    "mas/year", _.getPM2),
     Prop("Epoch",    "years",    _.getEpoch.getValue,    (t, d) => t.setEpoch(new Epoch(d, Units.YEARS))),

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
@@ -79,7 +79,7 @@ final class SiderealNameEditor(mags: MagnitudeEditor) extends TelescopePosEditor
   def edit(ctx: GOption[ObsContext], target: SPTarget, node: ISPNode): Unit = {
     this.spt = target
     nonreentrant {
-      name.setText(spt.getTarget.getName)
+      name.setText(spt.getName)
     }
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SiderealNameEditor.scala
@@ -84,7 +84,7 @@ final class SiderealNameEditor(mags: MagnitudeEditor) extends TelescopePosEditor
   }
 
   def processResult(target: Option[SiderealTarget]): Unit = Swing.onEDT {
-    val t = spt.getTarget.asInstanceOf[HmsDegTarget]
+    val t = spt.getHmsDegTarget.get
 
     target.foreach { i =>
       i.properMotion.foreach { pm =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/SourceDetailsEditor.scala
@@ -50,7 +50,7 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
 
   private val defaultGaussianSource = GaussianSource(0.5)
 
-  private def gaussianOrDefault(t: SPTarget): GaussianSource = t.getTarget.getSpatialProfile.fold(defaultGaussianSource)(_.asInstanceOf[GaussianSource])
+  private def gaussianOrDefault(t: SPTarget): GaussianSource = t.getSpatialProfile.fold(defaultGaussianSource)(_.asInstanceOf[GaussianSource])
 
   private val pointSourceDetails    = new JPanel()
   private val uniformSourceDetails  = new JPanel()
@@ -76,9 +76,9 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
   private val defaultEmissionLine = EmissionLine(2.2.microns, 500.kps, 5.0e-19.wattsPerSquareMeter, 1.0e-16.wattsPerSquareMeterPerMicron)
   private val defaultPowerLaw     = PowerLaw(1)
 
-  private def blackBodyOrDefault   (t: SPTarget): BlackBody     = t.getTarget.getSpectralDistribution.fold(defaultBlackBody)(_.asInstanceOf[BlackBody])
-  private def emissionLineOrDefault(t: SPTarget): EmissionLine  = t.getTarget.getSpectralDistribution.fold(defaultEmissionLine)(_.asInstanceOf[EmissionLine])
-  private def powerLawOrDefault    (t: SPTarget): PowerLaw      = t.getTarget.getSpectralDistribution.fold(defaultPowerLaw)(_.asInstanceOf[PowerLaw])
+  private def blackBodyOrDefault   (t: SPTarget): BlackBody     = t.getSpectralDistribution.fold(defaultBlackBody)(_.asInstanceOf[BlackBody])
+  private def emissionLineOrDefault(t: SPTarget): EmissionLine  = t.getSpectralDistribution.fold(defaultEmissionLine)(_.asInstanceOf[EmissionLine])
+  private def powerLawOrDefault    (t: SPTarget): PowerLaw      = t.getSpectralDistribution.fold(defaultPowerLaw)(_.asInstanceOf[PowerLaw])
 
   private val libraryStarDetails     = new ComboBox[LibraryStar](LibraryStar.Values) {
     renderer = Renderer(_.sedSpectrum)
@@ -228,7 +228,7 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
       deafTo(editElements:_*)
 
       // update UI elements to reflect the spatial profile
-      spt.getTarget.getSpatialProfile match {
+      spt.getSpatialProfile match {
         case None                        => profiles.selection.item = profilePanels.head
         case Some(PointSource)           => profiles.selection.item = profilePanels(1)
         case Some(GaussianSource(_))     => profiles.selection.item = profilePanels(2); profilePanels(2).panel.asInstanceOf[NumericPropertySheet[GaussianSource]].edit(obsContext, spTarget, node)
@@ -236,7 +236,7 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
       }
 
       // update UI elements to reflect the spectral distribution
-      spt.getTarget.getSpectralDistribution match {
+      spt.getSpectralDistribution match {
         case None                        => distributions.selection.item = distributionPanels.head
         case Some(s: LibraryStar)        => distributions.selection.item = distributionPanels(1); libraryStarDetails.selection.item = s
         case Some(s: LibraryNonStar)     => distributions.selection.item = distributionPanels(2); libraryNonStarDetails.selection.item = s
@@ -302,7 +302,7 @@ final class SourceDetailsEditor extends GridBagPanel with TelescopePosEditor wit
     private def updateAuxFileModel(programId: SPProgramID): Unit =  {
 
       // Determines the currently selected SED aux file (if any)
-      def selectedAuxFile = spt.getTarget.getSpectralDistribution match {
+      def selectedAuxFile = spt.getSpectralDistribution match {
         case Some(s: AuxFileSpectrum) => Some(s)
         case _                        => None
       }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/ValidAtEditor.scala
@@ -108,7 +108,7 @@ abstract class ValidAtEditor[A <: ITarget](empty: A) extends TelescopePosEditor 
     spt = target
     node = node0
     nonreentrant {
-      val nst = spt.getTarget.asInstanceOf[NonSiderealTarget]
+      val nst = spt.getNonSiderealTarget.get
       val d   = Option(nst.getDateForPosition) | new java.util.Date
       calendar.setDate(d)
       timeConfig.setTime(d)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/TargetTypeEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/TargetTypeEditor.scala
@@ -26,10 +26,7 @@ final class TargetTypeEditor extends DropDownListBoxWidget[AnyRef] with Telescop
   def edit(obsContext: GOption[ObsContext], spTarget: SPTarget, node: ISPNode): Unit = {
     spt = spTarget
     nonreentrant {
-      setSelectedItem(spt.getTarget match {
-        case s: HmsDegTarget => "Sidereal Target"
-        case _               => "Nonsidereal Target"
-      })
+      setSelectedItem(spt.getHmsDegTarget.map(_ => "Sidereal Target").getOrElse("Nonsidereal Target"))
     }
   }
 


### PR DESCRIPTION
This PR is in preparation for swapping the target model; the intent is to minimize the number of references to `ITarget` since this type is going away. Here we are removing references in the form `spt.getTarget.foo` by putting a method `foo` on `SPTarget` that delegates to the underlying `ITarget`. These will be replaced with equivalent operations on the underlying `Target` and then inlined back into the current call sites, where appropriate.

The changes here are largely mechanical. More will follow.