### PR TITLE
REL-2708 fix failing major body lookup

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -256,8 +256,8 @@ object HorizonsService2 {
 
           // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
           lazy val case1 =
-            """  +(.*?)  +(\d+) *$""".r.findFirstMatchIn(header).map { m =>
-              List(Row(HorizonsDesignation.MajorBody(m.group(2).toInt), m.group(1)))
+            """  +(.*?) / \((.+?)\)  +(\d+) *$""".r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.MajorBody(m.group(3).toInt), m.group(1)))
             } \/> "Could not match 'Charon / (Pluto)     901' header pattern."
 
           // First one that works, otherwise Nil because it falls through to small-body search

--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -256,7 +256,7 @@ object HorizonsService2 {
 
           // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
           lazy val case1 =
-            """  +(.*?)  +(\d+) $""".r.findFirstMatchIn(header).map { m =>
+            """  +(.*?)  +(\d+) *$""".r.findFirstMatchIn(header).map { m =>
               List(Row(HorizonsDesignation.MajorBody(m.group(2).toInt), m.group(1)))
             } \/> "Could not match 'Charon / (Pluto)     901' header pattern."
 

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -104,13 +104,13 @@ object HS2Spec extends Specification with ScalaCheck {
 
     "handle single result with trailing space (!)" in {
       runSearch(Search.MajorBody("charon")) must_== \/-(List(
-        Row(HD.MajorBody(901), "Charon / (Pluto)")
+        Row(HD.MajorBody(901), "Charon")
       ))
     }
 
     "handle single result without trailing space" in {
       runSearch(Search.MajorBody("europa")) must_== \/-(List(
-        Row(HD.MajorBody(502), "Europa / (Jupiter)")
+        Row(HD.MajorBody(502), "Europa")
       ))
     }   
 

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -102,9 +102,15 @@ object HS2Spec extends Specification with ScalaCheck {
       ))
     }
 
-    "handle single result" in {
+    "handle single result with trailing space (!)" in {
       runSearch(Search.MajorBody("charon")) must_== \/-(List(
         Row(HD.MajorBody(901), "Charon / (Pluto)")
+      ))
+    }
+
+    "handle single result without trailing space" in {
+      runSearch(Search.MajorBody("europa")) must_== \/-(List(
+        Row(HD.MajorBody(502), "Europa / (Jupiter)")
       ))
     }   
 


### PR DESCRIPTION
Non-sidereal name lookup was failing for some unique results for moons due to trailing whitespace differences in HORIZONS results (╯°□°）╯︵ ┻━┻ and was also renaming moons in an irritating way. Both fixed.