### PR TITLE
InstantiationFunctorTest bugfix

### DIFF
--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
@@ -33,6 +33,10 @@ class InstantiationFunctorTest extends SpModelTestBase {
     val fact = getFactory
     val prog = getProgram
 
+    // Remove any existing observations.
+    prog.setObservations(java.util.Collections.emptyList())
+    prog.setGroups(java.util.Collections.emptyList())
+
     // Setup the test program with a single template group with a single target
     // at (RA, Dec) (1, 2) and CC50 observing conditions.
     val tfNode = fact.createTemplateFolder(prog, WithSomeNewKey)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
@@ -77,6 +77,10 @@ class InstantiationFunctorTest extends SpModelTestBase {
     os.foreach(func.add)
     func.execute(getOdb, null, null)
 
+    // If the functor ended with an exception, rethrow it so it stops the test
+    // as well.
+    Option(func.getException).foreach { ex => throw ex }
+
     val obsKeys = os.map(_.getNodeKey).toSet
     getProgram.getAllObservations.asScala.toList.filter(o => obsKeys(o.getNodeKey))
   }


### PR DESCRIPTION
This update was part of [PR 822](https://github.com/gemini-hlsw/ocs/pull/822), which was recently closed without merging.  I'm adding it here as a standalone PR since it took a while to diagnose and fix and is an improvement regardless of the fate of the other changes in #822.

This change fixes a bug in test case setup that caused some tests to be skipped and also avoids printing several long stack traces to the log while running the `InstantiationFunctorTest`.  There isn't a JIRA issue for this since it only impacts test case output and didn't seem worth raising to the attention of the science staff.