### PR TITLE
REL-2726 - P2 Checks for Nonsidereal 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ project/OcsCredentials.scala
 !/bundle/edu.gemini.pot/src/main/resources/edu/gemini/spModel/target
 !/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/target
 !/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target
+!/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target
 !/bundle/edu.gemini.sp.vcs.log

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/checker/P2Checker.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/checker/P2Checker.java
@@ -26,6 +26,7 @@ import edu.gemini.p2checker.rules.pwfs.PwfsRule;
 import edu.gemini.p2checker.rules.trecs.TrecsRule;
 import edu.gemini.p2checker.rules.flamingos2.Flamingos2Rule;
 import edu.gemini.p2checker.rules.visitor.VisitorRule;
+import edu.gemini.p2checker.target.NonSiderealTargetRules;
 import edu.gemini.pot.sp.*;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
@@ -67,6 +68,7 @@ public final class P2Checker {
             _compositeRules.add(new SmartgcalMappingRule());
             _compositeRules.add(new PwfsRule());
             _compositeRules.add(new AgsAnalysisRule(mt));
+            _compositeRules.add(new NonSiderealTargetRules());
             if (rule != null)
                 _compositeRules.add(rule);
         }

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -1,0 +1,86 @@
+package edu.gemini.p2checker.target
+
+import edu.gemini.p2checker.api.{P2Problems, IP2Problems, ObservationElements, IRule}
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.core._
+import scalaz._, Scalaz._
+
+final class NonSiderealTargetRules extends IRule {
+  import NonSiderealTargetRules._
+
+  implicit class SemesterOps(s: Semester) {
+    def contains(time: Long, site: Site): Boolean =
+      time >= s.getStartDate(site).getTime &&
+      time <=   s.getEndDate(site).getTime
+  }
+
+  override def check(es: ObservationElements): IP2Problems = {
+    val p2p = new P2Problems
+    p2p.append(checkNoHorizonsDesignation(es))
+    p2p.append(checkNoSchedulingBlock(es))
+    p2p.append(checkSchedulingBlockOutsideSemester(es))
+    p2p.append(checkNoEphemerisForSchedulingBlock(es))
+    p2p
+  }
+
+  def checkNoHorizonsDesignation(es: ObservationElements): IP2Problems =
+    new P2Problems <| { p2p =>
+      for {
+        ocn <- es.getTargetObsComponentNode.asScalaOpt.toList
+        toc <- es.getTargetObsComp.asScalaOpt.toList
+        tar <- toc.getTargetEnvironment.getTargets.asScalaList
+        nst <- tar.getNonSiderealTarget.toList
+               if nst.horizonsDesignation.isEmpty
+      } p2p.addWarning(ERR_NO_HORIZONS_DESIGNATION,
+          s"Target ${nst.name} has no HORIZONS identifier; high-resolution ephemeris cannot be updated automatically.",
+          ocn)
+    }
+
+  def checkNoSchedulingBlock(es: ObservationElements): IP2Problems =
+    new P2Problems <| { p2p =>
+      for {
+        toc <- es.getTargetObsComp.asScalaOpt
+               if toc.getTargetEnvironment.getTargets.asScalaList.exists(_.isNonSidereal)
+      } p2p.addWarning(ERR_NO_SCHEDULING_BLOCK,
+          s"Observation ${es.getObservationNode.getObservationID} has nonsidereal targets but no scheduling block.",
+          es.getObservationNode)
+    }
+
+  def checkSchedulingBlockOutsideSemester(es: ObservationElements): IP2Problems =
+    new P2Problems <| { p2p =>
+      for {
+        toc  <- es.getTargetObsComp.asScalaOpt
+                if toc.getTargetEnvironment.getTargets.asScalaList.exists(_.isNonSidereal)
+        sb   <- es.getObservation.getSchedulingBlock.asScalaOpt
+        site <- Option(es.getObservationNode.getProgramID.site)
+        sem  <- es.getObservationNode.getProgramID.semester
+                if !sem.contains(sb.start, site)
+      } p2p.addWarning(ERR_SCHEDULING_BLOCK_SEM,
+          s"Scheduling block for ${es.getObservationNode.getObservationID} falls outside of ${sem}.",
+          es.getObservationNode)
+    }
+
+  def checkNoEphemerisForSchedulingBlock(es: ObservationElements): IP2Problems =
+    new P2Problems <| { p2p =>
+      for {
+        ocn <- es.getTargetObsComponentNode.asScalaOpt.toList
+        toc <- es.getTargetObsComp.asScalaOpt.toList
+        tar <- toc.getTargetEnvironment.getTargets.asScalaList
+        nst <- tar.getNonSiderealTarget.toList if nst.horizonsDesignation.isEmpty
+        sb  <- es.getObservation.getSchedulingBlock.asScalaOpt
+               if nst.coords(sb.start).isEmpty
+      } p2p.addWarning(ERR_NO_EPHEMERIS_FOR_BLOCK,
+          s"Target ${nst.name} has no defined coordinates for its scheduling block.",
+          ocn)
+    }
+
+}
+
+object NonSiderealTargetRules {
+
+  val ERR_NO_SCHEDULING_BLOCK     = "NoSchedulingBlock"
+  val ERR_SCHEDULING_BLOCK_SEM    = "SchedulingBlockOutsideSemester"
+  val ERR_NO_EPHEMERIS_FOR_BLOCK  = "NoEphemerisForSchedulingBlock"
+  val ERR_NO_HORIZONS_DESIGNATION = "NoHorizonsDesignation"
+
+}

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -52,7 +52,7 @@ final class NonSiderealTargetRules extends IRule {
         toc  <- es.getTargetObsComp.asScalaOpt
                 if toc.getTargetEnvironment.getTargets.asScalaList.exists(_.isNonSidereal)
         sb   <- es.getObservation.getSchedulingBlock.asScalaOpt
-        site <- Option(es.getObservationNode.getProgramID.site)
+        site <- Option(es.getObservationNode.getProgramID).flatMap(pid => Option(pid.site))
         sem  <- es.getObservationNode.getProgramID.semester
                 if !sem.contains(sb.start, site)
       } p2p.addWarning(ERR_SCHEDULING_BLOCK_SEM,

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -66,7 +66,7 @@ final class NonSiderealTargetRules extends IRule {
         ocn <- es.getTargetObsComponentNode.asScalaOpt.toList
         toc <- es.getTargetObsComp.asScalaOpt.toList
         tar <- toc.getTargetEnvironment.getTargets.asScalaList
-        nst <- tar.getNonSiderealTarget.toList if nst.horizonsDesignation.isEmpty
+        nst <- tar.getNonSiderealTarget.toList
         sb  <- es.getObservation.getSchedulingBlock.asScalaOpt
                if nst.coords(sb.start).isEmpty
       } p2p.addWarning(ERR_NO_EPHEMERIS_FOR_BLOCK,

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import edu.gemini.p2checker.target.NonSiderealTargetRules
 import edu.gemini.pot.sp.{ISPObservation, SPComponentType}
 import edu.gemini.pot.util.POTUtil
-import edu.gemini.spModel.core.{Site, Semester, SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target, SPProgramID}
+import edu.gemini.spModel.core.{Coordinates, Site, Semester, SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target, SPProgramID}
 import edu.gemini.spModel.obs.{SPObservation, SchedulingBlock}
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.target.SPTarget
@@ -56,7 +56,12 @@ class NonSiderealTargetRulesSpec extends RuleSpec {
 
     "error if no ephemeris for scheduling block" in
       expectAllOf(ERR_NO_EPHEMERIS_FOR_BLOCK) {
-        obs(NonSiderealTarget.empty, None)
+        obs(NonSiderealTarget.empty, Some(SchedulingBlock(0L)))
+      }
+
+    "on error if ephemeris for scheduling block" in
+      expectNoneOf(ERR_NO_EPHEMERIS_FOR_BLOCK) {
+        obs(NonSiderealTarget.empty.copy(ephemeris = ==>>.singleton(0L, Coordinates.zero)), Some(SchedulingBlock(0L)))
       }
 
   }

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import edu.gemini.p2checker.target.NonSiderealTargetRules
 import edu.gemini.pot.sp.{ISPObservation, SPComponentType}
 import edu.gemini.pot.util.POTUtil
-import edu.gemini.spModel.core.{SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target, SPProgramID}
+import edu.gemini.spModel.core.{Site, Semester, SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target, SPProgramID}
 import edu.gemini.spModel.obs.{SPObservation, SchedulingBlock}
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.target.SPTarget
@@ -38,11 +38,16 @@ class NonSiderealTargetRulesSpec extends RuleSpec {
 
   }
 
-  ERR_NO_SCHEDULING_BLOCK_SEM should {
+  ERR_SCHEDULING_BLOCK_SEM should {
 
-    "error if no scheduling block defined for program semester" in
-      expectAllOf(ERR_NO_SCHEDULING_BLOCK_SEM) {
-        obs(NonSiderealTarget.empty, None)
+    "error if scheduling block is outside semester" in
+      expectAllOf(ERR_SCHEDULING_BLOCK_SEM) {
+        obs(NonSiderealTarget.empty, Some(SchedulingBlock(0L)))
+      }
+
+    "no error if scheduling block is within semester" in
+      expectNoneOf(ERR_SCHEDULING_BLOCK_SEM) {
+        obs(NonSiderealTarget.empty, Some(SchedulingBlock(Semester.parse("2015A").getStartDate(Site.GS).getTime)))
       }
 
   }

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
@@ -1,0 +1,96 @@
+package edu.gemini.p2checker.rules
+
+import java.util.UUID
+
+import edu.gemini.p2checker.target.NonSiderealTargetRules
+import edu.gemini.pot.sp.{ISPObservation, SPComponentType}
+import edu.gemini.pot.util.POTUtil
+import edu.gemini.spModel.core.{SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target, SPProgramID}
+import edu.gemini.spModel.obs.{SPObservation, SchedulingBlock}
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.shared.util.immutable.ScalaConverters._
+
+import scalaz._, Scalaz._
+
+class NonSiderealTargetRulesSpec extends RuleSpec {
+
+  val ruleSet = new NonSiderealTargetRules()
+  import NonSiderealTargetRules._
+
+  ERR_NO_SCHEDULING_BLOCK should {
+
+    "error if no scheduling block defined with nonsidereal targets" in
+      expectAllOf(ERR_NO_SCHEDULING_BLOCK) {
+        obs(NonSiderealTarget.empty, None)
+      }
+
+    "no error if no scheduling block defined without nonsidereal targets" in
+      expectNoneOf(ERR_NO_SCHEDULING_BLOCK) {
+        obs(SiderealTarget.empty, None)
+      }
+
+    "no error if scheduling block defined" in
+      expectNoneOf(ERR_NO_SCHEDULING_BLOCK) {
+        obs(SiderealTarget.empty, Some(SchedulingBlock(0L)))
+      }
+
+  }
+
+  ERR_NO_SCHEDULING_BLOCK_SEM should {
+
+    "error if no scheduling block defined for program semester" in
+      expectAllOf(ERR_NO_SCHEDULING_BLOCK_SEM) {
+        obs(NonSiderealTarget.empty, None)
+      }
+
+  }
+
+  ERR_NO_EPHEMERIS_FOR_BLOCK should {
+
+    "error if no ephemeris for scheduling block" in
+      expectAllOf(ERR_NO_EPHEMERIS_FOR_BLOCK) {
+        obs(NonSiderealTarget.empty, None)
+      }
+
+  }
+
+  ERR_NO_HORIZONS_DESIGNATION should {
+
+    "error if no horizons designation" in {
+      expectAllOf(ERR_NO_HORIZONS_DESIGNATION) {
+        obs(NonSiderealTarget.empty, None)
+      }
+    }
+
+    "no error if horizons designation present" in {
+      expectNoneOf(ERR_NO_HORIZONS_DESIGNATION) {
+        obs(NonSiderealTarget.empty.copy(horizonsDesignation = Some(HorizonsDesignation.Comet("foo"))), None)
+      }
+    }
+
+  }
+
+  def obs(target: Target, sb: Option[SchedulingBlock]): ISPObservation = {
+    val f = POTUtil.createFactory(UUID.randomUUID())
+    val p = f.createProgram(null, SPProgramID.toProgramID("GS-2015A-Q-1"))
+    val o = f.createObservation(p, null) <| { on =>
+      p.addObservation(on)
+      on.getDataObject.asInstanceOf[SPObservation] <| { o =>
+        o.setSchedulingBlock(sb.asGeminiOpt)
+        on.setDataObject(o)
+      }
+    }
+    val e = o.findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV).get
+    val t = e.getDataObject.asInstanceOf[TargetObsComp] <| { toc =>
+      toc.getTargetEnvironment <| { te =>
+        val te2 = te.setBasePosition(new SPTarget(target))
+        toc.setTargetEnvironment(te2)
+      }
+      e.setDataObject(toc)
+    }
+    o
+  }
+
+}

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
@@ -25,6 +25,9 @@ package object core {
 
   type Ephemeris = Long ==>> Coordinates
 
+  implicit def SPProgramIdToRichProgramId(id: SPProgramID): RichSpProgramId =
+    new RichSpProgramId(id)
+
   /** Operations for maps of types that we can interpolate.  We use these for Ephemerides. */
   implicit class MoreMapOps[K, V](m: K ==>> V)(implicit O: Order[K], I: Interpolate[K,V]) {
 


### PR DESCRIPTION
This adds four P2 checks:
- `NoSchedulingBlock` - no scheduling block for non-sidereal observation
- `SchedulingBlockOutsideSemester` - if scheduling block doesn't fall within program semester
- `NoEphemerisForSchedulingBlock` - if ephemeris is undefined at scheduling block start
- `NoHorizonsDesignation` - if a nonsidereal target has no HORIZONS designation (this means the high-res lookup will fail)