### PR TITLE
REL-2698: HMS/DMS/Dec formatting updates

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Angle.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Angle.scala
@@ -409,18 +409,19 @@ object Angle {
 
   // Abstract over HMS/DMS
   private[core] def format3(a: Int, b: Int, c: Double, max: Int, sep: String, fractionalDigits: Int): String = {
-    val zs = "0" * fractionalDigits
-    val df = new DecimalFormat(s"00.$zs")
+    val df =
+      if (fractionalDigits > 0) new DecimalFormat(s"00.${"0" * fractionalDigits}")
+      else new DecimalFormat("00")
 
     val s0 = df.format(c)
-    val (s, carryC) = s0.startsWith("60.") ? ((s"00.$zs", 1)) | ((s0, 0))
+    val (s, carryC) = s0.startsWith("60") ? ((df.format(0), 1)) | ((s0, 0))
 
     val m0 = b + carryC
     val (m, carryB) = (m0 == 60) ? (("00", 1)) | ((f"$m0%02d", 0))
 
     val x = a + carryB
 
-    if (x == max) s"0${sep}00${sep}00.$zs"
+    if (x == max) s"0${sep}00$sep${df.format(0)}"
     else f"$x%d$sep$m$sep$s"
   }
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Angle.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Angle.scala
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.core
 
+import java.text.DecimalFormat
+
 import scalaz._, Scalaz._
 
 /** An angle, convertible to various representations. */
@@ -343,7 +345,7 @@ object Angle {
     def hours: Int
     def minutes: Int
     def seconds: Double
-    override def toString = s"DMS(${format3(hours, minutes, seconds)})"
+    override def toString = s"HMS(${format3(hours, minutes, seconds, 24, ":", 3)})"
   }
 
   /**
@@ -354,7 +356,7 @@ object Angle {
     def degrees: Int
     def minutes: Int
     def seconds: Double
-    override def toString = s"DMS(${format3(degrees, minutes, seconds)})"
+    override def toString = s"DMS(${format3(degrees, minutes, seconds, 360, ":", 2)})"
   }
 
   /** @group Type Members */
@@ -376,41 +378,51 @@ object Angle {
    * seconds.
    * @group Formatters
    */
-  def formatSexigesimal(a: Angle): String = {
+  def formatSexigesimal(a: Angle, sep: String = ":", fractionalDigits: Int = 2): String = {
     val dms = a.toSexigesimal
-    format3(dms.degrees, dms.minutes, dms.seconds)
+    format3(dms.degrees, dms.minutes, dms.seconds, 360, sep, fractionalDigits)
   }
 
   /**
    * Alias for [[Angle.formatSexigesimal]].
    * @group Formatters
    */
-  def formatDMS(a: Angle): String =
-    formatSexigesimal(a)
+  def formatDMS(a: Angle, sep: String = ":", fractionalDigits: Int = 2): String =
+    formatSexigesimal(a, sep, fractionalDigits)
 
   /**
    * Format the given `Angle` in hour angle format `h:mm:ss` with three fractional digits for
    * seconds.
    * @group Formatters
    */
-  def formatHourAngle(a: Angle): String = {
+  def formatHourAngle(a: Angle, sep: String = ":", fractionalDigits: Int = 3): String = {
     val hms = a.toHourAngle
-    format3(hms.hours, hms.minutes, hms.seconds)
+    format3(hms.hours, hms.minutes, hms.seconds, 24, sep, fractionalDigits)
   }
 
   /**
    * Alias for [[Angle.formatHourAngle]].
    * @group Formatters
    */
-  def formatHMS(a: Angle): String =
-    formatHourAngle(a)
+  def formatHMS(a: Angle, sep: String = ":", fractionalDigits: Int = 3): String =
+    formatHourAngle(a, sep, fractionalDigits)
 
   // Abstract over HMS/DMS
-  private[core] def format3(a: Int, b: Int, c: Double): String =
-    if (f"$c%06.03f".startsWith("60")) // grr
-      format3(a, b + 1, 0)
-    else
-      f"$a%d:$b%02d:$c%06.03f"
+  private[core] def format3(a: Int, b: Int, c: Double, max: Int, sep: String, fractionalDigits: Int): String = {
+    val zs = "0" * fractionalDigits
+    val df = new DecimalFormat(s"00.$zs")
+
+    val s0 = df.format(c)
+    val (s, carryC) = s0.startsWith("60.") ? ((s"00.$zs", 1)) | ((s0, 0))
+
+    val m0 = b + carryC
+    val (m, carryB) = (m0 == 60) ? (("00", 1)) | ((f"$m0%02d", 0))
+
+    val x = a + carryB
+
+    if (x == max) s"0${sep}00${sep}00.$zs"
+    else f"$x%d$sep$m$sep$s"
+  }
 
   def signedDegrees(d: Double): Double =
     ((d % 360) + 360) % 360 match {

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Declination.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Declination.scala
@@ -2,20 +2,20 @@ package edu.gemini.spModel.core
 
 import scalaz._, Scalaz._
 
-/** 
+/**
  * Newtype for an `Angle` in [270 - 360) + [0 - 90], tagged as a declination. By convention such
  * angles are logically in the range [-90 -90]; the provided formatters respect this convention.
  */
 sealed trait Declination extends java.io.Serializable {
-  
-  /** 
+
+  /**
    * This `Declination` as an angle in [270 - 360) + [0 - 90].
    * @group Conversions
    */
   def toAngle: Angle
 
-  /** 
-   * This `Declination` in degrees in (-90, 90]; for (0, 360] use `.toAngle.toDegrees`. 
+  /**
+   * This `Declination` in degrees in (-90, 90]; for (0, 360] use `.toAngle.toDegrees`.
    * @group Conversions
    */
   def toDegrees: Double = {
@@ -25,7 +25,7 @@ sealed trait Declination extends java.io.Serializable {
 
   /**
    * Offset this `Declination` by the given angle, returning the result and a carry bit. A carry
-   * of `true` indicates that the result lies on the opposite side of the sphere and the 
+   * of `true` indicates that the result lies on the opposite side of the sphere and the
    * associated `RightAscension` (if any) must be flipped by 180°.
    * @group Operations
    */
@@ -58,7 +58,7 @@ sealed trait Declination extends java.io.Serializable {
    * @see [[Declination.formatDegrees]]
    * @group Formatters
    */
-  def formatDegrees: String = 
+  def formatDegrees: String =
     Declination.formatDegrees(this)
 
   /**
@@ -79,7 +79,7 @@ sealed trait Declination extends java.io.Serializable {
 
 object Declination {
 
-  /** 
+  /**
    * Construct a `Declination` from an `Angle` normalizable in [270 - 360) + [0 - 90], if possible.
    * @group Constructors
    */
@@ -96,11 +96,11 @@ object Declination {
   def fromDegrees(d: Double): Option[Declination] =
     fromAngle(Angle.fromDegrees(d))
 
-  /** 
-   * The `Declination` at zero degrees. 
+  /**
+   * The `Declination` at zero degrees.
    * @group Constructors
    */
-  val zero: Declination = 
+  val zero: Declination =
     new Declination {
       def toAngle = Angle.zero
     }
@@ -118,26 +118,26 @@ object Declination {
    * followed by the degree sign.
    * @group Formatters
    */
-  def formatDegrees(dec: Declination): String = 
+  def formatDegrees(dec: Declination): String =
     f"${dec.toDegrees}%4.03f°"
 
   /**
-   * Format the given `Declination` in sexigesimal `d:mm:ss` with degrees in (-90, 90], with three 
+   * Format the given `Declination` in sexigesimal `d:mm:ss` with degrees in (-90, 90], with three
    * fractional digits for seconds.
    * @group Formatters
    */
-  def formatSexigesimal(dec: Declination): String = {
-    val a = dec.toDegrees
-    if (a < 0) "-" + Angle.fromDegrees(a.abs).formatSexigesimal
-    else Angle.fromDegrees(a).formatSexigesimal
+  def formatSexigesimal(dec: Declination, sep: String = ":", fractionalDigits: Int = 2): String = {
+    val a0       = dec.toDegrees
+    val (a, sgn) = if (a0 < 0) (a0.abs, "-") else (a0, "")
+    s"$sgn${Angle.formatSexigesimal(Angle.fromDegrees(a), sep, fractionalDigits)}"
   }
 
   /**
    * Alias for [[Declination.formatSexigesimal]]
    * @group Formatters
    */
-  def formatDMS(dec: Declination): String = 
-    formatSexigesimal(dec)
+  def formatDMS(dec: Declination, sep: String = ":", fractionalDigits: Int = 2): String =
+    formatSexigesimal(dec, sep, fractionalDigits)
 
 }
 

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/FormatTest.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/FormatTest.scala
@@ -27,6 +27,18 @@ class FormatTest extends FlatSpec {
     testHms("23:59:59.9998", 2, "0:00:00.00")
   }
 
+  it should "handle 0 fractional digits" in {
+    testHms("1:02:03.567", 0, "1:02:04")
+  }
+
+  it should "handle 0 fractional digits with rounding" in {
+    testHms("1:02:59.567", 0, "1:03:00")
+  }
+
+  it should "handle negative fractional digits" in {
+    testHms("1:02:03.567", -1, "1:02:04")
+  }
+
   "DMS second formatting" should "wrap around to 0 if rounding up degrees to 360" in {
     assert(Angle.parseDMS("359:59:59.9998").exists { a =>
       Angle.formatDMS(a) == "0:00:00.00"
@@ -54,6 +66,14 @@ class FormatTest extends FlatSpec {
 
   it should "carry over to degrees if rounding up minutes as well" in {
     testDec("-0:59:59.9998", 2, "-1:00:00.00")
+  }
+
+  it should "handle 0 fractional digits" in {
+    testDec("-0:00:59.99", 0, "-0:01:00")
+  }
+
+  it should "handle negative fractional digits" in {
+    testDec("-0:00:59.99", -2, "-0:01:00")
   }
 
   "HMS formatting" should "allow a custom separator" in {

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/FormatTest.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/FormatTest.scala
@@ -1,0 +1,64 @@
+package edu.gemini.spModel.core
+
+import org.scalatest.FlatSpec
+
+
+class FormatTest extends FlatSpec {
+
+  private def testHms(in: String, digits: Int, out: String): Unit = {
+    assert(Angle.parseHMS(in).exists { a =>
+      Angle.formatHMS(a, fractionalDigits = digits) == out
+    })
+  }
+
+  "HMS second formatting" should "not carry over if under 60" in {
+    testHms("0:00:59.9998", 4, "0:00:59.9998")
+  }
+
+  it should "carry over if rounding up to 60" in {
+    testHms("0:00:59.9998", 3, "0:01:00.000")
+  }
+
+  it should "carry over to hours if rounding up minutes as well" in {
+    testHms("0:59:59.9998", 1, "1:00:00.0")
+  }
+
+  it should "wrap around to 0 if rounding up hours to 24" in {
+    testHms("23:59:59.9998", 2, "0:00:00.00")
+  }
+
+  "DMS second formatting" should "wrap around to 0 if rounding up degrees to 360" in {
+    assert(Angle.parseDMS("359:59:59.9998").exists { a =>
+      Angle.formatDMS(a) == "0:00:00.00"
+    })
+  }
+
+  private def testDec(in: String, digits: Int, out: String): Unit = {
+    val dec = for {
+      a <- Angle.parseDMS(in).toOption
+      d <- Declination.fromAngle(a)
+    } yield d
+
+    assert(dec.exists { d =>
+      Declination.formatDMS(d, fractionalDigits = digits) == out
+    })
+  }
+
+  "Declination second formatting" should "carry not carry over if under 60" in {
+    testDec("-0:00:59.9998", 4, "-0:00:59.9998")
+  }
+
+  it should "carry over if rounding up to 60" in {
+    testDec("-0:00:59.9998", 3, "-0:01:00.000")
+  }
+
+  it should "carry over to degrees if rounding up minutes as well" in {
+    testDec("-0:59:59.9998", 2, "-1:00:00.00")
+  }
+
+  "HMS formatting" should "allow a custom separator" in {
+    assert(Angle.parseHMS("1:02:03.456").exists { a =>
+      Angle.formatHMS(a, " ", 1) == "1 02 03.5"
+    })
+  }
+}

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
@@ -30,7 +30,7 @@ class PlutoDemotionTest extends MigrationTest {
 
                   Assert.assertEquals("ValidAt", "10/28/15 7:39:58 PM UTC", SPTargetPio.formatter.format(t))
                   Assert.assertEquals("RA",      "15:41:38.380", c.ra.toAngle.formatHMS)
-                  Assert.assertEquals("Dec",     "-15:52:28.700", c.dec.formatDMS)
+                  Assert.assertEquals("Dec",     "-15:52:28.70", c.dec.formatDMS)
 
               case e => Assert.fail("Expected 1-element ephemeris, found " + e)
             }


### PR DESCRIPTION
This PR addresses several issues related to formatting angles.

1. Fixes a bug wherein you could end up with 60 minutes or arcminutes in a formatted RA or Dec.  For example, if you parse "0:59:59.999999" and then format it with just three digits to the right of the decimal you would end up with "0:60:00.000" instead of "1:00:00.000".

2. Makes it possible to specify precision when rounding fractional seconds (was fixed to 3 digits to the right of the decimal).

3. Changes declination / DMS to just two digits of precision to match the standard convention.

4. Makes it possible to use a separator other than `:` for the fields of a formatted RA/Dec. This is required for formatting ephemeris elements in the format expected by the TCS, which expects a single space to separate the fields.

For the commonly used syntax methods, there are no changes.  For example,

```scala
  someAngle.formatHMS
````

will select a `:` as the separator character and format to 3 decimal places as before.  The same for DMS and Declination except that it will default to 2 decimal places.  To change the separator or precision you have to use the more cumbersome `Angle.formatXXX` methods directly.

This code is a bit annoying and clumsy.  If someone sees a better way to do these things, please comment.