### PR TITLE
OCSADV-514: add position angle to active guide group

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -107,5 +107,14 @@ object AgsStrategy {
         env
       }
     }
+
+    def applyTo(ctx: ObsContext): ObsContext = {
+      // Make a new TargetEnvironment with the guide probe assignments.  Update
+      // the position angle as well if the automatic group is primary.
+      applyTo(ctx.getTargets) |> ctx.withTargets |> { ctx0 =>
+        val auto = ctx0.getTargets.getGuideEnvironment.guideEnv.primaryGroup.isAutomatic
+        auto ? ctx0.withPositionAngle(posAngle.toOldModel) | ctx0
+      }
+    }
   }
 }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -90,7 +90,7 @@ object AgsStrategy {
     def applyTo(env: TargetEnvironment): TargetEnvironment = {
       val targetMap = ==>>.fromList(assignments.map { case Assignment(gp,gs) =>
         gp -> new SPTarget(HmsDegTarget.fromSkyObject(gs.toOldModel))})
-      val newAuto: AutomaticGroup = AutomaticGroup.Active(targetMap)
+      val newAuto: AutomaticGroup = AutomaticGroup.Active(targetMap, posAngle)
 
       // If this is different from the old automatic GG, then replace.
       val oldGuideEnvironment = env.getGuideEnvironment

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -37,11 +37,6 @@ case class TestGemsStrategy(file: String) extends GemsStrategy {
 
 class GemsStrategySpec extends Specification with NoTimeConversions {
 
-  private def applySelection(ctx: ObsContext, sel: AgsStrategy.Selection): ObsContext = {
-    // Make a new TargetEnvironment with the guide probe assignments.
-    sel.applyTo(ctx.getTargets) |> {ctx.withTargets} |> {_.withPositionAngle(sel.posAngle.toOldModel)}
-  }
-
   "GemsStrategy" should {
     "support estimate" in {
       val ra = Angle.fromHMS(3, 19, 48.2341).getOrElse(Angle.zero)
@@ -123,7 +118,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       (mag3 < mag2) should beTrue
 
       // Analyze as a whole
-      val newCtx = selection.map(applySelection(ctx, _)).getOrElse(ctx)
+      val newCtx = selection.map(_.applyTo(ctx)).getOrElse(ctx)
       val analysis = gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow())
       analysis.collect {
         case AgsAnalysis.Usable(Canopus.Wfs.cwfs2, st, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, _) if st.some == cwfs2                         => Canopus.Wfs.cwfs2
@@ -197,7 +192,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       (mag3 < mag1 && mag2 < mag1) should beTrue
 
       // Analyze as a whole
-      val newCtx = selection.map(applySelection(ctx, _)).getOrElse(ctx)
+      val newCtx = selection.map(_.applyTo(ctx)).getOrElse(ctx)
       val analysis = gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow())
       analysis.collect {
         case AgsAnalysis.Usable(Canopus.Wfs.cwfs1, st, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, _) if st.some == cwfs1                         => Canopus.Wfs.cwfs1
@@ -262,7 +257,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val odgw2x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(5, 35, 23.887).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(69, 16, 18.20).getOrElse(Angle.zero)).getOrElse(Declination.zero))
       odgw2.map(_.coordinates ~= odgw2x) should beSome(true)
 
-      val newCtx = selection.map(applySelection(ctx, _)).getOrElse(ctx)
+      val newCtx = selection.map(_.applyTo(ctx)).getOrElse(ctx)
       // Analyze as a whole
       val analysis = gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow())
       analysis.collect {
@@ -338,7 +333,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       (mag3 < mag1 && mag2 < mag1) should beTrue
 
       // Analyze as a whole
-      val newCtx = selection.map(applySelection(ctx, _)).getOrElse(ctx)
+      val newCtx = selection.map(_.applyTo(ctx)).getOrElse(ctx)
       val analysis = gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow())
       analysis.collect {
         case AgsAnalysis.Usable(Canopus.Wfs.cwfs1, st, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, _) if st.some == cwfs1 => Canopus.Wfs.cwfs1
@@ -414,7 +409,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       (mag3 < mag1 && mag2 < mag1) should beTrue
 
       // Analyze as a whole
-      val newCtx = selection.map(applySelection(ctx, _)).getOrElse(ctx)
+      val newCtx = selection.map(_.applyTo(ctx)).getOrElse(ctx)
       val analysis = gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow())
       analysis.collect {
         case AgsAnalysis.Usable(Canopus.Wfs.cwfs1, st, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, _) if st.some == cwfs1 => Canopus.Wfs.cwfs1
@@ -479,7 +474,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val odgw4x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(12, 38, 50.005).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(49, 48, 00.89).getOrElse(Angle.zero)).getOrElse(Declination.zero))
       odgw4.map(_.coordinates ~= odgw4x) should beSome(true)
 
-      val newCtx = selection.map(applySelection(ctx, _)).getOrElse(ctx)
+      val newCtx = selection.map(_.applyTo(ctx)).getOrElse(ctx)
       // Analyze all the probes at once
       gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow()).collect {
         case AgsAnalysis.Usable(Canopus.Wfs.cwfs1, st, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, _) if st.some == cwfs1                         => Canopus.Wfs.cwfs1
@@ -543,7 +538,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       val odgw4x = Coordinates(RightAscension.fromAngle(Angle.fromHMS(12, 38, 50.005).getOrElse(Angle.zero)), Declination.fromAngle(Angle.zero - Angle.fromDMS(49, 48, 00.89).getOrElse(Angle.zero)).getOrElse(Declination.zero))
       odgw4.map(_.coordinates ~= odgw4x) should beSome(true)
 
-      val newCtx = selection.map(applySelection(ctx, _)).getOrElse(ctx)
+      val newCtx = selection.map(_.applyTo(ctx)).getOrElse(ctx)
       // Analyze all the probes at once
       gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow()).collect {
         case AgsAnalysis.Usable(Canopus.Wfs.cwfs1, st, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, _) if st.some == cwfs1                         => Canopus.Wfs.cwfs1

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -42,11 +42,6 @@ import Scalaz._
 class SingleProbeStrategySpec extends Specification with NoTimeConversions {
   private val magTable = ProbeLimitsTable.loadOrThrow()
 
-  private def applySelection(ctx: ObsContext, sel: AgsStrategy.Selection): ObsContext = {
-    // Make a new TargetEnvironment with the guide probe assignments.
-    sel.applyTo(ctx.getTargets) |> {ctx.withTargets} |> {_.withPositionAngle(sel.posAngle.toOldModel)}
-  }
-
   def offset(p: Int, q: Int): SkycalcOffset =
     new SkycalcOffset(SkycalcAngle.arcsecs(p), SkycalcAngle.arcsecs(q))
 
@@ -464,7 +459,7 @@ class SingleProbeStrategySpec extends Specification with NoTimeConversions {
     val guideStar = selection.flatMap(_.assignments.headOption.map(_.guideStar))
     guideStar.map(_.name) should beSome(expectedName)
     // Add GS to targets
-    val newCtx = selection.map(applySelection(ctx, _))
+    val newCtx = selection.map(_.applyTo(ctx))
     val analyzedSelection = ~newCtx.map(strategy.analyze(_, magTable))
     analyzedSelection should be size 1
     analyzedSelection.headOption.map(_.quality) should beSome(quality)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
@@ -84,7 +84,7 @@ trait Almosts {
       def almostEqual(a: GuideGrp, b: GuideGrp): Boolean =
         (a, b) match {
           case (ManualGroup(an, am), ManualGroup(bn, bm)) => (an === bn) && (am ~= bm)
-          case (Active(am), Active(bm))                   => am ~= bm
+          case (Active(am, apa), Active(bm, bpa))         => (am ~= bm) && (apa ~= bpa)
           case (Initial, Initial)                         => true
           case (Disabled, Disabled)                       => true
           case _                                          => false

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
@@ -2,7 +2,7 @@ package edu.gemini.spModel.target.env
 
 import edu.gemini.shared.util.immutable.ImList
 import edu.gemini.shared.util.immutable.ScalaConverters._
-import edu.gemini.spModel.core.{Declination, RightAscension}
+import edu.gemini.spModel.core.{Angle, Declination, RightAscension}
 import edu.gemini.spModel.guide.{GuideProbeMap, GuideProbe}
 import edu.gemini.spModel.target.SPTarget
 import org.scalacheck._
@@ -97,7 +97,10 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
 
   implicit val arbAutomaticActiveGroup: Arbitrary[AutomaticGroup.Active] =
     Arbitrary {
-      boundedListOf[(GuideProbe, SPTarget)](3).map(lst => ==>>.fromList(lst)).map(AutomaticGroup.Active)
+      for {
+        m <- boundedListOf[(GuideProbe, SPTarget)](3).map(lst => ==>>.fromList(lst))
+        a <- arbitrary[Angle]
+      } yield AutomaticGroup.Active(m, a)
     }
 
   implicit val arbAutomaticGroup: Arbitrary[AutomaticGroup] =

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -11,6 +11,7 @@ import edu.gemini.skycalc.Angle;
 import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
 import edu.gemini.shared.skyobject.coords.SkyCoordinates;
 import edu.gemini.skycalc.Coordinates;
+import edu.gemini.spModel.core.Angle$;
 import edu.gemini.spModel.core.MagnitudeBand;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
 import edu.gemini.spModel.gemini.gems.GemsInstrument;
@@ -130,7 +131,9 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
      * setting the selected position angle and guide probe.
      */
     public void applyResults(GemsGuideStars gemsGuideStars) {
-        apply(tpe.getContext(), gemsGuideStars.pa().toDegrees(), GuideGroup.createActive(gemsGuideStars.guideGroup().getAll()));
+        final edu.gemini.spModel.core.Angle posAngle;
+        posAngle = Angle$.MODULE$.fromDegrees(gemsGuideStars.pa().toDegrees());
+        apply(tpe.getContext(), gemsGuideStars.pa().toDegrees(), GuideGroup.createActive(gemsGuideStars.guideGroup().getAll(), posAngle));
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/AgsClient.scala
@@ -234,12 +234,14 @@ class AgsClient(ctx: TpeContext) extends Dialog {
       ctx.targets.commit()
 
       // Update the position angle, if necessary.
-      ctx.instrument.dataObject.foreach { inst =>
-        val deg = sel.posAngle.toDegrees
-        val old = inst.getPosAngleDegrees
-        if (deg != old) {
-          inst.setPosAngleDegrees(deg)
-          ctx.instrument.commit()
+      if (newEnv.getGuideEnvironment.guideEnv.primaryGroup.isAutomatic) {
+        ctx.instrument.dataObject.foreach { inst =>
+          val deg = sel.posAngle.toDegrees
+          val old = inst.getPosAngleDegrees
+          if (deg != old) {
+            inst.setPosAngleDegrees(deg)
+            ctx.instrument.commit()
+          }
         }
       }
     }


### PR DESCRIPTION
This PR tweaks the `AutomaticGroup.Active` group to add a position angle.  Depending on the position angle constraint in the observation context, BAGS will sometimes find a guide star at a position angle other than the current one.  For example, if the constraint is `FIXED_180` BAGS is allowed to search at the current position angle and the current position angle plus 180º.  Previously we were not keeping track of the position angle required to reach the guide stars found by BAGS.  This means that when switching to a manual group and then later back to the automatic guide group, the position angle might no longer correspond.  With this update, we will be able to restore the position angle associated with the BAGS guide star.