### PR TITLE
REL-2715: Making addition of manual guide groups easier

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/GuideEnvironment.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/GuideEnvironment.scala
@@ -52,6 +52,10 @@ final case class GuideEnvironment(guideEnv: GuideEnv) extends TargetContainer {
   def automaticGroup: GuideGroup =
     GuideGroup(guideEnv.auto)
 
+  /** Gets the manual groups. */
+  def manualGroups: List[GuideGroup] =
+    guideEnv.manual.map(_.toList.map(GuideGroup)) | Nil
+
   /** Gets the `GuideGroup` at the given index, if any.  If the index is out
     * of range, `None` is returned.  If the index is 0, the result will be the
     * automatic group, otherwise one of the manual groups.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -608,14 +608,14 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         final ImList<GuideGroup> newGroups = oldGroups.append(newGroup);
 
         // OT-34: make new group primary and select it
-        if (!positionTable.confirmGroupChange(primaryGroup, newGroup)) {
+        if (positionTable.confirmGroupChange(primaryGroup, newGroup)) {
+            obsComp.setTargetEnvironment(env.setGuideEnvironment(ge.setOptions(newGroups)
+                    .setPrimaryIndex(newGroupIdx)));
+            positionTable.selectGroup(igg);
+            return new Some<>(igg);
+        } else {
             return None.instance();
         }
-        obsComp.setTargetEnvironment(env.setGuideEnvironment(ge.setOptions(newGroups)
-                .setPrimaryIndex(newGroupIdx)));
-
-        positionTable.selectGroup(igg);
-        return new Some<>(igg);
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -619,7 +619,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         // Make and return a new primary group and target environment, if possible.
         final TargetEnvironment         newEnv;
-        final Option<IndexedGuideGroup> newIggOpt;
         if (positionTable.confirmGroupChange(primaryGroup, newGroup)) {
             newEnv = env.setGuideEnvironment(ge.setOptions(newGroups).setPrimaryIndex(newGroupIdx));
             return new Some<>(new Pair<>(newEnv, igg));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -544,7 +544,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             // group is present. This requires some ugly hacking.
             final Option<IndexedGuideGroup> iggOpt = positionTable.getSelectedGroupOrParentGroup(env)
                     .filter(igg -> !igg.group().isAutomatic())
-                    .orElse(() -> { return appendNewGroup(obsComp, positionTable); });
+                    .orElse(() -> appendNewGroup(obsComp, positionTable));
 
             // Env may have changed at this point if we appended a new group, so we must re-retrieve env.
             final TargetEnvironment newEnv = obsComp.getTargetEnvironment();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeEditorTools.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeEditorTools.java
@@ -127,6 +127,12 @@ final class TpeEditorTools {
                 .exists(te -> te.getGuideEnvironment().getPrimary().isManual());
     }
 
+    // Returns true if the only group is an auto group.
+    private boolean onlyAutomatic() {
+        return ImOption.fromScalaOpt(_tpe.getImageWidget().getContext().targets().env())
+                .exists(te -> te.getGuideEnvironment().manualGroups().isEmpty());
+    }
+
     /**
      * Update the enable states of the buttons based on the OT editable state and whether or not the group is
      * the automatic guide group.
@@ -205,6 +211,9 @@ final class TpeEditorTools {
         // Determine if we are in a manual group.
         final boolean manual = isManual();
 
+        // Determine if the only group is the auto group.
+        final boolean onlyAuto = onlyAutomatic();
+
         // Add create buttons according to the enabled state of each item.
         for (final TpeImageFeature feature : feats) {
             if (!(feature instanceof TpeCreatableFeature)) continue;
@@ -217,7 +226,7 @@ final class TpeEditorTools {
                     btn.setVisible(true);
 
                     // If we are on the auto group, only allow non WFS targets to be created.
-                    btn.setEnabled(manual || !isWFSTarget);
+                    btn.setEnabled(manual || onlyAuto || !isWFSTarget);
                 }
             }
         }


### PR DESCRIPTION
This is a weird bit of hackery that was requested by the astronomers.

In the target editor, previously, when an observation was created, the only things in the target table were the base and the auto guide group. If someone wanted a manual guide star, this required a two-step process, first adding the manual guide group and then adding the manual target to it.

The astronomers instead wanted manual targets to be able to be added in a one-step process, i.e. if there is no manual guide group, still allow users to add a manual target by automatically creating a manual guide group to hold the manual target.

This implements that bit of hackery.