### PR TITLE
REL-2716: Primary group selection simplification

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
@@ -99,7 +99,7 @@ public final class GemsGuideStarRule implements IRule {
                 }
             }
 
-            GuideGroup primaryGuideGroup = env.getOrCreatePrimaryGuideGroup();
+            GuideGroup primaryGuideGroup = env.getPrimaryGuideGroup();
             // get # cwfs
             int cwfs = 0;
             for (Canopus.Wfs canwfs : Canopus.Wfs.values()) {

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -26,7 +26,6 @@ import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeUtil;
 import edu.gemini.spModel.obs.ObsClassService;
 import edu.gemini.spModel.obs.ObservationStatus;
-import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obscomp.InstConstants;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
@@ -189,7 +188,7 @@ public class GeneralRule implements IRule {
                 }
             }
 
-            for (final GuideProbeTargets guideTargets : env.getOrCreatePrimaryGuideGroup()) {
+            for (final GuideProbeTargets guideTargets : env.getPrimaryGuideGroup()) {
                 final GuideProbe guider = guideTargets.getGuider();
                 // TODO: GuideProbeTargets.isEnabled
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/michelle/MichelleRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/michelle/MichelleRule.java
@@ -68,7 +68,7 @@ public class MichelleRule implements IRule {
         }
 
         private boolean hasOI(final TargetEnvironment env) {
-            final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
+            final GuideGroup grp = env.getPrimaryGuideGroup();
 
             final ImList<GuideProbeTargets> col = grp.getAllMatching(GuideProbe.Type.OIWFS);
             if ((col == null) || (col.size() == 0)) return false;

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
@@ -331,7 +331,7 @@ public class TrecsRule implements IRule {
                 if (baseTarget == null) return null;
 
 
-                for (GuideProbeTargets guideTargets : env.getOrCreatePrimaryGuideGroup()) {
+                for (GuideProbeTargets guideTargets : env.getPrimaryGuideGroup()) {
                     for (SPTarget target : guideTargets) {
 
                         // Calculate the distance to the base position in arcmin

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/WfsRuleSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/WfsRuleSpec.scala
@@ -38,7 +38,7 @@ class WfsRuleSpec extends Specification {
       val g   = te.getBase.clone() <| (g => g.setTarget(mod(g.getTarget.asInstanceOf[SiderealTarget])))
       val p   = GmosOiwfsGuideProbe.instance
       val gpt = GuideProbeTargets.create(p, g)
-      val gg  = te.getOrCreatePrimaryGuideGroup.setAll(List(gpt).asImList)
+      val gg  = te.getPrimaryGuideGroup.setAll(List(gpt).asImList)
       te.setPrimaryGuideGroup(gg)
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -868,7 +868,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         final TargetObsComp dataObj   = (TargetObsComp) obsComp.getDataObject();
         final TargetEnvironment tenv  = dataObj.getTargetEnvironment();
 
-        final GuideGroup gg = tenv.getOrCreatePrimaryGuideGroup();
+        final GuideGroup gg = tenv.getPrimaryGuideGroup();
 
         final Option<GuideProbeTargets> gptOpt = gg.get(Flamingos2OiwfsGuideProbe.instance);
         return gptOpt.exists(gpt -> gpt.getPrimary().isDefined());

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -505,7 +505,7 @@ public enum Canopus {
      */
     public Option<Area> probeArm(ObsContext ctx, Wfs cwfs, boolean validate) {
         return ctx.getBaseCoordinates().map(coords -> {
-            GuideProbeTargets targets = ctx.getTargets().getOrCreatePrimaryGuideGroup().get(cwfs).getOrNull();
+            GuideProbeTargets targets = ctx.getTargets().getPrimaryGuideGroup().get(cwfs).getOrNull();
             if (targets != null) {
                 SPTarget target = targets.getPrimary().getOrNull();
                 if (target != null && (!validate || cwfs.validate(target, ctx) == GuideStarValidation.VALID)) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgw.java
@@ -5,7 +5,6 @@ import edu.gemini.skycalc.Coordinates;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.gems.GemsGuideProbeGroup;
 import edu.gemini.spModel.guide.*;
-import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.*;
@@ -63,7 +62,7 @@ public enum GsaoiOdgw implements ValidatableGuideProbe {
 
             // Return an updated target environment that incorporates this
             // guide star.
-            final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
+            final GuideGroup grp = env.getPrimaryGuideGroup();
             final Option<GuideProbeTargets> gptOpt = grp.get(probe);
 
             if (gptOpt.exists(gpt -> gpt.containsTarget(guideStar)))

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -98,7 +98,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      * method and is equivalent to
      * <code>getGuideEnvironment().getPrimary().getOrElse(GuideGroup.EMPTY)</code>.
      */
-    public GuideGroup getOrCreatePrimaryGuideGroup() {
+    public GuideGroup getPrimaryGuideGroup() {
         return guide.getPrimary();
     }
 
@@ -126,11 +126,11 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      * equivalent to
      * <pre>
      *     TargetEnvironment env = ...
-     *     env.getOrCreatePrimaryGuideGroup().get(guider)
+     *     env.getPrimaryGuideGroup().get(guider)
      * </pre>
      */
     public Option<GuideProbeTargets> getPrimaryGuideProbeTargets(final GuideProbe guider) {
-        return getOrCreatePrimaryGuideGroup().get(guider);
+        return getPrimaryGuideGroup().get(guider);
     }
 
     /**
@@ -140,7 +140,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      * <code>gpt</code>.  This is a convenience method equivalent to
      * <pre>
      *     TargetEnvironment env = ...
-     *     env.setPrimaryGuideGroup(env.getOrCreatePrimaryGuideGroup().put(gpt))
+     *     env.setPrimaryGuideGroup(env.getPrimaryGuideGroup().put(gpt))
      * </pre>
      *
      * @param gpt guide probe targets to add or update in the primary guide
@@ -150,7 +150,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      * its primary group, but otherwise identical to <code>this</code>
      */
     public TargetEnvironment putPrimaryGuideProbeTargets(GuideProbeTargets gpt) {
-        return setPrimaryGuideGroup(getOrCreatePrimaryGuideGroup().put(gpt));
+        return setPrimaryGuideGroup(getPrimaryGuideGroup().put(gpt));
     }
 
     /**
@@ -160,7 +160,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      * that tis equivalent to
      * <pre>
      *     TargetEnvironment env = ...
-     *     env.setPrimaryGuideGroup(env.getOrCreatePrimaryGuideGroup().setAll(lst))
+     *     env.setPrimaryGuideGroup(env.getPrimaryGuideGroup().setAll(lst))
      * </pre>
      *
      * @param lst new list of GuideProbeTargets to apply to the primary guide
@@ -170,7 +170,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      * its primary group, but otherwise identical to <code>this</code>
      */
     public TargetEnvironment setAllPrimaryGuideProbeTargets(ImList<GuideProbeTargets> lst) {
-        return setPrimaryGuideGroup(getOrCreatePrimaryGuideGroup().setAll(lst));
+        return setPrimaryGuideGroup(getPrimaryGuideGroup().setAll(lst));
     }
 
     /**
@@ -276,14 +276,6 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
     public TargetEnvironment removeTarget(SPTarget target) {
         return setGuideEnvironment(guide.removeTarget(target)).setUserTargets(user.remove(target));
     }
-
-    /**
-     * Returns a TargetEnvironment equivalent to this one, but without the
-     * given guide group.
-     */
-//    public TargetEnvironment removeGroup(GuideGroup group) {
-//        return setGuideEnvironment(guide.removeGroup(group));
-//    }
 
     public TargetEnvironment removeGroup(int groupIndex) {
         return setGuideEnvironment(guide.removeGroup(groupIndex));

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/GuideSequence.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/GuideSequence.java
@@ -112,7 +112,7 @@ public final class GuideSequence implements ConfigPostProcessor {
      * "primary" assigned to it in the primary guide group.
      */
     public static ImList<GuideProbe> getRequiredGuiders(Option<TargetEnvironment> envOpt) {
-        return envOpt.map(env -> env.getOrCreatePrimaryGuideGroup().getAll().
+        return envOpt.map(env -> env.getPrimaryGuideGroup().getAll().
                         filter(gpt -> gpt.getPrimary().isDefined()).
                         map(GuideProbeTargets::getGuider)).getOrElse(ImCollections.emptyList());
     }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
@@ -83,7 +83,7 @@ public class GsaoiOdgwGroupTest extends TestCase {
         final TargetEnvironment env = group.add(guideTarget, baseContext);
 
         // Adds an ODGW1 target by default.
-        final ImList<GuideProbeTargets> col = env.getOrCreatePrimaryGuideGroup().getAll();
+        final ImList<GuideProbeTargets> col = env.getPrimaryGuideGroup().getAll();
         assertEquals(1, col.size());
 
         final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(GsaoiOdgw.odgw1);
@@ -110,7 +110,7 @@ public class GsaoiOdgwGroupTest extends TestCase {
             final TargetEnvironment env = group.add(guideTarget, baseContext);
 
             // Should have just one set of GuideTargets for the new guide star.
-            assertEquals(1, env.getOrCreatePrimaryGuideGroup().getAll().size());
+            assertEquals(1, env.getPrimaryGuideGroup().getAll().size());
 
             // Should be guide targets for the expected guide window.
             final Option<GuideProbeTargets> gtOpt = env.getPrimaryGuideProbeTargets(odgw);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/SetupTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/SetupTimeTest.java
@@ -134,7 +134,7 @@ public final class SetupTimeTest {
                 final TargetEnvironment env = dataObj.getTargetEnvironment();
 
                 // Remove the OIWFS if it exists.
-                final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
+                final GuideGroup grp = env.getPrimaryGuideGroup();
                 final ImList<GuideProbeTargets> gtList = grp.getAll().remove(gpt -> gpt.getGuider() == NifsOiwfsGuideProbe.instance);
                 final TargetEnvironment env2 = env.setPrimaryGuideGroup(grp.setAll(gtList));
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gsaoi/PlannedTimeTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gsaoi/PlannedTimeTest.scala
@@ -35,7 +35,7 @@ class PlannedTimeTest extends InstrumentSequenceTestBase[Gsaoi, GsaoiSeqConfig] 
 
     // Add a canopus guide star so that guiding will be turned on
     val env  = getTargetEnvironment
-    val grp  = env.getOrCreatePrimaryGuideGroup
+    val grp  = env.getPrimaryGuideGroup
     val target = new SPTarget(0.0, 0.0)
     val env2 = env.setPrimaryGuideGroup(grp.put(GuideProbeTargets.create(Canopus.Wfs.cwfs3, target)))
 

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -476,7 +476,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
 
         this.targetEnvironment = targetEnvironment;
         if (this.targetEnvironment != null) {
-            for (GuideProbe probe : targetEnvironment.getOrCreatePrimaryGuideGroup().getReferencedGuiders()) {
+            for (GuideProbe probe : targetEnvironment.getPrimaryGuideGroup().getReferencedGuiders()) {
                 String key = probe.getKey();
                 if (key.contains("OIWFS")) key = "OIWFS"; // trim off instrument
                 wfs.add(key);

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
@@ -593,7 +593,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
             // REL-293: check for WFS
             if (TargetObsComp.SP_TYPE.equals(type)) {
                 TargetObsComp targetObsComp = (TargetObsComp)comp.getDataObject();
-                for(GuideProbe guideProbe : targetObsComp.getTargetEnvironment().getOrCreatePrimaryGuideGroup().getReferencedGuiders()) {
+                for(GuideProbe guideProbe : targetObsComp.getTargetEnvironment().getPrimaryGuideGroup().getReferencedGuiders()) {
                     if (guideProbe instanceof Enum) {
                         ret.add((Enum)guideProbe);
                     }

--- a/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/Version.java
+++ b/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/Version.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.spModel.core;
 
 import java.io.Serializable;

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/To2009B.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/To2009B.java
@@ -66,7 +66,7 @@ public enum To2009B {
         // map indicates which targets should be used as the primary target for
         // each probe.
         final Map<GuideProbe, String> primaryTargetMap = OffsetIteratorUpdater.instance.updateOffsetIterators(obs,
-                obsContainer, env.getOrCreatePrimaryGuideGroup().getReferencedGuiders());
+                obsContainer, env.getPrimaryGuideGroup().getReferencedGuiders());
 
         // Use the primaryTargetMap to correct the primary guide star.
         for (final GuideProbe guider : primaryTargetMap.keySet()) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GuideConfigSouth.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GuideConfigSouth.java
@@ -1,6 +1,5 @@
 package edu.gemini.wdba.tcc;
 
-import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.ApplyOp;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
@@ -57,7 +56,7 @@ public class GuideConfigSouth extends ParamSet {
         // ODGW to be "on instrument".  Explicitly check for these probes.
         if (!oe.containsTargets(GuideProbe.Type.OIWFS)) return false;
         Set<GuideProbe> odgwSet = new HashSet<GuideProbe>(Arrays.asList(GsaoiOdgw.values()));
-        GuideGroup grp = oe.getTargetEnvironment().getOrCreatePrimaryGuideGroup();
+        GuideGroup grp = oe.getTargetEnvironment().getPrimaryGuideGroup();
         for (GuideProbeTargets gt : grp.getAllMatching(GuideProbe.Type.OIWFS)) {
             if (!odgwSet.contains(gt.getGuider())) return true;
         }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -163,7 +163,7 @@ public final class ObservationEnvironment {
     }
 
     public boolean containsTargets(GuideProbe.Type type) {
-        final GuideGroup grp = _targetEnv.getOrCreatePrimaryGuideGroup();
+        final GuideGroup grp = _targetEnv.getPrimaryGuideGroup();
         final ImList<GuideProbeTargets> gtList = grp.getAllMatching(type);
         return gtList.exists(GuideProbeTargets::containsTargets);
     }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -81,7 +81,7 @@ public class TccFieldConfig extends ParamSet {
 
     private String getPrimaryGuideGroupName() {
         TargetEnvironment env = _oe.getTargetEnvironment();
-        final GuideGroup gg = env.getOrCreatePrimaryGuideGroup();
+        final GuideGroup gg = env.getPrimaryGuideGroup();
         //Only return a name if there are more than one group.
         if ( env.getGroups().size() <= 1 ) return "";
         if (!gg.getName().isEmpty()) return gg.getName().getValue();
@@ -94,7 +94,7 @@ public class TccFieldConfig extends ParamSet {
 
     private void addTargets(TargetEnvironment env) throws WdbaGlueException {
         addBaseGroup(env);
-        for (GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) addGuideGroup(gt);
+        for (GuideProbeTargets gt : env.getPrimaryGuideGroup()) addGuideGroup(gt);
     }
 
     private static boolean isEmpty(String name) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/UnusedGuideConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/UnusedGuideConfig.java
@@ -72,7 +72,7 @@ public class UnusedGuideConfig extends ParamSet {
         // Now, handle the case where there are one or more offset iterators
         // in the sequence.
         Set<GuideProbe> refGuiders;
-        refGuiders = _oe.getTargetEnvironment().getOrCreatePrimaryGuideGroup().getReferencedGuiders();
+        refGuiders = _oe.getTargetEnvironment().getPrimaryGuideGroup().getReferencedGuiders();
 
         if (refGuiders.contains(PwfsGuideProbe.pwfs1) && probeUsed(PwfsGuideProbe.pwfs1, offsetNodes)) {
             putParameter(TccNames.PWFS1ACTIVE, TccNames.A);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -13,7 +13,6 @@ import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi;
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw;
 import edu.gemini.spModel.guide.GuideProbe;
-import edu.gemini.spModel.pio.xml.PioXmlUtil;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.*;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
@@ -393,7 +392,7 @@ public final class TargetGroupTest extends TestBase {
         // Count the number of targets (discounting the disabled guide targets)
         int targetCount = 1 + env.getUserTargets().size(); // base position + user
         int groupCount = 1; // base group
-        for (GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
+        for (GuideProbeTargets gt : env.getPrimaryGuideGroup()) {
             ++groupCount;
             targetCount += gt.getTargets().size();
         }
@@ -426,7 +425,7 @@ public final class TargetGroupTest extends TestBase {
         validateGroup(baseGroupElement, TccNames.BASE, baseName, targets);
 
         // Check each guide group.
-        for (GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
+        for (GuideProbeTargets gt : env.getPrimaryGuideGroup()) {
             GuideProbe guider = gt.getGuider();
             String name = nameMap.getGuiderName(guider);
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/offset/AbstractOffsetPosListEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/offset/AbstractOffsetPosListEditor.java
@@ -223,7 +223,7 @@ public abstract class AbstractOffsetPosListEditor<P extends OffsetPosBase> exten
         final TargetObsComp toc = getContextTargetObsCompDataObject();
         if (toc != null) {
             envOpt = new Some<TargetEnvironment>(toc.getTargetEnvironment());
-            referenced = envOpt.getValue().getOrCreatePrimaryGuideGroup().getReferencedGuiders();
+            referenced = envOpt.getValue().getPrimaryGuideGroup().getReferencedGuiders();
         }
 
         // Make sure that the position links are in sync with the referenced
@@ -242,7 +242,7 @@ public abstract class AbstractOffsetPosListEditor<P extends OffsetPosBase> exten
                     GuideProbeUtil.instance.getAvailableGuiders(getContextObservation());
         final Set<GuideProbe> noPrimary = new HashSet<GuideProbe>();
         if (!envOpt.isEmpty()) {
-            for (GuideProbeTargets gt : envOpt.getValue().getOrCreatePrimaryGuideGroup()) {
+            for (GuideProbeTargets gt : envOpt.getValue().getPrimaryGuideGroup()) {
                 if (gt.getPrimary().isEmpty()) {
                     noPrimary.add(gt.getGuider());
                 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -221,8 +221,9 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         final boolean notAutoTarget = !selectionIsAutoTarget();
         final boolean isGuideStar   = selectionIsGuideTarget();
 
+        // We allow the primary button to be set for auto targets as it will flag the auto group as primary.
         _w.removeButton.setEnabled (editable && notBase && notAutoTarget);
-        _w.primaryButton.setEnabled(editable && isGuideStar && notAutoTarget);
+        _w.primaryButton.setEnabled(editable && isGuideStar);
         _w.pasteButton.setEnabled(editable && notAutoTarget);
         _w.duplicateButton.setEnabled(editable && notAutoTarget);
         updateDetailEditorEnabledState(editable && notAutoTarget);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -448,7 +448,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         // Get the set of guiders that are referenced but not legal in this context, if any.  Any
         // "available" guider is legal, anything left over is referenced but not really available.
-        final Set<GuideProbe> illegalSet = env.getOrCreatePrimaryGuideGroup().getReferencedGuiders();
+        final Set<GuideProbe> illegalSet = env.getPrimaryGuideGroup().getReferencedGuiders();
         illegalSet.removeAll(avail);
 
         GuideProbe illegal = null;
@@ -688,7 +688,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             final boolean enabled = _curSelection.fold(
                     t -> {
                         final TargetEnvironment env = getDataObject().getTargetEnvironment();
-                        final ImList<GuideProbeTargets> gtList = env.getOrCreatePrimaryGuideGroup().getAllContaining(t);
+                        final ImList<GuideProbeTargets> gtList = env.getPrimaryGuideGroup().getAllContaining(t);
                         return gtList.nonEmpty() && !selectionIsAutoTarget();
                     },
                     igg -> true
@@ -718,7 +718,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             return None.instance();
         }).orElse(() -> selectedGroup().flatMap(igg -> {
             // Handle guide groups.
-            final GuideGroup primary = envOld.getOrCreatePrimaryGuideGroup();
+            final GuideGroup primary = envOld.getPrimaryGuideGroup();
             if (igg.group() == primary) {
                 DialogUtil.error("You can't remove the primary guide group.");
             } else if (selectionIsAutoGroup()) {
@@ -771,7 +771,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
                 // See if it is a guide star and duplicate it in the correct GuideTargets list.
                 boolean duplicated = false;
-                env.getOrCreatePrimaryGuideGroup();
+                env.getPrimaryGuideGroup();
                 final List<GuideGroup> groups = new ArrayList<>();
                 for (GuideGroup group : env.getGroups()) {
                     for (GuideProbeTargets gt : group) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/PrimaryTargetToggle.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/PrimaryTargetToggle.java
@@ -33,7 +33,7 @@ public enum PrimaryTargetToggle {
         if ((obsComp == null) || (target == null)) return;
 
         final TargetEnvironment env = obsComp.getTargetEnvironment();
-        final GuideGroup grp = env.getOrCreatePrimaryGuideGroup();
+        final GuideGroup grp = env.getPrimaryGuideGroup();
         final ImList<GuideProbeTargets> lst = grp.getAllContaining(target);
         if (lst.isEmpty()) return; // target not associated with any guider
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -920,7 +920,7 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
         final TargetEnvironment env = _dataObject.getTargetEnvironment();
         final Option<SPTarget> targetOpt = getSelectedPos();
         final Option<IndexedGuideGroup> iggOpt = targetOpt.flatMap(this::getTargetGroup).orElse(getSelectedGroup());
-        final boolean primaryGroupIsSelected = iggOpt.exists(igg -> igg.group().equals(env.getOrCreatePrimaryGuideGroup()));
+        final boolean primaryGroupIsSelected = iggOpt.exists(igg -> igg.group().equals(env.getPrimaryGuideGroup()));
 
         // All we need to do now is additionally check if the iggOpt group is selected. If it is, trigger if
         // and if not, fall through to else.
@@ -931,7 +931,7 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
         } else {
             // The current target or guide group is not promary, so mark ths owner guide group as primary.
             iggOpt.foreach(igg -> {
-                final GuideGroup primary = env.getOrCreatePrimaryGuideGroup();
+                final GuideGroup primary = env.getPrimaryGuideGroup();
 
                 // If the auto group is disabled and set to primary, then make it an initial auto group.
                 ImOption.apply(env.getGuideEnvironment()).foreach(ge -> {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -917,7 +917,6 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
     void updatePrimaryStar() {
         if (_env == null || !OTOptions.isEditable(_obsComp.getProgram(), _obsComp.getContextObservation())) return;
 
-        // TODO: This method must be tested in greater detail, since custom guiding is required for offset positions.
         final TargetEnvironment env = _dataObject.getTargetEnvironment();
         final Option<SPTarget> targetOpt = getSelectedPos();
         final Option<IndexedGuideGroup> iggOpt = targetOpt.flatMap(this::getTargetGroup).orElse(getSelectedGroup());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/StrehlFeature.java
@@ -318,7 +318,7 @@ public class StrehlFeature extends TpeImageFeature implements PropertyWatcher, M
         if (ctxOpt.isEmpty()) return targetList;
         ObsContext ctx = ctxOpt.getValue();
         TargetEnvironment env = ctx.getTargets();
-        GuideGroup group = env.getOrCreatePrimaryGuideGroup();
+        GuideGroup group = env.getPrimaryGuideGroup();
         guideProbeType = null;
         // The counts are used to guess which is tiptilt and which is flexure. See OT-33
         int oiwfsCount = 0;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -1,6 +1,5 @@
 package jsky.app.ot.tpe.feat;
 
-import edu.gemini.pot.ModelConverters$;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.spModel.guide.*;
@@ -292,7 +291,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
             final SPTarget tp = pme.taggedPos;
 
             final TargetEnvironment env = obsComp.getTargetEnvironment();
-            for (final GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
+            for (final GuideProbeTargets gt : env.getPrimaryGuideGroup()) {
                 if (!gt.getTargets().contains(tp)) continue;
 
                 if (positionIsClose(pme, tme.xWidget, tme.yWidget)) {
@@ -333,7 +332,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
             if (env == null) return false;
 
             // We do not allow deletion of auto guide stars.
-            final GuideGroup        gp  = env.getOrCreatePrimaryGuideGroup();
+            final GuideGroup        gp  = env.getPrimaryGuideGroup();
             if (gp.isAutomatic()) return false;
 
             final Option<GuideProbeTargets> gtOpt = gp.get(probe);
@@ -358,7 +357,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
         if (tp == null) return null;
 
         final TargetEnvironment env = obsComp.getTargetEnvironment();
-        for (final GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
+        for (final GuideProbeTargets gt : env.getPrimaryGuideGroup()) {
             if (gt.getTargets().contains(tp)) {
                 TargetSelection.setTargetForNode(env, getContext().targets().shell().get(), tp);
                 return tp;
@@ -395,7 +394,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
         final Map<Point2D.Double, Integer> overlapMap = new HashMap<>();
 
         // Draw all the guide targets.
-        for (final GuideProbeTargets gt : env.getOrCreatePrimaryGuideGroup()) {
+        for (final GuideProbeTargets gt : env.getPrimaryGuideGroup()) {
             final String tagBase = gt.getGuider().getKey();
 
             // Draw disabled targets in red.  Draw enabled but out of range
@@ -478,7 +477,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
         final TargetEnvironment env = obsComp.getTargetEnvironment();
 
         // We do not allow deletion of auto guide stars.
-        final GuideGroup        gp  = env.getOrCreatePrimaryGuideGroup();
+        final GuideGroup        gp  = env.getPrimaryGuideGroup();
         if (gp.isAutomatic()) return None.instance();
 
         final TpePositionMap pm = TpePositionMap.getMap(_iw);

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -271,7 +271,7 @@ object BagsManager {
 
       // Change the pos angle as appropriate if this is the auto group.
       selOpt.foreach { sel =>
-        if (newEnv.getOrCreatePrimaryGuideGroup().isAutomatic && selOpt.isDefined) {
+        if (newEnv.getPrimaryGuideGroup().isAutomatic && selOpt.isDefined) {
           ctx.instrument.dataObject.foreach { inst =>
             val deg = sel.posAngle.toDegrees
             val old = inst.getPosAngleDegrees


### PR DESCRIPTION
This is a tiny PR that allows simplification of setting the primary group in the target editor.

Previously, we required users to double click on the group entry in the table (or to select the group entry and click on the "Select Primary" button) to set a group as the primary guide group.

Now we allow a group to be designated as primary if any of its targets are double clicked, or selected with the "Select Primary" button clicked.