### PR TITLE
OCSADV-519-C: Initial AgsHash function

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
@@ -61,7 +61,7 @@ object AgsHash {
       val base = t.getBase.getTarget
 
       def toData(coord: GemOption[java.lang.Double]): Int =
-        coord.asScalaOpt.map(_.doubleValue.scaled(8)).##
+        coord.asScalaOpt.map(_.doubleValue).##
 
       val ra  = toData(base.getRaDegrees(time))
       val dec = toData(base.getDecDegrees(time))
@@ -72,12 +72,12 @@ object AgsHash {
     // Offset Positions, which are returned in a Set.  Order is not important
     // for the purpose of AGS calculations.
     M3.unorderedHash(ctx.getSciencePositions.asScala.map { o =>
-      (o.p.arcsec.scaled(3), o.q.arcsec.scaled(3))
+      (o.p.arcsec, o.q.arcsec)
     }) +=: buf
 
     // Position Angle
     Option(ctx.getPositionAngle).foreach { a =>
-      a.degrees.scaled(3).## +=: buf
+      a.degrees.## +=: buf
     }
 
     // Position Angle Constraint
@@ -139,10 +139,5 @@ object AgsHash {
 
     def arcsec: Double =
       a.toArcsecs.getMagnitude
-  }
-
-  private implicit class DoubleOps(d: Double) {
-    def scaled(scale: Int): Double =
-      BigDecimal(d).setScale(scale, BigDecimal.RoundingMode.HALF_UP).doubleValue()
   }
 }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
@@ -1,0 +1,124 @@
+package edu.gemini.ags.api
+
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.shared.util.immutable.{Option => GemOption}
+import edu.gemini.spModel.ags.AgsStrategyKey
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2
+import edu.gemini.spModel.gemini.gmos.{InstGmosNorth, InstGmosSouth}
+import edu.gemini.spModel.obs.context.ObsContext
+
+import java.time.Instant
+
+import scala.collection.mutable.ListBuffer
+import scala.util.hashing.{MurmurHash3 => M3}
+
+import scala.collection.JavaConverters._
+
+/** Computes an `Int` hash value that corresponds to the set of inputs to the
+  * AGS lookup.  If an observation is changed in some way and yet the hash
+  * algorithm computes the same value, there is no need to re-do the AGS search.
+  */
+object AgsHash {
+
+  /** Calculates the AGS hash for this context, using the current base position
+    * location.
+    *
+    * <em>Warning.</em> This method is not referentially transparent as it may
+    * provide distinct answers for the same input at different times
+    * (particularly for non-sidereal targets).
+    */
+  def hashNow(ctx: ObsContext): Int =
+    hash(ctx, Instant.now())
+
+  /** Calculates the AGS hash for this context, calculating the base position
+    * corresponding to the given time.
+    */
+  def hash(ctx: ObsContext, when: Instant): Int =
+    hash(ctx, when.toEpochMilli)
+
+
+  /** Calculates the AGS hash for this context, calculating the base position
+    * corresponding to the given time expressed in milliseconds since 1970.
+    */
+  def hash(ctx: ObsContext, when: Long): Int = {
+
+    val buf = ListBuffer.empty[Int]
+
+    // AGS Strategy
+    val strategyKey = AgsRegistrar.currentStrategy(ctx).map(_.key)
+    strategyKey.foreach { s =>
+      M3.stringHash(s.id) +=: buf
+    }
+
+    // Conditions
+    Option(ctx.getConditions).foreach { c =>
+      c.cc.## +=: c.iq.## +=: c.sb.## +=: buf
+    }
+
+    // Base Position
+    Option(ctx.getTargets).foreach { t =>
+      val time = Some(new java.lang.Long(when)).asGeminiOpt
+      val base = t.getBase.getTarget
+
+      def toData(coord: GemOption[java.lang.Double]): Int =
+        coord.asScalaOpt.map(_.doubleValue.scaled(8)).##
+
+      val ra  = toData(base.getRaDegrees(time))
+      val dec = toData(base.getDecDegrees(time))
+
+      ra +=: dec +=: buf
+    }
+
+    // Offset Positions, which are returned in a Set.  Order is not important
+    // for the purpose of AGS calculations.
+    M3.unorderedHash(ctx.getSciencePositions.asScala.map { o =>
+      (o.p.arcsec.scaled(3), o.q.arcsec.scaled(3))
+    }) +=: buf
+
+    // Position Angle
+    Option(ctx.getPositionAngle).foreach { a =>
+      a.degrees.scaled(3).## +=: buf
+    }
+
+    // Position Angle Constraint
+    Option(ctx.getPosAngleConstraint).foreach { pac =>
+      pac.## +=: buf
+    }
+
+    // IssPort
+    Option(ctx.getIssPort).foreach { iss =>
+      iss.## +=: buf
+    }
+
+    // Instrument-specific features.  These have an impact on the science area
+    // and probe arm position and hence, vignetting.  Vignetting is a factor in
+    // AGS calculations.
+    Option(ctx.getInstrument).foreach {
+      case i: Flamingos2 if strategyKey.contains(AgsStrategyKey.Flamingos2OiwfsKey)   =>
+        i.getFpu.## +=: i.getLyotWheel.getPlateScale.## +=: buf
+
+      case i: InstGmosNorth if strategyKey.contains(AgsStrategyKey.GmosNorthOiwfsKey) =>
+        i.getFPUnit.## +=: i.getFPUnitMode.## +=: buf
+
+      case i: InstGmosSouth if strategyKey.contains(AgsStrategyKey.GmosSouthOiwfsKey) =>
+        i.getFPUnit.## +=: i.getFPUnitMode.## +=: buf
+
+      case _                                                                          =>
+    }
+
+    M3.orderedHash(buf)
+  }
+
+  private implicit class AngleOps(a: edu.gemini.skycalc.Angle) {
+    def degrees: Double =
+      a.toDegrees.getMagnitude
+
+    def arcsec: Double =
+      a.toArcsecs.getMagnitude
+  }
+
+  private implicit class DoubleOps(d: Double) {
+    def scaled(scale: Int): Double =
+      BigDecimal(d).setScale(scale, BigDecimal.RoundingMode.HALF_UP).doubleValue()
+  }
+}

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
@@ -1,0 +1,217 @@
+package edu.gemini.ags.api
+
+import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.skycalc.{Offset => SkyCalcOffset}
+import edu.gemini.spModel.ags.AgsStrategyKey
+import edu.gemini.spModel.core.{Declination, Angle}
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2
+import edu.gemini.spModel.gemini.gmos.{GmosCommonType, InstGmosSouth, GmosSouthType, GmosNorthType, InstGmosNorth}
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{CloudCover, Conditions, ImageQuality, SkyBackground, WaterVapor}
+import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.telescope.{IssPort, PosAngleConstraint, PosAngleConstraintAware}
+
+import java.time.Instant
+
+import org.scalacheck.Prop._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import scalaz._
+import Scalaz._
+
+class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.test.SpModelArbitraries {
+  val now = Instant.now()
+
+  def hashSame(ctx0: ObsContext, ctx1: ObsContext): Boolean =
+    AgsHash.hash(ctx0, now) == AgsHash.hash(ctx1, now)
+
+  def hashDiffers(ctx0: ObsContext, ctx1: ObsContext): Boolean =
+    !hashSame(ctx0, ctx1)
+
+  "AgsHash" should {
+    "differ if the AGS strategy changes" in
+      forAll { (ctx0: ObsContext, k: AgsStrategyKey) =>
+        val key0 = AgsRegistrar.currentStrategy(ctx0).map(_.key)
+        val ctx1 = ctx0.withAgsStrategyOverride(Option(k).asGeminiOpt)
+        val key1 = AgsRegistrar.currentStrategy(ctx1).map(_.key)
+
+        (key0 == key1) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if the cloud cover changes" in
+      forAll { (ctx0: ObsContext, cc: CloudCover) =>
+        val ctx1 = ctx0.withConditions(ctx0.getConditions.cc(cc))
+        (ctx0.getConditions.cc == cc) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if the image quality changes" in
+      forAll { (ctx0: ObsContext, iq: ImageQuality) =>
+        val ctx1 = ctx0.withConditions(ctx0.getConditions.iq(iq))
+        (ctx0.getConditions.iq == iq) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if the sky background changes" in
+      forAll { (ctx0: ObsContext, sb: SkyBackground) =>
+        val ctx1 = ctx0.withConditions(ctx0.getConditions.sb(sb))
+        (ctx0.getConditions.sb == sb) == hashSame(ctx0, ctx1)
+      }
+
+    "stay the same if only the water vapor changes" in
+      forAll { (ctx0: ObsContext, wv: WaterVapor) =>
+        hashSame(ctx0, ctx0.withConditions(ctx0.getConditions.wv(wv)))
+      }
+
+    "differ if multiple conditions change" in
+      forAll { (ctx0: ObsContext, c: Conditions) =>
+        val ctx1 = ctx0.withConditions(c)
+
+        // ignoring water vapor, if the conditions differ the hash should differ
+        val c1   = c.wv(ctx0.getConditions.wv)
+        (ctx0.getConditions == c1) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if the ISS Port differs" in
+      forAll { (ctx0: ObsContext, iss: IssPort) =>
+        val ctx1 = ctx0.withIssPort(iss)
+        val iss1 = ctx1.getIssPort
+
+        (ctx0.getIssPort == iss1) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if the position angle constraint differs" in
+      forAll { (ctx0: ObsContext, pac: PosAngleConstraint) =>
+        val i1 = ctx0.getInstrument
+        i1 match {
+          case pacw: PosAngleConstraintAware => pacw.setPosAngleConstraint(pac)
+          case _                             => // do nothing
+        }
+
+        val ctx1 = ctx0.withInstrument(i1)
+        val pac1 = ctx1.getPosAngleConstraint
+
+        (ctx0.getPosAngleConstraint == pac1) == hashSame(ctx0, ctx1)
+      }
+
+    def scale(d: Double, s: Int): Double =
+      BigDecimal(d).setScale(s, BigDecimal.RoundingMode.HALF_UP).doubleValue()
+
+    "differ if the position angle changes significantly" in
+      forAll { (ctx0: ObsContext, pa: Angle) =>
+        val ctx1 = ctx0.withPositionAngle(pa.toOldModel)
+
+        val pa0  = ctx0.getPositionAngle.toDegrees.getMagnitude
+        val pa1  = ctx1.getPositionAngle.toDegrees.getMagnitude
+
+        (scale(pa0, 3) == scale(pa1, 3)) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if RA changes" in
+      forAll { (ctx0: ObsContext, ra: Angle) =>
+        val env0  = ctx0.getTargets
+        val base0 = env0.getBase
+        val base1 = base0.clone() <| (_.setRaDegrees(ra.toDegrees))
+        val env1  = env0.setBasePosition(base1)
+        val ctx1  = ctx0.withTargets(env1)
+
+        val time  = Option(new java.lang.Long(now.toEpochMilli)).asGeminiOpt
+        val ra0   = base0.getTarget.getRaDegrees(time).getValue
+        val ra1   = base1.getTarget.getRaDegrees(time).getValue
+
+        (scale(ra0,8) == scale(ra1,8)) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if Dec changes" in
+      forAll { (ctx0: ObsContext, dec: Declination) =>
+        val env0  = ctx0.getTargets
+        val base0 = env0.getBase
+        val base1 = base0.clone() <| (_.setDecDegrees(dec.toDegrees))
+        val env1  = env0.setBasePosition(base1)
+        val ctx1  = ctx0.withTargets(env1)
+
+        val time  = Option(new java.lang.Long(now.toEpochMilli)).asGeminiOpt
+        val dec0  = base0.getTarget.getDecDegrees(time).getValue
+        val dec1  = base1.getTarget.getDecDegrees(time).getValue
+
+        (scale(dec0,8) == scale(dec1,8)) == hashSame(ctx0, ctx1)
+      }
+
+    "differ if offset positions change" in
+      forAll { (ctx0: ObsContext, posList: java.util.Set[SkyCalcOffset]) =>
+        val ctx1 = ctx0.withSciencePositions(posList)
+
+        (ctx0.getSciencePositions == ctx1.getSciencePositions) == hashSame(ctx0, ctx1)
+      }
+
+    "stay the same if only an unimportant instrument feature changes" in
+      forAll { (ctx0: ObsContext) =>
+        val i1 = ctx0.getInstrument match {
+          case f2: Flamingos2    => f2 <| (_.setFilter(Flamingos2.Filter.K_SHORT))
+          case gn: InstGmosNorth => gn <| (_.setFilter(GmosNorthType.FilterNorth.OIII_G0318))
+          case gs: InstGmosSouth => gs <| (_.setFilter(GmosSouthType.FilterSouth.OIII_G0338))
+          case i0                => i0
+        }
+        hashSame(ctx0, ctx0.withInstrument(i1))
+      }
+
+    val F2Key = Option(AgsStrategyKey.Flamingos2OiwfsKey: AgsStrategyKey).asGeminiOpt
+
+    "differ if Flamingos2 FPU changes" in
+      forAll { (ctx0: ObsContext, f: Flamingos2, fpu2: Flamingos2.FPUnit) =>
+        val fpu1 = f.getFpu
+        val ctx1 = ctx0.withInstrument(f).withAgsStrategyOverride(F2Key)
+        val ctx2 = ctx1.withInstrument(f <| (_.setFpu(fpu2)))
+
+        (fpu1 == fpu2) == hashSame(ctx1, ctx2)
+      }
+
+    "differ if Flamingos2 plate scale changes" in
+      forAll { (ctx0: ObsContext, f: Flamingos2, ly2: Flamingos2.LyotWheel) =>
+        val ly1  = f.getLyotWheel
+        val ctx1 = ctx0.withInstrument(f).withAgsStrategyOverride(F2Key)
+        val ctx2 = ctx1.withInstrument(f <| (_.setLyotWheel(ly2)))
+
+        (ly1.getPlateScale == ly2.getPlateScale) == hashSame(ctx1, ctx2)
+      }
+
+    val GmosNKey = Option(AgsStrategyKey.GmosNorthOiwfsKey: AgsStrategyKey).asGeminiOpt
+
+    "differ if GMOS North FPU changes" in
+      forAll { (ctx0: ObsContext, g: InstGmosNorth, fpu2: GmosNorthType.FPUnitNorth) =>
+        val fpu1 = g.getFPUnit
+        val ctx1 = ctx0.withInstrument(g).withAgsStrategyOverride(GmosNKey)
+        val ctx2 = ctx1.withInstrument(g <| (_.setFPUnit(fpu2)))
+
+        (fpu1 == fpu2) == hashSame(ctx1, ctx2)
+      }
+
+    "differ if GMOS North FPU Mode changes" in
+      forAll { (ctx0: ObsContext, g: InstGmosNorth, mode2: GmosCommonType.FPUnitMode) =>
+        val mode1 = g.getFPUnitMode
+        val ctx1  = ctx0.withInstrument(g).withAgsStrategyOverride(GmosNKey)
+        val ctx2  = ctx1.withInstrument(g <| (_.setFPUnitMode(mode2)))
+
+        (mode1 == mode2) == hashSame(ctx1, ctx2)
+      }
+
+    val GmosSKey = Option(AgsStrategyKey.GmosSouthOiwfsKey: AgsStrategyKey).asGeminiOpt
+
+    "differ if GMOS South FPU changes" in
+      forAll { (ctx0: ObsContext, g: InstGmosSouth, fpu2: GmosSouthType.FPUnitSouth) =>
+        val fpu1 = g.getFPUnit
+        val ctx1 = ctx0.withInstrument(g).withAgsStrategyOverride(GmosSKey)
+        val ctx2 = ctx1.withInstrument(g <| (_.setFPUnit(fpu2)))
+
+        (fpu1 == fpu2) == hashSame(ctx1, ctx2)
+      }
+
+    "differ if GMOS South FPU Mode changes" in
+      forAll { (ctx0: ObsContext, g: InstGmosSouth, mode2: GmosCommonType.FPUnitMode) =>
+        val mode1 = g.getFPUnitMode
+        val ctx1  = ctx0.withInstrument(g).withAgsStrategyOverride(GmosSKey)
+        val ctx2  = ctx1.withInstrument(g <| (_.setFPUnitMode(mode2)))
+
+        (mode1 == mode2) == hashSame(ctx1, ctx2)
+      }
+  }
+}

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
@@ -98,9 +98,6 @@ class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.
         (ctx0.getPosAngleConstraint == pac1) == hashSame(ctx0, ctx1)
       }
 
-    def scale(d: Double, s: Int): Double =
-      BigDecimal(d).setScale(s, BigDecimal.RoundingMode.HALF_UP).doubleValue()
-
     "differ if the position angle changes significantly" in
       forAll { (ctx0: ObsContext, pa: Angle) =>
         val ctx1 = ctx0.withPositionAngle(pa.toOldModel)
@@ -108,7 +105,7 @@ class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.
         val pa0  = ctx0.getPositionAngle.toDegrees.getMagnitude
         val pa1  = ctx1.getPositionAngle.toDegrees.getMagnitude
 
-        (scale(pa0, 3) == scale(pa1, 3)) == hashSame(ctx0, ctx1)
+        (pa0 == pa1) == hashSame(ctx0, ctx1)
       }
 
     "differ if RA changes" in
@@ -123,7 +120,7 @@ class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.
         val ra0   = base0.getTarget.getRaDegrees(time).getValue
         val ra1   = base1.getTarget.getRaDegrees(time).getValue
 
-        (scale(ra0,8) == scale(ra1,8)) == hashSame(ctx0, ctx1)
+        (ra0 == ra1) == hashSame(ctx0, ctx1)
       }
 
     "differ if Dec changes" in
@@ -138,7 +135,7 @@ class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.
         val dec0  = base0.getTarget.getDecDegrees(time).getValue
         val dec1  = base1.getTarget.getDecDegrees(time).getValue
 
-        (scale(dec0,8) == scale(dec1,8)) == hashSame(ctx0, ctx1)
+        (dec0 == dec1) == hashSame(ctx0, ctx1)
       }
 
     "differ if offset positions change" in

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingCalcSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingCalcSpec.scala
@@ -1,6 +1,8 @@
 package edu.gemini.spModel.inst
 
 import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.util.immutable.ImOption
+import edu.gemini.spModel.ags.AgsStrategyKey.GmosNorthOiwfsKey
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.gmos._
 import edu.gemini.spModel.guide.VignettingCalculator
@@ -45,9 +47,11 @@ object VignettingCalcSpec extends Specification with ScalaCheck with VignettingA
   implicit val arbTest: Arbitrary[TestEnv] =
     Arbitrary {
       for {
-        ctx <- arbitrary[ObsContext]
-        can <- genCandidates(ctx)
-      } yield TestEnv(ctx, can)
+        ctx  <- arbitrary[ObsContext]
+        gmos <- arbitrary[InstGmosNorth]
+        gmosCtx = ctx.withInstrument(gmos).withAgsStrategyOverride(ImOption.apply(GmosNorthOiwfsKey))
+        can  <- genCandidates(gmosCtx)
+      } yield TestEnv(gmosCtx, can)
     }
 
   "VignettingCalculator" should {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
@@ -135,4 +135,13 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
     Arbitrary {
       arbitrary[GuideEnv].map(ge => GuideEnvironment(ge))
     }
+
+  implicit val arbTargetEnvironment: Arbitrary[TargetEnvironment] =
+    Arbitrary {
+      for {
+        b <- arbitrary[SPTarget]
+        g <- arbitrary[GuideEnvironment]
+        u <- boundedListOf[SPTarget](3)
+      } yield TargetEnvironment.create(b, g, u.asImList)
+    }
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
@@ -10,6 +10,7 @@ import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.FPUnitMode._
 import edu.gemini.spModel.gemini.gmos.{GmosCommonType, GmosSouthType, InstGmosSouth, GmosNorthType, InstGmosNorth}
+import edu.gemini.spModel.gemini.gsaoi.Gsaoi
 import edu.gemini.spModel.gemini.niri.{InstNIRI, Niri}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{CloudCover, Conditions, ImageQuality, SkyBackground, WaterVapor}
 import edu.gemini.spModel.obs.context.ObsContext
@@ -45,6 +46,7 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
         fpu       <- arbitrary[Flamingos2.FPUnit]
         disperser <- Gen.oneOf(Flamingos2.Disperser.values)
         lyot      <- arbitrary[Flamingos2.LyotWheel]
+        port      <- arbitrary[IssPort]
         posAngle  <- arbitrary[Angle]
         pac       <- arbitrary[PosAngleConstraint]
       } yield
@@ -53,6 +55,7 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
           (_.setFpu(fpu))                      <|
           (_.setDisperser(disperser))          <|
           (_.setLyotWheel(lyot))               <|
+          (_.setIssPort(port))                 <|
           (_.setPosAngleConstraint(pac))       <|
           (_.setPosAngle(posAngle.toDegrees))
 
@@ -70,7 +73,7 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
         filter   <- Gen.oneOf(GmosNorthType.FilterNorth.values)
         fpu      <- arbitrary[GmosNorthType.FPUnitNorth]
         mode     <- Gen.frequency((1, CUSTOM_MASK), (9, BUILTIN))
-        port     <- Gen.oneOf(IssPort.values)
+        port     <- arbitrary[IssPort]
         posAngle <- arbitrary[Angle]
         pac      <- arbitrary[PosAngleConstraint]
       } yield
@@ -92,7 +95,7 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
         filter   <- Gen.oneOf(GmosSouthType.FilterSouth.values)
         fpu      <- arbitrary[GmosSouthType.FPUnitSouth]
         mode     <- Gen.frequency((1, CUSTOM_MASK), (9, BUILTIN))
-        port     <- Gen.oneOf(IssPort.values)
+        port     <- arbitrary[IssPort]
         posAngle <- arbitrary[Angle]
         pac      <- arbitrary[PosAngleConstraint]
       } yield
@@ -105,13 +108,29 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
           (_.setPosAngle(posAngle.toDegrees))
     }
 
+  implicit val arbGsaoi: Arbitrary[Gsaoi] =
+    Arbitrary {
+      for {
+        port     <- arbitrary[IssPort]
+        posAngle <- arbitrary[Angle]
+      } yield
+        new Gsaoi                             <|
+          (_.setIssPort(port))                <|
+          (_.setPosAngle(posAngle.toDegrees))
+    }
+
+  implicit val arbNiriCamera: Arbitrary[Niri.Camera] =
+    Arbitrary { Gen.oneOf(Niri.Camera.values) }
+
   implicit val arbNiri: Arbitrary[InstNIRI] =
     Arbitrary {
       for {
+        camera    <- arbitrary[Niri.Camera]
         disperser <- Gen.oneOf(Niri.Disperser.values)
         posAngle  <- arbitrary[Angle]
       } yield
         new InstNIRI                        <|
+          (_.setCamera(camera))             <|
           (_.setDisperser(disperser))       <|
           (_.setPosAngle(posAngle.toDegrees))
     }
@@ -122,6 +141,7 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
         arbitrary[Flamingos2],
         arbitrary[InstGmosNorth],
         arbitrary[InstGmosSouth],
+        arbitrary[Gsaoi],
         arbitrary[InstNIRI]
       )
     }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
@@ -1,0 +1,185 @@
+package edu.gemini.spModel.test
+
+import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.util.immutable.None
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.skycalc.{Offset => SkyCalcOffset}
+import edu.gemini.spModel.ags.AgsStrategyKey
+import edu.gemini.spModel.core.{OffsetQ, OffsetP, Offset, Angle, Arbitraries}
+import edu.gemini.spModel.core.AngleSyntax._
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2
+import edu.gemini.spModel.gemini.gmos.GmosCommonType.FPUnitMode._
+import edu.gemini.spModel.gemini.gmos.{GmosCommonType, GmosSouthType, InstGmosSouth, GmosNorthType, InstGmosNorth}
+import edu.gemini.spModel.gemini.niri.{InstNIRI, Niri}
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{CloudCover, Conditions, ImageQuality, SkyBackground, WaterVapor}
+import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.obscomp.SPInstObsComp
+import edu.gemini.spModel.target.env.TargetEnvironment
+import edu.gemini.spModel.telescope.{PosAngleConstraint, IssPort}
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+import scala.collection.JavaConverters._
+
+import scalaz._, Scalaz._
+
+
+trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.Arbitraries {
+
+  // TODO: Eventually all instruments should be included and all instrument
+  // TODO: features as well.  They should probably also be broken out into
+  // TODO: individual Arbitraries.
+
+  implicit val arbFlamingos2Fpu: Arbitrary[Flamingos2.FPUnit] =
+    Arbitrary { Gen.oneOf(Flamingos2.FPUnit.values) }
+
+  implicit val arbFlamingos2Lyout: Arbitrary[Flamingos2.LyotWheel] =
+    Arbitrary { Gen.oneOf(Flamingos2.LyotWheel.values) }
+
+  implicit val arbFlamingos2: Arbitrary[Flamingos2] =
+    Arbitrary {
+      for {
+        filter    <- Gen.oneOf(Flamingos2.Filter.values)
+        fpu       <- arbitrary[Flamingos2.FPUnit]
+        disperser <- Gen.oneOf(Flamingos2.Disperser.values)
+        lyot      <- arbitrary[Flamingos2.LyotWheel]
+        posAngle  <- arbitrary[Angle]
+        pac       <- arbitrary[PosAngleConstraint]
+      } yield
+        new Flamingos2()                       <|
+          (_.setFilter(filter))                <|
+          (_.setFpu(fpu))                      <|
+          (_.setDisperser(disperser))          <|
+          (_.setLyotWheel(lyot))               <|
+          (_.setPosAngleConstraint(pac))       <|
+          (_.setPosAngle(posAngle.toDegrees))
+
+    }
+
+  implicit val argGmosFpuMode: Arbitrary[GmosCommonType.FPUnitMode] =
+    Arbitrary { Gen.oneOf(CUSTOM_MASK, BUILTIN) }
+
+  implicit val arbGmosNFpu: Arbitrary[GmosNorthType.FPUnitNorth] =
+    Arbitrary { Gen.oneOf(GmosNorthType.FPUnitNorth.values) }
+
+  implicit val arbGmosN: Arbitrary[InstGmosNorth] =
+    Arbitrary {
+      for {
+        filter   <- Gen.oneOf(GmosNorthType.FilterNorth.values)
+        fpu      <- arbitrary[GmosNorthType.FPUnitNorth]
+        mode     <- Gen.frequency((1, CUSTOM_MASK), (9, BUILTIN))
+        port     <- Gen.oneOf(IssPort.values)
+        posAngle <- arbitrary[Angle]
+        pac      <- arbitrary[PosAngleConstraint]
+      } yield
+        new InstGmosNorth                      <|
+          (_.setFilter(filter))                <|
+          (_.setFPUnit(fpu))                   <|
+          (_.setFPUnitMode(mode))              <|
+          (_.setIssPort(port))                 <|
+          (_.setPosAngleConstraint(pac))       <|
+          (_.setPosAngle(posAngle.toDegrees))
+    }
+
+  implicit val arbGmosSFpu: Arbitrary[GmosSouthType.FPUnitSouth] =
+    Arbitrary { Gen.oneOf(GmosSouthType.FPUnitSouth.values) }
+
+  implicit val arbGmosS: Arbitrary[InstGmosSouth] =
+    Arbitrary {
+      for {
+        filter   <- Gen.oneOf(GmosSouthType.FilterSouth.values)
+        fpu      <- arbitrary[GmosSouthType.FPUnitSouth]
+        mode     <- Gen.frequency((1, CUSTOM_MASK), (9, BUILTIN))
+        port     <- Gen.oneOf(IssPort.values)
+        posAngle <- arbitrary[Angle]
+        pac      <- arbitrary[PosAngleConstraint]
+      } yield
+        new InstGmosSouth                     <|
+          (_.setFilter(filter))               <|
+          (_.setFPUnit(fpu))                  <|
+          (_.setFPUnitMode(mode))             <|
+          (_.setIssPort(port))                <|
+          (_.setPosAngleConstraint(pac))      <|
+          (_.setPosAngle(posAngle.toDegrees))
+    }
+
+  implicit val arbNiri: Arbitrary[InstNIRI] =
+    Arbitrary {
+      for {
+        disperser <- Gen.oneOf(Niri.Disperser.values)
+        posAngle  <- arbitrary[Angle]
+      } yield
+        new InstNIRI                        <|
+          (_.setDisperser(disperser))       <|
+          (_.setPosAngle(posAngle.toDegrees))
+    }
+
+  implicit val arbInst: Arbitrary[SPInstObsComp] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[Flamingos2],
+        arbitrary[InstGmosNorth],
+        arbitrary[InstGmosSouth],
+        arbitrary[InstNIRI]
+      )
+    }
+
+  val genSmallOffset: Gen[SkyCalcOffset] =
+    for {
+      pi <- Gen.chooseNum(-50, 50)
+      qi <- Gen.chooseNum(-50, 50)
+    } yield Offset(pi.toDouble.arcsecs[OffsetP], qi.toDouble.arcsecs[OffsetQ]).toOldModel
+
+  implicit val arbSciencePosSet: Arbitrary[java.util.Set[SkyCalcOffset]] =
+    Arbitrary {
+      for {
+        count <- Gen.chooseNum(1, 4)
+        offs  <- Gen.listOfN(count, genSmallOffset)
+      } yield new java.util.HashSet(offs.asJava)
+    }
+
+  implicit val arbCloudCover: Arbitrary[CloudCover] =
+    Arbitrary { Gen.oneOf(CloudCover.values) }
+
+  implicit val arbImageQuality: Arbitrary[ImageQuality] =
+    Arbitrary { Gen.oneOf(ImageQuality.values) }
+
+  implicit val arbSkyBackground: Arbitrary[SkyBackground] =
+    Arbitrary { Gen.oneOf(SkyBackground.values) }
+
+  implicit val arbWaterVapor: Arbitrary[WaterVapor] =
+    Arbitrary { Gen.oneOf(WaterVapor.values) }
+
+  implicit val arbConditions: Arbitrary[Conditions] =
+    Arbitrary {
+      for {
+        cc <- arbitrary[CloudCover]
+        iq <- arbitrary[ImageQuality]
+        sb <- arbitrary[SkyBackground]
+        wv <- arbitrary[WaterVapor]
+      } yield new Conditions(cc, iq, sb, wv)
+    }
+
+  implicit val arbPositionAngleConstraint: Arbitrary[PosAngleConstraint] =
+    Arbitrary { Gen.oneOf(PosAngleConstraint.values) }
+
+  implicit val arbIssPort: Arbitrary[IssPort] =
+    Arbitrary { Gen.oneOf(IssPort.values) }
+
+  implicit val arbAgsStrategy: Arbitrary[AgsStrategyKey] =
+    Arbitrary { Gen.oneOf(AgsStrategyKey.All) }
+
+  implicit val arbContext: Arbitrary[ObsContext] =
+    Arbitrary {
+      for {
+        ags  <- arbitrary[Option[AgsStrategyKey]]
+        env  <- arbitrary[TargetEnvironment]
+        inst <- arbitrary[SPInstObsComp]
+        site  = inst.getSite.asScala.headOption.asGeminiOpt
+        cond <- arbitrary[Conditions]
+        offs <- arbitrary[java.util.Set[SkyCalcOffset]]
+      } yield ObsContext.create(ags.asGeminiOpt, env, inst, site, cond, offs, null, None.instance())
+    }
+}


### PR DESCRIPTION
This PR introduces a simple hash function for AGS.  In particular, given an `ObsContext` it will compute a hash value based on variables that play a role in AGS calculations.  The plan is to store this information in an LRU cache in the OT to avoid performing AGS lookups unless there is a chance that the algorithm will come up with a different result.

I think I did a somewhat reasonable job taking into account the various factors in play but nevertheless I expect I've overlooked some details.  This function will likely grow a bit as missing elements are discovered but should serve as a starting point.