### PR TITLE
REL-492: GMOS ITC warning when 4x spectral binning selected with IFU …

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -335,6 +335,11 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
             if ((gp.fpMask().isIFU() || isIfu2()) && gp.spatialBinning() != 1) {
                 add (new ItcWarning("Spatial binning is strongly discouraged with IFU observations."));
             }
+            if ((gp.fpMask().isIFU() || isIfu2()) && gp.spectralBinning() == 4) {
+                add (new ItcWarning("THE SPECTRAL RESOLUTION IS UNDERSAMPLED. " +
+                        "The effective slit width of the IFU fibers is 0.31 arcsec, " +
+                        "and binning by four yields fewer than 1 pixel per resolution element for all gratings. "));
+            }
         }};
     }
 


### PR DESCRIPTION
…mode.

After consulting with Andy and Kathy, this is the warning that is generated when spectral binning equals 4.  Should look good in the OT too.