### PR TITLE
OCSADV-383-B: rename ephemeris files

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/HorizonsDesignationSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/HorizonsDesignationSpec.scala
@@ -1,0 +1,15 @@
+package edu.gemini.spModel.core
+
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object HorizonsDesignationSpec extends Specification with ScalaCheck with Arbitraries with Helpers {
+
+  "HorizonsDesignation" should {
+    "round trip from String" !
+      forAll { (hd: HorizonsDesignation) =>
+        HorizonsDesignation.read(hd.show).contains(hd)
+      }
+  }
+}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisExport.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisExport.scala
@@ -200,7 +200,7 @@ class TcsEphemerisExport(dir: File, night: Night, site: Site, odb: IDBDatabaseSe
 
   def writeEphemeris(hid: HorizonsDesignation, em: EphemerisMap): TryExport[File] = {
     // See TcsConfig.ephemerisFile
-    val fileName = URLEncoder.encode(s"${hid.toString}.eph", UTF_8.name)
+    val fileName = URLEncoder.encode(s"${hid.show}.eph", UTF_8.name)
     val file     = new File(dir, fileName)
     TryExport.fromTryCatch(t => WriteError(hid, t)) {
       Files.write(Paths.get(file.toURI), formatEphemeris(em).getBytes(UTF_8))

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisExport.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisExport.scala
@@ -199,6 +199,7 @@ class TcsEphemerisExport(dir: File, night: Night, site: Site, odb: IDBDatabaseSe
     }.leftMap(e => HorizonsError(hid, e): ExportError)
 
   def writeEphemeris(hid: HorizonsDesignation, em: EphemerisMap): TryExport[File] = {
+    // See TcsConfig.ephemerisFile
     val fileName = URLEncoder.encode(s"${hid.toString}.eph", UTF_8.name)
     val file     = new File(dir, fileName)
     TryExport.fromTryCatch(t => WriteError(hid, t)) {

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/TcsEphemerisExportTest.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/TcsEphemerisExportTest.scala
@@ -116,7 +116,7 @@ object TcsEphemerisExportTest extends TestSupport {
     "export parseable ephemeris files" in {
       withTempDir { dir =>
         val exp = new TcsEphemerisExport(dir.toFile, night, site, null, java.util.Collections.emptySet[Principal])
-        exp.exportOne(dir.toFile, MajorBody(606), "Titan").run.unsafePerformIO() match {
+        exp.exportOne(dir.toFile, MajorBody(606)).run.unsafePerformIO() match {
           case -\/(err)  =>
             TcsEphemerisExport.ExportError.logError(err, log, "")
             false

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccConfig.java
@@ -36,7 +36,7 @@ public final class TccConfig {
      * Default constructor - constructs an empty paramset.
      */
     public TccConfig(Site site) {
-        _paramSets = new ArrayList<ParamSet>();
+        _paramSets = new ArrayList<>();
         _site = site;
     }
 
@@ -82,9 +82,7 @@ public final class TccConfig {
             doc.setRootElement(e);
 
             // First add the field
-            for (int i = 0, size = _paramSets.size(); i < size; i++) {
-                e.add(_paramSets.get(i));
-            }
+            _paramSets.forEach(ps -> e.add(ps));
 
             OutputFormat format = new OutputFormat("  ", true);
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccNames.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccNames.java
@@ -34,6 +34,7 @@ public final class TccNames {
     public static final String DAILYMOT = "dailymot";
     public static final String DEPLOYABLE_BAFFLE = "deployableBaffle";
     public static final String ECCENTRICITY = "eccentricity";
+    public static final String EPHEMERIS = "ephemeris";
     public static final String EPOCH = "epoch";
     public static final String EPOCHOFEL = "epochofel";
     public static final String EPOCHOFPERI = "epochofperi";

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
@@ -1,9 +1,17 @@
 package edu.gemini.wdba.tcc;
 
-/**
- *
- */
-public class TcsConfig extends ParamSet {
+import edu.gemini.spModel.core.HorizonsDesignation;
+import edu.gemini.spModel.core.NonSiderealTarget;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class TcsConfig extends ParamSet {
+
+    private static final Logger LOG = Logger.getLogger(TcsConfig.class.getName());
 
     private ObservationEnvironment _oe;
 
@@ -14,6 +22,20 @@ public class TcsConfig extends ParamSet {
         addAttribute(NAME, oe.getObservationTitle());
         addAttribute(TYPE, TccNames.TCS_CONFIGURATION);
         _oe = oe;
+    }
+
+    /**
+     * Returns the name of the ephemeris file associated with the given
+     * horizons designation.
+     */
+    public static String ephemerisFile(final HorizonsDesignation hd) {
+        try {
+            // See TcsEphemerisExport.
+            return URLEncoder.encode(hd.toString() + ".eph", StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException ex) {
+            LOG.log(Level.SEVERE, "UTF-8 is not supported!", ex);
+            throw new RuntimeException(ex);
+        }
     }
 
     /**
@@ -29,6 +51,17 @@ public class TcsConfig extends ParamSet {
         String chopState = is.getChopState();
         if (chopState != null) {
             putParameter(TccNames.CHOP, chopState);
+        }
+
+        // Add a parameter that identifies the ephemeris file to look for if
+        // this is a non-sidereal target.
+        final scala.Option<NonSiderealTarget> nsOption = _oe.getTargetEnvironment().getBase().getNonSiderealTarget();
+        if (nsOption.isDefined()) {
+            final NonSiderealTarget ns = nsOption.get();
+            final scala.Option<HorizonsDesignation> hdOption = ns.horizonsDesignation();
+            if (hdOption.isDefined()) {
+                putParameter(TccNames.EPHEMERIS, ephemerisFile(hdOption.get()));
+            }
         }
         return true;
     }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
@@ -31,7 +31,7 @@ public final class TcsConfig extends ParamSet {
     public static String ephemerisFile(final HorizonsDesignation hd) {
         try {
             // See TcsEphemerisExport.
-            return URLEncoder.encode(hd.toString() + ".eph", StandardCharsets.UTF_8.name());
+            return URLEncoder.encode(hd.show() + ".eph", StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException ex) {
             LOG.log(Level.SEVERE, "UTF-8 is not supported!", ex);
             throw new RuntimeException(ex);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
@@ -15,11 +15,6 @@ import edu.gemini.spModel.telescope.IssPortProvider;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Test cases for {@link edu.gemini.wdba.tcc.Flamingos2Support}.
  */
@@ -42,15 +37,15 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
         obs.addObsComponent(obsComp);
     }
 
-    protected class ObsComponentPair<T extends ISPDataObject> {
+    protected class ObsComponentPair<D extends ISPDataObject> {
         public ISPObsComponent obsComp;
-        public T dataObject;
+        public D dataObject;
 
         public ObsComponentPair(SPComponentType type) throws Exception {
             obsComp = odb.getFactory().createObsComponent(prog, type, null);
             obs.addObsComponent(obsComp);
             //noinspection unchecked
-            dataObject = (T) obsComp.getDataObject();
+            dataObject = (D) obsComp.getDataObject();
         }
 
         public void store() throws Exception {
@@ -59,7 +54,7 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
     }
 
     protected ObsComponentPair<InstAltair> addAltair() throws Exception {
-        return new ObsComponentPair<InstAltair>(InstAltair.SP_TYPE);
+        return new ObsComponentPair<>(InstAltair.SP_TYPE);
     }
 
     protected ObsComponentPair<InstAltair> addAltair(AltairParams.GuideStarType type) throws Exception {
@@ -74,7 +69,7 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
     }
 
     protected ObsComponentPair<Gems> addGems() throws Exception {
-        return new ObsComponentPair<Gems>(Gems.SP_TYPE);
+        return new ObsComponentPair<>(Gems.SP_TYPE);
     }
 
     protected T getInstrument() throws Exception {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
@@ -86,20 +86,6 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
         obsComp.setDataObject(dataObj);
     }
 
-    protected Map<String, String> getTcsConfigurationMap(Document doc) throws Exception {
-        Map<String, String> res = new HashMap<String, String>();
-
-        Element psetElement = getTcsConfiguration(doc);
-        @SuppressWarnings({"unchecked"}) List<Element> params = (List<Element>) psetElement.elements();
-        for (Element paramElement : params) {
-            String name  = paramElement.attributeValue("name");
-            String value = paramElement.attributeValue("value");
-            res.put(name, value);
-        }
-
-        return Collections.unmodifiableMap(res);
-    }
-
     protected String getInstrumentConfig(Document doc) throws Exception {
         return getTcsConfigurationMap(doc).get(TccNames.INSTRUMENT);
     }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TestBase.java
@@ -80,14 +80,11 @@ public abstract class TestBase extends TestCase {
     }
 
     protected Document parse(String tccConfigXml) throws Exception {
-        SAXReader sax = new SAXReader();
+        final SAXReader sax = new SAXReader();
 
-        Reader rdr = new StringReader(tccConfigXml);
-        Document doc;
-        try {
+        final Document doc;
+        try (Reader rdr = new StringReader(tccConfigXml)) {
             doc = sax.read(rdr);
-        } finally {
-            rdr.close();
         }
         return doc;
     }
@@ -126,26 +123,10 @@ public abstract class TestBase extends TestCase {
         return getTccFieldContainedParamSet(doc, TargetGroupConfig.TYPE_VALUE);
     }
 
-    protected Element getTargetGroup(Document doc, String name) {
-        for (Element e : getTargetGroups(doc)) {
-            String thisName = e.attributeValue(ParamSet.NAME);
-            if (name.equals(thisName)) return e;
-        }
-        return null;
-    }
-
     protected List<Element> getTargets(Document doc) {
         List<Element> res = getTccFieldContainedParamSet(doc, "hmsdegTarget");
         res.addAll(getTccFieldContainedParamSet(doc, "conicTarget"));
         return res;
-    }
-
-    protected Element getTarget(Document doc, String name) {
-        for (Element e : getTccFieldContainedParamSet(doc, "hmsdegTarget")) {
-            String thisName = e.attributeValue(ParamSet.NAME);
-            if (name.equals(thisName)) return e;
-        }
-        return null;
     }
 
     protected Element getTcsConfiguration(Document doc) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TestBase.java
@@ -24,9 +24,7 @@ import org.dom4j.io.SAXReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.security.Principal;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * A base class for creating unit test code for the TCC configuration file
@@ -152,5 +150,19 @@ public abstract class TestBase extends TestCase {
 
     protected Element getTcsConfiguration(Document doc) {
         return getSubconfig(doc, TccNames.TCS_CONFIGURATION);
+    }
+
+    protected Map<String, String> getTcsConfigurationMap(Document doc) throws Exception {
+        final Map<String, String> res = new HashMap<>();
+
+        final Element psetElement = getTcsConfiguration(doc);
+        @SuppressWarnings({"unchecked"}) List<Element> params = (List<Element>) psetElement.elements();
+        for (Element paramElement : params) {
+            final String name  = paramElement.attributeValue("name");
+            final String value = paramElement.attributeValue("value");
+            res.put(name, value);
+        }
+
+        return Collections.unmodifiableMap(res);
     }
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
@@ -1,0 +1,53 @@
+package edu.gemini.wdba.tcc
+
+import edu.gemini.spModel.core.{Declination, Angle, RightAscension, Coordinates, SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target}
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.util.SPTreeUtil
+import org.junit.Assert._
+import org.junit.Test
+
+import scalaz.==>>
+
+
+final class TcsConfigTest extends TestBase {
+
+  private def setBase(target: Target): Unit = {
+    val oc  = SPTreeUtil.findTargetEnvNode(obs)
+    val toc = oc.getDataObject.asInstanceOf[TargetObsComp]
+    val env = toc.getTargetEnvironment
+    env.getBase.setTarget(target)
+
+    oc.setDataObject(toc)
+  }
+
+  @Test
+  def testNonSiderealWithHorizonsDesignation(): Unit = {
+    val titan = HorizonsDesignation.MajorBody(606)
+    setBase(NonSiderealTarget("Titan", ==>>.empty, Some(titan), List.empty, None, None))
+    val m   = getTcsConfigurationMap(getSouthResults)
+    assertEquals(TcsConfig.ephemerisFile(titan), m.get(TccNames.EPHEMERIS))
+  }
+
+  @Test
+  def testNonSiderealWithoutHorizonsDesignation(): Unit = {
+    setBase(NonSiderealTarget("Titan", ==>>.empty, None, List.empty, None, None))
+    val m = getTcsConfigurationMap(getSouthResults)
+    assertNull(m.get(TccNames.EPHEMERIS))
+  }
+
+  @Test
+  def testSidreal(): Unit = {
+    setBase(SiderealTarget("NGC 1407",
+                           Coordinates(RightAscension.fromAngle(Angle.parseHMS("3:40:11.9").toOption.get),
+                                       Declination.fromAngle(Angle.parseDMS("-18:34:48").toOption.get).get),
+                           None,
+                           None,
+                           None,
+                           Nil,
+                           None,
+                           None))
+
+    val m = getTcsConfigurationMap(getSouthResults)
+    assertNull(m.get(TccNames.EPHEMERIS))
+  }
+}


### PR DESCRIPTION
This PR changes the names given to ephemeris files written for the TCS.  Currently the TCC (or is it the TCS?) takes the target name and appends `.eph` and then looks for a matching filename. Since there is no guarantee that human readable names entered by the user map to unique non-sidereal targets, this is a recipe for fault reports.  Instead, we’ll use the unique `HorizonsDesignation` as the filename and tell the TCC (or TCS via the TCC) what filename to look for when it loads a configuration from the WDBA.  This requires a corresponding update in the TCC/TCS.