### PR TITLE
OCSADV-514-B: Add Auto Disabled

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/init/ObservationNI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/init/ObservationNI.java
@@ -21,6 +21,7 @@ import edu.gemini.spModel.obslog.ObsQaLog;
 import edu.gemini.spModel.obsrecord.ObsExecStatus;
 import edu.gemini.spModel.seqcomp.InstrumentSequenceSync;
 import edu.gemini.spModel.seqcomp.SeqBase;
+import edu.gemini.spModel.target.env.*;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.telescope.IssPortSync;
 import edu.gemini.spModel.too.Too;
@@ -178,5 +179,21 @@ public class ObservationNI implements ISPNodeInitializer {
         if (qa != null) qa.setDataObject(new ObsQaLog());
         final ISPObsExecLog exec = obs.getObsExecLog();
         if (exec != null) exec.setDataObject(new ObsExecLog());
+
+        // Reset disabled automatic groups.
+        for (ISPObsComponent oc : obs.getObsComponents()) {
+            if (oc.getType() == SPComponentType.TELESCOPE_TARGETENV) {
+                final TargetObsComp     toc = (TargetObsComp) oc.getDataObject();
+                final TargetEnvironment env = toc.getTargetEnvironment();
+                final GuideEnvironment genv = env.getGuideEnvironment();
+
+                if (genv.guideEnv().auto() instanceof AutomaticGroup.Disabled$) {
+                    toc.setTargetEnvironment(
+                        TargetEnv.auto().set(env, AutomaticGroup.Initial$.MODULE$)
+                    );
+                    oc.setDataObject(toc);
+                }
+            }
+        }
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -45,7 +45,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     // for serialization
     private static final long serialVersionUID = 4L;
 
-    public static final String VERSION = "2016A-1";
+    public static final String VERSION = "2016B-1";
 
     /** This property records the program queue/classical state. */
     public static final String PROGRAM_MODE_PROP = "programMode";

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -346,26 +346,19 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
 
     private static GuideEnvironment parseGuideEnvironment(ParamSet parent) {
         // Add guide information
-        ParamSet guidePset = parent.getParamSet(GuideEnvironment.ParamSetName());
+        final ParamSet guidePset = parent.getParamSet(GuideEnvironment.ParamSetName());
         if (guidePset != null) return GuideEnvironment.fromParamSet(guidePset);
 
-        // Check for pre-2010B guide probe targets
-        List<ParamSet> guideProbeTargets = parent.getParamSets("guider");
-        if (guideProbeTargets.isEmpty()) {
-            // nothing there, return a default empty guide environment
-            return GuideEnvironment.Initial();
-        }
-
         // Parse the old pre-2010B information into a GuideEnvironment
-        List<GuideProbeTargets> lst = new ArrayList<>();
+        final List<ParamSet> guideProbeTargets = parent.getParamSets("guider");
+        final List<GuideProbeTargets> lst = new ArrayList<>();
         for (ParamSet ps : guideProbeTargets) {
-            GuideProbeTargets gpt = GuideProbeTargets.fromParamSet(ps);
-            if (gpt == null) continue;
-            lst.add(gpt);
+            final GuideProbeTargets gpt = GuideProbeTargets.fromParamSet(ps);
+            if (gpt != null) lst.add(gpt);
         }
 
-        GuideGroup grp = GuideGroup.create(None.STRING, DefaultImList.create(lst));
-        return GuideEnvironment.create(OptionsListImpl.create(grp));
+        final GuideGroup grp = GuideGroup.create(None.STRING, DefaultImList.create(lst));
+        return GuideEnvironment.create(OptionsListImpl.create(new GuideGroup(AutomaticGroup.Disabled$.MODULE$), grp).setPrimaryIndex(1));
     }
 
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/GuideEnv.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/GuideEnv.scala
@@ -73,7 +73,8 @@ object GuideEnv {
   /** Initial/default `GuideEnv`. Contains an `AutomaticGroup.Initial` and no
     * manual groups.
     */
-  val initial: GuideEnv = GuideEnv(AutomaticGroup.Initial, none)
+  val Initial: GuideEnv  = GuideEnv(AutomaticGroup.Initial, none)
+  val Disabled: GuideEnv = GuideEnv(AutomaticGroup.Disabled, none)
 
   val auto: GuideEnv @> AutomaticGroup =
     Lens.lensu((ge,a) => ge.copy(auto = a), _.auto)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/GuideGroup.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/GuideGroup.scala
@@ -281,11 +281,11 @@ object GuideGroup extends ((GuideGrp) => GuideGroup) {
 
   val ParamSetName = "guideGroup"
 
-  sealed trait TypeTag
-  case object AutoInitialTag  extends TypeTag
-  case object AutoDisabledTag extends TypeTag
-  case object AutoActiveTag   extends TypeTag
-  case object ManualTag       extends TypeTag
+  sealed trait GroupTypeTag
+  case object AutoInitialTag  extends GroupTypeTag
+  case object AutoDisabledTag extends GroupTypeTag
+  case object AutoActiveTag   extends GroupTypeTag
+  case object ManualTag       extends GroupTypeTag
 
   private val AllTags = List(AutoInitialTag, AutoDisabledTag, AutoActiveTag, ManualTag)
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/env/Pre2010BTargetEnvironmentIoTest.java
@@ -1,14 +1,15 @@
 package edu.gemini.spModel.target.env;
 
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.pio.xml.PioXmlFactory;
 import edu.gemini.spModel.pio.xml.PioXmlUtil;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 import org.junit.Test;
 
 import java.io.File;
@@ -41,8 +42,12 @@ public class Pre2010BTargetEnvironmentIoTest {
                 verifyTarget("BaseName", env.getBase());
                 assertEquals(0, env.getUserTargets().size());
 
-                // Just the one automatic group
-                assertEquals(1, env.getGuideEnvironment().getOptions().size());
+                // An initial disabled auto group and a manual primary group
+                final ImList<GuideGroup> groups = env.getGuideEnvironment().getOptions();
+                assertEquals(2, groups.size());
+                assertTrue(groups.get(0).grp() instanceof AutomaticGroup.Disabled$);
+                assertTrue(groups.get(1).grp() instanceof ManualGroup);
+                assertTrue(1 == env.getGuideEnvironment().getPrimaryIndex());
             }
         },
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
@@ -82,12 +82,13 @@ trait Almosts {
 
   implicit val AlmostEqualGuideGrp: AlmostEqual[GuideGrp] =
     new AlmostEqual[GuideGrp] {
-      import AutomaticGroup.{Active, Initial}
+      import AutomaticGroup.{Active, Initial, Disabled}
       def almostEqual(a: GuideGrp, b: GuideGrp): Boolean =
         (a, b) match {
           case (ManualGroup(an, am), ManualGroup(bn, bm)) => (an === bn) && (am ~= bm)
           case (Active(am), Active(bm))                   => am ~= bm
           case (Initial, Initial)                         => true
+          case (Disabled, Disabled)                       => true
           case _                                          => false
         }
     }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
@@ -102,7 +102,7 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
 
   implicit val arbAutomaticGroup: Arbitrary[AutomaticGroup] =
     Arbitrary {
-      oneOf[AutomaticGroup](AutomaticGroup.Initial, arbitrary[AutomaticGroup.Active])
+      oneOf[AutomaticGroup](AutomaticGroup.Initial, AutomaticGroup.Disabled, arbitrary[AutomaticGroup.Active])
     }
 
   implicit val arbGuideGrp: Arbitrary[GuideGrp] =

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/GuideGroupSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/GuideGroupSpec.scala
@@ -51,6 +51,11 @@ class GuideGroupSpec extends Specification with ScalaCheck with Arbitraries with
         !GuideGroup(AutomaticGroup.Initial).contains(gp)
       }
 
+    "be false for any guide probe for the disabled automatic group" in
+      forAll { (gp: GuideProbe) =>
+        !GuideGroup(AutomaticGroup.Disabled).contains(gp)
+      }
+
     "be true iff there are targets associated with the guide probe" in
       forAll { (g: GuideGroup) =>
         AllProbes.forall { gp =>
@@ -89,6 +94,7 @@ class GuideGroupSpec extends Specification with ScalaCheck with Arbitraries with
               case ManualGroup(_, m)        => m.lookup(gp).flatMap(_.focus)
               case AutomaticGroup.Active(m) => m.lookup(gp)
               case AutomaticGroup.Initial   => None
+              case AutomaticGroup.Disabled  => None
             })
           }
         }
@@ -177,6 +183,7 @@ class GuideGroupSpec extends Specification with ScalaCheck with Arbitraries with
         g.grp match {
           case AutomaticGroup.Active(m) => guiders == m.keySet
           case AutomaticGroup.Initial   => guiders.isEmpty
+          case AutomaticGroup.Disabled  => guiders.isEmpty
           case ManualGroup(_, m)        => guiders == m.keySet
         }
       }
@@ -299,6 +306,12 @@ class GuideGroupSpec extends Specification with ScalaCheck with Arbitraries with
     "return nothing for automatic initial groups" in
       forAll { (t: SPTarget) =>
         val gg = GuideGroup(AutomaticGroup.Initial)
+        gg.getAllContaining(t).isEmpty
+      }
+
+    "return nothing for automatic disabled groups" in
+      forAll { (t: SPTarget) =>
+        val gg = GuideGroup(AutomaticGroup.Disabled)
         gg.getAllContaining(t).isEmpty
       }
 

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
@@ -18,6 +18,7 @@ import edu.gemini.spModel.io.impl.migration.to2014A.To2014A;
 import edu.gemini.spModel.io.impl.migration.to2015A.To2015A;
 import edu.gemini.spModel.io.impl.migration.to2015B.To2015B;
 import edu.gemini.spModel.io.impl.migration.to2016A.To2016A;
+import edu.gemini.spModel.io.impl.migration.to2016B.To2016B;
 import edu.gemini.spModel.io.impl.migration.toPalote.Grillo2Palote;
 import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obscomp.SPGroup;
@@ -218,6 +219,9 @@ public final class PioSpXmlParser {
 
         // Update pre-2016A programs
         To2016A.updateProgram(doc);
+
+        // Update pre-2016B programs
+        To2016B.updateProgram(doc);
 
         // We will special case the Phase 1 container.
         Container p1Container = null;

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
@@ -19,7 +19,7 @@ object PioSyntax {
     }
 
     def findContainers(spc: SPComponentType): List[Container] =
-      allContainers.filter(_.componentType.exists(_ == spc))
+      allContainers.filter(_.componentType.contains(spc))
 
   }
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
@@ -24,16 +24,7 @@ object To2015B extends Migration {
   import PioSyntax._
   import BrightnessParser._
 
-  val Version_2015B = Version.`match`("2015B-1")
-
-  def isPre2015B(c: Container): Boolean =
-    c.getVersion.compareTo(Version_2015B) < 0
-
-  // Entry point here
-  def updateProgram(d: Document): Unit =
-    d.containers.find(_.getKind == SpIOTags.PROGRAM).filter(isPre2015B).foreach { _ =>
-      conversions.foreach(_.apply(d))
-    }
+  val version = Version.`match`("2015B-1")
 
   // These constants are take from mainline code, where they are private to implementations and
   // ultimately will go away (but we will need them here for a while longer).
@@ -105,7 +96,7 @@ object To2015B extends Migration {
   private val PioFactory = new PioXmlFactory()
 
   // These will be applied in the given order
-  private val conversions: List[Document => Unit] = List(
+  val conversions: List[Document => Unit] = List(
     brightnessToMagnitude,
     uselessSystemsToJ2000,
     b1950ToJ2000,

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/To2016A.scala
@@ -1,7 +1,6 @@
 package edu.gemini.spModel.io.impl.migration.to2016A
 
 import edu.gemini.pot.sp.SPComponentType
-import edu.gemini.spModel.io.impl.SpIOTags
 import edu.gemini.spModel.io.impl.migration.Migration
 import edu.gemini.spModel.io.impl.migration.PioSyntax._
 import edu.gemini.spModel.pio.{Container, Document, Param, Version}
@@ -17,21 +16,12 @@ import squants.radio.{WattsPerSquareMeter, WattsPerSquareMeterPerMicron}
  */
 object To2016A extends Migration {
 
-  val Version_2016A = Version.`match`("2016A-1")
+  val version = Version.`match`("2016A-1")
 
   val PARAMSET_EMISSION_LINE = "EmissionLine"
 
-  def isPre2016A(c: Container): Boolean =
-    c.getVersion.compareTo(Version_2016A) < 0
-
-  // Entry point here
-  def updateProgram(d: Document): Unit =
-    d.containers.find(_.getKind == SpIOTags.PROGRAM).filter(isPre2016A).foreach { _ =>
-      conversions.foreach(_.apply(d))
-    }
-
   // These will be applied in the given order
-  private val conversions: List[Document => Unit] = List(
+  val conversions: List[Document => Unit] = List(
     addUnitsToELine, demotePluto, updateGpiUnblockedModes, GsaMigration.convertDatasetRecords
   )
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -1,0 +1,71 @@
+package edu.gemini.spModel.io.impl.migration.to2016B
+
+import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.io.impl.migration.Migration
+import edu.gemini.spModel.io.impl.migration.PioSyntax._
+import edu.gemini.spModel.pio.xml.PioXmlFactory
+import edu.gemini.spModel.pio.{Pio, ParamSet, Document, Version}
+import edu.gemini.spModel.target.env.GuideGroup
+
+import scala.collection.JavaConverters._
+
+import scalaz._
+import Scalaz._
+
+object To2016B extends Migration {
+  val version = Version.`match`("2016B-1")
+
+  val conversions: List[Document => Unit] = List(
+    updateGuideEnvironment
+  )
+
+  val fact = new PioXmlFactory
+
+  private def updateGuideEnvironment(d: Document): Unit = {
+
+    def disabledGroup: ParamSet =
+      fact.createParamSet(GuideGroup.ParamSetName) <|
+        (ps => Pio.addParam(fact, ps, "tag", GuideGroup.AutoDisabledTag.toString))
+
+    def addEmptyGuideEnv(targetEnv: ParamSet): Unit = {
+      val guideEnv = fact.createParamSet("guideEnv")
+
+      Pio.addIntParam(fact, guideEnv, "primary", 0)
+      guideEnv.addParamSet(disabledGroup)
+
+      targetEnv.addParamSet(guideEnv)
+    }
+
+    def addDisabledAutomaticGroup(guideEnv: ParamSet): Unit = {
+      val manualGroups = guideEnv.getParamSets("guideGroup").asScala.toList
+
+      // Add the manual tag to all the existing groups.
+      manualGroups.foreach { grp =>
+        Pio.addParam(fact, grp, "tag", GuideGroup.ManualTag.toString)
+      }
+
+      // Increment primary group to account for the new auto group
+      val primary = Pio.getIntValue(guideEnv, "primary", 0) + (manualGroups.nonEmpty ? 1 | 0)
+      val param   = Option(guideEnv.getParam("primary")) | {
+        fact.createParam("primary") <| guideEnv.addParam
+      }
+      param.setValue(primary.toString)
+
+      // Remove all guide gropus.
+      while (guideEnv.removeChild("guideGroup") != null) {}
+
+      // Add them back in the correct order.
+      (disabledGroup :: manualGroups).foreach(guideEnv.addParamSet)
+    }
+
+    val tes = for {
+      obs <- d.findContainers(SPComponentType.OBSERVATION_BASIC)
+      env <- obs.findContainers(SPComponentType.TELESCOPE_TARGETENV)
+      ps  <- env.allParamSets.filter(_.getName == "targetEnv")
+    } yield ps
+
+    tes.foreach { paramSet =>
+      Option(paramSet.getParamSet("guideEnv")).fold(addEmptyGuideEnv(paramSet))(addDisabledAutomaticGroup)
+    }
+  }
+}

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/groupMigration.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/groupMigration.xml
@@ -1,0 +1,433 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2016A-1" subtype="basic" key="aff871bb-d34f-4a88-b965-aba58a98f6bd" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="debfbe51-decc-4c4f-90fa-cc7a37b2f4b9" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="No Groups"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="1b8830c3-5359-43ef-929c-be2026c2d751" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="4ed6b480-12a5-4274-9b61-e269f3725b37" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="843e9a60-3081-42b2-aa3a-b12e6f7cc8e0" name="GMOS-S">
+        <paramset name="GMOS-S" kind="dataObj">
+          <param name="exposureTime" value="300.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <paramset name="parallacticAngleDuration">
+            <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
+            <param name="explicitDuration" value="0"/>
+          </paramset>
+          <param name="adc" value="NONE"/>
+          <param name="ampCount" value="TWELVE"/>
+          <param name="gainChoice" value="LOW"/>
+          <param name="ampReadMode" value="SLOW"/>
+          <param name="detectorManufacturer" value="HAMAMATSU"/>
+          <param name="disperser" value="MIRROR"/>
+          <param name="fpuMode" value="BUILTIN"/>
+          <param name="fpu" value="FPU_NONE"/>
+          <param name="filter" value="NONE"/>
+          <param name="ccdXBinning" value="ONE"/>
+          <param name="ccdYBinning" value="ONE"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="stageMode" value="FOLLOW_XYZ"/>
+          <param name="dtaXOffset" value="ZERO"/>
+          <param name="builtinROI" value="FULL_FRAME"/>
+          <param name="useNS" value="FALSE"/>
+          <param name="mosPreimaging" value="NO"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="d8969949-1b12-4b2b-a996-d21d481f2c7d" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="9f1bf006-93c0-4ce2-95c2-b65e43b1f833" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="832f370e-4eaa-47fa-9a95-316e64d5075d" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="9820c503-ff91-4a06-84cd-f770bb9d8f7c" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="One Manual Group"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="3ee541fb-c0fc-4d58-93bd-9b1bf1b08ff7" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="46ef879d-4cb8-4ed4-9d0f-c7e7896ac7f2" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="0"/>
+              <paramset name="guideGroup">
+                <paramset name="guider">
+                  <param name="key" value="GMOS OIWFS"/>
+                  <paramset name="bagsResult">
+                    <param name="bagsResultId" value="NoSearchPerformed"/>
+                  </paramset>
+                  <param name="primary" value="0"/>
+                  <paramset name="spTarget">
+                    <param name="name" value="Foo"/>
+                    <param name="system" value="J2000"/>
+                    <param name="epoch" value="2000.0" units="years"/>
+                    <param name="c1" value="00:00:00.000"/>
+                    <param name="c2" value="00:00:00.00"/>
+                    <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+                    <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+                    <param name="parallax" value="0.0" units="mas"/>
+                    <param name="z" value="0.0"/>
+                  </paramset>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="76bbd950-ce06-4960-a72d-afd5c3618898" name="GMOS-S">
+        <paramset name="GMOS-S" kind="dataObj">
+          <param name="exposureTime" value="300.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <paramset name="parallacticAngleDuration">
+            <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
+            <param name="explicitDuration" value="0"/>
+          </paramset>
+          <param name="adc" value="NONE"/>
+          <param name="ampCount" value="TWELVE"/>
+          <param name="gainChoice" value="LOW"/>
+          <param name="ampReadMode" value="SLOW"/>
+          <param name="detectorManufacturer" value="HAMAMATSU"/>
+          <param name="disperser" value="MIRROR"/>
+          <param name="fpuMode" value="BUILTIN"/>
+          <param name="fpu" value="FPU_NONE"/>
+          <param name="filter" value="NONE"/>
+          <param name="ccdXBinning" value="ONE"/>
+          <param name="ccdYBinning" value="ONE"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="stageMode" value="FOLLOW_XYZ"/>
+          <param name="dtaXOffset" value="ZERO"/>
+          <param name="builtinROI" value="FULL_FRAME"/>
+          <param name="useNS" value="FALSE"/>
+          <param name="mosPreimaging" value="NO"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b6561a3b-e1d4-4abe-abdf-061d112924eb" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="7cbfde0c-2bed-4f1d-9320-050498ed5599" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="db8b6028-1886-47bd-a367-f3cdac7296ab" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="f13a8f6f-aefc-4f38-8de8-0b6d8f591518" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="Two Manual Groups"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="631c08f4-5424-4ca7-bcca-f30429310fe0" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="3dfc0212-7671-44a0-b12e-7129f33caca5" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="1"/>
+              <paramset name="guideGroup">
+                <paramset name="guider">
+                  <param name="key" value="GMOS OIWFS"/>
+                  <paramset name="bagsResult">
+                    <param name="bagsResultId" value="NoSearchPerformed"/>
+                  </paramset>
+                  <param name="primary" value="0"/>
+                  <paramset name="spTarget">
+                    <param name="name" value=""/>
+                    <param name="system" value="J2000"/>
+                    <param name="epoch" value="2000.0" units="years"/>
+                    <param name="c1" value="00:00:00.000"/>
+                    <param name="c2" value="00:00:00.00"/>
+                    <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+                    <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+                    <param name="parallax" value="0.0" units="mas"/>
+                    <param name="z" value="0.0"/>
+                  </paramset>
+                </paramset>
+              </paramset>
+              <paramset name="guideGroup">
+                <paramset name="guider">
+                  <param name="key" value="GMOS OIWFS"/>
+                  <paramset name="bagsResult">
+                    <param name="bagsResultId" value="NoSearchPerformed"/>
+                  </paramset>
+                  <param name="primary" value="0"/>
+                  <paramset name="spTarget">
+                    <param name="name" value=""/>
+                    <param name="system" value="J2000"/>
+                    <param name="epoch" value="2000.0" units="years"/>
+                    <param name="c1" value="00:00:00.000"/>
+                    <param name="c2" value="00:00:00.00"/>
+                    <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+                    <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+                    <param name="parallax" value="0.0" units="mas"/>
+                    <param name="z" value="0.0"/>
+                  </paramset>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="bdb73a0d-b04c-43cf-95a4-c14d3f154868" name="GMOS-S">
+        <paramset name="GMOS-S" kind="dataObj">
+          <param name="exposureTime" value="300.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <paramset name="parallacticAngleDuration">
+            <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
+            <param name="explicitDuration" value="0"/>
+          </paramset>
+          <param name="adc" value="NONE"/>
+          <param name="ampCount" value="TWELVE"/>
+          <param name="gainChoice" value="LOW"/>
+          <param name="ampReadMode" value="SLOW"/>
+          <param name="detectorManufacturer" value="HAMAMATSU"/>
+          <param name="disperser" value="MIRROR"/>
+          <param name="fpuMode" value="BUILTIN"/>
+          <param name="fpu" value="FPU_NONE"/>
+          <param name="filter" value="NONE"/>
+          <param name="ccdXBinning" value="ONE"/>
+          <param name="ccdYBinning" value="ONE"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="stageMode" value="FOLLOW_XYZ"/>
+          <param name="dtaXOffset" value="ZERO"/>
+          <param name="builtinROI" value="FULL_FRAME"/>
+          <param name="useNS" value="FALSE"/>
+          <param name="mosPreimaging" value="NO"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="8e99d47e-2d61-47ec-88e1-7ba60369e1ba" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="554e479d-4e0f-45a1-b613-070e0f8553b7" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="cb59237e-1692-49d1-8f11-1c111a5d7848" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="debfbe51-decc-4c4f-90fa-cc7a37b2f4b9"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="10"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="cb59237e-1692-49d1-8f11-1c111a5d7848"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="f13a8f6f-aefc-4f38-8de8-0b6d8f591518"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="17"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3dfc0212-7671-44a0-b12e-7129f33caca5"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="631c08f4-5424-4ca7-bcca-f30429310fe0"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="7cbfde0c-2bed-4f1d-9320-050498ed5599"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="46ef879d-4cb8-4ed4-9d0f-c7e7896ac7f2"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="23"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="9f1bf006-93c0-4ce2-95c2-b65e43b1f833"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="554e479d-4e0f-45a1-b613-070e0f8553b7"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b6561a3b-e1d4-4abe-abdf-061d112924eb"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d8969949-1b12-4b2b-a996-d21d481f2c7d"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1b8830c3-5359-43ef-929c-be2026c2d751"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="832f370e-4eaa-47fa-9a95-316e64d5075d"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="76bbd950-ce06-4960-a72d-afd5c3618898"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="843e9a60-3081-42b2-aa3a-b12e6f7cc8e0"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="bdb73a0d-b04c-43cf-95a4-c14d3f154868"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4ed6b480-12a5-4274-9b61-e269f3725b37"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="aff871bb-d34f-4a88-b965-aba58a98f6bd"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="3"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3ee541fb-c0fc-4d58-93bd-9b1bf1b08ff7"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="8e99d47e-2d61-47ec-88e1-7ba60369e1ba"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="db8b6028-1886-47bd-a367-f3cdac7296ab"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="9820c503-ff91-4a06-84cd-f770bb9d8f7c"/>
+      <param name="1feece17-a8bc-4cd8-bb72-da9d0eb52966" value="26"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/GroupMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/GroupMigrationTest.scala
@@ -1,0 +1,61 @@
+package edu.gemini.spModel.io.impl.migration.to2016B
+
+import edu.gemini.pot.sp.{SPComponentType, ISPObservation, ISPProgram}
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import edu.gemini.spModel.target.env.{ManualGroup, GuideGroup, AutomaticGroup}
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import org.junit.{Assert, Test}
+
+import scala.collection.JavaConverters._
+
+
+class GroupMigrationTest extends MigrationTest {
+
+  @Test def testGroupMigration(): Unit =
+    withTestProgram("groupMigration.xml", { (_, p) => validateProgram(p)})
+
+  private def validateProgram(p: ISPProgram): Unit = {
+    val obsList = p.getAllObservations.asScala
+
+    Assert.assertTrue(obsList.size == 3)
+
+    List(validateNoGroups(_), validateOneGroup(_), validateTwoGroups(_)).zip(obsList).foreach { case (f, o) => f(o) }
+  }
+
+  private def groups(o: ISPObservation): (Int, List[GuideGroup]) = {
+    val n = o.getObsComponents.asScala.find(_.getType == SPComponentType.TELESCOPE_TARGETENV).getOrElse(sys.error("Missing target environment"))
+    val e = n.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment
+    (e.getGuideEnvironment.getPrimaryIndex.intValue, e.getGroups.toList.asScala.toList)
+  }
+
+  private def assertAuto(g: GuideGroup): Unit =
+    Assert.assertTrue(g.grp.isInstanceOf[AutomaticGroup.Disabled.type])
+
+  private def assertManual(g: GuideGroup): Unit =
+    Assert.assertTrue(g.grp.isInstanceOf[ManualGroup])
+
+  private def validateNoGroups(o: ISPObservation): Unit =
+    groups(o) match {
+      case (0, a :: Nil) => assertAuto(a)
+      case _ => Assert.fail("Expected a single disabled automatic group.")
+    }
+
+  private def validateOneGroup(o: ISPObservation): Unit =
+    groups(o) match {
+      case (1, a :: m :: Nil) =>
+        assertAuto(a)
+        assertManual(m)
+      case _                  =>
+        Assert.fail("Expected an automatic disabled group and a primary manual group")
+    }
+
+  private def validateTwoGroups(o: ISPObservation): Unit =
+    groups(o) match {
+      case (2, a :: m0 :: m1 :: Nil) =>
+        assertAuto(a)
+        assertManual(m0)
+        assertManual(m1)
+      case _                  =>
+        Assert.fail("Expected an automatic disabled group and two manual groups")
+    }
+}

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -18,7 +18,6 @@ import edu.gemini.spModel.target.obsComp.TargetSelection;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
 import edu.gemini.spModel.target.offset.OffsetPosList;
 import edu.gemini.spModel.target.offset.OffsetUtil;
-import edu.gemini.spModel.target.system.ITarget;
 import jsky.app.ot.OT;
 import jsky.app.ot.OTOptions;
 import jsky.app.ot.util.Resources;
@@ -204,7 +203,18 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
 
         static final class GroupRow extends AbstractRow {
             private static String extractName(final GuideGroup group) {
-                return group.getName().getOrElse("Auto");
+                final GuideGrp grp = group.grp();
+                final String name;
+                if (grp.isAutomatic()) {
+                    if (grp instanceof AutomaticGroup.Disabled$) {
+                        name = "Auto (Disabled)";
+                    } else {
+                        name = "Auto";
+                    }
+                } else {
+                    name = group.getName().getOrElse("Manual");
+                }
+                return name;
             }
 
             private final Option<IndexedGuideGroup> group;


### PR DESCRIPTION
This is an addendum to the model refactoring for the `GuideEnvironment` and friends.  In particular it introduces a third kind of `AutomaticGroup`, `Disabled`, joining `Initial` and `Active`.  `Disabled` is used when importing old programs from XML that do not have an automatic group.  This addresses a concern voiced by Andy when the automatic group concept was proposed in Hawaii in December.  Previously old observations would have been set to `Initial` and available for BAGS searches.  Now BAGS will be made to ignore `Disabled` automatic groups.

In the UI, these will show up with a distinctive name like "Auto (Disabled)".  It isn't done yet, but I propose that for unobserved observations you should be able to select the automatic group as primary and have it switch to `Initial`.  Beyond that I hope no other controls are needed to switch back and forth to/from `Disabled` though it wouldn't be too difficult to implement.

![autodisabled](https://cloud.githubusercontent.com/assets/4906023/13326281/f95b74c8-dbc3-11e5-8cc6-64a5e547340e.png)

I also moved the migration code that adds an automatic group on import from pre-2016B programs into the common migration area.  The caveat being some really old pre-2010B migration that I left in place.