### PR TITLE
REL-2725: bugfix for color feedback in coordinates

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/CoordinateEditor.scala
@@ -57,7 +57,7 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
         ra.setForeground(Color.BLACK)
         dec.setEnabled(true)
         dec.setText(t.coordinates.dec.formatDMS)
-        ra.setForeground(Color.BLACK)
+        dec.setForeground(Color.BLACK)
       }
 
       def disable(t: Target): Unit = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/CoordinateEditor.scala
@@ -54,8 +54,10 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
       def enable(t: SiderealTarget): Unit = {
         ra.setEnabled(true)
         ra.setText(t.coordinates.ra.toAngle.formatHMS)
+        ra.setForeground(Color.BLACK)
         dec.setEnabled(true)
         dec.setText(t.coordinates.dec.formatDMS)
+        ra.setForeground(Color.BLACK)
       }
 
       def disable(t: Target): Unit = {


### PR DESCRIPTION
When the model is refreshed because of an edit, the RA/Dec editor text color should be reset to black.  See [REL-2725](http://jira.gemini.edu:8080/browse/REL-2725).