### PR TITLE
Make SchedulingBlock.duration optional

### DIFF
--- a/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
+++ b/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
@@ -6,7 +6,6 @@ import edu.gemini.skycalc.HHMMSS;
 import edu.gemini.shared.util.immutable.Option;
 
 import edu.gemini.shared.util.immutable.Some;
-import edu.gemini.shared.util.immutable.None;
 import edu.gemini.spModel.core.*;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
@@ -31,7 +30,6 @@ import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
-import edu.gemini.spModel.target.system.*;
 import edu.gemini.spModel.telescope.PosAngleConstraint;
 import edu.gemini.spModel.telescope.PosAngleConstraintAware;
 
@@ -173,7 +171,7 @@ public enum ToContext {
     public ObsContext apply(HttpServletRequest req) throws RequestException {
 
         // Construct a scheduling block at the current time with zero length.
-        SchedulingBlock sb      = new SchedulingBlock(System.currentTimeMillis(), 0L);
+        SchedulingBlock sb      = SchedulingBlock.apply(System.currentTimeMillis());
         TargetEnvironment env   = targetEnv(req, sb.start());
         Conditions conds        = conds(req);
         SPInstObsComp inst      = parseOption(req, INST, INST_OP);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -145,7 +145,7 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
 
     // The next scheduling block for the observation. Begin with None.
     private Option<SchedulingBlock> _schedulingBlock =
-            new Some(new SchedulingBlock(System.currentTimeMillis(), 0L));
+            new Some(SchedulingBlock.apply(System.currentTimeMillis()));
 
     private Option<AgsStrategyKey> _agsStrategyOverride = None.instance();
 
@@ -592,7 +592,7 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
         }
         if (!_schedulingBlock.isEmpty()) {
             Pio.addLongParam(factory, paramSet, SCHEDULING_BLOCK_START_PROP, getSchedulingBlock().getValue().start());
-            Pio.addLongParam(factory, paramSet, SCHEDULING_BLOCK_DURATION_PROP, getSchedulingBlock().getValue().duration());
+            Pio.addLongParam(factory, paramSet, SCHEDULING_BLOCK_DURATION_PROP, getSchedulingBlock().getValue().durationOrZero());
         }
 
         Pio.addParam(factory, paramSet, QA_STATE_PROP, getOverriddenObsQaState().name());
@@ -660,7 +660,7 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
         if (v == null || v2 == null) {
             setSchedulingBlock(None.instance());
         } else {
-            setSchedulingBlock(new Some<>(SchedulingBlock$.MODULE$.valueOf(v, v2)));
+            setSchedulingBlock(new Some<>(SchedulingBlock.unsafeFromStrings(v, v2)));
         }
 
         v = Pio.getValue(paramSet, QA_STATE_PROP);

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -50,8 +50,8 @@ object ObsTargetCalculatorService {
       // science time is plannedTime.totalTime - plannedTime.setup.time
       // Ideally, if you hover over duration box in GUI, should say acquisition + science time OR not.
 
-      // Since we need start < end explicitly, if the duration is 0, we cannot use it.
-      val duration = if (b.duration > 0) b.duration else plannedTime.totalTime
+      // Since we need start < end explicitly, if the duration is None, we cannot use it.
+      val duration = b.duration getOrElse plannedTime.totalTime
       val end      = b.start + duration
 
       // If the duration is going to be smaller than the default step size of 30 seconds used by the

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
@@ -19,6 +19,10 @@ object SchedulingBlock {
   // Private impl allows us to have default equality and so on with smart constructors
   private case class Impl(val start: Long, val duration: Option[Long]) extends SchedulingBlock
 
+  // N.B. yes, return type should be Some[...]
+  def unapply(s: SchedulingBlock): Some[(Long, Option[Long])] =
+    Some((s.start, s.duration))
+
   def apply(start: Long): SchedulingBlock =
     apply(start, None)
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
@@ -1,11 +1,34 @@
 package edu.gemini.spModel.obs
 
-case class SchedulingBlock(start: Long, duration: Long) {
-  def useRemainingTime: Boolean = duration == 0L
+/** A reference time for planning observations. */
+sealed abstract class SchedulingBlock {
+
+  /** A point in time. */
+  def start: Long
+
+  /** An optional duration, always positive if present. */
+  def duration: Option[Long]
+
+  /** Duration, if any, otherwise zero. */
+  def durationOrZero = duration.getOrElse(0L)
+
 }
 
 object SchedulingBlock {
-  def valueOf(startString: String, durationString: String): SchedulingBlock = {
-    SchedulingBlock(startString.toLong, durationString.toLong)
-  }
+
+  // Private impl allows us to have default equality and so on with smart constructors
+  private case class Impl(val start: Long, val duration: Option[Long]) extends SchedulingBlock
+
+  def apply(start: Long): SchedulingBlock =
+    apply(start, None)
+
+  def apply(start: Long, duration: Long): SchedulingBlock =
+    apply(start, Some(duration))
+
+  def apply(start: Long, duration: Option[Long]): SchedulingBlock =
+    new Impl(start, duration.filter(_ > 0))
+
+  def unsafeFromStrings(startString: String, durationString: String): SchedulingBlock =
+    apply(startString.toLong, durationString.toLong)
+
 }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
@@ -22,11 +22,11 @@ class SchedulingBlockMigrationTest extends Specification with MigrationTest {
   "2016B Schedling Block Migration" should {
 
     "Preserve Existing Scheduling Blocks" in withTestProgram2("schedulingBlock.xml") { p =>
-      p.findSchedulingBlock("some") must_== Some(SchedulingBlock(1457551614113L,92500L))
+      p.findSchedulingBlock("some") must_== Some(SchedulingBlock(1457551614113L, Some(92500L)))
     }
 
     "Use Valid-At For Non-Sidereal Base Positions" in withTestProgram2("schedulingBlock.xml") { p =>
-      p.findSchedulingBlock("nonsidereal") must_== Some(SchedulingBlock(1454284800000L,0L))
+      p.findSchedulingBlock("nonsidereal") must_== Some(SchedulingBlock(1454284800000L))
     }
 
     "Ignore Sidereal Observations" in withTestProgram2("schedulingBlock.xml") { p =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -206,7 +206,7 @@ class ParallacticAngleControls extends GridBagPanel with Publisher {
       val dateTimeStr = dateFormat.format(new Date(sb.start))
 
       // Include tenths of a minute if not even.
-      val duration = sb.duration / 60000.0
+      val duration = sb.durationOrZero / 60000.0
       val durationFmt = if (Math.round(duration * 10) == (Math.floor(duration) * 10).toLong) "%.0f" else "%.1f"
       //val durationStr = durationFmt.format(duration)
       //val pluralOrNot = if ("1".equals(durationStr)) "" else "s"

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleDialog.scala
@@ -165,9 +165,9 @@ class ParallacticAngleDialog(owner: java.awt.Window, observation: ISPObservation
     }
 
     // Set the number of minutes of duration, converting from ms.
-    val durationField = new NumberField(Some(schedulingBlock.duration / 60000.0), allowEmpty = false) {
+    val durationField = new NumberField(Some(schedulingBlock.durationOrZero / 60000.0), allowEmpty = false) {
       peer.setColumns(5)
-      enabled = !schedulingBlock.useRemainingTime
+      enabled = schedulingBlock.duration.isDefined
     }
 
     // Reset duration to 0.0 if nonsense is typed in and the focus is lost.
@@ -197,7 +197,7 @@ class ParallacticAngleDialog(owner: java.awt.Window, observation: ISPObservation
     }
 
     new ButtonGroup(remainingTimeButton, setToButton) {
-      if (schedulingBlock.useRemainingTime) select(remainingTimeButton)
+      if (schedulingBlock.duration.isEmpty) select(remainingTimeButton)
       else select(setToButton)
     }
 


### PR DESCRIPTION
This finishes a simplification started with #860. A scheduling block with duration zero had a special meaning ("remaining time"); we now use `None` for that, and any `Some(duration)` will always be positive.