### PR TITLE
REL-2722: BAGS now ignores instruments with no AGS strategies

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -101,14 +101,15 @@ final class BagsManager(executorService: ExecutorService) {
     * a delay of at least `delay` milliseconds.
     */
   def enqueue(observation: ISPObservation, delay: Long): Unit = {
-    // Performs checks to rule out disabled guide groups, instruments like GPI, etc.
+    // Performs checks to rule out disabled guide groups, instruments without guiding strategies (e.g. GPI),
+    // observation classes that do not have guiding (e.g. daytime calibration).
     def isEligibleForBags(ctx: ObsContext): Boolean = {
       val enabledGroup = ctx.getTargets.getGuideEnvironment.guideEnv.auto match {
         case AutomaticGroup.Initial | AutomaticGroup.Active(_,_) => true
         case _                                                   => false
       }
       enabledGroup &&
-        (ctx.getInstrument.getType != SPComponentType.INSTRUMENT_GPI) &&
+        (AgsRegistrar.validStrategies(ctx).nonEmpty) &&
         ObsClassService.lookupObsClass(observation) != ObsClass.DAY_CAL
 
     }


### PR DESCRIPTION
Formerly, BAGS deemed GPI observations as unworthy of eligibility specifically as per an old JIRA task.
@cquiroz pointed out that this was not necessarily the best way to do things, and I agreed:
It is better if BAGS checks with `AgsRegistrar` if the current `ObsContext` allows any `AgsStrategies`, and if not, then do not register an observation with BAGS.

This allows us to add future instruments that have no strategies without having to explicitly remember to change `BagsManager`.