### PR TITLE
OCSADV-139-B: cleanup

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsParser.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsParser.scala
@@ -121,7 +121,7 @@ final class ProbeLimitsParser extends JavaTokenParsers {
 
   def read(is: InputStream): String \/ CalcMap =
     for {
-      cm <- \/.fromTryCatch(read(Source.fromInputStream(is, "UTF8"))).fold(message(_).left, identity)
+      cm <- \/.fromTryCatchNonFatal(read(Source.fromInputStream(is, "UTF8"))).fold(message(_).left, identity)
       _  <- validate(cm)
     } yield cm
 }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsParser.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/conf/ProbeLimitsParser.scala
@@ -40,7 +40,7 @@ object ProbeLimitsParser {
     def missingIds: ValidationNel[String, Unit] =
       AllLimitsIds.filterNot(cm.contains).map(_.name) match {
         case Nil => ().success
-        case ids => ids.mkString("Missing table for: ", ", ", "").failNel
+        case ids => ids.mkString("Missing table for: ", ", ", "").failureNel
       }
 
     def incompleteTables: ValidationNel[String, Unit] = {
@@ -52,7 +52,7 @@ object ProbeLimitsParser {
 
       errors match {
         case Nil    => ().success
-        case h :: t => NonEmptyList.nel(h, t.toList).fail
+        case h :: t => NonEmptyList.nel(h, t.toList).failure
       }
     }
 

--- a/bundle/edu.gemini.gsa.query/src/test/scala/edu/gemini/gsa/query/JsonCodecsSpec.scala
+++ b/bundle/edu.gemini.gsa.query/src/test/scala/edu/gemini/gsa/query/JsonCodecsSpec.scala
@@ -12,7 +12,7 @@ import org.specs2.mutable.Specification
 
 import java.time.Instant
 
-import scalaz.syntax.id._
+import scalaz.syntax.either._
 
 object JsonCodecsSpec extends Specification with ScalaCheck with Arbitraries {
 

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -296,7 +296,7 @@ object ConfigExtractor {
   def extractDoubleFromString(c: Config, key: ItemKey): String \/ Double = {
     val v = for {
       s <- extractWithThrowable[String](c, key)
-      d <- \/.fromTryCatch(s.toDouble)
+      d <- \/.fromTryCatchNonFatal(s.toDouble)
     } yield d
     v.leftMap(_.getMessage)
    }
@@ -309,7 +309,7 @@ object ConfigExtractor {
       new Error(s"Missing config value for key ${key.getPath}").left[A]
 
     Option(c.getItemValue(key)).fold(missingKey[A](key)) { v =>
-      \/.fromTryCatch(clazz.runtimeClass.cast(v).asInstanceOf[A])
+      \/.fromTryCatchNonFatal(clazz.runtimeClass.cast(v).asInstanceOf[A])
     }
 
   }

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
@@ -27,10 +27,10 @@ object ConfigUtil {
       def as[A](implicit clazz: ClassTag[A]): ExtractFailure \/ A =
         for {
           v <- Option(c.getItemValue(key)) \/> s"Missing config value for key ${key.getPath}"
-          b <- \/.fromTryCatch(clazz.runtimeClass.cast(v).asInstanceOf[A]).leftMap(_.getMessage)
+          b <- \/.fromTryCatchNonFatal(clazz.runtimeClass.cast(v).asInstanceOf[A]).leftMap(_.getMessage)
         } yield b
     }
-    def extract(key: ItemKey) = new Extracted(key)  
+    def extract(key: ItemKey) = new Extracted(key)
   }
 
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
@@ -127,7 +127,7 @@ case class MergePlan(update: Tree[MergeNode], delete: Set[Missing]) {
     }.liftVcs
 
     def doEdit(mt: Tree[(MergeNode, ISPNode)]): VcsAction[Unit] =
-      \/.fromTryCatch {
+      \/.fromTryCatchNonFatal {
         edit(mt)
         p.setVersions(vm(p))
       }.leftMap(VcsException).liftVcs

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
@@ -169,7 +169,7 @@ class VcsServer(odb: IDBDatabaseService) { vs =>
     VcsAction(lock(k)) >> { try { body} finally { unlock(k) } }
 
   private  def putProg(p: ISPProgram): TryVcs[Unit] =
-    \/.fromTryCatch(odb.put(p)).leftMap {
+    \/.fromTryCatchNonFatal(odb.put(p)).leftMap {
       case clash: DBIDClashException => VcsFailure.idClash(clash)
       case ex                        => VcsException(ex)
     }.as(())

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Commands.scala
@@ -20,7 +20,7 @@ trait Commands {
 
 object Commands {
   def parseId(s: String): String \/ SPProgramID =
-    \/.fromTryCatch {
+    \/.fromTryCatchNonFatal {
       SPProgramID.toProgramID(s)
     }.leftMap(_ => s"Sorry, '$s' isn't a valid program id")
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/package.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/package.scala
@@ -49,7 +49,7 @@ package object vcs2 {
    * elements as VcsFailures.
    */
   def safeGet[A](a: => A, failureMessage: => String): TryVcs[A] =
-    \/.fromTryCatch(a).leftMap { t =>
+    \/.fromTryCatchNonFatal(a).leftMap { t =>
       VcsException(t): VcsFailure
     }.flatMap { Option(_).toTryVcs(failureMessage) }
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/GsaMigration.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016A/GsaMigration.scala
@@ -33,7 +33,7 @@ object GsaMigration {
       val qaMap     = qaRecords.flatMap { qa =>
         for {
           ls <- Option(Pio.getValue(qa, "label"))
-          l  <- \/.fromTryCatch(new DatasetLabel(ls)).toOption
+          l  <- \/.fromTryCatchNonFatal(new DatasetLabel(ls)).toOption
           qs <- Option(Pio.getValue(qa, "qaState"))
           q  <- Option(DatasetQaState.parseType(qs))
         } yield l -> q
@@ -43,7 +43,7 @@ object GsaMigration {
       execRecords.flatMap { ps =>
         for {
           ls <- Option(Pio.getValue(ps, "dataset/datasetLabel"))
-          l  <- \/.fromTryCatch(new DatasetLabel(ls)).toOption
+          l  <- \/.fromTryCatchNonFatal(new DatasetLabel(ls)).toOption
         } yield OldExecRecord(ps, qaMap.getOrElse(l, DatasetQaState.UNDEFINED))
       }
     }

--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/Signed.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/Signed.scala
@@ -41,7 +41,7 @@ class Signed[+A] private (private val so: SignedObject)(implicit mf: Manifest[A]
 object Signed extends DSA {
 
   def fromSignedObject[A](so: SignedObject)(implicit mf: Manifest[A]): Exception \/ Signed[A] =
-    \/.fromTryCatch(new Signed[A](so)).leftMap {
+    \/.fromTryCatchNonFatal(new Signed[A](so)).leftMap {
       case e:Exception => e
       case t => throw t
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -153,7 +153,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
     private def listenToDoc(): Unit = doc.addDocumentListener(docListener)
     private def deafToDoc(): Unit   = doc.removeDocumentListener(docListener)
 
-    def displayedValue: Option[A] = \/.fromTryCatch(read(readDoc)).toOption
+    def displayedValue: Option[A] = \/.fromTryCatchNonFatal(read(readDoc)).toOption
 
     private def showCommonValue(ps: Iterable[TemplateParameters]): Unit = {
       deafToDoc()

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details/package.scala
@@ -63,8 +63,8 @@ package object details {
 
   def forkSwingWorker[A <: AnyRef](constructImpl: => A)(finishedImpl: Throwable \/ A => Unit): Unit =
     new SwingWorker {
-      def construct = \/.fromTryCatch(constructImpl)
-      override def finished = finishedImpl(getValue.asInstanceOf[Throwable \/ A])
+      def construct = \/.fromTryCatchNonFatal(constructImpl)
+      override def finished() = finishedImpl(getValue.asInstanceOf[Throwable \/ A])
     }.start()
 
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/obscat/ObsCatalogHelper.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/obscat/ObsCatalogHelper.scala
@@ -121,7 +121,7 @@ object ObsCatalogHelper {
 
         // Remote ones via TRPC. Result type ends up the same
         case db @ Remote(peer) => authFuture {
-          TrpcClient(peer, 10 * 1000, TIMEOUT_MS).withKeyChain(OT.getKeyChain).apply(r => run(db, r[IDBQueryRunner])).fold(QueryFailure(db, _).fail, _.success)
+          TrpcClient(peer, 10 * 1000, TIMEOUT_MS).withKeyChain(OT.getKeyChain).apply(r => run(db, r[IDBQueryRunner])).fold(QueryFailure(db, _).failure, _.success)
         }
 
       }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsPeerSelectionDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsPeerSelectionDialog.scala
@@ -57,7 +57,7 @@ class VcsPeerSelectionDialog(c: Option[Component], pid: SPProgramID, allPeers: L
 
   private def loc(comp: Option[java.awt.Component]): Point = {
     def safeLocation(c0: java.awt.Component): Option[Point] =
-      \/.fromTryCatch(c0.getLocationOnScreen).toOption
+      \/.fromTryCatchNonFatal(c0.getLocationOnScreen).toOption
 
     def viewer: Option[SPViewer] =
       SPViewer.instances().asScala.find { v =>
@@ -75,7 +75,7 @@ class VcsPeerSelectionDialog(c: Option[Component], pid: SPProgramID, allPeers: L
   location = loc(c.map(_.peer))
 
   private def peerForDefaultSite = Option(pid.site).flatMap { site =>
-    allPeers.find(p => Option(p.site).exists(_ == site))
+    allPeers.find(p => Option(p.site).contains(site))
   }
 
   private var choice = peerForDefaultSite orElse ObservingPeer.get orElse allPeers.headOption
@@ -173,7 +173,7 @@ class VcsPeerSelectionDialog(c: Option[Component], pid: SPProgramID, allPeers: L
   def onePeer(p: Peer) = new Content {
     def message = "This program was not fetched from a remote database."
     def panel   = new GridBagPanel {
-      layout(new Label(s"Synchronize ${pid} with")) = new Constraints() {
+      layout(new Label(s"Synchronize $pid with")) = new Constraints() {
         gridx  = 0
         insets = new Insets(0, 0, 0, 5)
       }
@@ -187,7 +187,7 @@ class VcsPeerSelectionDialog(c: Option[Component], pid: SPProgramID, allPeers: L
     def message = "This program was not fetched from a remote database.  Select the database with which to synchronize."
 
     def panel   = new GridBagPanel {
-      layout(new Label(s"Synchronize ${pid} with")) = new Constraints() {
+      layout(new Label(s"Synchronize $pid with")) = new Constraints() {
         gridx  = 0
         insets = new Insets(0, 0, 0, 5)
       }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/VcsSyncAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/VcsSyncAction.scala
@@ -54,7 +54,7 @@ final class VcsSyncAction(viewer: SPViewer) extends AbstractViewerAction(viewer,
   }
 
   private def isShowIcons: Boolean =
-    \/.fromTryCatch(viewer.getParentFrame.getToolBar.isShowPictures) | true
+    \/.fromTryCatchNonFatal(viewer.getParentFrame.getToolBar.isShowPictures) | true
 
   listenTo(viewer.getVcsStateTracker)
 


### PR DESCRIPTION
Just a bit of cleanup and deprecation warning removal related to the scalaz update from a few weeks ago.  Most significantly, I switched `fromTryCatch` to `fromTryCatchNonFatal` which is what I believe we almost always want.