### PR TITLE
REL-2598: Template Parameter Editor RA Bug

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPTarget.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPTarget.scala
@@ -18,18 +18,11 @@ import scalaz._, Scalaz._
 object SPTarget {
 
   /** Construct a new SPTarget from the given paramset */
-  def fromParamSet(pset: ParamSet): SPTarget = {
-    return SPTargetPio.fromParamSet(pset)
-  }
-
-  // Some convenience lenses
-  private val ra:  Target @?> RightAscension = Target.coords >=> Coordinates.ra.partial
-  private val dec: Target @?> Declination    = Target.coords >=> Coordinates.dec.partial
-
+  def fromParamSet(pset: ParamSet): SPTarget =
+    SPTargetPio.fromParamSet(pset)
 }
 
 final class SPTarget(private var target: Target) extends WatchablePos {
-  import SPTarget._
 
   def this() =
     this(SiderealTarget.empty)
@@ -89,28 +82,28 @@ final class SPTarget(private var target: Target) extends WatchablePos {
     setTarget(Target.name.set(target, s))
 
   def setRaDegrees(value: Double): Unit =
-    ra.set(target, RightAscension.fromDegrees(value)).foreach(setTarget)
+    Target.ra.set(target, RightAscension.fromDegrees(value)).foreach(setTarget)
 
   def setRaHours(value: Double): Unit =
-    ra.set(target, RightAscension.fromHours(value)).foreach(setTarget)
+    Target.ra.set(target, RightAscension.fromHours(value)).foreach(setTarget)
 
   def setRaString(hms: String): Unit =
     for {
       a <- Angle.parseHMS(hms).toOption
-      t <- ra.set(target, RightAscension.fromAngle(a))
+      t <- Target.ra.set(target, RightAscension.fromAngle(a))
     } setTarget(t)
 
   def setDecDegrees(value: Double): Unit =
     for {
       d <- Declination.fromDegrees(value)
-      t <- dec.set(target, d)
+      t <- Target.dec.set(target, d)
     } setTarget(t)
 
   def setDecString(dms: String): Unit =
     for {
       a <- Angle.parseDMS(dms).toOption
       d <- Declination.fromAngle(a)
-      t <- dec.set(target, d)
+      t <- Target.dec.set(target, d)
     } setTarget(t)
 
   def setRaDecDegrees(ra: Double, dec: Double): Unit =

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
@@ -2,8 +2,8 @@ package edu.gemini.spModel.core
 
 import scalaz._, Scalaz._
 
-/** 
- * Algebraic type for targets of observation. 
+/**
+ * Algebraic type for targets of observation.
  */
 sealed trait Target extends Product with Serializable {
 
@@ -43,6 +43,12 @@ trait TargetLenses {
       pRunTarget(SiderealTarget.coordinates.partial),
       PLens.nil.run
     ))
+
+  val ra:  Target @?> RightAscension =
+    coords >=> Coordinates.ra.partial
+
+  val dec: Target @?> Declination    =
+    coords >=> Coordinates.dec.partial
 
   val pm: Target @?> ProperMotion =
     PLens(_.fold(

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -2,7 +2,7 @@ package jsky.app.ot.editor.template
 
 import edu.gemini.pot.sp.ISPTemplateParameters
 import edu.gemini.shared.util.TimeValue
-import edu.gemini.shared.util.immutable.{ DefaultImList, None => JNone, Option => JOption }
+import edu.gemini.shared.util.immutable.{None => JNone, Option => JOption}
 import edu.gemini.spModel.`type`.ObsoletableSpType
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
@@ -72,8 +72,7 @@ object TemplateParametersEditor {
     def nextY(): Int = (-1 :: layout.values.toList.map(_.gridy)).max + 1
 
     def layoutRow(r: Row): Unit = {
-      val y    = nextY()
-      val size = r.components.length
+      val y = nextY()
 
       r.components.zipWithIndex.foreach { case (c, i) =>
         layout(c) = new Constraints {
@@ -409,7 +408,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
     }
 
     def showTypeSpecificWidgets(ps: Iterable[TemplateParameters]): Unit = {
-      val isSid = common(ps)(tp => targetType(tp.getTarget)).exists(_ == Sidereal)
+      val isSid = common(ps)(tp => targetType(tp.getTarget)).contains(Sidereal)
       CoordinatesPanel.showSiderealRows(isSid)
       magScroll.visible = isSid
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -261,8 +261,8 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val raField = new BoundTextField[Double](10)(
         read = s => hms.parse(s),
         show = hms.format,
-        get  = _.getTarget.getRaHours(JNoneLong).getOrElse(0.0),
-        set  = setTarget((a, b) => a.setRaHours(b))
+        get  = _.getTarget.getRaDegrees(JNoneLong).getOrElse(0.0),
+        set  = setTarget((a, b) => a.setRaDegrees(b))
       )
 
       val dms = new DMSFormat()

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -255,11 +255,6 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
 
       val JNoneLong: JOption[java.lang.Long] = JNone.instance[java.lang.Long]
 
-      // These are defined in object SPTarget, but private.  Can we open them
-      // up and/or provide get/set for RightAscension/Declination on SPTarget?
-      val ra:  Target @?> RightAscension = Target.coords >=> Coordinates.ra.partial
-      val dec: Target @?> Declination    = Target.coords >=> Coordinates.dec.partial
-
       def updateCoordinate[A](lens: Target @?> A): (TemplateParameters, A) => TemplateParameters =
         setTarget((a, b) => lens.set(a.getTarget, b).foreach(a.setTarget))
 
@@ -267,14 +262,14 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         read = s => Angle.parseHMS(s).map(RightAscension.fromAngle).valueOr(ex => throw ex),
         show = _.toAngle.formatHMS,
         get  = _.getTarget.getCoordinates(None).map(_.ra) | RightAscension.zero,
-        set  = updateCoordinate(ra)
+        set  = updateCoordinate(Target.ra)
       )
 
       val decField = new BoundTextField[Declination](10)(
         read = s => Angle.parseDMS(s).flatMap(a => Declination.fromAngle(a) \/> new IllegalArgumentException(s"$s is not a valid declination")).valueOr(ex => throw ex),
         show = _.formatDMS,
         get  = _.getTarget.getCoordinates(None).map(_.dec) | Declination.zero,
-        set  = updateCoordinate(dec)
+        set  = updateCoordinate(Target.dec)
       )
 
       def pmField(lens: SiderealTarget @> Double): BoundTextField[Double] =


### PR DESCRIPTION
This PR corrects a bug in the OT template parameters editor.  It parses and shows RA values in degrees as a `Double` and yet was getting/setting in hours as a `Double`.  I updated the editor to work with `RightAscension` and `Declination` from `spModel.core` and avoid this type of issue.