### PR TITLE
persistent new target

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -77,17 +77,14 @@ public final class SPTarget extends TransitionalSPTarget {
 
     // for testing only; this will go away
 
-    private transient Target _newTarget;
+    private Target _newTarget = SiderealTarget.empty(); // never null
 
     public Target getNewTarget() {
-        if (_newTarget == null)
-            _newTarget = SiderealTarget.empty();
         return _newTarget;
     }
 
     public void setNewTarget(Target target) {
         _newTarget = target;
-        System.out.println("*** SPTarget.setNewTarget: " + target);
         _notifyOfUpdate();
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -1,6 +1,5 @@
 package edu.gemini.spModel.target;
 
-import edu.gemini.pot.ModelConverters$;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.Option;
@@ -17,7 +16,6 @@ import edu.gemini.spModel.target.system.*;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
-import java.util.NoSuchElementException;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -1,11 +1,13 @@
 package edu.gemini.spModel.target;
 
+import edu.gemini.pot.ModelConverters$;
 import edu.gemini.shared.skyobject.Magnitude;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.core.Redshift;
 import edu.gemini.spModel.core.Redshift$;
+import edu.gemini.spModel.core.Target;
 import edu.gemini.spModel.pio.Param;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
@@ -15,6 +17,7 @@ import edu.gemini.spModel.target.system.*;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
+import java.util.NoSuchElementException;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,6 +48,8 @@ public class SPTargetPio {
     private static final String _N = "n";
     private static final String _PERIHELION = "perihelion";
     private static final String _EPOCH_OF_PERIHELION = "epochOfPeri";
+
+    private static final String _TARGET = "target";
 
     public static final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.FULL);
     static {
@@ -145,6 +150,9 @@ public class SPTargetPio {
         if (target.getSpectralDistribution().isDefined()) {
             paramSet.addParamSet(SourcePio.toParamSet(target.getSpectralDistribution().get(), factory));
         }
+
+        // The new target
+        paramSet.addParamSet(TargetParamSetCodecs.TargetParamSetCodec().encode(_TARGET, spt.getNewTarget()));
 
         return paramSet;
     }
@@ -320,6 +328,13 @@ public class SPTargetPio {
         // Add spatial profile and spectral distribution
         spt.setSpatialProfile(SourcePio.profileFromParamSet(paramSet));
         spt.setSpectralDistribution(SourcePio.distributionFromParamSet(paramSet));
+
+        // New target ... N.B. This entire class will go away so forgive the .get() below.
+        final ParamSet ntps = paramSet.getParamSet(_TARGET);
+        if (ntps != null) {
+            final Target t = TargetParamSetCodecs.TargetParamSetCodec().decode(ntps).toOption().get();
+            spt.setNewTarget(t);
+        }
 
     }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SPTargetSerializationSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SPTargetSerializationSpec.scala
@@ -1,0 +1,34 @@
+package edu.gemini.spModel.target
+
+import edu.gemini.spModel.core.Arbitraries
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.Target._
+import edu.gemini.spModel.pio.codec._
+import edu.gemini.spModel.core.TargetSpec.canSerialize
+
+import scalaz._
+import Scalaz._
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop._
+import org.scalacheck.Gen
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import AlmostEqual.AlmostEqualOps
+
+object SPTargetSerializationSpec extends Specification with ScalaCheck with Arbitraries with Helpers {
+
+  "SPTarget Serialization" should {
+
+    "Preserve New Target" !
+      forAll { (t: Target) =>
+        canSerializeP({
+          val spt = new SPTarget
+          spt.setNewTarget(t)
+          spt
+        })((a, b) => a.getNewTarget == b.getNewTarget)
+      }
+
+  }
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -24,6 +24,7 @@ import edu.gemini.spModel.target.TargetParamSetCodecs._
   */
 object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
   {
+
     "SPTargetPio" should {
       "store source profile and distribution" !
         prop { (sd: Option[SpectralDistribution], sp: Option[SpatialProfile]) =>
@@ -41,6 +42,7 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
           assert(spt.getSpectralDistribution === spt2.getSpectralDistribution)
         }
     }
+
     "SPTargetPio" should {
       "store redshift" ! {
         prop { (z: Redshift) =>
@@ -56,22 +58,23 @@ object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
 
           (spt.getHmsDegTarget, spt2.getHmsDegTarget) match {
             case (Some(t1), Some(t2)) => assert(t1.getRedshift === t2.getRedshift)
-            case _ => assert(false)
+            case _                    => assert(false)
           }
         }
       }
     }
-  }
 
-  "SPTargetPIO" should {
-    "Preserve New Target" !
-      forAll { (t: Target) =>
-        val spt1 = new SPTarget; spt1.setNewTarget(t)
-        val spt2 = SPTargetPio.fromParamSet(SPTargetPio.getParamSet(spt1, new PioXmlFactory))
-        spt1.getNewTarget ~= spt2.getNewTarget // pio can lose floating point precision :-\
-      }
-  }
+    "SPTargetPIO" should {
+      "Preserve New Target" !
+        forAll { (t: Target) =>
+          val spt1 = new SPTarget;
+          spt1.setNewTarget(t)
+          val spt2 = SPTargetPio.fromParamSet(SPTargetPio.getParamSet(spt1, new PioXmlFactory))
+          spt1.getNewTarget ~= spt2.getNewTarget // pio can lose floating point precision :-\
+        }
+    }
 
+  }
 
   val ParamRa  = "c1"
   val ParamDec = "c2"

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -1,9 +1,13 @@
 package edu.gemini.spModel.target
 
-import edu.gemini.spModel.core.{SpectralDistribution, SpatialProfile, Redshift, Arbitraries}
+import edu.gemini.spModel.core.{Target, SpectralDistribution, SpatialProfile, Redshift, Arbitraries}
+import edu.gemini.spModel.pio.codec.ParamSetCodec
 import edu.gemini.spModel.pio.{Pio, ParamSet}
-import edu.gemini.spModel.pio.xml.PioXmlFactory
+import edu.gemini.spModel.pio.xml.{PioXmlUtil, PioXmlFactory}
+import edu.gemini.spModel.target.SPTargetSerializationSpec.canSerializeP
+import edu.gemini.spModel.core.AlmostEqual._
 import edu.gemini.spModel.target.system.{ConicTarget, HmsDegTarget, ITarget}
+import org.scalacheck.Prop.forAll
 import org.specs2.ScalaCheck
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
@@ -11,53 +15,62 @@ import squants.motion.KilometersPerSecond
 
 import edu.gemini.shared.util.immutable.{ None => JNone }
 import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.pio.codec.CodecSyntax._
+import edu.gemini.spModel.target.TargetParamSetCodecs._
 
 /** Tests Pio input/output operations for SpTargets.
   * Currently this only tests that the source profile and distribution are stored and retrieved.
   * Feel free to expand on this; however, I guess this will all become obsolete once we switch to the new target model.
   */
-object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
-  {
+class SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
 
-    "SPTargetPio" should {
-      "store source profile and distribution" !
-        prop { (sd: Option[SpectralDistribution], sp: Option[SpatialProfile]) =>
+  "SPTargetPio" should {
+    "store source profile and distribution" !
+      prop { (sd: Option[SpectralDistribution], sp: Option[SpatialProfile]) =>
 
-          val factory = new PioXmlFactory()
+        val factory = new PioXmlFactory()
 
-          val spt = new SPTarget(10, 10)
-          spt.setSpatialProfile(sp)
-          spt.setSpectralDistribution(sd)
+        val spt = new SPTarget(10, 10)
+        spt.setSpatialProfile(sp)
+        spt.setSpectralDistribution(sd)
 
-          val pset = SPTargetPio.getParamSet(spt, factory)
-          val spt2 = SPTargetPio.fromParamSet(pset)
+        val pset = SPTargetPio.getParamSet(spt, factory)
+        val spt2 = SPTargetPio.fromParamSet(pset)
 
-          assert(spt.getSpatialProfile === spt2.getSpatialProfile)
-          assert(spt.getSpectralDistribution === spt2.getSpectralDistribution)
-        }
-    }
-    "SPTargetPio" should {
-      "store redshift" ! {
-        prop { (z: Redshift) =>
+        assert(spt.getSpatialProfile === spt2.getSpatialProfile)
+        assert(spt.getSpectralDistribution === spt2.getSpectralDistribution)
+      }
+  }
+  "SPTargetPio" should {
+    "store redshift" ! {
+      prop { (z: Redshift) =>
 
-          val factory = new PioXmlFactory()
-          val t = new HmsDegTarget
+        val factory = new PioXmlFactory()
+        val t = new HmsDegTarget
 
-          t.setRedshift(z)
-          val spt = new SPTarget(t)
+        t.setRedshift(z)
+        val spt = new SPTarget(t)
 
-          val pset = SPTargetPio.getParamSet(spt, factory)
-          val spt2 = SPTargetPio.fromParamSet(pset)
+        val pset = SPTargetPio.getParamSet(spt, factory)
+        val spt2 = SPTargetPio.fromParamSet(pset)
 
-          (spt.getHmsDegTarget, spt2.getHmsDegTarget) match {
-            case (Some(t1), Some(t2)) => assert(t1.getRedshift === t2.getRedshift)
-            case _                    => assert(false)
-          }
+        (spt.getHmsDegTarget, spt2.getHmsDegTarget) match {
+          case (Some(t1), Some(t2)) => assert(t1.getRedshift === t2.getRedshift)
+          case _                    => assert(false)
         }
       }
     }
-
   }
+
+  "SPTargetPIO" should {
+    "Preserve New Target" !
+      forAll { (t: Target) =>
+        val spt1 = new SPTarget; spt1.setNewTarget(t)
+        val spt2 = SPTargetPio.fromParamSet(SPTargetPio.getParamSet(spt1, new PioXmlFactory))
+        spt1.getNewTarget ~= spt2.getNewTarget // pio can lose floating point precision :-\
+      }
+  }
+
 
   val ParamRa  = "c1"
   val ParamDec = "c2"

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/SpTargetPioSpec.scala
@@ -22,41 +22,42 @@ import edu.gemini.spModel.target.TargetParamSetCodecs._
   * Currently this only tests that the source profile and distribution are stored and retrieved.
   * Feel free to expand on this; however, I guess this will all become obsolete once we switch to the new target model.
   */
-class SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
+object SpTargetPioSpec extends Specification with ScalaCheck with Arbitraries {
+  {
+    "SPTargetPio" should {
+      "store source profile and distribution" !
+        prop { (sd: Option[SpectralDistribution], sp: Option[SpatialProfile]) =>
 
-  "SPTargetPio" should {
-    "store source profile and distribution" !
-      prop { (sd: Option[SpectralDistribution], sp: Option[SpatialProfile]) =>
+          val factory = new PioXmlFactory()
 
-        val factory = new PioXmlFactory()
+          val spt = new SPTarget(10, 10)
+          spt.setSpatialProfile(sp)
+          spt.setSpectralDistribution(sd)
 
-        val spt = new SPTarget(10, 10)
-        spt.setSpatialProfile(sp)
-        spt.setSpectralDistribution(sd)
+          val pset = SPTargetPio.getParamSet(spt, factory)
+          val spt2 = SPTargetPio.fromParamSet(pset)
 
-        val pset = SPTargetPio.getParamSet(spt, factory)
-        val spt2 = SPTargetPio.fromParamSet(pset)
+          assert(spt.getSpatialProfile === spt2.getSpatialProfile)
+          assert(spt.getSpectralDistribution === spt2.getSpectralDistribution)
+        }
+    }
+    "SPTargetPio" should {
+      "store redshift" ! {
+        prop { (z: Redshift) =>
 
-        assert(spt.getSpatialProfile === spt2.getSpatialProfile)
-        assert(spt.getSpectralDistribution === spt2.getSpectralDistribution)
-      }
-  }
-  "SPTargetPio" should {
-    "store redshift" ! {
-      prop { (z: Redshift) =>
+          val factory = new PioXmlFactory()
+          val t = new HmsDegTarget
 
-        val factory = new PioXmlFactory()
-        val t = new HmsDegTarget
+          t.setRedshift(z)
+          val spt = new SPTarget(t)
 
-        t.setRedshift(z)
-        val spt = new SPTarget(t)
+          val pset = SPTargetPio.getParamSet(spt, factory)
+          val spt2 = SPTargetPio.fromParamSet(pset)
 
-        val pset = SPTargetPio.getParamSet(spt, factory)
-        val spt2 = SPTargetPio.fromParamSet(pset)
-
-        (spt.getHmsDegTarget, spt2.getHmsDegTarget) match {
-          case (Some(t1), Some(t2)) => assert(t1.getRedshift === t2.getRedshift)
-          case _                    => assert(false)
+          (spt.getHmsDegTarget, spt2.getHmsDegTarget) match {
+            case (Some(t1), Some(t2)) => assert(t1.getRedshift === t2.getRedshift)
+            case _ => assert(false)
+          }
         }
       }
     }

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/CodecSyntax.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/CodecSyntax.scala
@@ -2,17 +2,15 @@ package edu.gemini.spModel.pio.codec
 
 import scalaz._, Scalaz._
 
-import scala.collection.JavaConverters._
 import edu.gemini.spModel.pio._
-import edu.gemini.spModel.pio.xml.PioXmlFactory
 
 object CodecSyntax {
 
-  class ParamSetCodecOps[A](a: A)(implicit ev: ParamSetCodec[A]) {
+  implicit class ParamSetCodecOps[A](a: A)(implicit ev: ParamSetCodec[A]) {
     def encode(key: String): ParamSet = ev.encode(key, a)
   }
 
-  class ParamSetOps(ps: ParamSet) {
+  implicit class ParamSetOps(ps: ParamSet) {
     def decode[A](implicit ev: ParamSetCodec[A]): PioError \/ A = ev.decode(ps)
   }
 


### PR DESCRIPTION
This makes the new `Target` carried by `SPTarget` persistent and hooks it up to PIO serialization. This is not yet visible in the UI. It will be renamed, etc., in a later PR.