### PR TITLE
REL-2733: Making auto disabled guide groups enableable

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -928,11 +928,11 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
             // If the auto group is disabled and set to primary, then make it an initial auto group.
             ImOption.apply(env.getGuideEnvironment()).foreach(ge -> {
                 final GuideGrp grp = igg.group().grp();
-                if (ge != null && grp instanceof AutomaticGroup.Disabled$) {
+                if (grp instanceof AutomaticGroup.Disabled$) {
                     final TargetEnvironment envNew = env.setGuideEnvironment(ge.setAutomaticGroup(GuideGroup.AutomaticInitial()).setPrimaryIndex(0));
                     _dataObject.setTargetEnvironment(envNew);
                     _model.enableAutoRow(envNew);
-                } else if (ge != null && primary != igg.group() && confirmGroupChange(primary, igg.group())) {
+                } else if (primary != igg.group() && confirmGroupChange(primary, igg.group())) {
                     _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setPrimaryIndex(igg.index())));
 
                     // If we are switching to an automatic group, we also
@@ -963,21 +963,17 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
     // given value.  This is done in response to making the automatic guide
     // group primary.
     private void updatePosAngle(Angle posAngle) {
-        final ISPObservation obs = _obsComp.getContextObservation();
-        if (obs != null) {
-            final ISPObsComponent oc = SPTreeUtil.findInstrument(obs);
-            if (oc != null) {
+        ImOption.apply(_obsComp.getContextObservation()).foreach(obs -> {
+            ImOption.apply(SPTreeUtil.findInstrument(obs)).foreach(oc -> {
                 final SPInstObsComp inst = (SPInstObsComp) oc.getDataObject();
                 final double oldPosAngle = inst.getPosAngleDegrees();
                 final double newPosAngle = posAngle.toDegrees();
                 if (oldPosAngle != newPosAngle) {
                     inst.setPosAngleDegrees(newPosAngle);
                     oc.setDataObject(inst);
-
-                    // We need to re-evaluate the guiding
                 }
-            }
-        }
+            });
+        });
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -922,31 +922,27 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
         final Option<IndexedGuideGroup> iggOpt = targetOpt.flatMap(this::getTargetGroup).orElse(getSelectedGroup());
         final boolean primaryGroupIsSelected = iggOpt.exists(igg -> igg.group().equals(env.getPrimaryGuideGroup()));
 
-        if (!primaryGroupIsSelected) {
-            // The current target or guide group is not primary, so mark ths owner guide group as primary.
-            iggOpt.foreach(igg -> {
-                final GuideGroup primary = env.getPrimaryGuideGroup();
+        iggOpt.foreach(igg -> {
+            final GuideGroup primary = env.getPrimaryGuideGroup();
 
-                // If the auto group is disabled and set to primary, then make it an initial auto group.
-                ImOption.apply(env.getGuideEnvironment()).foreach(ge -> {
-                    final GuideGrp grp = igg.group().grp();
-                    if (ge != null && grp instanceof AutomaticGroup.Disabled$) {
-                        final TargetEnvironment envNew = env.setGuideEnvironment(ge.setAutomaticGroup(GuideGroup.AutomaticInitial()).setPrimaryIndex(0));
-                        _dataObject.setTargetEnvironment(envNew);
-                        _model.enableAutoRow(envNew);
-                    }
-                    else if (ge != null && primary != igg.group() && confirmGroupChange(primary, igg.group())) {
-                        _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setPrimaryIndex(igg.index())));
+            // If the auto group is disabled and set to primary, then make it an initial auto group.
+            ImOption.apply(env.getGuideEnvironment()).foreach(ge -> {
+                final GuideGrp grp = igg.group().grp();
+                if (ge != null && grp instanceof AutomaticGroup.Disabled$) {
+                    final TargetEnvironment envNew = env.setGuideEnvironment(ge.setAutomaticGroup(GuideGroup.AutomaticInitial()).setPrimaryIndex(0));
+                    _dataObject.setTargetEnvironment(envNew);
+                    _model.enableAutoRow(envNew);
+                } else if (ge != null && primary != igg.group() && confirmGroupChange(primary, igg.group())) {
+                    _dataObject.setTargetEnvironment(env.setGuideEnvironment(ge.setPrimaryIndex(igg.index())));
 
-                        // If we are switching to an automatic group, we also
-                        // possibly need to update the position angle.
-                        if (grp instanceof AutomaticGroup.Active) {
-                            updatePosAngle(((AutomaticGroup.Active) grp).posAngle());
-                        }
+                    // If we are switching to an automatic group, we also
+                    // possibly need to update the position angle.
+                    if (grp instanceof AutomaticGroup.Active) {
+                        updatePosAngle(((AutomaticGroup.Active) grp).posAngle());
                     }
-                });
+                }
             });
-        }
+        });
 
         // If we are not the auto group and the update was triggered on a guide star:
         // 1. If the group was originally primary, then toggle the star as primary.


### PR DESCRIPTION
This morning's PR for REL-2716 accidentally introduced a bug that ignored double clicks / primary setting on the already primary guide group.

This is problematic since if the auto guide group is the only guide group and disabled, we rely on the user double-clicking or clicking the set primary button to enable the auto group and thus make BAGS run.

This fixes that by removing the check that was done to see if the currently selected guide group is the primary, and not processing the guide group if that is the case.