### PR TITLE
REL-2702 Workaround for mystery o'clock

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -42,8 +42,16 @@ public class SPTargetPio {
         try {
             return format.parse(dateStr);
         } catch (final ParseException e) {
-            LOGGER.log(Level.WARNING, " Invalid date found " + dateStr);
-            return null;
+            try {
+
+                // At some point during 16A the server started writing out times with o'clock in
+                // them ... unclear why this happened. Workaround...
+                return format.parse(dateStr.replace("o'clock ", ""));
+
+            } catch (final ParseException ee) {
+                LOGGER.log(Level.WARNING, " Invalid date found " + dateStr);
+                return null;
+            }
         }
     }
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -88,7 +88,7 @@ object To2016B extends Migration {
   def updateSchedulingBlocks(d: Document): Unit =
     for {
       (o, b) <- obsAndBases(d) if o.value("schedulingBlockStart").isEmpty
-      date   <- b.value("validAt").flatMap(s => Option(SPTargetPio.parseDate(s)))
+      date   <- b.value("validAt").map(SPTargetPio.parseDate)
     } {
       Pio.addLongParam(fact, o, "schedulingBlockStart", date.getTime)
       Pio.addLongParam(fact, o, "schedulingBlockDuration", 0L)
@@ -180,7 +180,7 @@ object To2016B extends Migration {
   // Generic Nonsidereal
   def nonsidereal(ps: ParamSet, cs: Coordinates): State[NonSiderealTarget, Ephemeris] =
     NonSiderealTarget.ephemeris := ps.value("validAt")
-                                     .flatMap(s => Option(SPTargetPio.parseDate(s)))
+                                     .map(SPTargetPio.parseDate)
                                      .map(d => IMap(d.getTime -> cs))
                                      .getOrElse(IMap.empty)
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -88,7 +88,7 @@ object To2016B extends Migration {
   def updateSchedulingBlocks(d: Document): Unit =
     for {
       (o, b) <- obsAndBases(d) if o.value("schedulingBlockStart").isEmpty
-      date   <- b.value("validAt").map(SPTargetPio.parseDate)
+      date   <- b.value("validAt").flatMap(s => Option(SPTargetPio.parseDate(s)))
     } {
       Pio.addLongParam(fact, o, "schedulingBlockStart", date.getTime)
       Pio.addLongParam(fact, o, "schedulingBlockDuration", 0L)
@@ -180,7 +180,7 @@ object To2016B extends Migration {
   // Generic Nonsidereal
   def nonsidereal(ps: ParamSet, cs: Coordinates): State[NonSiderealTarget, Ephemeris] =
     NonSiderealTarget.ephemeris := ps.value("validAt")
-                                     .map(SPTargetPio.parseDate)
+                                     .flatMap(s => Option(SPTargetPio.parseDate(s)))
                                      .map(d => IMap(d.getTime -> cs))
                                      .getOrElse(IMap.empty)
 


### PR DESCRIPTION
Ok this works around the weirdness of the production ODB adding `o'clock` in the date formats for `validAt` ... I don't know why this is happening, but this works around it. To be continued...