### PR TITLE
more prep for target model swap

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
@@ -1,8 +1,10 @@
 package edu.gemini.ags.gems
 
 import edu.gemini.pot.ModelConverters._
+import edu.gemini.shared.skyobject.Magnitude
+import edu.gemini.shared.util.immutable.ImList
 import edu.gemini.shared.util.immutable.ScalaConverters._
-import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.{SingleBand, RBandsList, SiderealTarget}
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.shared.skyobject
@@ -28,8 +30,8 @@ object GemsUtils4Java {
   /**
    * Outputs the target magnitudes used by the Asterism table on the Manual Search for GEMS
    */
-  def probeMagnitudeInUse(guideProbe: GuideProbe, referenceBand: skyobject.Magnitude.Band, target: ITarget): String = {
-    val availableMagnitudes = target.getMagnitudes.asScalaList.map(_.toNewModel)
+  def probeMagnitudeInUse(guideProbe: GuideProbe, referenceBand: skyobject.Magnitude.Band, mags: ImList[Magnitude]): String = {
+    val availableMagnitudes = mags.asScalaList.map(_.toNewModel)
     // TODO Use GemsMagnitudeTable
     val bandsList = if (Canopus.Wfs.Group.instance.getMembers.contains(guideProbe)) {
         RBandsList

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -46,6 +46,8 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
     override val backend = TestVoTableBackend(file)
   }
 
+  val NoTime = JNone.instance[java.lang.Long]
+
   "GemsCatalogResultsSpec" should {
     "support Gsaoi Search on TYC 8345-1155-1" in {
       val base = new WorldCoords("17:25:27.529", "-48:27:24.02")
@@ -81,10 +83,10 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       set.contains(GsaoiOdgw.odgw3) should beFalse
       set.contains(GsaoiOdgw.odgw4) should beTrue
 
-      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget
-      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget
-      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget
-      val odgw4 = group.get(GsaoiOdgw.odgw4).getValue.getPrimary.getValue.getTarget
+      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue
+      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue
+      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue
+      val odgw4 = group.get(GsaoiOdgw.odgw4).getValue.getPrimary.getValue
       cwfs1.getName must beEqualTo("208-152095")
       cwfs2.getName must beEqualTo("208-152215")
       cwfs3.getName must beEqualTo("208-152039")
@@ -95,14 +97,14 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val cwfs3x = Coordinates.create("17:25:24.719", "-48:26:58.00")
       val odgw4x = Coordinates.create("17:25:27.552", "-48:27:23.86")
 
-      (Angle.fromDegrees(cwfs1x.getRaDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getRaDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getRaDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(odgw4x.getRaDeg) ~= Angle.fromDegrees(odgw4.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(odgw4x.getDecDeg) ~= Angle.fromDegrees(odgw4.getSkycalcCoordinates.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getRaDeg)  ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getRaDeg)  ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getRaDeg)  ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(odgw4x.getRaDeg)  ~= Angle.fromDegrees(odgw4.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(odgw4x.getDecDeg) ~= Angle.fromDegrees(odgw4.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
 
       val cwfs1Mag = cwfs1.getMagnitude(JMagnitude.Band.r).getValue.getBrightness
       val cwfs2Mag = cwfs2.getMagnitude(JMagnitude.Band.UC).getValue.getBrightness
@@ -142,10 +144,10 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       set.contains(GsaoiOdgw.odgw3) should beFalse
       set.contains(GsaoiOdgw.odgw4) should beFalse
 
-      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget
-      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget
-      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget
-      val odgw2 = group.get(GsaoiOdgw.odgw2).getValue.getPrimary.getValue.getTarget
+      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue
+      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue
+      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue
+      val odgw2 = group.get(GsaoiOdgw.odgw2)  .getValue.getPrimary.getValue
       cwfs1.getName must beEqualTo("104-014597")
       cwfs2.getName must beEqualTo("104-014608")
       cwfs3.getName must beEqualTo("104-014547")
@@ -156,14 +158,14 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val cwfs3x = Coordinates.create("05:35:18.423", "-69:16:30.67")
       val odgw2x = Coordinates.create("05:35:23.887", "-69:16:18.20")
 
-      (Angle.fromDegrees(cwfs1x.getRaDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getRaDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getRaDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(odgw2x.getRaDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(odgw2x.getDecDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getRaDeg)  ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getRaDeg)  ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getRaDeg)  ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(odgw2x.getRaDeg)  ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(odgw2x.getDecDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
 
       val cwfs1Mag = cwfs1.getMagnitude(JMagnitude.Band.UC).getValue.getBrightness
       val cwfs2Mag = cwfs2.getMagnitude(JMagnitude.Band.UC).getValue.getBrightness
@@ -203,10 +205,10 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       set.contains(GsaoiOdgw.odgw3) should beFalse
       set.contains(GsaoiOdgw.odgw4) should beFalse
 
-      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue.getTarget
-      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget
-      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget
-      val odgw2 = group.get(GsaoiOdgw.odgw2).getValue.getPrimary.getValue.getTarget
+      val cwfs1 = group.get(Canopus.Wfs.cwfs1).getValue.getPrimary.getValue
+      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue
+      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue
+      val odgw2 = group.get(GsaoiOdgw.odgw2)  .getValue.getPrimary.getValue
       cwfs1.getName must beEqualTo("289-128909")
       cwfs2.getName must beEqualTo("289-128878")
       cwfs3.getName must beEqualTo("289-128908")
@@ -217,14 +219,14 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val cwfs3x = Coordinates.create("17:40:21.594", "-32:15:50.38")
       val odgw2x = Coordinates.create("17:40:19.295", "-32:14:58.34")
 
-      (Angle.fromDegrees(cwfs1x.getRaDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getRaDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getRaDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates.getDecDeg)) should beTrue
-      (Angle.fromDegrees(odgw2x.getRaDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getRaDeg)) should beTrue
-      (Angle.fromDegrees(odgw2x.getDecDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getRaDeg)  ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs1x.getDecDeg) ~= Angle.fromDegrees(cwfs1.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getRaDeg)  ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs2x.getDecDeg) ~= Angle.fromDegrees(cwfs2.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getRaDeg)  ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(cwfs3x.getDecDeg) ~= Angle.fromDegrees(cwfs3.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
+      (Angle.fromDegrees(odgw2x.getRaDeg)  ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates(NoTime).getValue.getRaDeg)) should beTrue
+      (Angle.fromDegrees(odgw2x.getDecDeg) ~= Angle.fromDegrees(odgw2.getSkycalcCoordinates(NoTime).getValue.getDecDeg)) should beTrue
 
       val cwfs1Mag = cwfs1.getMagnitude(JMagnitude.Band.UC).getValue.getBrightness
       val cwfs2Mag = cwfs2.getMagnitude(JMagnitude.Band.UC).getValue.getBrightness
@@ -264,9 +266,9 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       set.contains(GsaoiOdgw.odgw3) should beFalse
       set.contains(GsaoiOdgw.odgw4) should beTrue
 
-      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getTarget.getSkycalcCoordinates
-      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getTarget.getSkycalcCoordinates
-      val odgw4 = group.get(GsaoiOdgw.odgw4).getValue.getPrimary.getValue.getTarget.getSkycalcCoordinates
+      val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue.getSkycalcCoordinates(NoTime).getValue
+      val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue.getSkycalcCoordinates(NoTime).getValue
+      val odgw4 = group.get(GsaoiOdgw.odgw4)  .getValue.getPrimary.getValue.getSkycalcCoordinates(NoTime).getValue
 
       val cwfs2x = Coordinates.create("12:38:44.500", "-49:47:58.38")
       val cwfs3x = Coordinates.create("12:38:50.005", "-49:48:00.89")

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
@@ -107,7 +107,7 @@ trait UCAC3Regression {
           val equalGroup = expectedGuideGroup.zip(actualGuideGroup).map {
             case (egg, acc) =>
               val sameGuider = egg.getGuider == acc.getGuider
-              sameGuider && sameCoordinates(egg.getPrimary.getValue.getTarget, acc.getPrimary.getValue.getTarget)
+              sameGuider && sameCoordinates(egg.getPrimary.getValue, acc.getPrimary.getValue)
           }
           val sameStrehl = math.abs(expected.strehl.avg - actual.strehl.avg) < 0.0001
           sameStrehl && equalGroup.forall(_ == true)
@@ -123,7 +123,7 @@ trait UCAC3Regression {
 
 
   // Compare if two targets have the same RA/Dec ... they are assumed to be sidereal
-  def sameCoordinates(a: ITarget, b: ITarget): Boolean = {
+  def sameCoordinates(a: SPTarget, b: SPTarget): Boolean = {
     val when = JNone.instance[java.lang.Long]
     same(a.getRaDegrees(when),  b.getRaDegrees(when)) &&
     same(a.getDecDegrees(when), b.getDecDegrees(when))

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ObservationElements.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ObservationElements.java
@@ -166,6 +166,10 @@ public class ObservationElements implements Serializable {
         return _observation == null ? None.instance() : _observation.getSchedulingBlock();
     }
 
+    public Option<Long> getSchedulingBlockStart() {
+        return getSchedulingBlockStart();
+    }
+
     private void _setInstrumentNode(ISPObsComponent inst) {
         _instrumentNode = inst;
         if (inst != null) {

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ObservationElements.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/api/ObservationElements.java
@@ -167,7 +167,7 @@ public class ObservationElements implements Serializable {
     }
 
     public Option<Long> getSchedulingBlockStart() {
-        return getSchedulingBlockStart();
+        return getSchedulingBlock().map(SchedulingBlock::start);
     }
 
     private void _setInstrumentNode(ISPObsComponent inst) {

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
@@ -175,7 +175,7 @@ public final class AltairRule implements IRule {
                     boolean isPwfs  = (altair.getMode() == AltairParams.Mode.LGS_P1);
                     boolean isAowfs = (altair.getMode() == AltairParams.Mode.LGS);
                     if (altair.getGuideStarType() == AltairParams.GuideStarType.NGS) {
-                        final boolean offAxis = altairOffAxisGuiding(target.getTargetEnvironment(), elements.getSchedulingBlock().map(SchedulingBlock::start));
+                        final boolean offAxis = altairOffAxisGuiding(target.getTargetEnvironment(), elements.getSchedulingBlockStart());
                         if (offAxis && altair.getFieldLens() == AltairParams.FieldLens.OUT) {
                             //Altair NGS without Field Lens (Warning: The Altair field lens is recommended for off-axis targets.)
                             problems.addWarning(PREFIX + "NO_FIELD_LENS", NO_FIELD_LENS, aoNode);

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -462,15 +462,7 @@ public class GeneralRule implements IRule {
     private static boolean _isTooTarget(SPTarget p1Target, ObservationElements elems) {
         final ISPObservation obs = elems.getObservationNode();
         if (obs == null || !Too.isToo(obs)) return false;
-
-        final ITarget t = p1Target.getTarget();
-        if (t instanceof HmsDegTarget) {
-            final HmsDegTarget hmsDeg = (HmsDegTarget) t;
-            return hmsDeg.getRa().getValue()  == 0.0 &&
-                   hmsDeg.getDec().getValue() == 0.0; ///
-        }
-
-        return false;
+        return p1Target.isTooTarget();
     }
 
     // true if both defined and diff <= tolerance

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -440,7 +440,7 @@ public class GeneralRule implements IRule {
     // targets are equal only if positions are defined and within _getMinDistance
     private static boolean _areTargetsEquals(SPTarget p1Target, SPTarget target, ObservationElements elems) {
 
-        final Option<Long> when = elems.getSchedulingBlock().map(SchedulingBlock::start);
+        final Option<Long> when = elems.getSchedulingBlockStart();
 
         Option<Double> spRA = target.getRaHours(when);
         Option<Double> spDec = target.getDecDegrees(when);

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
@@ -193,7 +193,7 @@ public final class NifsRule implements IRule {
                 if (baseTarget == null || oiTarget.isEmpty() || aoTarget.isEmpty()) return null;
                 //now, let's compare coordinates. If they are the same, raise an error
 
-                final Option<Long> when = elements.getSchedulingBlock().map(SchedulingBlock::start);
+                final Option<Long> when = elements.getSchedulingBlockStart();
 
                 baseTarget.getRaHours(when).foreach(baseC1 ->
                 baseTarget.getDecDegrees(when).foreach(baseC2 ->

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -7,6 +7,7 @@ import edu.gemini.skycalc.Offset;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.nifs.InstNIFS;
 import edu.gemini.spModel.guide.*;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 
@@ -101,7 +102,9 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
     }
 
     public Option<BoundaryPosition> checkBoundaries(SPTarget guideStar, ObsContext ctx) {
-        return checkBoundaries(guideStar.getTarget().getSkycalcCoordinates(), ctx);
+        return guideStar
+            .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+            .flatMap(coords -> checkBoundaries(coords, ctx));
     }
 
     public Option<BoundaryPosition> checkBoundaries(final Coordinates coords, final ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -103,7 +103,7 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
 
     public Option<BoundaryPosition> checkBoundaries(SPTarget guideStar, ObsContext ctx) {
         return guideStar
-            .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+            .getSkycalcCoordinates(ctx.getSchedulingBlockStart())
             .flatMap(coords -> checkBoundaries(coords, ctx));
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2OiwfsGuideProbe.java
@@ -7,6 +7,7 @@ import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.gems.GemsGuideProbeGroup;
 import edu.gemini.spModel.guide.*;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 
@@ -99,7 +100,7 @@ public enum Flamingos2OiwfsGuideProbe implements GuideProbe, ValidatableGuidePro
 
     @Override
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -226,7 +226,7 @@ public enum Canopus {
         public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
             final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
             final Wfs self = this;
-            return guideStar.getTarget().getSkycalcCoordinates(when).map(coords ->
+            return guideStar.getSkycalcCoordinates(when).map(coords ->
                 Canopus.instance.getProbesInRange(coords, ctx).contains(self) ?
                         GuideStarValidation.VALID : GuideStarValidation.INVALID
             ).getOrElse(GuideStarValidation.UNDEFINED);
@@ -242,16 +242,16 @@ public enum Canopus {
         // coordinates of the given guide star
         // (i.e.: The guide star is vignetted by the wfs probe arm)
         private static Option<Boolean> isVignetted(Wfs wfs, SPTarget guideStar, ObsContext ctx) {
-            return ctx.getBaseCoordinates().flatMap(coords ->
-                wfs.probeArm(ctx, false).map(a -> {
-                if (a == null) return false;
-
-                CoordinateDiff diff = new CoordinateDiff(coords, guideStar.getTarget().getSkycalcCoordinates());
-                Offset dis = diff.getOffset();
-                double p = -dis.p().toArcsecs().getMagnitude();
-                double q = -dis.q().toArcsecs().getMagnitude();
-                return a.contains(p, q);
-            }));
+            return guideStar.getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start)).flatMap(gscoords ->
+                    ctx.getBaseCoordinates().flatMap(coords ->
+                    wfs.probeArm(ctx, false).map(a -> {
+                        if (a == null) return false;
+                        CoordinateDiff diff = new CoordinateDiff(coords, gscoords);
+                        Offset dis = diff.getOffset();
+                        double p = -dis.p().toArcsecs().getMagnitude();
+                        double q = -dis.q().toArcsecs().getMagnitude();
+                        return a.contains(p, q);
+                    })));
         }
 
         /**
@@ -271,19 +271,23 @@ public enum Canopus {
             SPTarget guideStar = guideStarOpt.getValue();
 
             // Calculate the difference between the coordinate and the observation's base position.
-            return ctx.getBaseCoordinates().map(base -> {
-                CoordinateDiff diff = new CoordinateDiff(base, guideStar.getTarget().getSkycalcCoordinates());
-                // Get offset and switch it to be defined in the same coordinate
-                // system as the shape.
-                Offset dis = diff.getOffset();
-                double p = -dis.p().toArcsecs().getMagnitude();
-                double q = -dis.q().toArcsecs().getMagnitude();
-                Set<Offset> offsets = new TreeSet<Offset>();
-                offsets.add(offset);
+            return guideStar
+                .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+                .flatMap(gscoords -> ctx.getBaseCoordinates()
+                    .map(base -> {
+                        CoordinateDiff diff = new CoordinateDiff(base, gscoords);
+                        // Get offset and switch it to be defined in the same coordinate
+                        // system as the shape.
+                        Offset dis = diff.getOffset();
+                        double p = -dis.p().toArcsecs().getMagnitude();
+                        double q = -dis.q().toArcsecs().getMagnitude();
+                        Set<Offset> offsets = new TreeSet<Offset>();
+                        offsets.add(offset);
 
-                Area a = Canopus.instance.offsetIntersection(ctx, offsets);
-                return a != null && a.contains(p, q);
-            }).getOrElse(false);
+                        Area a = Canopus.instance.offsetIntersection(ctx, offsets);
+                        return a != null && a.contains(p, q);
+                    }))
+                .getOrElse(false);
         }
     }
 
@@ -354,13 +358,17 @@ public enum Canopus {
         SPTarget base   = ctx.getTargets().getBase();
         SPTarget target = spTargetOpt.getValue();
 
-        CoordinateDiff diff;
-        diff = new CoordinateDiff(base.getTarget().getSkycalcCoordinates(), target.getTarget().getSkycalcCoordinates());
-        Offset o = diff.getOffset();
-        double p = -o.p().toArcsecs().getMagnitude();
-        double q = -o.q().toArcsecs().getMagnitude();
-        Point2D pt = new Point2D.Double(p, q);
-        return new Some<Point2D>(pt);
+        final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
+
+        return
+            base.getSkycalcCoordinates(when).flatMap(bc ->
+            target.getSkycalcCoordinates(when).map(tc -> {
+                CoordinateDiff diff = new CoordinateDiff(bc, tc);
+                Offset o = diff.getOffset();
+                double p = -o.p().toArcsecs().getMagnitude();
+                double q = -o.q().toArcsecs().getMagnitude();
+                return new Point2D.Double(p, q);
+            }));
     }
 
     private static final Angle[] rotation = new Angle[IssPort.values().length];

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -224,7 +224,7 @@ public enum Canopus {
         public abstract Option<Area> probeArm(ObsContext ctx, boolean validate);
 
         public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-            final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
+            final Option<Long> when = ctx.getSchedulingBlockStart();
             final Wfs self = this;
             return guideStar.getSkycalcCoordinates(when).map(coords ->
                 Canopus.instance.getProbesInRange(coords, ctx).contains(self) ?
@@ -242,7 +242,7 @@ public enum Canopus {
         // coordinates of the given guide star
         // (i.e.: The guide star is vignetted by the wfs probe arm)
         private static Option<Boolean> isVignetted(Wfs wfs, SPTarget guideStar, ObsContext ctx) {
-            return guideStar.getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start)).flatMap(gscoords ->
+            return guideStar.getSkycalcCoordinates(ctx.getSchedulingBlockStart()).flatMap(gscoords ->
                     ctx.getBaseCoordinates().flatMap(coords ->
                     wfs.probeArm(ctx, false).map(a -> {
                         if (a == null) return false;
@@ -272,7 +272,7 @@ public enum Canopus {
 
             // Calculate the difference between the coordinate and the observation's base position.
             return guideStar
-                .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+                .getSkycalcCoordinates(ctx.getSchedulingBlockStart())
                 .flatMap(gscoords -> ctx.getBaseCoordinates()
                     .map(base -> {
                         CoordinateDiff diff = new CoordinateDiff(base, gscoords);
@@ -358,7 +358,7 @@ public enum Canopus {
         SPTarget base   = ctx.getTargets().getBase();
         SPTarget target = spTargetOpt.getValue();
 
-        final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
+        final Option<Long> when = ctx.getSchedulingBlockStart();
 
         return
             base.getSkycalcCoordinates(when).flatMap(bc ->

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -73,7 +73,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     public Option<BoundaryPosition> checkBoundaries(final SPTarget guideStar, final ObsContext ctx) {
         return guideStar
-            .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+            .getSkycalcCoordinates(ctx.getSchedulingBlockStart())
             .flatMap(cs -> checkBoundaries(cs, ctx));
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -14,6 +14,7 @@ import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.guide.VignettingCalculator;
 import edu.gemini.spModel.guide.*;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.telescope.IssPort;
@@ -71,7 +72,9 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
     }
 
     public Option<BoundaryPosition> checkBoundaries(final SPTarget guideStar, final ObsContext ctx) {
-        return checkBoundaries(guideStar.getTarget().getSkycalcCoordinates(), ctx);
+        return guideStar
+            .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+            .flatMap(cs -> checkBoundaries(cs, ctx));
     }
 
     public Option<BoundaryPosition> checkBoundaries(final Coordinates coords, final ObsContext ctx) {
@@ -102,7 +105,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public GuideStarValidation validate(final SPTarget guideStar, final ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 
     public GuideStarValidation validate(final SkyObject guideStar, final ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GnirsOiwfsGuideProbe.java
@@ -8,6 +8,7 @@ import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.guide.*;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.telescope.IssPort;
@@ -96,6 +97,6 @@ public enum GnirsOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
@@ -92,7 +92,7 @@ public class GpiCB extends AbstractObsComponentCB {
             final TargetObsComp toc = (TargetObsComp) targetcomp.getDataObject();
             if (toc != null) {
                 if (toc.getTargetEnvironment().getBase() != null) {
-                    ImList<Magnitude> magnitudes = toc.getTargetEnvironment().getBase().getTarget().getMagnitudes();
+                    ImList<Magnitude> magnitudes = toc.getTargetEnvironment().getBase().getMagnitudes();
                     magnitudes.filter(new MagnitudeFilter(Magnitude.Band.H)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_H_PROP));
                     magnitudes.filter(new MagnitudeFilter(Magnitude.Band.I)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_I_PROP));
                 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -55,7 +55,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
             // Select the appropriate guider, if any.
             final TargetEnvironment env = ctx.getTargets();
             final Option<GuideProbe> probeOpt = guideStar
-                .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+                .getSkycalcCoordinates(ctx.getSchedulingBlockStart())
                 .flatMap(cs -> select(cs, ctx));
 
             // If no probe is defined, just use ODGW1 since we're adding a target that is off the valid range.
@@ -136,7 +136,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
     }
 
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-        final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
+        final Option<Long> when = ctx.getSchedulingBlockStart();
         return guideStar.getSkycalcCoordinates(when).map(coords -> {
             // Get the id of the detector in which the guide star lands, if any
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -54,7 +54,9 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
         @Override public TargetEnvironment add(final SPTarget guideStar, final ObsContext ctx) {
             // Select the appropriate guider, if any.
             final TargetEnvironment env = ctx.getTargets();
-            final Option<GuideProbe> probeOpt = select(guideStar.getTarget().getSkycalcCoordinates(), ctx);
+            final Option<GuideProbe> probeOpt = guideStar
+                .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+                .flatMap(cs -> select(cs, ctx));
 
             // If no probe is defined, just use ODGW1 since we're adding a target that is off the valid range.
             final GuideProbe probe = probeOpt.getOrElse(GsaoiOdgw.odgw1);
@@ -135,7 +137,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
-        return guideStar.getTarget().getSkycalcCoordinates(when).map(coords -> {
+        return guideStar.getSkycalcCoordinates(when).map(coords -> {
             // Get the id of the detector in which the guide star lands, if any
 
             Option<GsaoiDetectorArray.Id> idOpt = GsaoiDetectorArray.instance.getId(coords, ctx);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NiciOiwfsGuideProbe.java
@@ -8,6 +8,7 @@ import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.guide.*;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 
@@ -62,6 +63,6 @@ public enum NiciOiwfsGuideProbe implements ValidatableGuideProbe {
     }
     @Override
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/NifsOiwfsGuideProbe.java
@@ -79,6 +79,6 @@ public enum NifsOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     @Override
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/NiriOiwfsGuideProbe.java
@@ -61,6 +61,6 @@ public enum NiriOiwfsGuideProbe implements ValidatableGuideProbe {
 
     @Override
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-        return GuideProbeUtil.instance.validate(guideStar.getTarget().getSkycalcCoordinates(), this, ctx);
+        return GuideProbeUtil.instance.validate(guideStar, this, ctx);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
@@ -104,7 +104,7 @@ public enum GuideProbeUtil {
 
     public GuideStarValidation validate(final SPTarget guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
         final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
-        return guideStar.getTarget().getSkycalcCoordinates(when).map(coords ->
+        return guideStar.getSkycalcCoordinates(when).map(coords ->
             validate(coords, guideProbe, ctx)).getOrElse(GuideStarValidation.UNDEFINED);
     }
 
@@ -147,14 +147,16 @@ public enum GuideProbeUtil {
             // and we must rotate the patrol field according to position angle
             final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians().getMagnitude()));
             // find distance of base position to the guide star
-            return ctx.getBaseCoordinates().map(baseCoordinates -> {
-                final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, guideStar.getTarget().getSkycalcCoordinates());
-                final Offset dis = diff.getOffset();
-                final double p = -dis.p().toArcsecs().getMagnitude();
-                final double q = -dis.q().toArcsecs().getMagnitude();
-                // and now check if that guide star is inside the correctly transformed/rotated patrol field
-                return rotatedPatrolField.getArea().contains(p, q);
-            }).getOrElse(false);
+            return
+                guideStar.getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start)).flatMap(gcs ->
+                ctx.getBaseCoordinates().map(baseCoordinates -> {
+                    final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, gcs);
+                    final Offset dis = diff.getOffset();
+                    final double p = -dis.p().toArcsecs().getMagnitude();
+                    final double q = -dis.q().toArcsecs().getMagnitude();
+                    // and now check if that guide star is inside the correctly transformed/rotated patrol field
+                    return rotatedPatrolField.getArea().contains(p, q);
+                })).getOrElse(false);
         });
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
@@ -103,7 +103,7 @@ public enum GuideProbeUtil {
     }
 
     public GuideStarValidation validate(final SPTarget guideStar, final GuideProbe guideProbe, final ObsContext ctx) {
-        final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
+        final Option<Long> when = ctx.getSchedulingBlockStart();
         return guideStar.getSkycalcCoordinates(when).map(coords ->
             validate(coords, guideProbe, ctx)).getOrElse(GuideStarValidation.UNDEFINED);
     }
@@ -148,7 +148,7 @@ public enum GuideProbeUtil {
             final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians().getMagnitude()));
             // find distance of base position to the guide star
             return
-                guideStar.getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start)).flatMap(gcs ->
+                guideStar.getSkycalcCoordinates(ctx.getSchedulingBlockStart()).flatMap(gcs ->
                 ctx.getBaseCoordinates().map(baseCoordinates -> {
                     final CoordinateDiff diff = new CoordinateDiff(baseCoordinates, gcs);
                     final Offset dis = diff.getOffset();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
@@ -269,7 +269,7 @@ public class PatrolField {
         @Override
         public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
             return
-                guideStar.getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start)).flatMap(guideCoordinates ->
+                guideStar.getSkycalcCoordinates(ctx.getSchedulingBlockStart()).flatMap(guideCoordinates ->
                 ctx.getBaseCoordinates().map(baseCoordinates -> {
                     // Calculate the difference between the coordinate and the observation's
                     // base position.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsSchedulingReport.java
@@ -85,7 +85,7 @@ public final class ObsSchedulingReport implements Serializable {
             if (SPSiteQuality.SP_TYPE.equals(type)) {
                 sq = (SPSiteQuality) obsComp.getDataObject();
             } else if (TargetObsComp.SP_TYPE.equals(type)) {
-                coords = getCoordinates(obsComp, _dataObj.getSchedulingBlock().map(SchedulingBlock::start));
+                coords = getCoordinates(obsComp, _dataObj.getSchedulingBlockStart());
             }
         }
         _siteQuality = sq;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -321,6 +321,13 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
     }
 
     /**
+     * Get the scheduling block's starting time.
+     */
+    public Option<Long> getSchedulingBlockStart() {
+        return getSchedulingBlockStart();
+    }
+
+    /**
      * Set the scheduling block.
      */
     public void setSchedulingBlock(Option<SchedulingBlock> newValue) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -444,15 +444,7 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
             return false;
         } else {
             final TargetObsComp toc = (TargetObsComp) targetComp.getDataObject();
-            final ITarget target = toc.getBase().getTarget();
-            final boolean too;
-            if (target instanceof HmsDegTarget) {
-                final HmsDegTarget hms = (HmsDegTarget) target;
-                too = hms.getRa().getValue() == 0 && hms.getDec().getValue() == 0;
-            } else {
-                too = false;
-            }
-            return !too;
+            return !toc.getBase().isTooTarget();
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -263,7 +263,7 @@ public final class ObsContext {
     }
 
     public Option<Coordinates> getBaseCoordinates() {
-        final Option<Long> when = getSchedulingBlock().map(SchedulingBlock::start);
+        final Option<Long> when = getSchedulingBlockStart();
         SPTarget target = targets.getBase();
         return
             target.getRaDegrees(when).flatMap(raDeg ->
@@ -359,6 +359,10 @@ public final class ObsContext {
 
     public Option<SchedulingBlock> getSchedulingBlock() {
         return schedulingBlock;
+    }
+
+    public Option<Long> getSchedulingBlockStart() {
+        return schedulingBlock.map(SchedulingBlock::start);
     }
 
     public String toString() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -281,7 +281,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     /* ValidatableGuideProbe */
 
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
-        final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
+        final Option<Long> when = ctx.getSchedulingBlockStart();
         return guideStar.getSkycalcCoordinates(when).map(coords ->
             validate(coords, ctx)
         ).getOrElse(GuideStarValidation.UNDEFINED);
@@ -297,7 +297,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
 
     public Option<BoundaryPosition> checkBoundaries(SPTarget guideStar, ObsContext ctx){
         return guideStar
-            .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+            .getSkycalcCoordinates(ctx.getSchedulingBlockStart())
             .flatMap(cs -> checkBoundaries(cs, ctx));
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -282,7 +282,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
 
     public GuideStarValidation validate(SPTarget guideStar, ObsContext ctx) {
         final Option<Long> when = ctx.getSchedulingBlock().map(SchedulingBlock::start);
-        return guideStar.getTarget().getSkycalcCoordinates(when).map(coords ->
+        return guideStar.getSkycalcCoordinates(when).map(coords ->
             validate(coords, ctx)
         ).getOrElse(GuideStarValidation.UNDEFINED);
     }
@@ -296,7 +296,9 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     }
 
     public Option<BoundaryPosition> checkBoundaries(SPTarget guideStar, ObsContext ctx){
-        return checkBoundaries(guideStar.getTarget().getSkycalcCoordinates(), ctx);
+        guideStar
+            .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
+            .flatMap(cs -> checkBoundaries(cs, ctx));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -296,7 +296,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
     }
 
     public Option<BoundaryPosition> checkBoundaries(SPTarget guideStar, ObsContext ctx){
-        guideStar
+        return guideStar
             .getSkycalcCoordinates(ctx.getSchedulingBlock().map(SchedulingBlock::start))
             .flatMap(cs -> checkBoundaries(cs, ctx));
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -3,8 +3,10 @@ package edu.gemini.spModel.target.system;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.skycalc.Coordinates;
 import edu.gemini.spModel.core.SpatialProfile;
 import edu.gemini.spModel.core.SpectralDistribution;
+import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.target.WatchablePos;
 
 // transitional; will go away
@@ -111,7 +113,7 @@ public abstract class TransitionalSPTarget extends WatchablePos {
 
     public scala.Option<HmsDegTarget> getHmsDegTarget() {
         ITarget t = getTarget();
-        return (t instanceof  HmsDegTarget) ? new scala.Some<>((HmsDegTarget) t) : scala.Option.empty();
+        return (t instanceof HmsDegTarget) ? new scala.Some<>((HmsDegTarget) t) : scala.Option.empty();
     }
 
     public scala.Option<NonSiderealTarget> getNonSiderealTarget() {
@@ -135,6 +137,11 @@ public abstract class TransitionalSPTarget extends WatchablePos {
 
     public boolean isNonSidereal() {
         return !isSidereal();
+    }
+
+
+    public synchronized Option<Coordinates> getSkycalcCoordinates(Option<Long> when) {
+        return getTarget().getSkycalcCoordinates(when);
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -144,4 +144,8 @@ public abstract class TransitionalSPTarget extends WatchablePos {
         return getTarget().getSkycalcCoordinates(when);
     }
 
+    public ImList<Magnitude> getMagnitudes() {
+        return getTarget().getMagnitudes();
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/system/TransitionalSPTarget.java
@@ -9,6 +9,8 @@ import edu.gemini.spModel.core.SpectralDistribution;
 import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.target.WatchablePos;
 
+import java.util.Set;
+
 // transitional; will go away
 public abstract class TransitionalSPTarget extends WatchablePos {
 
@@ -146,6 +148,20 @@ public abstract class TransitionalSPTarget extends WatchablePos {
 
     public ImList<Magnitude> getMagnitudes() {
         return getTarget().getMagnitudes();
+    }
+
+    public boolean isTooTarget() {
+        final ITarget t = getTarget();
+        if (t instanceof HmsDegTarget) {
+            final HmsDegTarget hmsDeg = (HmsDegTarget) t;
+            return hmsDeg.getRa().getValue() == 0.0 &&
+                    hmsDeg.getDec().getValue() == 0.0; ///
+        }
+        return false;
+    }
+
+    public Set<Magnitude.Band> getMagnitudeBands() {
+        return getTarget().getMagnitudeBands();
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -188,7 +188,7 @@ object ModelConverters {
     def toNewModel:SiderealTarget = {
       val name        = sp.getName
       val coords      = sp.getTarget.getSkycalcCoordinates
-      val mags        = sp.getTarget.getMagnitudes.asScalaList.map(_.toNewModel)
+      val mags        = sp.getMagnitudes.asScalaList.map(_.toNewModel)
       val ra          = Angle.fromDegrees(coords.getRaDeg)
       val dec         = Angle.fromDegrees(coords.getDecDeg)
       val coordinates = Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -1,6 +1,7 @@
 package edu.gemini.pot
 
 import edu.gemini.shared.skyobject
+import edu.gemini.shared.util.immutable
 import edu.gemini.skycalc
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
@@ -186,11 +187,11 @@ object ModelConverters {
 
   implicit class SPTarget2SiderealTarget(val sp:SPTarget) extends AnyVal {
     def toNewModel:SiderealTarget = {
+      val when        = immutable.None.instance[java.lang.Long]
       val name        = sp.getName
-      val coords      = sp.getTarget.getSkycalcCoordinates
       val mags        = sp.getMagnitudes.asScalaList.map(_.toNewModel)
-      val ra          = Angle.fromDegrees(coords.getRaDeg)
-      val dec         = Angle.fromDegrees(coords.getDecDeg)
+      val ra          = Angle.fromDegrees(sp.getRaDegrees(when).getOrElse(0.0))
+      val dec         = Angle.fromDegrees(sp.getDecDegrees(when).getOrElse(0.0))
       val coordinates = Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))
 
       // Only HmsDegTargets have a proper motion, radial velocity, etc

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -33,8 +33,12 @@ object ObsTargetCalculatorService {
 
     // Now, based on the SchedulingBlock determine if a TargetCalc should be created.
     // Get the TargetEnvironment if it exists, and from there, extract the RA and Dec.
-    def coords = obs.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV).map {
-      _.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment.getBase.getTarget.getSkycalcCoordinates
+    def coords = obs.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV).flatMap {
+      _.getDataObject
+        .asInstanceOf[TargetObsComp]
+        .getTargetEnvironment
+        .getBase
+        .getSkycalcCoordinates(block.map(_.start : java.lang.Long).asGeminiOpt).asScalaOpt
     }
 
     def calc(s: Site, b: SchedulingBlock, c: Coordinates): TargetCalculator = {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -59,7 +59,7 @@ public final class SPTargetSkyObjectTest {
             SkyObject   obj = new SkyObject.Builder("xyz", coords).build();
             SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
-            assertEquals(0, target.getTarget().getMagnitudes().size());
+            assertEquals(0, target.getMagnitudes().size());
             assertEquals(0, target.getTarget().getMagnitudeBands().size());
 
             HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
@@ -85,7 +85,7 @@ public final class SPTargetSkyObjectTest {
         SkyObject obj = createSkyObject(input);
         final SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
 
-        final ImList<Magnitude> mags = target.getTarget().getMagnitudes();
+        final ImList<Magnitude> mags = target.getMagnitudes();
         assertEquals(expected.size(), mags.size());
 
         final Set<Magnitude.Band> bands = target.getTarget().getMagnitudeBands();
@@ -121,7 +121,7 @@ public final class SPTargetSkyObjectTest {
 
         // Put a new magnitude for the K band.
         target.putMagnitude(magK2);
-        ImList<Magnitude> magList = target.getTarget().getMagnitudes();
+        ImList<Magnitude> magList = target.getMagnitudes();
 
         assertEquals(2, magList.size());
         assertEquals(magJ1, target.getMagnitude(Magnitude.Band.J).getValue());
@@ -129,7 +129,7 @@ public final class SPTargetSkyObjectTest {
 
         // Replace the existing J band mag with a new one.
         target.putMagnitude(magJ3);
-        magList = target.getTarget().getMagnitudes();
+        magList = target.getMagnitudes();
         assertEquals(2, magList.size());
         assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());
         assertEquals(magK2, target.getMagnitude(Magnitude.Band.K).getValue());
@@ -142,7 +142,7 @@ public final class SPTargetSkyObjectTest {
 
         // Put a new magnitude for the K band.
         target.setMagnitudes(DefaultImList.create(magJ3, magK2));
-        ImList<Magnitude> magList = target.getTarget().getMagnitudes();
+        ImList<Magnitude> magList = target.getMagnitudes();
 
         assertEquals(2, magList.size());
         assertEquals(magJ3, target.getMagnitude(Magnitude.Band.J).getValue());

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -57,12 +57,11 @@ public final class SPTargetSkyObjectTest {
             coords = coords.builder().pmRa(pmRa).pmDec(pmDec).build();
 
             SkyObject   obj = new SkyObject.Builder("xyz", coords).build();
-            SPTarget target = new SPTarget(HmsDegTarget.fromSkyObject(obj));
+            HmsDegTarget hmsDeg = HmsDegTarget.fromSkyObject(obj);
+            SPTarget target = new SPTarget(hmsDeg);
 
             assertEquals(0, target.getMagnitudes().size());
             assertEquals(0, target.getTarget().getMagnitudeBands().size());
-
-            HmsDegTarget hmsDeg = (HmsDegTarget) target.getTarget();
 
             assertEquals("xyz", target.getName());
             assertEquals(15.0, target.getRaDegrees(None.instance()).getValue(), 0.000001);
@@ -88,7 +87,7 @@ public final class SPTargetSkyObjectTest {
         final ImList<Magnitude> mags = target.getMagnitudes();
         assertEquals(expected.size(), mags.size());
 
-        final Set<Magnitude.Band> bands = target.getTarget().getMagnitudeBands();
+        final Set<Magnitude.Band> bands = target.getMagnitudeBands();
         assertEquals(expected.size(), bands.size());
         expected.foreach(new ApplyOp<Magnitude>() {
             @Override public void apply(Magnitude magnitude) {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target/SPTargetSkyObjectTest.java
@@ -61,7 +61,7 @@ public final class SPTargetSkyObjectTest {
             SPTarget target = new SPTarget(hmsDeg);
 
             assertEquals(0, target.getMagnitudes().size());
-            assertEquals(0, target.getTarget().getMagnitudeBands().size());
+            assertEquals(0, target.getMagnitudeBands().size());
 
             assertEquals("xyz", target.getName());
             assertEquals(15.0, target.getRaDegrees(None.instance()).getValue(), 0.000001);

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
@@ -26,9 +26,7 @@ trait Almosts {
     new AlmostEqual[SPTarget] {
       val Now = ImOption.apply[java.lang.Long](System.currentTimeMillis)
 
-      def almostEqual(a: SPTarget, b: SPTarget): Boolean = {
-        val at = a.getTarget
-        val bt = b.getTarget
+      def almostEqual(at: SPTarget, bt: SPTarget): Boolean = {
         (at.getName === bt.getName) &&
           (at.getRaDegrees(Now) ~= bt.getRaDegrees(Now)) &&
           (at.getDecDegrees(Now) ~= bt.getDecDegrees(Now))

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -404,7 +404,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
     }
 
     public String getTargetName() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getTarget().getName() : "");
+        return (targetEnvironment != null ? targetEnvironment.getBase().getName() : "");
     }
 
     public String getWavefrontSensors() {

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetSurvey.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2015B/TargetSurvey.scala
@@ -33,7 +33,7 @@ object TargetSurvey extends SafeApp {
   type Stats = Map[(String, String), (Int, Map[Magnitude.Band, Int])]
 
   def magnitudeMap(t: SPTarget): Map[Magnitude.Band, Int] =
-    t.getTarget.getMagnitudes.asScalaList.map(_.getBand).strengthR(1).toMap
+    t.getMagnitudes.asScalaList.map(_.getBand).strengthR(1).toMap
 
   def examineTarget(t: SPTarget): Stats =
     Map((t.getTarget.getClass.getSimpleName, t.getTarget.getTag.tccName) -> ((1, magnitudeMap(t))))

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/util/ReportUtils.java
@@ -381,7 +381,7 @@ public class ReportUtils {
             // Figure out the RA of the base position
             final TargetObsComp targetEnv = (TargetObsComp) targetEnvComp.getDataObject();
             final SPTarget target = targetEnv.getBase();
-            final Option<Long> when = ((SPObservation) obsShell.getDataObject()).getSchedulingBlock().map(SchedulingBlock::start);
+            final Option<Long> when = ((SPObservation) obsShell.getDataObject()).getSchedulingBlockStart();
             final Option<Integer> raHours = getRaHours(target, when);
             raHours.forEach(h -> hourSet.add(h));
         }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -147,7 +147,7 @@ public final class TargetConfig extends ParamSet {
     }
 
     private Option<Element> _createMagnitudes(SPTarget target) {
-        ImList<Magnitude> magList = target.getTarget().getMagnitudes();
+        ImList<Magnitude> magList = target.getMagnitudes();
         if (magList.size() == 0) return None.instance();
 
         final ParamSet ps = new ParamSet(TccNames.MAGNITUDES);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -90,7 +90,7 @@ public final class TargetMagnitudeTest extends TestBase {
     private void validateMagnitudes(final Element element, final SPTarget target) {
         final String MAG_PATH = "paramset[@name='" + TccNames.MAGNITUDES + "']";
         final Element magGroupElement = (Element) element.selectSingleNode(MAG_PATH);
-        final ImList<Magnitude> mags = target.getTarget().getMagnitudes();
+        final ImList<Magnitude> mags = target.getMagnitudes();
         if (magGroupElement == null) {
             assertEquals(0, mags.size());
             return;

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
@@ -527,7 +527,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
         final TargetObsComp targetEnv = (TargetObsComp) targetObsComp.getDataObject();
         final SPTarget tp = targetEnv.getBase();
 
-        final Option<Long> when = ((SPObservation) o.getDataObject()).getSchedulingBlock().map(SchedulingBlock::start);
+        final Option<Long> when = ((SPObservation) o.getDataObject()).getSchedulingBlockStart();
         final Option<Double> raOp  = tp.getRaDegrees(when).map(x -> x / 15.);
         final Option<Double> decOp = tp.getDecDegrees(when);
 
@@ -622,7 +622,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
         if (targetObsComp != null) {
             final TargetObsComp targetEnv = (TargetObsComp) targetObsComp.getDataObject();
             final SPTarget tp = targetEnv.getBase();
-            final Option<Long> when = obs.getSchedulingBlock().map(SchedulingBlock::start);
+            final Option<Long> when = obs.getSchedulingBlockStart();
             ra = tp.getRaDegrees(when).getOrNull();
             dec = tp.getDecDegrees(when).getOrNull();
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -787,7 +787,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
             public TargetDetails(final SPTarget target) {
                 this.target = target.getTarget().clone();
-                this.mag    = target.getTarget().getMagnitudes();
+                this.mag    = target.getMagnitudes();
             }
 
             public ITarget getTarget() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -181,7 +181,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
             final Set<Magnitude.Band> options = new TreeSet<>(Magnitude.Band.WAVELENGTH_COMPARATOR);
             options.addAll(Arrays.asList(Magnitude.Band.values()));
             //noinspection ConstantConditions
-            options.removeAll(target.getTarget().getMagnitudeBands());
+            options.removeAll(target.getMagnitudeBands());
             options.add(band);
             cb.removeActionListener(changeBandAction);
             cb.setModel(new DefaultComboBoxModel<>(options.toArray(new Magnitude.Band[options.size()])));
@@ -271,7 +271,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
             // bands and show that nothing is selected.
             final Set<Magnitude.Band> options = new TreeSet<>(Magnitude.Band.WAVELENGTH_COMPARATOR);
             options.addAll(Arrays.asList(Magnitude.Band.values()));
-            options.removeAll(target.getTarget().getMagnitudeBands());
+            options.removeAll(target.getMagnitudeBands());
             cb.setMaximumRowCount(options.size());
             cb.removeActionListener(addAction);
             cb.setModel(new DefaultComboBoxModel<>(options.toArray(new Magnitude.Band[options.size()])));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/MagnitudeEditor.java
@@ -265,7 +265,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
 
             // Make the remove button active if there are existing magnitude
             // values.
-            rmButton.setEnabled(target.getTarget().getMagnitudes().size()>0);
+            rmButton.setEnabled(target.getMagnitudes().size()>0);
 
             // Update the combo-box options to contain the unused magnitude
             // bands and show that nothing is selected.
@@ -411,7 +411,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
         // If there is no magnitude info though, switch to add mode so that
         // the user doesn't have to push the + button.
         Mode mode = Mode.edit;
-        if ((target != null) && (target.getTarget().getMagnitudes().size() == 0)) {
+        if ((target != null) && (target.getMagnitudes().size() == 0)) {
             mode = Mode.add;
         }
         reinit(target, mode);
@@ -439,7 +439,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
                 final JScrollBar sb = scroll.getVerticalScrollBar();
                 sb.setValue(sb.getMaximum());
 
-                if (target.getTarget().getMagnitudes().size() > 0) {
+                if (target.getMagnitudes().size() > 0) {
                     newRow.getBandCombo().getValue().requestFocusInWindow();
                 }
             });
@@ -482,12 +482,12 @@ public class MagnitudeEditor implements TelescopePosEditor {
 
         final Magnitude newMag = new Magnitude(b, Magnitude.UNDEFINED_MAG, 0, b.defaultSystem);
 
-        target.setMagnitudes(target.getTarget().getMagnitudes().cons(newMag));
+        target.setMagnitudes(target.getMagnitudes().cons(newMag));
         focusOn(b);
     }
 
     void removeBand(Magnitude.Band b) {
-        target.setMagnitudes(target.getTarget().getMagnitudes().filter(new NotBand(b)));
+        target.setMagnitudes(target.getMagnitudes().filter(new NotBand(b)));
     }
 
     void changeBand(Magnitude.Band from, Magnitude.Band to) {
@@ -497,7 +497,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
         final Magnitude newMag = new Magnitude(to, oldMag.getBrightness(), oldMag.getError(), oldMag.getSystem());
 
         target.setMagnitudes(
-               target.getTarget().getMagnitudes().filter(new NotBand(from)).cons(newMag)
+               target.getMagnitudes().filter(new NotBand(from)).cons(newMag)
         );
         focusOn(to);
     }
@@ -510,7 +510,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
         final Magnitude newMag = new Magnitude(band, oldMag.getBrightness(), oldMag.getError(), system);
 
         target.setMagnitudes(
-               target.getTarget().getMagnitudes().filter(new NotBand(band)).cons(newMag)
+               target.getMagnitudes().filter(new NotBand(band)).cons(newMag)
         );
         focusOn(band);
     }
@@ -524,7 +524,7 @@ public class MagnitudeEditor implements TelescopePosEditor {
             final Magnitude newMag = new Magnitude(oldMag.getBand(), d, oldMag.getError(), oldMag.getSystem());
             target.deleteWatcher(watcher);
             target.setMagnitudes(
-                   target.getTarget().getMagnitudes().filter(new NotBand(b)).cons(newMag)
+                   target.getMagnitudes().filter(new NotBand(b)).cons(newMag)
             );
             target.addWatcher(watcher);
         } catch (Exception ex) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -277,7 +277,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
 
             // Add the base position first.
             final SPTarget base = env.getBase();
-            final Option<Long> when = ctx.flatMap(c -> c.getSchedulingBlock().map(SchedulingBlock::start));
+            final Option<Long> when = ctx.flatMap(c -> c.getSchedulingBlockStart());
             final Option<Coordinates> baseCoords = getCoordinates(base, when);
             tmpRows.add(new BaseTargetRow(base, when));
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -340,7 +340,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
             final Set<Magnitude.Band> bands = new TreeSet<>(Magnitude.Band.WAVELENGTH_COMPARATOR);
 
             // Extract all the magnitude bands from the environment.
-            env.getTargets().foreach(spTarget -> bands.addAll(spTarget.getTarget().getMagnitudeBands()));
+            env.getTargets().foreach(spTarget -> bands.addAll(spTarget.getMagnitudeBands()));
 
             // Create an immutable sorted list containing the results.
             return DefaultImList.create(bands);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -427,7 +427,7 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
 
     // Returns a mascot Star object for the given target, if coordinates are known
     private Option<Star> targetToStar(SPTarget target) {
-        final Option<Long> when = _iw.getContext().schedulingBlockJava().map(SchedulingBlock::start);
+        final Option<Long> when = _iw.getContext().schedulingBlockStartJava();
         return
             target.getRaDegrees(when).flatMap(ra ->
             target.getDecDegrees(when).map(dec -> {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -236,7 +236,7 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         SPTarget tp = _ctx.targets().baseOrNull();
         if (tp != null) {
             // Get the RA and Dec from the pos list.
-            final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
+            final Option<Long> when = _ctx.schedulingBlockStartJava();
             ra = tp.getRaDegrees(when).getOrElse(0.0);
             dec = tp.getDecDegrees(when).getOrElse(0.0);
         } else {
@@ -253,8 +253,8 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
         if (newBasePos == null) return oldBasePos != null;
         if (oldBasePos == null) return true;
 
-        final Option<Long> oldWhen = oldCtx.schedulingBlockJava().map(SchedulingBlock::start);
-        final Option<Long> newWhen = newCtx.schedulingBlockJava().map(SchedulingBlock::start);
+        final Option<Long> oldWhen = oldCtx.schedulingBlockStartJava();
+        final Option<Long> newWhen = newCtx.schedulingBlockStartJava();
 
         return !(oldBasePos.getRaDegrees(oldWhen).equals(newBasePos.getRaDegrees(newWhen)) &&
                 oldBasePos.getDecDegrees(oldWhen).equals(newBasePos.getDecDegrees(newWhen)));
@@ -339,7 +339,7 @@ public class TelescopePosEditor extends JSkyCat implements TpeMouseObserver {
 
         final ImageCatalog imageCatalog = ImageCatalog.instance().user();
 
-        final Option<Long> when = ctx.schedulingBlockJava().map(SchedulingBlock::start);
+        final Option<Long> when = ctx.schedulingBlockStartJava();
 
         _baseTarget.getRaDegrees(when).flatMap(ra ->
             _baseTarget.getDecDegrees(when).flatMap( dec -> {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -484,7 +484,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
 
         // Get the equinox assumed by the coordinate conversion methods (depends on current image)
         final SPTarget target = (SPTarget) tp;
-        final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
+        final Option<Long> when = _ctx.schedulingBlockStartJava();
         final double x = target.getRaDegrees(when).getOrElse(0.0);
         final double y = target.getDecDegrees(when).getOrElse(0.0);
         final WorldCoords pos = new WorldCoords(x, y, 2000.);
@@ -820,7 +820,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
      * The Base position has been updated.
      */
     public void basePosUpdate(final SPTarget target) {
-        final Option<Long> when = _ctx.schedulingBlockJava().map(SchedulingBlock::start);
+        final Option<Long> when = _ctx.schedulingBlockStartJava();
         final double x = target.getRaDegrees(when).getOrElse(0.0);
         final double y = target.getDecDegrees(when).getOrElse(0.0);
         WorldCoords pos = new WorldCoords(x, y, 2000.);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -180,7 +180,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
             if (_guideProbeTargets != null) {
                 if (!_guideProbeTargets.getPrimary().isEmpty()) {
                     GuideProbe guideProbe = _guideProbeTargets.getGuider();
-                    return GemsUtils4Java.probeMagnitudeInUse(guideProbe, _band, _guideProbeTargets.getPrimary().getValue().getTarget());
+                    return GemsUtils4Java.probeMagnitudeInUse(guideProbe, _band, _guideProbeTargets.getPrimary().getValue().getMagnitudes());
                 }
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
                 GemsStrehl strehl = _gemsGuideStars.strehl();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -577,7 +577,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
     }
 
     private void analyzeDone() {
-        final Option<Long> when = _tpe.getObsContext().flatMap(ObsContext::getSchedulingBlock).map(SchedulingBlock::start);
+        final Option<Long> when = _tpe.getObsContext().flatMap(ObsContext::getSchedulingBlockStart);
         CandidateAsterismsTreeTableModel treeTableModel = new CandidateAsterismsTreeTableModel(
                 _model.getGemsGuideStars(), ModelConverters.toOldBand(_model.getBand().getBand()), when);
         _candidateAsterismsTreeTable.setTreeTableModel(treeTableModel);

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -16,6 +16,7 @@ import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.obscomp.SPInstObsComp
 import edu.gemini.spModel.rich.shared.immutable.asScalaOpt
+import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.system.ITarget
 import jsky.app.ot.userprefs.observer.ObservingPeer
 import jsky.app.ot.util.OtColor
@@ -123,7 +124,7 @@ trait ItcTable extends Table {
       targetEnv <- parameters.targetEnvironment
       analysis  <- parameters.analysisMethod
       probe     <- extractGuideProbe()
-      src       <- extractSource(targetEnv.getBase.getTarget, uc)
+      src       <- extractSource(targetEnv.getBase, uc)
       tele      <- ConfigExtractor.extractTelescope(port, probe, targetEnv, uc.config)
       ins       <- ConfigExtractor.extractInstrumentDetails(instrument, probe, targetEnv, uc.config, cond)
       srcFrac   <- extractSourceFraction(uc, instrument)
@@ -183,7 +184,7 @@ trait ItcTable extends Table {
     o.flatten.fold("Could not identify ags strategy or guide probe type".left[GuideProbe])(_.right)
   }
 
-  private def extractSource(target: ITarget, c: ItcUniqueConfig): String \/ SourceDefinition = {
+  private def extractSource(target: SPTarget, c: ItcUniqueConfig): String \/ SourceDefinition = {
     for {
       (mag, band, system) <- extractSourceMagnitude(target, c.config)
       srcProfile          <- parameters.spatialProfile
@@ -194,7 +195,7 @@ trait ItcTable extends Table {
     }
   }
 
-  private def extractSourceMagnitude(target: ITarget, c: Config): String \/ (Double, MagnitudeBand, BrightnessUnit) = {
+  private def extractSourceMagnitude(target: SPTarget, c: Config): String \/ (Double, MagnitudeBand, BrightnessUnit) = {
 
     def closestBand(bands: List[Magnitude], wl: Wavelength) =
       // note, at this point we've filtered out all bands without a wavelength

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -330,7 +330,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
             if (inc) {
               target.putMagnitude(zero)
             } else {
-              val mags = target.getTarget.getMagnitudes.toList.asScala.filterNot(_.getBand == band)
+              val mags = target.getMagnitudes.toList.asScala.filterNot(_.getBand == band)
               target.setMagnitudes(DefaultImList.create(mags.asJava))
             }}
           )

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/CoordinateEditor.scala
@@ -52,7 +52,7 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
     spt = target0
 
     nonreentrant {
-      val when = ctx.asScalaOpt.flatMap(_.getSchedulingBlock.asScalaOpt).map(_.start).map(java.lang.Long.valueOf).asGeminiOpt
+      val when = ctx.asScalaOpt.flatMap(_.getSchedulingBlockStart.asScalaOpt).asGeminiOpt //  :-\
       target.getRaString(when).asScalaOpt.foreach(ra.setText)
       target.getDecString(when).asScalaOpt.foreach(dec.setText)
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -205,7 +205,13 @@ case class TpeContext(node: Option[ISPNode]) {
   def schedulingBlock: Option[SchedulingBlock] =
     obsShell.flatMap(_.getDataObject.asInstanceOf[SPObservation].getSchedulingBlock.asScalaOpt)
 
+  def schedulingBlockStart: Option[Long] =
+    schedulingBlock.map(_.start)
+
   def schedulingBlockJava: JOption[SchedulingBlock] =
     schedulingBlock.asGeminiOpt
+
+  def schedulingBlockStartJava: JOption[java.lang.Long] =
+    schedulingBlockStart.map(a => a : java.lang.Long).asGeminiOpt
 
 }


### PR DESCRIPTION
This PR removes some more references to `ITarget`, trivially other than calls to `getTarget().getSkycalcCoordinates()` which now need a time value.