### PR TITLE
REL-2713: Daytime calibration observations should not be run by BAGS

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsClassService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsClassService.java
@@ -56,7 +56,7 @@ public final class ObsClassService {
             }
         }
 
-        // default value is sicence
+        // default value is science
         if (obsClass == null) obsClass = ObsClass.SCIENCE;
 
         // Cache the results.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -432,8 +432,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         // Update the guiding feedback.
         final ISPObsComponent node = getContextTargetObsComp();
-        final SPTarget      target = TargetSelection.getTargetForNode(env, node).getOrNull();
-        _w.detailEditor.gfe().edit(ctx, target, node);
+        TargetSelection.getTargetForNode(env, node).foreach(target -> _w.detailEditor.gfe().edit(ctx, target, node));
     }
 
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -432,7 +432,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         // Update the guiding feedback.
         final ISPObsComponent node = getContextTargetObsComp();
-        TargetSelection.getTargetForNode(env, node).foreach(target -> _w.detailEditor.gfe().edit(ctx, target, node));
+        TargetSelection.getTargetForNode(env, node).foreach(target -> _w.detailEditor.guidingFeedbackEditor().edit(ctx, target, node));
     }
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -12,8 +12,9 @@ import edu.gemini.catalog.votable.{CatalogException, GenericError}
 import edu.gemini.pot.sp._
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.guide.GuideProbe
-import edu.gemini.spModel.obs.{ObservationStatus, SPObservation}
+import edu.gemini.spModel.obs.{ObsClassService, ObservationStatus, SPObservation}
 import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.obsclass.ObsClass
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.env.{AutomaticGroup, GuideEnv, GuideEnvironment}
 import jsky.app.ot.OT
@@ -118,9 +119,11 @@ final class BagsManager(executorService: ExecutorService) {
       !curHash.contains(newHash)
     }
 
-    def notObserved(o: ISPObservation): Boolean = {
+    def notObserved(o: ISPObservation): Boolean =
       ObservationStatus.computeFor(o) != ObservationStatus.OBSERVED
-    }
+
+    def notDaytimeCalibration(o: ISPObservation): Boolean =
+      ObsClassService.lookupObsClass(o) != ObsClass.DAY_CAL
 
     Option(observation).foreach { obs =>
       synchronized {
@@ -132,7 +135,12 @@ final class BagsManager(executorService: ExecutorService) {
           // or (b) we don't care about that program anymore, so we're done.
           if (dequeue(key, obs.getProgramID)) {
             // Otherwise construct an obs context, verify that it's bagworthy, and go
-            ObsContext.create(obs).asScalaOpt.filter(ctx => isEligibleForBags(ctx) && hasBeenUpdated(obs, ctx) && notObserved(obs)).foreach { ctx =>
+            ObsContext.create(obs).asScalaOpt.filter(ctx =>
+              isEligibleForBags(ctx)
+              && hasBeenUpdated(obs, ctx)
+              && notObserved(obs)
+              && notDaytimeCalibration(obs)
+            ).foreach { ctx =>
               //   do the lookup
               //   on success {
               //      if we're in the queue again, it means something changed while this task was

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -107,7 +107,10 @@ final class BagsManager(executorService: ExecutorService) {
         case AutomaticGroup.Initial | AutomaticGroup.Active(_,_) => true
         case _                                                   => false
       }
-      enabledGroup && (ctx.getInstrument.getType != SPComponentType.INSTRUMENT_GPI)
+      enabledGroup &&
+        (ctx.getInstrument.getType != SPComponentType.INSTRUMENT_GPI) &&
+        ObsClassService.lookupObsClass(observation) != ObsClass.DAY_CAL
+
     }
 
     def hasBeenUpdated(o: ISPObservation, ctx: ObsContext): Boolean = {
@@ -121,9 +124,6 @@ final class BagsManager(executorService: ExecutorService) {
 
     def notObserved(o: ISPObservation): Boolean =
       ObservationStatus.computeFor(o) != ObservationStatus.OBSERVED
-
-    def notDaytimeCalibration(o: ISPObservation): Boolean =
-      ObsClassService.lookupObsClass(o) != ObsClass.DAY_CAL
 
     Option(observation).foreach { obs =>
       synchronized {
@@ -139,7 +139,6 @@ final class BagsManager(executorService: ExecutorService) {
               isEligibleForBags(ctx)
               && hasBeenUpdated(obs, ctx)
               && notObserved(obs)
-              && notDaytimeCalibration(obs)
             ).foreach { ctx =>
               //   do the lookup
               //   on success {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/TargetDetailPanel.scala
@@ -35,8 +35,8 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
 
   def curDetailEditorJava: GOption[TargetDetailEditor] = curDetailEditor.asGeminiOpt
 
-  val source = new SourceDetailsEditor
-  val gfe    = new GuidingFeedbackEditor
+  val source                = new SourceDetailsEditor
+  val guidingFeedbackEditor = new GuidingFeedbackEditor
 
   // Put it all together
   setLayout(new GridBagLayout)
@@ -48,7 +48,7 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
     c.weighty   = 1.0
     c.fill      = GridBagConstraints.BOTH
   })
-  add(gfe.getComponent, new GridBagConstraints() <| { c =>
+  add(guidingFeedbackEditor.getComponent, new GridBagConstraints() <| { c =>
     c.gridx     = 0
     c.gridy     = 1
     c.weightx   = 1
@@ -75,10 +75,10 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
     }
 
     // Forward the `edit` call.
-    tpw.   edit(obsContext, spTarget, node)
-    tde.   edit(obsContext, spTarget, node)
-    gfe.   edit(obsContext, spTarget, node)
-    source.edit(obsContext, spTarget, node)
+    tpw.                  edit(obsContext, spTarget, node)
+    tde.                  edit(obsContext, spTarget, node)
+    guidingFeedbackEditor.edit(obsContext, spTarget, node)
+    source.               edit(obsContext, spTarget, node)
 
   }
 


### PR DESCRIPTION
Precisely what the subject says 😄 .
We now check when determining if an observation is eligible for BAGS if it is a `DAY_CAL` observation, and if it is, we mark it as ineligible.

Also fixed a minor typo, and added a small safeguard to targets in `EdCompTargetList` for possible `null`s.
