### PR TITLE
REL-2723: Allow enabling of disabled auto groups

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -314,7 +314,7 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
         // Update the auto row of a table.
         // This is called when the auto row should be changed from disabled to initial.
         void enableAutoRow(final TargetEnvironment env) {
-            final GroupRow autoGroupRow = new GroupRow(true, true, 0, env.getGuideEnvironment().automaticGroup(),
+            final GroupRow autoGroupRow = new GroupRow(true, false, 0, env.getGuideEnvironment().automaticGroup(),
                     Collections.emptyList());
             rows.set(1, autoGroupRow);
             fireTableRowsUpdated(1, 1);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -929,22 +929,23 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
                 final GuideGroup primary = env.getOrCreatePrimaryGuideGroup();
 
                 // If the auto group is disabled and set to primary, then make it an initial auto group.
-                final GuideGrp grp = igg.group().grp();
-                final GuideEnvironment ge = env.getGuideEnvironment();
-                if (ge != null && grp instanceof AutomaticGroup.Disabled$) {
-                    final TargetEnvironment envNew = env.setGuideEnvironment(ge.setAutomaticGroup(GuideGroup.AutomaticInitial()).setPrimaryIndex(0));
-                    _dataObject.setTargetEnvironment(envNew);
-                    _model.enableAutoRow(envNew);
-                }
-                else if (ge != null && primary != igg.group() && confirmGroupChange(primary, igg.group())) {
-                    _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setPrimaryIndex(igg.index())));
-
-                    // If we are switching to an automatic group, we also
-                    // possibly need to update the position angle.
-                    if (grp instanceof AutomaticGroup.Active) {
-                        updatePosAngle(((AutomaticGroup.Active) grp).posAngle());
+                ImOption.apply(env.getGuideEnvironment()).foreach(ge -> {
+                    final GuideGrp grp = igg.group().grp();
+                    if (ge != null && grp instanceof AutomaticGroup.Disabled$) {
+                        final TargetEnvironment envNew = env.setGuideEnvironment(ge.setAutomaticGroup(GuideGroup.AutomaticInitial()).setPrimaryIndex(0));
+                        _dataObject.setTargetEnvironment(envNew);
+                        _model.enableAutoRow(envNew);
                     }
-                }
+                    else if (ge != null && primary != igg.group() && confirmGroupChange(primary, igg.group())) {
+                        _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setPrimaryIndex(igg.index())));
+
+                        // If we are switching to an automatic group, we also
+                        // possibly need to update the position angle.
+                        if (grp instanceof AutomaticGroup.Active) {
+                            updatePosAngle(((AutomaticGroup.Active) grp).posAngle());
+                        }
+                    }
+                });
             });
         }
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -311,6 +311,15 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
             return tmpRows;
         }
 
+        // Update the auto row of a table.
+        // This is called when the auto row should be changed from disabled to initial.
+        void enableAutoRow(final TargetEnvironment env) {
+            final GroupRow autoGroupRow = new GroupRow(true, true, 0, env.getGuideEnvironment().automaticGroup(),
+                    Collections.emptyList());
+            rows.set(1, autoGroupRow);
+            fireTableRowsUpdated(1, 1);
+        }
+
         // Replace the auto group and return a new TableData.
         // Note that we work under the assumption that there is ALWAYS an auto group, which should be the case,
         // and that it is in row position 1 of the table (directly after the base).
@@ -918,17 +927,22 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
             getSelectedGroup().foreach(igg -> {
                 final TargetEnvironment env = _dataObject.getTargetEnvironment();
                 final GuideGroup primary = env.getOrCreatePrimaryGuideGroup();
-                if (primary != igg.group() && confirmGroupChange(primary, igg.group())) {
-                    final GuideEnvironment ge = env.getGuideEnvironment();
-                    if (ge != null) {
-                        _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setPrimaryIndex(igg.index())));
 
-                        // If we are switching to an automatic group, we also
-                        // possibly need to update the position angle.
-                        final GuideGrp grp = igg.group().grp();
-                        if (grp instanceof AutomaticGroup.Active) {
-                            updatePosAngle(((AutomaticGroup.Active) grp).posAngle());
-                        }
+                // If the auto group is disabled and set to primary, then make it an initial auto group.
+                final GuideGrp grp = igg.group().grp();
+                final GuideEnvironment ge = env.getGuideEnvironment();
+                if (ge != null && grp instanceof AutomaticGroup.Disabled$) {
+                    final TargetEnvironment envNew = env.setGuideEnvironment(ge.setAutomaticGroup(GuideGroup.AutomaticInitial()).setPrimaryIndex(0));
+                    _dataObject.setTargetEnvironment(envNew);
+                    _model.enableAutoRow(envNew);
+                }
+                else if (ge != null && primary != igg.group() && confirmGroupChange(primary, igg.group())) {
+                    _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setPrimaryIndex(igg.index())));
+
+                    // If we are switching to an automatic group, we also
+                    // possibly need to update the position angle.
+                    if (grp instanceof AutomaticGroup.Active) {
+                        updatePosAngle(((AutomaticGroup.Active) grp).posAngle());
                     }
                 }
             });


### PR DESCRIPTION
In the current model, when a pre-2016 program is imported, the auto guide group is set to disabled.
It must be possible to enable these auto groups, and the mechanism that we have decided to allow this to be done is to have the disabled auto group selected as the primary or double clicked.

This change simply sets a disabled auto group to an enabled one, updates the table model, and then fires an event indicating that the table has been updated. BAGS handles the rest, and performs a lookup.