### PR TITLE
REL-2732 Fix Coordinate Enablement

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/CoordinateEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/CoordinateEditor.scala
@@ -50,23 +50,12 @@ class CoordinateEditor extends TelescopePosEditor with ReentrancyHack {
   def edit(ctx: GOption[ObsContext], target0: SPTarget, node: ISPNode): Unit = {
     spt = target0
     nonreentrant {
-
-      def enable(t: SiderealTarget): Unit = {
-        ra.setEnabled(true)
-        ra.setText(t.coordinates.ra.toAngle.formatHMS)
+      Target.coords.get(newTarget).foreach { cs =>
+        ra.setText(cs.ra.toAngle.formatHMS)
         ra.setForeground(Color.BLACK)
-        dec.setEnabled(true)
-        dec.setText(t.coordinates.dec.formatDMS)
+        dec.setText(cs.dec.formatDMS)
         dec.setForeground(Color.BLACK)
       }
-
-      def disable(t: Target): Unit = {
-        ra.setEnabled(false)
-        dec.setEnabled(false)
-      }
-
-      newTarget.fold(disable, enable, disable)
-
     }
   }
 


### PR DESCRIPTION
This simplifies the editor initialization, simply ignoring targets that don't have fixed coordinates rather than disabling the controls. They are never visible in this case so it doesn't matter ... we're doing this in a lot of places.