### PR TITLE
REL-1623: Add Y-band to ITC brightness normalization

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -89,6 +89,7 @@
           <option value="i">i' (0.77µm) </option>
           <option value="I">I (0.87µm)</option>
           <option value="z">z' (0.92µm) </option>
+          <option value="Y">Y (1.02µm)</option>
           <option value="J">J (1.25µm)</option>
           <option value="H">H (1.65µm)</option>
           <option value="K">K (2.2µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -92,7 +92,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K" selected>K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -90,7 +90,8 @@
                 <option value="i">i' (0.77µm) </option>
                 <option value="I">I (0.87µm)</option>
                 <option value="z">z' (0.92µm) </option>
-                <option value="J">J (1.25µm)</option>
+				<option value="Y">Y (1.02µm)</option>
+				<option value="J">J (1.25µm)</option>
 				<option value="H">H (1.65µm)</option>
 				<option value="K">K (2.2µm)</option>
 				<option value="L">L' (3.76µm)</option>
@@ -609,5 +610,6 @@
 	</div>
 
 </form>
+</div>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -90,7 +90,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K">K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -90,7 +90,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K" selected>K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -90,7 +90,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K" selected>K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -88,7 +88,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K">K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -88,7 +88,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K" selected>K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -90,7 +90,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K" selected>K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -91,7 +91,8 @@
                     <option value="i">i' (0.77µm) </option>
                     <option value="I">I (0.87µm)</option>
                     <option value="z">z' (0.92µm) </option>
-                    <option value="J">J (1.25µm)</option>
+					<option value="Y">Y (1.02µm)</option>
+					<option value="J">J (1.25µm)</option>
                     <option value="H">H (1.65µm)</option>
                     <option value="K">K (2.2µm)</option>
                     <option value="L">L' (3.76µm)</option>


### PR DESCRIPTION
Added "Y (1.02µm)" to the pull down menu at the top of all ITC webpage forms.