### PR TITLE
fix ephemeris resolution display

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
@@ -62,10 +62,10 @@ class EphemerisEditor extends TelescopePosEditor with ReentrancyHack {
       } {
         start.setText(formatDate(a))
         end  .setText(formatDate(b))
-        val res = (b - a) / e.size
+        val hrs: Double = (b - a) / (e.size.toDouble * 1000 * 60 * 60)
         e.findMin.map(_._1).map(formatDate).foreach(start.setText)
         e.findMax.map(_._1).map(formatDate).foreach(end.setText)
-        size.setText(res / (1000 * 60 * 60) + " minutes")
+        size.setText(f"${e.size} elems @ ~$hrs%3.1f hrs")
       }
 
       // Scheduled time and coordinates


### PR DESCRIPTION
Resolution in hours was mislabeled as minutes. Added count.

![image](https://cloud.githubusercontent.com/assets/1200131/14186501/8166ec1e-f733-11e5-8371-860b09e31a6e.png)
