### PR TITLE
REL-2712: BAGS PA not being set correctly

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -258,17 +258,17 @@ object BagsManager {
       if (oldEnv != newEnv) {
         targetComp.setTargetEnvironment(newEnv)
         ctx.targets.commit()
+      }
 
-        // Change the pos angle as appropriate if this is the auto group.
-        selOpt.foreach { sel =>
-          if (newEnv.getOrCreatePrimaryGuideGroup().isAutomatic && selOpt.isDefined) {
-            ctx.instrument.dataObject.foreach { inst =>
-              val deg = sel.posAngle.toDegrees
-              val old = inst.getPosAngleDegrees
-              if (deg != old) {
-                inst.setPosAngleDegrees(deg)
-                ctx.instrument.commit()
-              }
+      // Change the pos angle as appropriate if this is the auto group.
+      selOpt.foreach { sel =>
+        if (newEnv.getOrCreatePrimaryGuideGroup().isAutomatic && selOpt.isDefined) {
+          ctx.instrument.dataObject.foreach { inst =>
+            val deg = sel.posAngle.toDegrees
+            val old = inst.getPosAngleDegrees
+            if (deg != old) {
+              inst.setPosAngleDegrees(deg)
+              ctx.instrument.commit()
             }
           }
         }


### PR DESCRIPTION
This is a small bug where if the auto group was active, the position angle was not always being set correctly when it changed.

This would happen previously, say, if the PA was changed, and triggered a BAGS lookup that resulted in the same auto group. In that case `newEnv` and `oldEnv` were considered the same, so the subsequent PA changing code was not run.

Now, instead, if the primary guide group is the auto guide group, we simply set the associated PA.