### PR TITLE
REL-2709 ephemeris for remaining obs time

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
@@ -50,7 +50,7 @@ package object core {
     /** Construct an exact or interpolated slice. */
     def iSlice(lo: K, hi: K): Option[K ==>> V] =
       ^(iLookup(lo), iLookup(hi)) { (lov, hiv) =>
-        m.trim(O(_, lo), O(_, hi)) + (lo -> lov) + (hi -> hiv)
+        m.filterWithKey((k, _) => O.greaterThanOrEqual(k, lo) && O.lessThanOrEqual(k, hi)) + (lo -> lov) + (hi -> hiv)
       }
 
     /** Construct a table of (K, V) values on the given interval. */


### PR DESCRIPTION
This finishes up REL-2709. The ephemeris track is now highlighted from the current time through the end of the scheduling block (or remaining obs time if scheduling block duration is unspecified).

![image](https://cloud.githubusercontent.com/assets/1200131/14691514/7a1a37b2-0706-11e6-8339-d2c5bb69d2a7.png)

