### PR TITLE
REL-2720: Position angle text field updating

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
@@ -1,9 +1,3 @@
-// Copyright 1997 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: EdCompInstBase.java 47001 2012-07-26 19:40:02Z swalker $
-//
 package jsky.app.ot.gemini.editor;
 
 import edu.gemini.pot.sp.ISPObsComponent;
@@ -60,26 +54,21 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
         }
     }
 
-    // -- Implement the TextBoxWidgetWatcher interface --
-
-
     /**
      * A key was pressed in the given TextBoxWidget.
      */
-    public void textBoxKeyPress(TextBoxWidget tbwe) {
+    public void textBoxKeyPress(final TextBoxWidget tbwe) {
         if (getDataObject() != null) {
             _ignoreChanges = true;
             try {
                 if (tbwe == getPosAngleTextBox()) {
-                    /* The default position angle */
                     final double defaultPositionAngle = 0.0;
                     getDataObject().setPosAngleDegrees(tbwe.getDoubleValue(defaultPositionAngle));
                 } else if (tbwe == getExposureTimeTextBox()) {
-                    double expTime = tbwe.getDoubleValue(getDefaultExposureTime());
-                    if (isForceIntegerExposureTime()) expTime = Math.floor(expTime);
-                    getDataObject().setExposureTime(expTime);
+                    final double expTime    = tbwe.getDoubleValue(getDefaultExposureTime());
+                    final double expTimeAdj = isForceIntegerExposureTime() ? Math.floor(expTime) : expTime;
+                    getDataObject().setExposureTime(expTimeAdj);
                 } else if (tbwe == getCoaddsTextBox()) {
-                    /* The default number of coadds */
                     final int defaultCoadds = 1;
                     getDataObject().setCoadds(tbwe.getIntegerValue(defaultCoadds));
                 }
@@ -89,27 +78,24 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
         }
     }
 
-    // ignore
-    public void textBoxAction(TextBoxWidget tbwe) {
-    }
-
-
-    /** Implements the PropertyChangeListener interface */
-    public void propertyChange(PropertyChangeEvent evt) {
+    public void propertyChange(final PropertyChangeEvent evt) {
         if (_ignoreChanges) return;
-        TextBoxWidget tbwe = getPosAngleTextBox();
-        if (tbwe != null && getDataObject() != null) {
+
+        // Ignore model changes to the pos angle if the pos angle text box has the focus.
+        // This is to avoid changing the text box value when BAGS selects an auto group at +180.
+        final TextBoxWidget posAngleTextBox = getPosAngleTextBox();
+        if (posAngleTextBox != null && getDataObject() != null && !posAngleTextBox.hasFocus()) {
             final String newAngle = getDataObject().getPosAngleDegreesStr();
-            if (!newAngle.equals(tbwe.getText())) {
-                tbwe.setText(newAngle);
+            if (!newAngle.equals(posAngleTextBox.getText())) {
+                posAngleTextBox.setText(newAngle);
             }
         }
-        tbwe = getExposureTimeTextBox();
-        // Added this check because TReCS doesn't have an exposure time box!
-        if (tbwe != null && getDataObject() != null) {
+
+        final TextBoxWidget expTimeTextBox = getExposureTimeTextBox();
+        if (expTimeTextBox != null && getDataObject() != null) {
             final String newExpTime = getDataObject().getExposureTimeAsString();
-            if (!newExpTime.equals(tbwe.getText())) {
-                tbwe.setText(newExpTime);
+            if (!newExpTime.equals(expTimeTextBox.getText())) {
+                expTimeTextBox.setText(newExpTime);
             }
         }
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
@@ -5,6 +5,8 @@ import edu.gemini.spModel.obscomp.SPInstObsComp;
 import jsky.app.ot.editor.OtItemEditor;
 import jsky.util.gui.TextBoxWidget;
 
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -40,6 +42,17 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
             if (getPosAngleTextBox() != null) {
                 getPosAngleTextBox().setText(getDataObject().getPosAngleDegreesStr());
                 getPosAngleTextBox().addWatcher(this);
+
+                // We now ignore changes to the pos angle if the text field is being edited.
+                // As a result, make sure everything is synched when editing starts / stops.
+                getPosAngleTextBox().addFocusListener(new FocusAdapter() {
+                    @Override public void focusLost(final FocusEvent e) {
+                        updatePosAngle();
+                    }
+                    @Override public void focusGained(final FocusEvent e) {
+                        updatePosAngle();
+                    }
+                });
             }
 
             if (getExposureTimeTextBox() != null) {
@@ -78,7 +91,8 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
         }
     }
 
-    public void propertyChange(final PropertyChangeEvent evt) {
+    // Copy the data model pos angle value to the pos angle text field.
+    private void updatePosAngle() {
         if (_ignoreChanges) return;
 
         // Ignore model changes to the pos angle if the pos angle text box has the focus.
@@ -90,6 +104,11 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
                 posAngleTextBox.setText(newAngle);
             }
         }
+    }
+
+    // Copy the data model exposure time value to the exposure time text field.
+    private void updateExpTime() {
+        if (_ignoreChanges) return;
 
         final TextBoxWidget expTimeTextBox = getExposureTimeTextBox();
         if (expTimeTextBox != null && getDataObject() != null) {
@@ -98,6 +117,11 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
                 expTimeTextBox.setText(newExpTime);
             }
         }
+    }
+
+    public void propertyChange(final PropertyChangeEvent evt) {
+        updatePosAngle();
+        updateExpTime();
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
@@ -79,8 +79,7 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
                     getDataObject().setPosAngleDegrees(tbwe.getDoubleValue(defaultPositionAngle));
                 } else if (tbwe == getExposureTimeTextBox()) {
                     final double expTime    = tbwe.getDoubleValue(getDefaultExposureTime());
-                    final double expTimeAdj = isForceIntegerExposureTime() ? Math.floor(expTime) : expTime;
-                    getDataObject().setExposureTime(expTimeAdj);
+                    getDataObject().setExposureTime(expTime);
                 } else if (tbwe == getCoaddsTextBox()) {
                     final int defaultCoadds = 1;
                     getDataObject().setCoadds(tbwe.getIntegerValue(defaultCoadds));
@@ -93,28 +92,28 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
 
     // Copy the data model pos angle value to the pos angle text field.
     private void updatePosAngle() {
-        if (_ignoreChanges) return;
-
-        // Ignore model changes to the pos angle if the pos angle text box has the focus.
-        // This is to avoid changing the text box value when BAGS selects an auto group at +180.
-        final TextBoxWidget posAngleTextBox = getPosAngleTextBox();
-        if (posAngleTextBox != null && getDataObject() != null && !posAngleTextBox.hasFocus()) {
-            final String newAngle = getDataObject().getPosAngleDegreesStr();
-            if (!newAngle.equals(posAngleTextBox.getText())) {
-                posAngleTextBox.setText(newAngle);
+        if (!_ignoreChanges) {
+            // Ignore model changes to the pos angle if the pos angle text box has the focus.
+            // This is to avoid changing the text box value when BAGS selects an auto group at +180.
+            final TextBoxWidget posAngleTextBox = getPosAngleTextBox();
+            if (posAngleTextBox != null && getDataObject() != null && !posAngleTextBox.hasFocus()) {
+                final String newAngle = getDataObject().getPosAngleDegreesStr();
+                if (!newAngle.equals(posAngleTextBox.getText())) {
+                    posAngleTextBox.setText(newAngle);
+                }
             }
         }
     }
 
     // Copy the data model exposure time value to the exposure time text field.
     private void updateExpTime() {
-        if (_ignoreChanges) return;
-
-        final TextBoxWidget expTimeTextBox = getExposureTimeTextBox();
-        if (expTimeTextBox != null && getDataObject() != null) {
-            final String newExpTime = getDataObject().getExposureTimeAsString();
-            if (!newExpTime.equals(expTimeTextBox.getText())) {
-                expTimeTextBox.setText(newExpTime);
+        if (!_ignoreChanges) {
+            final TextBoxWidget expTimeTextBox = getExposureTimeTextBox();
+            if (expTimeTextBox != null && getDataObject() != null) {
+                final String newExpTime = getDataObject().getExposureTimeAsString();
+                if (!newExpTime.equals(expTimeTextBox.getText())) {
+                    expTimeTextBox.setText(newExpTime);
+                }
             }
         }
     }
@@ -141,11 +140,6 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
     /** The default exposure time. Subclasses can override. **/
     protected double getDefaultExposureTime() {
         return 60.0;
-    }
-
-    /** If true, force an integer exposure time. Subclasses can override. **/
-    protected boolean isForceIntegerExposureTime() {
-        return false;
     }
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -4,7 +4,7 @@ import java.awt.CardLayout
 import java.text.NumberFormat
 import java.util.Locale
 
-import edu.gemini.pot.sp.{SPComponentType, ISPObsComponent}
+import edu.gemini.pot.sp.{ISPObsComponent, SPComponentType}
 import edu.gemini.shared.gui.EnableDisableComboBox
 import edu.gemini.skycalc.Angle
 import edu.gemini.spModel.core.Site
@@ -19,10 +19,10 @@ import jsky.app.ot.util.OtColor
 
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
-import scala.swing.event.{SelectionChanged, ValueChanged}
+import scala.swing.event.{FocusGained, FocusLost, SelectionChanged, ValueChanged}
 import scala.util.Try
-
-import scalaz._, Scalaz._
+import scalaz._
+import Scalaz._
 
 
 class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
@@ -75,6 +75,9 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
         ui.parallacticAngleControlsOpt.foreach(_.positionAngleChanged(positionAngleTextField.text))
         ui.positionAngleTextField.validate()
         copyPosAngleToInstrument()
+
+      case FocusGained(`positionAngleTextField`, _, _) | FocusLost(`positionAngleTextField`, _, _) =>
+        editor.foreach(e => ui.positionAngleTextField.text = numberFormatter.format(e.getDataObject.getPosAngle))
     }
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -77,7 +77,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
         copyPosAngleToInstrument()
 
       case FocusGained(`positionAngleTextField`, _, _) | FocusLost(`positionAngleTextField`, _, _) =>
-        editor.foreach(e => ui.positionAngleTextField.text = numberFormatter.format(e.getDataObject.getPosAngle))
+        copyPosAngleToTextField()
     }
 
 
@@ -194,7 +194,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     // Ignore changes to the position angle text field if it is being edited, i.e. has the focus.
     // This is to avoid BAGS changing the contents to +180 while editing is occurring.
     if (!ui.positionAngleTextField.hasFocus) {
-      ui.positionAngleTextField.text = numberFormatter.format(instrument.getPosAngle)
+      copyPosAngleToTextField()
     }
     ui.positionAngleTextField.enabled = instrument.getPosAngleConstraint != PosAngleConstraint.UNBOUNDED
     ui.controlsPanel.updatePanel()
@@ -220,6 +220,18 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       e.getDataObject.setPosAngle(a)
     }
 
+  /**
+    * Copies the position angle in the data object to the position angle text field.
+    */
+  private def copyPosAngleToTextField(): Unit = {
+    editor.foreach(e => {
+      val newAngleStr = numberFormatter.format(e.getDataObject.getPosAngleDegrees)
+      val oldAngleStr = ui.positionAngleTextField.text
+      if (!newAngleStr.equals(oldAngleStr)) {
+        ui.positionAngleTextField.text = newAngleStr
+      }
+    })
+  }
 
   /**
    * Called whenever a selection is made in the position angle constraint combo box.


### PR DESCRIPTION
Changing the position angle for an instrument can trigger a BAGS lookup, and if the position angle constraint is set to allow 180 degree flips, then when BAGS selects an auto group, if the auto group is at +180, the position angle text field in the instrument editors will be reflected to show this.

This is problematic when the user is editing the position angle text field, which triggers BAGS lookups, which can set the PA and thus contents of the field currently being edited.

This change simply ignores overwriting the contents of the PA text field if the field has the focus, i.e. is currently being edited. Thus, while BAGS may store PA in the model, the text field is not updated while edited.

Once the focus is gained / lost, if necessary, the text field is updated to reflect the model as well.