### PR TITLE
16b Target Model Converters

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTarget.java
@@ -72,7 +72,9 @@ public final class SPTarget extends TransitionalSPTarget {
 
     /** Clone this SPTarget. */
     public SPTarget clone() {
-        return new SPTarget(_target.clone());
+        final SPTarget t = new SPTarget(_target.clone());
+        t.setNewTarget(_newTarget);
+        return t;
     }
 
     // for testing only; this will go away
@@ -87,6 +89,5 @@ public final class SPTarget extends TransitionalSPTarget {
         _newTarget = target;
         _notifyOfUpdate();
     }
-
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -58,7 +58,7 @@ public class SPTargetPio {
         return formatter.format(d);
     }
 
-    private static synchronized Date parseDate(final String dateStr) {
+    public static synchronized Date parseDate(final String dateStr) {
         if (dateStr == null) return null;
 
         DateFormat format = formatter;

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
@@ -3,7 +3,7 @@ package edu.gemini.spModel.io.impl.migration
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.io.impl.SpIOTags
 import edu.gemini.spModel.pio.xml.PioXmlUtil
-import edu.gemini.spModel.pio.{ParamSet, Document, Version}
+import edu.gemini.spModel.pio.{Container, ParamSet, Document, Version}
 
 import java.io.StringWriter
 
@@ -29,6 +29,7 @@ trait Migration {
     }
 
   val ParamSetBase               = "base"
+  val ParamSetObservation        = "Observation"
   val ParamSetTarget             = "spTarget"
   val ParamSetTemplateParameters = "Template Parameters"
 
@@ -51,6 +52,15 @@ trait Migration {
 
     templateTargets ++ obsTargets
   }
+
+
+  /** (obs paramset, target paramset) paramset pairs **/
+  protected def obsAndBases(d: Document): List[(ParamSet, ParamSet)] =
+    for {
+      obs <- d.findContainers(SPComponentType.OBSERVATION_BASIC)
+      env <- obs.findContainers(SPComponentType.TELESCOPE_TARGETENV)
+      ps  <- env.allParamSets if ps.getName == ParamSetBase
+    } yield (obs.getParamSet(ParamSetObservation), ps)
 
   /** Writes the document to an XML String for debugging. */
   protected def formatDocument(d: Document): String = {

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
@@ -51,6 +51,9 @@ object PioSyntax {
     def value(key: String): Option[String] =
       Option(p.getParam(key)).map(_.getValue)
 
+    def double(key: String): Option[Double] =
+      Option(p.getParam(key)).map(_.getValue.toDouble)
+
   }
 
 }

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -21,6 +21,14 @@ object To2016B extends Migration {
 
   val fact = new PioXmlFactory
 
+  def updateTargets(d: Document): Unit = {
+    // TODO
+  }
+
+  def updateSchedulingBlocks(d: Document): Unit = {
+    // TODO
+  }
+
   private def updateGuideEnvironment(d: Document): Unit = {
 
     def disabledGroup: ParamSet =

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -1,14 +1,20 @@
-package edu.gemini.spModel.io.impl.migration.to2016B
+package edu.gemini.spModel.io.impl.migration
+package to2016B
 
 import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.core.Semester
+import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.io.impl.migration.Migration
 import edu.gemini.spModel.io.impl.migration.PioSyntax._
+import edu.gemini.spModel.obs.SPObservation
 import edu.gemini.spModel.pio.xml.PioXmlFactory
 import edu.gemini.spModel.pio.{Pio, ParamSet, Document, Version}
+import edu.gemini.spModel.target.SPTargetPio
 import edu.gemini.spModel.target.env.GuideGroup
 
 import scala.collection.JavaConverters._
 
+import PioSyntax._
 import scalaz._
 import Scalaz._
 
@@ -16,18 +22,10 @@ object To2016B extends Migration {
   val version = Version.`match`("2016B-1")
 
   val conversions: List[Document => Unit] = List(
-    updateGuideEnvironment
+    updateGuideEnvironment, updateSchedulingBlocks, updateTargets // order matters!
   )
 
   val fact = new PioXmlFactory
-
-  def updateTargets(d: Document): Unit = {
-    // TODO
-  }
-
-  def updateSchedulingBlocks(d: Document): Unit = {
-    // TODO
-  }
 
   private def updateGuideEnvironment(d: Document): Unit = {
 
@@ -76,4 +74,25 @@ object To2016B extends Migration {
       Option(paramSet.getParamSet("guideEnv")).fold(addEmptyGuideEnv(paramSet))(addDisabledAutomaticGroup)
     }
   }
+
+  // Add a scheduling block to nonsidereal observations that don't have one. A duration of 0ms means
+  // that the planned time will be used by internal calculations, which is a reasonable default.
+  def updateSchedulingBlocks(d: Document): Unit =
+    for {
+      (o, b) <- obsAndBases(d) if o.value("schedulingBlockStart").isEmpty
+      date   <- b.value("validAt").map(SPTargetPio.parseDate)
+    } {
+      Pio.addLongParam(fact, o, "schedulingBlockStart", date.getTime)
+      Pio.addLongParam(fact, o, "schedulingBlockDuration", 0L)
+    }
+
+  // Update targets to the new model
+  def updateTargets(d: Document): Unit =
+    allTargets(d).foreach { t =>
+      // TODO
+    }
+
 }
+
+
+

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/schedulingBlock.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/schedulingBlock.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2016A-1" subtype="basic" key="3674b296-3ccc-411c-bcc3-7c01406ce869" name="GS-2016A-Q-1">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="title" value="schedulingBlockTest"/>
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="piInfo">
+        <param name="firstName" value=""/>
+        <param name="lastName" value=""/>
+        <param name="email" value=""/>
+        <param name="phone" value=""/>
+      </paramset>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b78c9563-68d1-4157-989b-295b2b2d0d68" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="none"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="9fffe1ae-f97e-486f-a92e-dd8601e9f95d" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="44419923-44da-4417-aae1-4c325ea533f1" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="02cc9f7c-5281-404a-8cbf-8c78ef3aa113" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="951ff418-2e50-47a6-a01e-987c1fc08d2f" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="4968aaf0-aa39-4feb-b51a-5d8a9aa06983" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="060d5899-6860-4546-9efa-8894277f8744" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="some"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="schedulingBlockStart" value="1457551614113"/>
+        <param name="schedulingBlockDuration" value="92500"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="08eb0e92-f2a6-4a4a-a749-d80a8b758aa6" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="50952e16-5dbd-4b87-8915-dcb5a5e220b3" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="61a59516-f691-4e04-9f93-50d4e024b2c2" name="GMOS-S">
+        <paramset name="GMOS-S" kind="dataObj">
+          <param name="exposureTime" value="300.0"/>
+          <param name="posAngle" value="140.42"/>
+          <param name="coadds" value="1"/>
+          <paramset name="parallacticAngleDuration">
+            <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
+            <param name="explicitDuration" value="0"/>
+          </paramset>
+          <param name="adc" value="NONE"/>
+          <param name="ampCount" value="TWELVE"/>
+          <param name="gainChoice" value="LOW"/>
+          <param name="ampReadMode" value="SLOW"/>
+          <param name="detectorManufacturer" value="HAMAMATSU"/>
+          <param name="disperser" value="B1200_G5321"/>
+          <param name="disperserLambda" value="550.0"/>
+          <param name="disperserOrder" value="ONE"/>
+          <param name="fpuMode" value="BUILTIN"/>
+          <param name="fpu" value="LONGSLIT_4"/>
+          <param name="filter" value="g_G0325"/>
+          <param name="ccdXBinning" value="ONE"/>
+          <param name="ccdYBinning" value="ONE"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+          <param name="posAngleConstraint" value="PARALLACTIC_ANGLE"/>
+          <param name="stageMode" value="FOLLOW_XYZ"/>
+          <param name="dtaXOffset" value="ZERO"/>
+          <param name="builtinROI" value="FULL_FRAME"/>
+          <param name="useNS" value="FALSE"/>
+          <param name="mosPreimaging" value="NO"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="d360a857-be53-48a7-81e8-c382c0f117b0" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="a8eddd15-babc-4c86-8235-f7e727c4952b" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c4bfb628-7801-4470-8b67-228a149ef10c" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="93c27549-0813-4231-99b6-fe10c691bad0" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="nonsidereal"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="c272f91e-66c9-4559-bc76-5d28631a9ff5" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="9c1d6169-87cc-4043-b8c2-6e5d26e3c55e" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="validAt" value="2/1/16 12:00:00 AM UTC"/>
+              <param name="system" value="MPC minor planet"/>
+              <param name="epoch" value="0.0" units="JD"/>
+              <param name="anode" value="0.0" units="degrees"/>
+              <param name="aq" value="0.0" units="au"/>
+              <param name="e" value="0.0"/>
+              <param name="inclination" value="0.0" units="degrees"/>
+              <param name="lm" value="0.0" units="degrees"/>
+              <param name="n" value="0.0" units="degrees/day"/>
+              <param name="perihelion" value="0.0" units="degrees"/>
+              <param name="epochOfPeri" value="0.0" units="JD"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="f49f63b2-3324-4963-be05-47a260cb60dd" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="3db18908-4714-4a5e-ada0-5fb211800db6" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="4c71ff90-9570-4c80-9f39-1a89066168ef" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="9c1d6169-87cc-4043-b8c2-6e5d26e3c55e"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="02cc9f7c-5281-404a-8cbf-8c78ef3aa113"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c4bfb628-7801-4470-8b67-228a149ef10c"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="61a59516-f691-4e04-9f93-50d4e024b2c2"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="17"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3674b296-3ccc-411c-bcc3-7c01406ce869"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="22"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="9fffe1ae-f97e-486f-a92e-dd8601e9f95d"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="951ff418-2e50-47a6-a01e-987c1fc08d2f"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d360a857-be53-48a7-81e8-c382c0f117b0"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="50952e16-5dbd-4b87-8915-dcb5a5e220b3"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="f49f63b2-3324-4963-be05-47a260cb60dd"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="08eb0e92-f2a6-4a4a-a749-d80a8b758aa6"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="a8eddd15-babc-4c86-8235-f7e727c4952b"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="44419923-44da-4417-aae1-4c325ea533f1"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c272f91e-66c9-4559-bc76-5d28631a9ff5"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="060d5899-6860-4546-9efa-8894277f8744"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="7"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3db18908-4714-4a5e-ada0-5fb211800db6"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4968aaf0-aa39-4feb-b51a-5d8a9aa06983"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="93c27549-0813-4231-99b6-fe10c691bad0"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="12"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4c71ff90-9570-4c80-9f39-1a89066168ef"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b78c9563-68d1-4157-989b-295b2b2d0d68"/>
+      <param name="549b7ccb-2716-4871-b2a8-4cd42eb1b525" value="5"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
@@ -21,10 +21,284 @@
       <param name="completed" value="false"/>
       <param name="notifyPi" value="YES"/>
     </paramset>
-
-
-
-
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="9c348131-beb6-424c-9515-51dd3d2d633b" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="sidereal"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="58df0a77-f45b-4401-9d48-2da69b0ebe9e" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="265660f7-ce23-46bc-92b8-4b4fd2cdf23e" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="barnard's star"/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="17:57:48.498"/>
+              <param name="c2" value="04:41:36.21"/>
+              <param name="pm1" value="-798.58" units="milli-arcsecs/year"/>
+              <param name="pm2" value="10328.12" units="milli-arcsecs/year"/>
+              <param name="parallax" value="548.31" units="mas"/>
+              <param name="z" value="-3.69E-4"/>
+              <paramset name="magnitudeList">
+                <paramset name="magnitude">
+                  <param name="band" value="U"/>
+                  <param name="val" value="12.497"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="B"/>
+                  <param name="val" value="11.24"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="V"/>
+                  <param name="val" value="9.511"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="R"/>
+                  <param name="val" value="8.298"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="I"/>
+                  <param name="val" value="6.741"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="J"/>
+                  <param name="val" value="5.244"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="H"/>
+                  <param name="val" value="4.83"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="K"/>
+                  <param name="val" value="4.524"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+              </paramset>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ca066b4b-38a7-4421-a172-3873daf4be2d" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="2a99225f-b237-44e7-9836-a4b0e0b4fe08" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="4ec9ee31-89c5-42c6-978d-590193f1dac5" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4890894e-13ed-4710-a211-ac6826762200" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="named"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="6db9ac71-61bb-4627-a867-44670ed0d83d" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="d7756c36-3811-4b93-b347-ab47dfa491d4" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="Mars"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="system" value="Solar system object"/>
+              <param name="object" value="MARS"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="800dc294-3738-4d54-b3cd-c921304aa567" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="17b7fac7-a2cd-4b50-ad28-b31d2ff46ed2" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="6b9387b2-42b0-4cf2-b438-1521d1acc5a6" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4ab6d658-ca40-4978-abe1-6ce4a64dc288" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="jpl-minor-body"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="74b11b2f-7ee6-47d5-b2bf-a4af7cd77e86" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e2def4c6-14c3-4e91-8ce2-634b3ab3f3f4" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="jpl-minor-body"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="system" value="JPL minor body"/>
+              <param name="epoch" value="0.0" units="JD"/>
+              <param name="anode" value="0.0" units="degrees"/>
+              <param name="aq" value="0.0" units="au"/>
+              <param name="e" value="0.0"/>
+              <param name="inclination" value="0.0" units="degrees"/>
+              <param name="lm" value="0.0" units="degrees"/>
+              <param name="n" value="0.0" units="degrees/day"/>
+              <param name="perihelion" value="0.0" units="degrees"/>
+              <param name="epochOfPeri" value="0.0" units="JD"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="1038665f-8bb2-4016-a991-a4d61cf194a8" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="86b688f9-c83f-42c6-a793-9e0273f17325" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="b5990661-6d96-4c1c-91c4-2c1b89d202a3" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="55bc25f3-74da-43f0-b0c2-cedaed64f26c" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="mpc-minor-planet"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="1e930928-4f6f-4f3c-b4a3-0fdc4015f3b9" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="87881445-2e3c-417e-9abf-a5815760e951" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="mpc-minor-planet"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="system" value="MPC minor planet"/>
+              <param name="epoch" value="0.0" units="JD"/>
+              <param name="anode" value="0.0" units="degrees"/>
+              <param name="aq" value="0.0" units="au"/>
+              <param name="e" value="0.0"/>
+              <param name="inclination" value="0.0" units="degrees"/>
+              <param name="lm" value="0.0" units="degrees"/>
+              <param name="n" value="0.0" units="degrees/day"/>
+              <param name="perihelion" value="0.0" units="degrees"/>
+              <param name="epochOfPeri" value="0.0" units="JD"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ad4206ce-d89e-4028-b69a-b545453a0a98" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c0d1aaf3-cc8f-42c4-ae55-0f8ffd52c1d9" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2c46b405-5b7e-433f-8d54-85574b13daa5" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
     <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e864ea1f-53de-4f64-b8df-a2737dfd93b9" name="">
       <paramset name="Observation" kind="dataObj">
         <param name="title" value="too"/>

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2016A-1" subtype="basic" key="59ddb441-318d-4ccd-af32-9dec72b0853c" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="title" value="targetMigration"/>
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="piInfo">
+        <param name="firstName" value=""/>
+        <param name="lastName" value=""/>
+        <param name="email" value=""/>
+        <param name="phone" value=""/>
+      </paramset>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="9c348131-beb6-424c-9515-51dd3d2d633b" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="sidereal"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="58df0a77-f45b-4401-9d48-2da69b0ebe9e" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="265660f7-ce23-46bc-92b8-4b4fd2cdf23e" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="vega"/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="18:36:56.336"/>
+              <param name="c2" value="38:47:01.28"/>
+              <param name="pm1" value="200.94" units="milli-arcsecs/year"/>
+              <param name="pm2" value="286.23" units="milli-arcsecs/year"/>
+              <param name="parallax" value="130.23" units="mas"/>
+              <param name="z" value="-6.9E-5"/>
+              <paramset name="magnitudeList">
+                <paramset name="magnitude">
+                  <param name="band" value="U"/>
+                  <param name="val" value="0.03"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="B"/>
+                  <param name="val" value="0.03"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="V"/>
+                  <param name="val" value="0.03"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="R"/>
+                  <param name="val" value="0.07"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="I"/>
+                  <param name="val" value="0.1"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="J"/>
+                  <param name="val" value="-0.18"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="H"/>
+                  <param name="val" value="-0.03"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="K"/>
+                  <param name="val" value="0.13"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+              </paramset>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ca066b4b-38a7-4421-a172-3873daf4be2d" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="2a99225f-b237-44e7-9836-a4b0e0b4fe08" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="4ec9ee31-89c5-42c6-978d-590193f1dac5" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4890894e-13ed-4710-a211-ac6826762200" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="named"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="6db9ac71-61bb-4627-a867-44670ed0d83d" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="d7756c36-3811-4b93-b347-ab47dfa491d4" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="Mars"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="system" value="Solar system object"/>
+              <param name="object" value="MARS"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="800dc294-3738-4d54-b3cd-c921304aa567" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="17b7fac7-a2cd-4b50-ad28-b31d2ff46ed2" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="6b9387b2-42b0-4cf2-b438-1521d1acc5a6" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4ab6d658-ca40-4978-abe1-6ce4a64dc288" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="jpl-minor-body"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="74b11b2f-7ee6-47d5-b2bf-a4af7cd77e86" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e2def4c6-14c3-4e91-8ce2-634b3ab3f3f4" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="jpl-minor-body"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="system" value="JPL minor body"/>
+              <param name="epoch" value="0.0" units="JD"/>
+              <param name="anode" value="0.0" units="degrees"/>
+              <param name="aq" value="0.0" units="au"/>
+              <param name="e" value="0.0"/>
+              <param name="inclination" value="0.0" units="degrees"/>
+              <param name="lm" value="0.0" units="degrees"/>
+              <param name="n" value="0.0" units="degrees/day"/>
+              <param name="perihelion" value="0.0" units="degrees"/>
+              <param name="epochOfPeri" value="0.0" units="JD"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="1038665f-8bb2-4016-a991-a4d61cf194a8" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="86b688f9-c83f-42c6-a793-9e0273f17325" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="b5990661-6d96-4c1c-91c4-2c1b89d202a3" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="55bc25f3-74da-43f0-b0c2-cedaed64f26c" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="mpc-minor-planet"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="1e930928-4f6f-4f3c-b4a3-0fdc4015f3b9" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="87881445-2e3c-417e-9abf-a5815760e951" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="mpc-minor-planet"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="system" value="MPC minor planet"/>
+              <param name="epoch" value="0.0" units="JD"/>
+              <param name="anode" value="0.0" units="degrees"/>
+              <param name="aq" value="0.0" units="au"/>
+              <param name="e" value="0.0"/>
+              <param name="inclination" value="0.0" units="degrees"/>
+              <param name="lm" value="0.0" units="degrees"/>
+              <param name="n" value="0.0" units="degrees/day"/>
+              <param name="perihelion" value="0.0" units="degrees"/>
+              <param name="epochOfPeri" value="0.0" units="JD"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ad4206ce-d89e-4028-b69a-b545453a0a98" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c0d1aaf3-cc8f-42c4-ae55-0f8ffd52c1d9" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2c46b405-5b7e-433f-8d54-85574b13daa5" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e864ea1f-53de-4f64-b8df-a2737dfd93b9" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="too"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="508ceac2-cb93-489f-90d2-0cdfcf010a75" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="ad3049b5-e617-46c1-b9d2-d9f78f876f12" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value=""/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="3e8ef587-3a77-430f-8b06-f4385ad2b2a9" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="ef951d10-4edc-4a0f-a14b-7aff9b2614c4" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2660502d-693f-4288-b72e-9881c0c28db1" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="ad4206ce-d89e-4028-b69a-b545453a0a98"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1e930928-4f6f-4f3c-b4a3-0fdc4015f3b9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2a99225f-b237-44e7-9836-a4b0e0b4fe08"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="800dc294-3738-4d54-b3cd-c921304aa567"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4ec9ee31-89c5-42c6-978d-590193f1dac5"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="6db9ac71-61bb-4627-a867-44670ed0d83d"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ca066b4b-38a7-4421-a172-3873daf4be2d"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="58df0a77-f45b-4401-9d48-2da69b0ebe9e"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="74b11b2f-7ee6-47d5-b2bf-a4af7cd77e86"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2660502d-693f-4288-b72e-9881c0c28db1"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="86b688f9-c83f-42c6-a793-9e0273f17325"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4890894e-13ed-4710-a211-ac6826762200"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="6"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="87881445-2e3c-417e-9abf-a5815760e951"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="18"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="55bc25f3-74da-43f0-b0c2-cedaed64f26c"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="5"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="265660f7-ce23-46bc-92b8-4b4fd2cdf23e"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="6"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3e8ef587-3a77-430f-8b06-f4385ad2b2a9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4ab6d658-ca40-4978-abe1-6ce4a64dc288"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="28"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b5990661-6d96-4c1c-91c4-2c1b89d202a3"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e864ea1f-53de-4f64-b8df-a2737dfd93b9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="17b7fac7-a2cd-4b50-ad28-b31d2ff46ed2"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c0d1aaf3-cc8f-42c4-ae55-0f8ffd52c1d9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="6b9387b2-42b0-4cf2-b438-1521d1acc5a6"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="508ceac2-cb93-489f-90d2-0cdfcf010a75"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e2def4c6-14c3-4e91-8ce2-634b3ab3f3f4"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="15"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="9c348131-beb6-424c-9515-51dd3d2d633b"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="9"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2c46b405-5b7e-433f-8d54-85574b13daa5"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="59ddb441-318d-4ccd-af32-9dec72b0853c"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="6"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ef951d10-4edc-4a0f-a14b-7aff9b2614c4"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1038665f-8bb2-4016-a991-a4d61cf194a8"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ad3049b5-e617-46c1-b9d2-d9f78f876f12"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d7756c36-3811-4b93-b347-ab47dfa491d4"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="8"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
@@ -58,33 +58,8 @@
               <param name="z" value="-3.69E-4"/>
               <paramset name="magnitudeList">
                 <paramset name="magnitude">
-                  <param name="band" value="U"/>
-                  <param name="val" value="12.497"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="B"/>
-                  <param name="val" value="11.24"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="V"/>
-                  <param name="val" value="9.511"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="R"/>
-                  <param name="val" value="8.298"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="I"/>
-                  <param name="val" value="6.741"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="J"/>
-                  <param name="val" value="5.244"/>
+                  <param name="band" value="K"/>
+                  <param name="val" value="4.524"/>
                   <param name="system" value="Vega"/>
                 </paramset>
                 <paramset name="magnitude">
@@ -93,8 +68,33 @@
                   <param name="system" value="Vega"/>
                 </paramset>
                 <paramset name="magnitude">
-                  <param name="band" value="K"/>
-                  <param name="val" value="4.524"/>
+                  <param name="band" value="J"/>
+                  <param name="val" value="5.244"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="I"/>
+                  <param name="val" value="6.741"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="R"/>
+                  <param name="val" value="8.298"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="V"/>
+                  <param name="val" value="9.511"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="B"/>
+                  <param name="val" value="11.24"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="band" value="U"/>
+                  <param name="val" value="12.497"/>
                   <param name="system" value="Vega"/>
                 </paramset>
               </paramset>
@@ -148,8 +148,9 @@
           <paramset name="targetEnv">
             <paramset name="base">
               <param name="name" value="Mars"/>
-              <param name="c1" value="00:00:00.000"/>
-              <param name="c2" value="00:00:00.00"/>
+              <param name="c1" value="16:03:57.960"/>
+              <param name="c2" value="-19:34:06.70"/>
+              <param name="validAt" value="3/14/16 10:27:09 PM UTC"/>
               <param name="system" value="Solar system object"/>
               <param name="object" value="MARS"/>
             </paramset>
@@ -201,19 +202,22 @@
         <paramset name="Targets" kind="dataObj">
           <paramset name="targetEnv">
             <paramset name="base">
-              <param name="name" value="jpl-minor-body"/>
-              <param name="c1" value="00:00:00.000"/>
-              <param name="c2" value="00:00:00.00"/>
+              <param name="name" value="halley"/>
+              <param name="horizons-object-id" value="900033"/>
+              <param name="horizons-object-type" value="0"/>
+              <param name="c1" value="08:21:58.410"/>
+              <param name="c2" value="01:53:33.90"/>
+              <param name="validAt" value="3/14/16 10:27:40 PM UTC"/>
               <param name="system" value="JPL minor body"/>
-              <param name="epoch" value="0.0" units="JD"/>
-              <param name="anode" value="0.0" units="degrees"/>
-              <param name="aq" value="0.0" units="au"/>
-              <param name="e" value="0.0"/>
-              <param name="inclination" value="0.0" units="degrees"/>
-              <param name="lm" value="0.0" units="degrees"/>
+              <param name="epoch" value="2449400.5" units="JD"/>
+              <param name="anode" value="58.42008097656843" units="degrees"/>
+              <param name="aq" value="0.5859781115169086" units="au"/>
+              <param name="e" value="0.9671429084623044"/>
+              <param name="inclination" value="162.2626905791606" units="degrees"/>
+              <param name="lm" value="38.384264476436" units="degrees"/>
               <param name="n" value="0.0" units="degrees/day"/>
-              <param name="perihelion" value="0.0" units="degrees"/>
-              <param name="epochOfPeri" value="0.0" units="JD"/>
+              <param name="perihelion" value="111.3324851045177" units="degrees"/>
+              <param name="epochOfPeri" value="2446467.395317051" units="JD"/>
             </paramset>
             <paramset name="guideEnv"/>
           </paramset>
@@ -263,19 +267,22 @@
         <paramset name="Targets" kind="dataObj">
           <paramset name="targetEnv">
             <paramset name="base">
-              <param name="name" value="mpc-minor-planet"/>
-              <param name="c1" value="00:00:00.000"/>
-              <param name="c2" value="00:00:00.00"/>
+              <param name="name" value="beer"/>
+              <param name="horizons-object-id" value="1896"/>
+              <param name="horizons-object-type" value="1"/>
+              <param name="c1" value="05:55:04.560"/>
+              <param name="c2" value="21:04:58.80"/>
+              <param name="validAt" value="3/14/16 10:28:05 PM UTC"/>
               <param name="system" value="MPC minor planet"/>
-              <param name="epoch" value="0.0" units="JD"/>
-              <param name="anode" value="0.0" units="degrees"/>
-              <param name="aq" value="0.0" units="au"/>
-              <param name="e" value="0.0"/>
-              <param name="inclination" value="0.0" units="degrees"/>
-              <param name="lm" value="0.0" units="degrees"/>
+              <param name="epoch" value="2455271.5" units="JD"/>
+              <param name="anode" value="182.1735572024307" units="degrees"/>
+              <param name="aq" value="2.368063037173691" units="au"/>
+              <param name="e" value="0.2215143419686845"/>
+              <param name="inclination" value="2.220418347744165" units="degrees"/>
+              <param name="lm" value="212.8061703595739" units="degrees"/>
               <param name="n" value="0.0" units="degrees/day"/>
-              <param name="perihelion" value="0.0" units="degrees"/>
-              <param name="epochOfPeri" value="0.0" units="JD"/>
+              <param name="perihelion" value="180.0542620681246" units="degrees"/>
+              <param name="epochOfPeri" value="2455815.7211546064" units="JD"/>
             </paramset>
             <paramset name="guideEnv"/>
           </paramset>
@@ -410,6 +417,7 @@
     <paramset name="node">
       <param name="key" value="87881445-2e3c-417e-9abf-a5815760e951"/>
       <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="18"/>
+      <param name="50960219-3682-4709-a9e1-004af855bfc4" value="6"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="55bc25f3-74da-43f0-b0c2-cedaed64f26c"/>
@@ -454,6 +462,7 @@
     <paramset name="node">
       <param name="key" value="e2def4c6-14c3-4e91-8ce2-634b3ab3f3f4"/>
       <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="15"/>
+      <param name="50960219-3682-4709-a9e1-004af855bfc4" value="23"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="9c348131-beb6-424c-9515-51dd3d2d633b"/>
@@ -482,6 +491,7 @@
     <paramset name="node">
       <param name="key" value="d7756c36-3811-4b93-b347-ab47dfa491d4"/>
       <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="8"/>
+      <param name="50960219-3682-4709-a9e1-004af855bfc4" value="1"/>
     </paramset>
   </container>
 </document>

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
@@ -308,7 +308,7 @@
     </container>
     <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e864ea1f-53de-4f64-b8df-a2737dfd93b9" name="">
       <paramset name="Observation" kind="dataObj">
-        <param name="title" value="too"/>
+        <param name="title" value="origin"/>
         <param name="libraryId" value=""/>
         <param name="priority" value="LOW"/>
         <param name="tooOverrideRapid" value="false"/>
@@ -332,7 +332,7 @@
         <paramset name="Targets" kind="dataObj">
           <paramset name="targetEnv">
             <paramset name="base">
-              <param name="name" value="bob"/>
+              <param name="name" value="zero"/>
               <param name="system" value="J2000"/>
               <param name="epoch" value="2000.0" units="years"/>
               <param name="c1" value="00:00:00.000"/>

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigration.xml
@@ -21,284 +21,10 @@
       <param name="completed" value="false"/>
       <param name="notifyPi" value="YES"/>
     </paramset>
-    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="9c348131-beb6-424c-9515-51dd3d2d633b" name="">
-      <paramset name="Observation" kind="dataObj">
-        <param name="title" value="sidereal"/>
-        <param name="libraryId" value=""/>
-        <param name="priority" value="LOW"/>
-        <param name="tooOverrideRapid" value="false"/>
-        <param name="phase2Status" value="PI_TO_COMPLETE"/>
-        <param name="qaState" value="UNDEFINED"/>
-        <param name="overrideQaState" value="false"/>
-      </paramset>
-      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="58df0a77-f45b-4401-9d48-2da69b0ebe9e" name="Observing Conditions">
-        <paramset name="Observing Conditions" kind="dataObj">
-          <param name="CloudCover" value="ANY"/>
-          <param name="ImageQuality" value="ANY"/>
-          <param name="SkyBackground" value="ANY"/>
-          <param name="WaterVapor" value="ANY"/>
-          <param name="ElevationConstraintType" value="NONE"/>
-          <param name="ElevationConstraintMin" value="0.0"/>
-          <param name="ElevationConstraintMax" value="0.0"/>
-          <paramset name="timing-window-list"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="265660f7-ce23-46bc-92b8-4b4fd2cdf23e" name="Targets">
-        <paramset name="Targets" kind="dataObj">
-          <paramset name="targetEnv">
-            <paramset name="base">
-              <param name="name" value="vega"/>
-              <param name="system" value="J2000"/>
-              <param name="epoch" value="2000.0" units="years"/>
-              <param name="c1" value="18:36:56.336"/>
-              <param name="c2" value="38:47:01.28"/>
-              <param name="pm1" value="200.94" units="milli-arcsecs/year"/>
-              <param name="pm2" value="286.23" units="milli-arcsecs/year"/>
-              <param name="parallax" value="130.23" units="mas"/>
-              <param name="z" value="-6.9E-5"/>
-              <paramset name="magnitudeList">
-                <paramset name="magnitude">
-                  <param name="band" value="U"/>
-                  <param name="val" value="0.03"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="B"/>
-                  <param name="val" value="0.03"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="V"/>
-                  <param name="val" value="0.03"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="R"/>
-                  <param name="val" value="0.07"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="I"/>
-                  <param name="val" value="0.1"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="J"/>
-                  <param name="val" value="-0.18"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="H"/>
-                  <param name="val" value="-0.03"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-                <paramset name="magnitude">
-                  <param name="band" value="K"/>
-                  <param name="val" value="0.13"/>
-                  <param name="system" value="Vega"/>
-                </paramset>
-              </paramset>
-            </paramset>
-            <paramset name="guideEnv"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ca066b4b-38a7-4421-a172-3873daf4be2d" name="Observing Log">
-        <paramset name="Observing Log" kind="dataObj">
-          <paramset name="obsQaRecord"/>
-        </paramset>
-      </container>
-      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="2a99225f-b237-44e7-9836-a4b0e0b4fe08" name="Observation Exec Log">
-        <paramset name="Observation Exec Log" kind="dataObj">
-          <paramset name="obsExecRecord">
-            <paramset name="datasets"/>
-            <paramset name="events"/>
-            <paramset name="configMap"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="4ec9ee31-89c5-42c6-978d-590193f1dac5" name="Sequence">
-        <paramset name="Sequence" kind="dataObj"/>
-      </container>
-    </container>
-    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4890894e-13ed-4710-a211-ac6826762200" name="">
-      <paramset name="Observation" kind="dataObj">
-        <param name="title" value="named"/>
-        <param name="libraryId" value=""/>
-        <param name="priority" value="LOW"/>
-        <param name="tooOverrideRapid" value="false"/>
-        <param name="phase2Status" value="PI_TO_COMPLETE"/>
-        <param name="qaState" value="UNDEFINED"/>
-        <param name="overrideQaState" value="false"/>
-      </paramset>
-      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="6db9ac71-61bb-4627-a867-44670ed0d83d" name="Observing Conditions">
-        <paramset name="Observing Conditions" kind="dataObj">
-          <param name="CloudCover" value="ANY"/>
-          <param name="ImageQuality" value="ANY"/>
-          <param name="SkyBackground" value="ANY"/>
-          <param name="WaterVapor" value="ANY"/>
-          <param name="ElevationConstraintType" value="NONE"/>
-          <param name="ElevationConstraintMin" value="0.0"/>
-          <param name="ElevationConstraintMax" value="0.0"/>
-          <paramset name="timing-window-list"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="d7756c36-3811-4b93-b347-ab47dfa491d4" name="Targets">
-        <paramset name="Targets" kind="dataObj">
-          <paramset name="targetEnv">
-            <paramset name="base">
-              <param name="name" value="Mars"/>
-              <param name="c1" value="00:00:00.000"/>
-              <param name="c2" value="00:00:00.00"/>
-              <param name="system" value="Solar system object"/>
-              <param name="object" value="MARS"/>
-            </paramset>
-            <paramset name="guideEnv"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="800dc294-3738-4d54-b3cd-c921304aa567" name="Observing Log">
-        <paramset name="Observing Log" kind="dataObj">
-          <paramset name="obsQaRecord"/>
-        </paramset>
-      </container>
-      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="17b7fac7-a2cd-4b50-ad28-b31d2ff46ed2" name="Observation Exec Log">
-        <paramset name="Observation Exec Log" kind="dataObj">
-          <paramset name="obsExecRecord">
-            <paramset name="datasets"/>
-            <paramset name="events"/>
-            <paramset name="configMap"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="6b9387b2-42b0-4cf2-b438-1521d1acc5a6" name="Sequence">
-        <paramset name="Sequence" kind="dataObj"/>
-      </container>
-    </container>
-    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4ab6d658-ca40-4978-abe1-6ce4a64dc288" name="">
-      <paramset name="Observation" kind="dataObj">
-        <param name="title" value="jpl-minor-body"/>
-        <param name="libraryId" value=""/>
-        <param name="priority" value="LOW"/>
-        <param name="tooOverrideRapid" value="false"/>
-        <param name="phase2Status" value="PI_TO_COMPLETE"/>
-        <param name="qaState" value="UNDEFINED"/>
-        <param name="overrideQaState" value="false"/>
-      </paramset>
-      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="74b11b2f-7ee6-47d5-b2bf-a4af7cd77e86" name="Observing Conditions">
-        <paramset name="Observing Conditions" kind="dataObj">
-          <param name="CloudCover" value="ANY"/>
-          <param name="ImageQuality" value="ANY"/>
-          <param name="SkyBackground" value="ANY"/>
-          <param name="WaterVapor" value="ANY"/>
-          <param name="ElevationConstraintType" value="NONE"/>
-          <param name="ElevationConstraintMin" value="0.0"/>
-          <param name="ElevationConstraintMax" value="0.0"/>
-          <paramset name="timing-window-list"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e2def4c6-14c3-4e91-8ce2-634b3ab3f3f4" name="Targets">
-        <paramset name="Targets" kind="dataObj">
-          <paramset name="targetEnv">
-            <paramset name="base">
-              <param name="name" value="jpl-minor-body"/>
-              <param name="c1" value="00:00:00.000"/>
-              <param name="c2" value="00:00:00.00"/>
-              <param name="system" value="JPL minor body"/>
-              <param name="epoch" value="0.0" units="JD"/>
-              <param name="anode" value="0.0" units="degrees"/>
-              <param name="aq" value="0.0" units="au"/>
-              <param name="e" value="0.0"/>
-              <param name="inclination" value="0.0" units="degrees"/>
-              <param name="lm" value="0.0" units="degrees"/>
-              <param name="n" value="0.0" units="degrees/day"/>
-              <param name="perihelion" value="0.0" units="degrees"/>
-              <param name="epochOfPeri" value="0.0" units="JD"/>
-            </paramset>
-            <paramset name="guideEnv"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="1038665f-8bb2-4016-a991-a4d61cf194a8" name="Observing Log">
-        <paramset name="Observing Log" kind="dataObj">
-          <paramset name="obsQaRecord"/>
-        </paramset>
-      </container>
-      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="86b688f9-c83f-42c6-a793-9e0273f17325" name="Observation Exec Log">
-        <paramset name="Observation Exec Log" kind="dataObj">
-          <paramset name="obsExecRecord">
-            <paramset name="datasets"/>
-            <paramset name="events"/>
-            <paramset name="configMap"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="b5990661-6d96-4c1c-91c4-2c1b89d202a3" name="Sequence">
-        <paramset name="Sequence" kind="dataObj"/>
-      </container>
-    </container>
-    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="55bc25f3-74da-43f0-b0c2-cedaed64f26c" name="">
-      <paramset name="Observation" kind="dataObj">
-        <param name="title" value="mpc-minor-planet"/>
-        <param name="libraryId" value=""/>
-        <param name="priority" value="LOW"/>
-        <param name="tooOverrideRapid" value="false"/>
-        <param name="phase2Status" value="PI_TO_COMPLETE"/>
-        <param name="qaState" value="UNDEFINED"/>
-        <param name="overrideQaState" value="false"/>
-      </paramset>
-      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="1e930928-4f6f-4f3c-b4a3-0fdc4015f3b9" name="Observing Conditions">
-        <paramset name="Observing Conditions" kind="dataObj">
-          <param name="CloudCover" value="ANY"/>
-          <param name="ImageQuality" value="ANY"/>
-          <param name="SkyBackground" value="ANY"/>
-          <param name="WaterVapor" value="ANY"/>
-          <param name="ElevationConstraintType" value="NONE"/>
-          <param name="ElevationConstraintMin" value="0.0"/>
-          <param name="ElevationConstraintMax" value="0.0"/>
-          <paramset name="timing-window-list"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="87881445-2e3c-417e-9abf-a5815760e951" name="Targets">
-        <paramset name="Targets" kind="dataObj">
-          <paramset name="targetEnv">
-            <paramset name="base">
-              <param name="name" value="mpc-minor-planet"/>
-              <param name="c1" value="00:00:00.000"/>
-              <param name="c2" value="00:00:00.00"/>
-              <param name="system" value="MPC minor planet"/>
-              <param name="epoch" value="0.0" units="JD"/>
-              <param name="anode" value="0.0" units="degrees"/>
-              <param name="aq" value="0.0" units="au"/>
-              <param name="e" value="0.0"/>
-              <param name="inclination" value="0.0" units="degrees"/>
-              <param name="lm" value="0.0" units="degrees"/>
-              <param name="n" value="0.0" units="degrees/day"/>
-              <param name="perihelion" value="0.0" units="degrees"/>
-              <param name="epochOfPeri" value="0.0" units="JD"/>
-            </paramset>
-            <paramset name="guideEnv"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ad4206ce-d89e-4028-b69a-b545453a0a98" name="Observing Log">
-        <paramset name="Observing Log" kind="dataObj">
-          <paramset name="obsQaRecord"/>
-        </paramset>
-      </container>
-      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c0d1aaf3-cc8f-42c4-ae55-0f8ffd52c1d9" name="Observation Exec Log">
-        <paramset name="Observation Exec Log" kind="dataObj">
-          <paramset name="obsExecRecord">
-            <paramset name="datasets"/>
-            <paramset name="events"/>
-            <paramset name="configMap"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2c46b405-5b7e-433f-8d54-85574b13daa5" name="Sequence">
-        <paramset name="Sequence" kind="dataObj"/>
-      </container>
-    </container>
+
+
+
+
     <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e864ea1f-53de-4f64-b8df-a2737dfd93b9" name="">
       <paramset name="Observation" kind="dataObj">
         <param name="title" value="too"/>
@@ -325,7 +51,7 @@
         <paramset name="Targets" kind="dataObj">
           <paramset name="targetEnv">
             <paramset name="base">
-              <param name="name" value=""/>
+              <param name="name" value="bob"/>
               <param name="system" value="J2000"/>
               <param name="epoch" value="2000.0" units="years"/>
               <param name="c1" value="00:00:00.000"/>
@@ -417,7 +143,7 @@
     </paramset>
     <paramset name="node">
       <param name="key" value="265660f7-ce23-46bc-92b8-4b4fd2cdf23e"/>
-      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="6"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="39"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="3e8ef587-3a77-430f-8b06-f4385ad2b2a9"/>
@@ -477,7 +203,7 @@
     </paramset>
     <paramset name="node">
       <param name="key" value="ad3049b5-e617-46c1-b9d2-d9f78f876f12"/>
-      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d7756c36-3811-4b93-b347-ab47dfa491d4"/>

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigrationToo.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2016B/targetMigrationToo.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2016A-1" subtype="basic" key="59ddb441-318d-4ccd-af32-9dec72b0853c" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="title" value="targetMigration"/>
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="rapid"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="piInfo">
+        <param name="firstName" value=""/>
+        <param name="lastName" value=""/>
+        <param name="email" value=""/>
+        <param name="phone" value=""/>
+      </paramset>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e864ea1f-53de-4f64-b8df-a2737dfd93b9" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="origin"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="508ceac2-cb93-489f-90d2-0cdfcf010a75" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="ad3049b5-e617-46c1-b9d2-d9f78f876f12" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <param name="name" value="zero"/>
+              <param name="system" value="J2000"/>
+              <param name="epoch" value="2000.0" units="years"/>
+              <param name="c1" value="00:00:00.000"/>
+              <param name="c2" value="00:00:00.00"/>
+              <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
+              <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
+              <param name="parallax" value="0.0" units="mas"/>
+              <param name="z" value="0.0"/>
+            </paramset>
+            <paramset name="guideEnv"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="3e8ef587-3a77-430f-8b06-f4385ad2b2a9" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="ef951d10-4edc-4a0f-a14b-7aff9b2614c4" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2660502d-693f-4288-b72e-9881c0c28db1" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="ad4206ce-d89e-4028-b69a-b545453a0a98"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1e930928-4f6f-4f3c-b4a3-0fdc4015f3b9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2a99225f-b237-44e7-9836-a4b0e0b4fe08"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="800dc294-3738-4d54-b3cd-c921304aa567"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4ec9ee31-89c5-42c6-978d-590193f1dac5"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="6db9ac71-61bb-4627-a867-44670ed0d83d"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ca066b4b-38a7-4421-a172-3873daf4be2d"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="58df0a77-f45b-4401-9d48-2da69b0ebe9e"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="74b11b2f-7ee6-47d5-b2bf-a4af7cd77e86"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2660502d-693f-4288-b72e-9881c0c28db1"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="86b688f9-c83f-42c6-a793-9e0273f17325"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4890894e-13ed-4710-a211-ac6826762200"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="6"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="87881445-2e3c-417e-9abf-a5815760e951"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="18"/>
+      <param name="50960219-3682-4709-a9e1-004af855bfc4" value="6"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="55bc25f3-74da-43f0-b0c2-cedaed64f26c"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="5"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="265660f7-ce23-46bc-92b8-4b4fd2cdf23e"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="39"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3e8ef587-3a77-430f-8b06-f4385ad2b2a9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4ab6d658-ca40-4978-abe1-6ce4a64dc288"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="28"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b5990661-6d96-4c1c-91c4-2c1b89d202a3"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e864ea1f-53de-4f64-b8df-a2737dfd93b9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="17b7fac7-a2cd-4b50-ad28-b31d2ff46ed2"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c0d1aaf3-cc8f-42c4-ae55-0f8ffd52c1d9"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="6b9387b2-42b0-4cf2-b438-1521d1acc5a6"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="508ceac2-cb93-489f-90d2-0cdfcf010a75"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e2def4c6-14c3-4e91-8ce2-634b3ab3f3f4"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="15"/>
+      <param name="50960219-3682-4709-a9e1-004af855bfc4" value="23"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="9c348131-beb6-424c-9515-51dd3d2d633b"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="9"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2c46b405-5b7e-433f-8d54-85574b13daa5"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="59ddb441-318d-4ccd-af32-9dec72b0853c"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="6"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ef951d10-4edc-4a0f-a14b-7aff9b2614c4"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1038665f-8bb2-4016-a991-a4d61cf194a8"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ad3049b5-e617-46c1-b9d2-d9f78f876f12"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d7756c36-3811-4b93-b347-ab47dfa491d4"/>
+      <param name="a2608ece-27f8-49b0-aeff-e6a0b766cb6e" value="8"/>
+      <param name="50960219-3682-4709-a9e1-004af855bfc4" value="1"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/MigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/MigrationTest.scala
@@ -12,7 +12,7 @@ import org.junit.Assert._
  */
 trait MigrationTest {
 
-  protected def withTestOdb(block: IDBDatabaseService => Unit): Unit = {
+  protected def withTestOdb[A](block: IDBDatabaseService => A): A = {
     val odb = DBLocalDatabase.createTransient()
     try {
       block(odb)
@@ -21,12 +21,15 @@ trait MigrationTest {
     }
   }
 
-  protected def withTestProgram(programName: String, block: (IDBDatabaseService, ISPProgram) => Unit): Unit = withTestOdb { odb =>
+  protected def withTestProgram[A](programName: String, block: (IDBDatabaseService, ISPProgram) => A): A = withTestOdb { odb =>
     val parser = new PioSpXmlParser(odb.getFactory)
     parser.parseDocument(new InputStreamReader(getClass.getResourceAsStream(programName))) match {
       case p: ISPProgram => block(odb, p)
-      case _             => fail("Expecting a science program")
+      case _             => sys.error("Expecting a science program")
     }
   }
+
+  protected def withTestProgram2[A](programName: String)(block: ISPProgram => A): A =
+    withTestProgram(programName, (_, p) => block(p))
 
 }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/MigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/MigrationTest.scala
@@ -1,11 +1,10 @@
 package edu.gemini.spModel.io.impl.migration
 
-import java.io.InputStreamReader
+import java.io.{FileReader, InputStreamReader}
 
 import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.pot.spdb.{DBLocalDatabase, IDBDatabaseService}
 import edu.gemini.spModel.io.impl.PioSpXmlParser
-import org.junit.Assert._
 
 /**
  * Base trait for all migration tests
@@ -31,5 +30,37 @@ trait MigrationTest {
 
   protected def withTestProgram2[A](programName: String)(block: ISPProgram => A): A =
     withTestProgram(programName, (_, p) => block(p))
+
+}
+
+/** Read a bunch of .xml files, reporting any errors. */
+object MigrationTester {
+  import java.io.File
+
+  def main(args: Array[String]): Unit =
+    args match {
+      case Array(dir) => go(new File(dir))
+      case _          => println("usage: MigrationTester <dir>")
+    }
+
+  private def go(dir: File): Unit = {
+    val db = DBLocalDatabase.createTransient
+    try {
+      val parser = new PioSpXmlParser(db.getFactory)
+      val files  = Option(dir.listFiles).getOrElse(Array.empty[File]).filter(_.getName.endsWith(".xml")).sortBy(_.getName)
+      val total  = files.length
+      files.zipWithIndex.foreach { case (f, n) =>
+        print(s"[$n/$total] ${f.getName} ... ")
+        try {
+          parser.parseDocument(new FileReader(f))
+          println(" [ok]")
+        } catch {
+          case e: Exception => println(s" ${Console.RED}[err] ${e.getMessage}${Console.RESET}")
+        }
+      }
+    } finally {
+      db.getDBAdmin.shutdown()
+    }
+  }
 
 }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
@@ -1,0 +1,27 @@
+package edu.gemini.spModel.io.impl.migration.to2016B
+
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import org.specs2.mutable.Specification
+
+/**
+  * Created by rnorris on 2/26/16.
+  */
+class SchedulingBlockMigrationTest extends Specification with MigrationTest {
+
+  "2016B Schedling Block Migration" should {
+
+    "Preserve Existing Scheduling Blocks" in {
+      failure("not implemented")
+    }
+
+    "Use Valid-At For Non-Sidereal Base Positions" in {
+      failure("not implemented")
+    }
+
+    "Use Program Semester for Sidereal Observations" in {
+      failure("not implemented")
+    }
+
+  }
+
+}

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
@@ -1,25 +1,36 @@
 package edu.gemini.spModel.io.impl.migration.to2016B
 
+import edu.gemini.pot.sp.ISPProgram
 import edu.gemini.spModel.io.impl.migration.MigrationTest
+import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
 import org.specs2.mutable.Specification
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.shared.util.immutable.ScalaConverters._
 
-/**
-  * Created by rnorris on 2/26/16.
-  */
 class SchedulingBlockMigrationTest extends Specification with MigrationTest {
+
+  implicit class MoreProgramOps(p: ISPProgram) {
+
+    def findObsByTitle(title: String): Option[SPObservation] =
+      p.allObservations.flatMap(_.spObservation.toList).find(_.getTitle == title)
+
+    def findSchedulingBlock(title: String): Option[SchedulingBlock] =
+      p.findObsByTitle(title).flatMap(_.getSchedulingBlock.asScalaOpt)
+
+  }
 
   "2016B Schedling Block Migration" should {
 
-    "Preserve Existing Scheduling Blocks" in {
-      failure("not implemented")
+    "Preserve Existing Scheduling Blocks" in withTestProgram2("schedulingBlock.xml") { p =>
+      p.findSchedulingBlock("some") must_== Some(SchedulingBlock(1457551614113L,92500L))
     }
 
-    "Use Valid-At For Non-Sidereal Base Positions" in {
-      failure("not implemented")
+    "Use Valid-At For Non-Sidereal Base Positions" in withTestProgram2("schedulingBlock.xml") { p =>
+      p.findSchedulingBlock("nonsidereal") must_== Some(SchedulingBlock(1454284800000L,0L))
     }
 
-    "Use Program Semester for Sidereal Observations" in {
-      failure("not implemented")
+    "Ignore Sidereal Observations" in withTestProgram2("schedulingBlock.xml") { p =>
+      p.findSchedulingBlock("none") must_== None
     }
 
   }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -1,7 +1,7 @@
 package edu.gemini.spModel.io.impl.migration.to2016B
 
 import edu.gemini.pot.sp.{SPComponentType, ISPProgram}
-import edu.gemini.spModel.core.Target
+import edu.gemini.spModel.core.{TooTarget, Target}
 import edu.gemini.spModel.io.impl.migration.MigrationTest
 import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
 import edu.gemini.spModel.target.SPTarget
@@ -16,7 +16,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
 
     def findBaseByObsTitle(title: String): Option[Target] =
       for {
-        isp <- p.allObservations.filter(_.title == title).headOption
+        isp <- p.allObservations.find(_.title == title)
         x   <- isp.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV)
         spt <- x.dataObject.map(_.asInstanceOf[TargetObsComp].getBase)
       } yield spt.getNewTarget
@@ -46,8 +46,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
     }
 
     "Migrate TOO Targets" in withTestProgram2("targetMigration.xml") { p =>
-      p.findBaseByObsTitle("too") must beSome
-      failure("not implemented")
+      p.findBaseByObsTitle("too") must_== Some(TooTarget("bob"))
     }
 
   }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -1,32 +1,52 @@
 package edu.gemini.spModel.io.impl.migration.to2016B
 
+import edu.gemini.pot.sp.{SPComponentType, ISPProgram}
+import edu.gemini.spModel.core.Target
 import edu.gemini.spModel.io.impl.migration.MigrationTest
+import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.obsComp.TargetObsComp
 import org.specs2.mutable.Specification
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.shared.util.immutable.ScalaConverters._
 
-/**
-  * Created by rnorris on 2/26/16.
-  */
 class TargetMigrationTest extends Specification with MigrationTest {
+
+  implicit class MoreProgramOps(p: ISPProgram) {
+
+    def findBaseByObsTitle(title: String): Option[Target] =
+      for {
+        isp <- p.allObservations.filter(_.title == title).headOption
+        x   <- isp.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV)
+        spt <- x.dataObject.map(_.asInstanceOf[TargetObsComp].getBase)
+      } yield spt.getNewTarget
+
+  }
 
   "2016B Target Migration" should {
 
-    "Migrate Sidereal Targets" in {
+    "Migrate Sidereal Targets" in withTestProgram2("targetMigration.xml") { p =>
+      p.findBaseByObsTitle("sidereal") must beSome
       failure("not implemented")
     }
 
-    "Migrate Named Targets" in {
+    "Migrate Named Targets" in withTestProgram2("targetMigration.xml") { p =>
+      p.findBaseByObsTitle("named") must beSome
       failure("not implemented")
     }
 
-    "Migrate JPL Minor Bodies" in {
+    "Migrate JPL Minor Bodies" in withTestProgram2("targetMigration.xml") { p =>
+      p.findBaseByObsTitle("jpl-minor-body") must beSome
       failure("not implemented")
     }
 
-    "Migrate MPC Minor Planets" in {
+    "Migrate MPC Minor Planets" in withTestProgram2("targetMigration.xml") { p =>
+      p.findBaseByObsTitle("mpc-minor-planet") must beSome
       failure("not implemented")
     }
 
-    "Migrate TOO Targets" in {
+    "Migrate TOO Targets" in withTestProgram2("targetMigration.xml") { p =>
+      p.findBaseByObsTitle("too") must beSome
       failure("not implemented")
     }
 

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -1,7 +1,7 @@
 package edu.gemini.spModel.io.impl.migration.to2016B
 
 import edu.gemini.pot.sp.{SPComponentType, ISPProgram}
-import edu.gemini.spModel.core.{TooTarget, Target}
+import edu.gemini.spModel.core._
 import edu.gemini.spModel.io.impl.migration.MigrationTest
 import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
 import edu.gemini.spModel.target.SPTarget
@@ -9,6 +9,7 @@ import edu.gemini.spModel.target.obsComp.TargetObsComp
 import org.specs2.mutable.Specification
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.shared.util.immutable.ScalaConverters._
+import scalaz._, Scalaz._
 
 class TargetMigrationTest extends Specification with MigrationTest {
 
@@ -19,15 +20,37 @@ class TargetMigrationTest extends Specification with MigrationTest {
         isp <- p.allObservations.find(_.title == title)
         x   <- isp.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV)
         spt <- x.dataObject.map(_.asInstanceOf[TargetObsComp].getBase)
-      } yield spt.getNewTarget
+      } yield spt.getNewTarget <| println
 
   }
 
   "2016B Target Migration" should {
 
     "Migrate Sidereal Targets" in withTestProgram2("targetMigration.xml") { p =>
-      p.findBaseByObsTitle("sidereal") must beSome
-      failure("not implemented")
+      import MagnitudeBand._, MagnitudeSystem._
+      p.findBaseByObsTitle("sidereal") must_== Some(
+        SiderealTarget(
+          "barnard's star",
+          Coordinates.fromDegrees(269.4520749999999, 4.693391666666685).get,
+          Some(ProperMotion(
+            RightAscensionAngularVelocity(AngularVelocity(-798.58)),
+            DeclinationAngularVelocity(AngularVelocity(10328.12)),Epoch(2000.0))
+          ),
+          Some(Redshift(-3.69E-4)),
+          Some(Parallax(548.31)),
+          List(
+            Magnitude(12.497,U,None,Vega),
+            Magnitude(11.24,B,None,Vega),
+            Magnitude(9.511,V,None,Vega),
+            Magnitude(8.298,R,None,Vega),
+            Magnitude(6.741,I,None,Vega),
+            Magnitude(5.244,J,None,Vega),
+            Magnitude(4.83,H,None,Vega),
+            Magnitude(4.524,K,None,Vega)),
+          None,
+          None
+        )
+      )
     }
 
     "Migrate Named Targets" in withTestProgram2("targetMigration.xml") { p =>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -1,0 +1,35 @@
+package edu.gemini.spModel.io.impl.migration.to2016B
+
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import org.specs2.mutable.Specification
+
+/**
+  * Created by rnorris on 2/26/16.
+  */
+class TargetMigrationTest extends Specification with MigrationTest {
+
+  "2016B Target Migration" should {
+
+    "Migrate Sidereal Targets" in {
+      failure("not implemented")
+    }
+
+    "Migrate Named Targets" in {
+      failure("not implemented")
+    }
+
+    "Migrate JPL Minor Bodies" in {
+      failure("not implemented")
+    }
+
+    "Migrate MPC Minor Planets" in {
+      failure("not implemented")
+    }
+
+    "Migrate TOO Targets" in {
+      failure("not implemented")
+    }
+
+  }
+
+}

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -1,6 +1,7 @@
 package edu.gemini.spModel.io.impl.migration.to2016B
 
 import edu.gemini.pot.sp.{SPComponentType, ISPProgram}
+import edu.gemini.spModel.core.HorizonsDesignation.MajorBody
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.io.impl.migration.MigrationTest
 import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
@@ -20,11 +21,15 @@ class TargetMigrationTest extends Specification with MigrationTest {
         isp <- p.allObservations.find(_.title == title)
         x   <- isp.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV)
         spt <- x.dataObject.map(_.asInstanceOf[TargetObsComp].getBase)
-      } yield spt.getNewTarget <| println
+      } yield spt.getNewTarget // <| println
 
   }
 
   "2016B Target Migration" should {
+
+    "Migrate TOO Targets" in withTestProgram2("targetMigration.xml") { p =>
+      p.findBaseByObsTitle("too") must_== Some(TooTarget("bob"))
+    }
 
     "Migrate Sidereal Targets" in withTestProgram2("targetMigration.xml") { p =>
       import MagnitudeBand._, MagnitudeSystem._
@@ -34,19 +39,19 @@ class TargetMigrationTest extends Specification with MigrationTest {
           Coordinates.fromDegrees(269.4520749999999, 4.693391666666685).get,
           Some(ProperMotion(
             RightAscensionAngularVelocity(AngularVelocity(-798.58)),
-            DeclinationAngularVelocity(AngularVelocity(10328.12)),Epoch(2000.0))
+            DeclinationAngularVelocity(AngularVelocity(10328.12)), Epoch.J2000)
           ),
           Some(Redshift(-3.69E-4)),
           Some(Parallax(548.31)),
           List(
-            Magnitude(12.497,U,None,Vega),
-            Magnitude(11.24,B,None,Vega),
-            Magnitude(9.511,V,None,Vega),
-            Magnitude(8.298,R,None,Vega),
-            Magnitude(6.741,I,None,Vega),
-            Magnitude(5.244,J,None,Vega),
-            Magnitude(4.83,H,None,Vega),
-            Magnitude(4.524,K,None,Vega)),
+            Magnitude( 4.524, K, None, Vega),
+            Magnitude( 4.83,  H, None, Vega),
+            Magnitude( 5.244, J, None, Vega),
+            Magnitude( 6.741, I, None, Vega),
+            Magnitude( 8.298, R, None, Vega),
+            Magnitude( 9.511, V, None, Vega),
+            Magnitude(11.24,  B, None, Vega),
+            Magnitude(12.497, U, None, Vega)),
           None,
           None
         )
@@ -54,22 +59,38 @@ class TargetMigrationTest extends Specification with MigrationTest {
     }
 
     "Migrate Named Targets" in withTestProgram2("targetMigration.xml") { p =>
-      p.findBaseByObsTitle("named") must beSome
-      failure("not implemented")
+      p.findBaseByObsTitle("named") must_== Some(
+        NonSiderealTarget(
+          "Mars",
+          IMap(1457994429000L -> Coordinates.fromDegrees(240.99149999999997, 340.4314722222223).get),
+          Some(MajorBody(499)),
+          List(),
+          None,
+          None)
+      )
     }
 
     "Migrate JPL Minor Bodies" in withTestProgram2("targetMigration.xml") { p =>
-      p.findBaseByObsTitle("jpl-minor-body") must beSome
-      failure("not implemented")
+      p.findBaseByObsTitle("jpl-minor-body") must_== Some(
+        NonSiderealTarget(
+          "halley",
+          IMap(1457994460000L -> Coordinates.fromDegrees(125.49337500000001, 1.8927499999999782).get),
+          None,
+          List(),
+          None,
+          None)
+      )
     }
 
     "Migrate MPC Minor Planets" in withTestProgram2("targetMigration.xml") { p =>
-      p.findBaseByObsTitle("mpc-minor-planet") must beSome
-      failure("not implemented")
-    }
-
-    "Migrate TOO Targets" in withTestProgram2("targetMigration.xml") { p =>
-      p.findBaseByObsTitle("too") must_== Some(TooTarget("bob"))
+      p.findBaseByObsTitle("mpc-minor-planet") must_== Some(NonSiderealTarget(
+        "beer",
+        IMap(1457994485000L -> Coordinates.fromDegrees(88.769, 21.08299999999997).get),
+        None,
+        List(),
+        None,
+        None)
+      )
     }
 
   }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -27,8 +27,24 @@ class TargetMigrationTest extends Specification with MigrationTest {
 
   "2016B Target Migration" should {
 
-    "Migrate TOO Targets" in withTestProgram2("targetMigration.xml") { p =>
-      p.findBaseByObsTitle("too") must_== Some(TooTarget("bob"))
+    "Migrate TOO Target" in withTestProgram2("targetMigrationToo.xml") { p =>
+      p.findBaseByObsTitle("origin") must_== Some(
+        TooTarget("zero")
+      )
+    }
+    
+    "Migrate Sidereal Target at the Origin" in withTestProgram2("targetMigration.xml") { p =>
+      p.findBaseByObsTitle("origin") must_== Some(
+        SiderealTarget(
+          "zero",
+          Coordinates.zero,
+          None,
+          Some(Redshift(0.0)),
+          Some(Parallax(0.0)),
+          List(),
+          None,
+          None)
+      )
     }
 
     "Migrate Sidereal Targets" in withTestProgram2("targetMigration.xml") { p =>


### PR DESCRIPTION
This adds code to the `To2016B` program converter to generate new-model targets from old ones and add a zero-length scheduling block to nonsidereal observations, corresponding with the single-element ephemeris generated from the existing fixed coordinates and `validAt` time. Right now the deserialized values contain *both* old and new targets; the old target will be removed once it is unused.