### PR TITLE
REL-2695: change default proprietary period

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/dataflow/GsaAspect.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/dataflow/GsaAspect.java
@@ -49,12 +49,12 @@ public final class GsaAspect implements Serializable {
 
     static {
         TYPE_MAP.put(ProgramType.Calibration$.MODULE$,        new GsaAspect(true,  0));
-        TYPE_MAP.put(ProgramType.Classical$.MODULE$,          new GsaAspect(true, 18));
+        TYPE_MAP.put(ProgramType.Classical$.MODULE$,          new GsaAspect(true, 12));
         TYPE_MAP.put(ProgramType.DemoScience$.MODULE$,        new GsaAspect(true,  3));
-        TYPE_MAP.put(ProgramType.DirectorsTime$.MODULE$,      new GsaAspect(true, 18));
+        TYPE_MAP.put(ProgramType.DirectorsTime$.MODULE$,      new GsaAspect(true, 12));
         TYPE_MAP.put(ProgramType.FastTurnaround$.MODULE$,     new GsaAspect(true,  6));
-        TYPE_MAP.put(ProgramType.LargeProgram$.MODULE$,       new GsaAspect(true, 18));
-        TYPE_MAP.put(ProgramType.Queue$.MODULE$,              new GsaAspect(true, 18));
+        TYPE_MAP.put(ProgramType.LargeProgram$.MODULE$,       new GsaAspect(true, 12));
+        TYPE_MAP.put(ProgramType.Queue$.MODULE$,              new GsaAspect(true, 12));
         TYPE_MAP.put(ProgramType.SystemVerification$.MODULE$, new GsaAspect(true,  3));
     }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/dataflow/ProprietaryTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/dataflow/ProprietaryTest.scala
@@ -59,7 +59,7 @@ class ProprietaryTest extends InstrumentSequenceTestBase[Flamingos2, SeqConfigFl
     doTest(SPProgramID.toProgramID("GS-2015B-Q-1"), vis, months: _*)
 
   @Test def testDefaultSetup(): Unit =
-    doTest(PUBLIC, 18)
+    doTest(PUBLIC, 12)
 
   @Test def testExplicitSetup(): Unit = {
     getProgram.update { _.setGsaAspect(new GsaAspect(true, 999, PRIVATE)) }
@@ -74,7 +74,7 @@ class ProprietaryTest extends InstrumentSequenceTestBase[Flamingos2, SeqConfigFl
   @Test def testChanging(): Unit = {
     val o2 = addSeqComponent(getInstSeqComp, SeqRepeatObserve.SP_TYPE)
     o2.dataObject = new SeqRepeatObserve <| (_.setObsClass(ObsClass.DAY_CAL))
-    doTest(PUBLIC, 18, 0)
+    doTest(PUBLIC, 12, 0)
   }
 
   @Test def testDefaultPeriods(): Unit =


### PR DESCRIPTION
A trivial update to the default proprietary period for C, DD, LP, and Q programs.