### PR TITLE
Revert "Remove seqexec related bundles"

### DIFF
--- a/app/all-bundles/build.sbt
+++ b/app/all-bundles/build.sbt
@@ -35,6 +35,8 @@ ocsAppManifest := {
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_qpt_server).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_qpt_server).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_qpt_shared).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_qpt_shared).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_qv_plugin).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_qv_plugin).value)),
+    BundleSpec((sbt.Keys.name in bundle_edu_gemini_seqexec_server).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_seqexec_server).value)),
+    BundleSpec((sbt.Keys.name in bundle_edu_gemini_seqexec_shared).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_seqexec_shared).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_services_client).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_services_client).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_services_server).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_services_server).value)),
     BundleSpec((sbt.Keys.name in bundle_edu_gemini_shared_ca).value, Version.parse((sbt.Keys.version in bundle_edu_gemini_shared_ca).value)),

--- a/app/seqexec-server/build.sbt
+++ b/app/seqexec-server/build.sbt
@@ -1,0 +1,113 @@
+import OcsKeys._
+import edu.gemini.osgi.tools.Version
+import edu.gemini.osgi.tools.app.{ Configuration => AppConfig, _ }
+import edu.gemini.osgi.tools.app.Configuration.Distribution.{ Test => TestDistro, _ }
+
+ocsAppSettings
+
+ocsAppManifest := {
+  val v = ocsVersion.value.toBundleVersion
+  Application(
+    id = "seqexec-server", 
+    name = "Seqexec Server",
+    version = ocsVersion.value.toString,
+    configs = List(
+      common(v),
+        development(v),
+        with_test_dbs(v),
+          mac_test(v),
+          linux64_test(v),
+        with_production_dbs(v),
+          mac(v),
+          linux64(v)
+      )
+    )
+}
+
+// COMMON
+def common(version: Version) = AppConfig(
+  id = "common",
+  vmargs = List(
+    "-Xmx1024M"
+  ),
+  props = Map(
+    "org.osgi.framework.storage.clean"                 -> "onFirstInit",
+    "edu.gemini.spdb.mode"                             -> "api",
+    "org.osgi.framework.startlevel.beginning"          -> "100",
+    "edu.gemini.util.security.auth.ui.showDatabaseTab" -> "true",
+          "org.osgi.framework.bootdelegation"          -> "*"
+  ),
+  log = Some("%a/log/seqexec.%u.%g.log"),
+  bundles = List(
+    BundleSpec("edu.gemini.ags",               version),
+    BundleSpec("edu.gemini.osgi.main",         Version(4,  2, 1)),
+    BundleSpec("edu.gemini.seqexec.server",    version),
+    BundleSpec("edu.gemini.shared.gui",        version),
+    BundleSpec("edu.gemini.spModel.io",        version),
+    BundleSpec("edu.gemini.spModel.smartgcal", version),
+    BundleSpec("edu.gemini.epics.acm",         version),
+    BundleSpec("slf4j.api",                    Version(1, 6, 4)),
+    BundleSpec("slf4j.jdk14",                  Version(1, 6, 4)),
+    BundleSpec("org.apache.commons.logging",   Version(1, 1, 0)),
+    BundleSpec("com.squants",                  Version(0, 6, 1))
+  )
+)
+
+// WITH-TEST-DBS
+def with_test_dbs(version: Version) = AppConfig(
+  id = "with-test-dbs",
+  props = Map(
+    "edu.gemini.util.trpc.peer.GN" -> "gnodbtest2.gemini.edu:8443:Gemini North ODB (Test)",
+    "edu.gemini.util.trpc.peer.GS" -> "gsodbtest2.gemini.edu:8443:Gemini South ODB (Test)"
+    )
+) extending List(common(version))
+
+// WITH-PRODUCTION-DBS
+def with_production_dbs(version: Version) = AppConfig(
+  id = "with-production-dbs",
+  props = Map(
+    "edu.gemini.util.trpc.peer.GN" -> "gnodb.gemini.edu:8443:Gemini North ODB (Test)",
+    "edu.gemini.util.trpc.peer.GS" -> "gsodb.gemini.edu:8443:Gemini South ODB (Test)"
+  )
+) extending List(common(version))
+
+// MAC-TEST
+def mac_test(version: Version) = AppConfig(
+  id = "mac-test",
+  distribution = List(MacOS),
+  log = Some("%h/Library/Logs/edu.gemini.seqexec/seqexec.%u.%g.log")
+) extending List(with_test_dbs(version))
+
+// MAC
+def mac(version: Version) = AppConfig(
+  id = "mac",
+  distribution = List(MacOS),
+  log = Some("%h/Library/Logs/edu.gemini.seqexec/seqexec.%u.%g.log")
+) extending List(with_production_dbs(version))
+
+// LINUX64-TEST
+def linux64_test(version: Version) = AppConfig(
+  id = "linux64-test",
+  distribution = List(Linux64)
+) extending List(with_test_dbs(version))
+
+// LINUX64
+def linux64(version: Version) = AppConfig(
+  id = "linux64",
+  distribution = List(Linux64)
+) extending List(with_production_dbs(version))
+
+// DEVELOPMENT
+def development(version: Version) = AppConfig(
+  id = "development",
+  distribution = List(TestDistro),
+  props = Map(
+    "edu.gemini.util.trpc.peer.GN" -> "localhost:8443:Gemini North ODB (Local)",
+    "edu.gemini.util.trpc.peer.GS" -> "localhost:8443:Gemini South ODB (Local)"
+  ),
+  bundles = List(
+    BundleSpec(99, "org.apache.felix.gogo.runtime", Version(0, 10, 0)),
+    BundleSpec(99, "org.apache.felix.gogo.command", Version(0, 12, 0)),
+    BundleSpec(99, "org.apache.felix.gogo.shell",   Version(0, 10, 0))
+  )
+) extending List(common(version))

--- a/bundle/edu.gemini.seqexec.server/TCS_Configuration.md
+++ b/bundle/edu.gemini.seqexec.server/TCS_Configuration.md
@@ -1,0 +1,77 @@
+# Step Execution
+The execution of a step in a sequence involves two stages:
+1. The configuration of all the systems involved, normally the telescope, the instrument, and sometimes GCAL.
+2. The observation itself, that will produce the image.
+
+# TCS Configuration
+All of the telescope systems are configured through TCS, with the exception of some configuration items from GeMS and
+Altair. The TCS configuration applied by Seqexec involves the elements described in the following paragraphs.
+
+# Telescope configuration
+* Telescope offset, for any of three defined positions (A, B and C, although only A is used)
+* Target wavelength, changed to follow filter changes in the instrument.
+* M2 beam: points M2 to one of the three defined positions.
+
+## Guide Configuration
+* M2 tip-tilt guide: activates the processing of tip tilt corrections in M2.
+* M2 tip-tilt correction sources: defines which guiders to use. The alternatives are PWFS1, PWFS2, OIWFS and GAOS (Gems
+or Altair)
+* M2 coma guide: activates the processing of coma corrections in M2.
+* M1 guide: activates the processing of high order corrections in M1.
+* M1 source: defines which guider to use for corrections.
+* Mount guide: activates the offloading of low frequency tip-tilt corrections to the mount.
+
+## Probe Tracking
+Guider probes follow a track provided by TCS to stay on target. The telescope can move (nod) between 3 positions, while
+M2 can also move (chop) between those positions. TCS can be configured to update a probe target track only for certain
+combinations of nod-chop positions. A probe following a target track is then controlled by two configuration elements:
+
+* Follow flag: tells the probe to move following the target track provided by TCS.
+* Nod-chop guide configuration: tells TCS for which positions of M2 and the telescope it should update the target track
+of the probe.
+
+Those configuration elements exist for PWFS1, PWFS2, OIWFS, AOWFS (Altair guide star), Canopus WFS 1 to 3 (GeMS guide
+stars), and GSAOI ODGW 1 to 4 (also for GeMS).
+
+## Probe Parking
+Each probe can be parked when not in use, although sometimes that is not desirable. One such case is in a sequence that
+takes several observations alternating between two positions. One of the guiders may be usable only at one of those
+positions. If that is the case, the probe will not be parked in steps that uses the position that the guider cannot
+reach, so it is already in position on the steps that use the other position.
+
+## AG Configuration
+* Science Fold position
+* HRWFS Probe Position
+
+## Guider Activation
+Each guider can be activated or deactivated. An activated guider takes images and produces optical error measurements.
+
+# Why Configuring TCS Is Not That Simple
+The biggest complication in configuring the TCS is that certain configurations may affect the guiding. For example, if
+a telescope offset is too big, it may not be possible to move the telescope while guiding. In that case instead of one
+action the configuration must go through three stages:
+
+1. Deactivate guiding. Deactivating the processing of corrections is enough, and that is how it is done in the current
+Seqexec
+2. Change TCS configuration
+3. Reactivate guiding. The processing of corrections is always enabled at this stage, after the TCS configuration has
+settled.
+
+Other conditions that affect the TCS configurations are:
+
+* Inability to use an OIWFS for certain steps. For example, if there is a Dark between two normal observations. In some
+instruments darks are taken closing the instrument cover to block light, which will also block the light to the
+instrument guider. A similar case is when taking a calibration.
+* Some instrument guiders have special requirements. For example, NICI required to block the light to its internal AO
+every time the telescope was moved.
+* Altair and GeMS have themselves some special behaviors. It is desirable that those behaviors are encapsulated (and not
+all over the code, like in the current Seqexec)
+
+Most of those behaviors depend on how the TCS configuration will change, which in turn points to the need to compute the
+set of changes before they are applied.
+
+# Structure of the TCS Configuration Code
+The code that configures TCS will be separated in at least two layers. At the top layer is the code that translates
+the step parameters to a TCS configuration and deals with the details described above. The bottom layer deals with the
+actual TCS, reading its state and sending commands to it. The bottom layer behavior will be defined by an interface. A
+dummy implementation will be created for testing purposes.

--- a/bundle/edu.gemini.seqexec.server/build.sbt
+++ b/bundle/edu.gemini.seqexec.server/build.sbt
@@ -1,0 +1,34 @@
+
+
+// note: inter-project dependencies are declared at the top, in projects.sbt
+
+name := "edu.gemini.seqexec.server"
+
+// version set in ThisBuild
+
+unmanagedJars in Compile ++= Seq(
+  new File(baseDirectory.value, "../../lib/bundle/squants_2.11-0.6.1.jar"),
+  new File(baseDirectory.value, "../../lib/bundle/org-apache-commons-httpclient_2.10-2.0.0.jar"),
+  new File(baseDirectory.value, "../../lib/bundle/argonaut_2.11-6.2.jar"),
+  new File(baseDirectory.value, "../../lib/bundle/monocle-core_2.11-1.2.1.jar"),
+  new File(baseDirectory.value, "../../lib/bundle/monocle-macro_2.11-1.2.1.jar")
+)
+
+libraryDependencies ++= Seq(
+  "org.scala-lang" %  "scala-compiler"    % "2.11.7",
+  "org.scodec"     %% "scodec-bits"       % "1.0.9",
+  "org.scalaz"     %% "scalaz-core"       % ScalaZVersion,
+  "org.scalaz"     %% "scalaz-concurrent" % ScalaZVersion)
+
+
+osgiSettings
+
+ocsBundleSettings
+
+OsgiKeys.bundleActivator := Some("edu.gemini.seqexec.server.osgi.Activator")
+
+OsgiKeys.bundleSymbolicName := name.value
+
+OsgiKeys.dynamicImportPackage := Seq("")
+
+OsgiKeys.exportPackage := Seq()

--- a/bundle/edu.gemini.seqexec.server/src/main/java/edu/gemini/seqexec/server/tcs/BinaryEnabledDisabled.java
+++ b/bundle/edu.gemini.seqexec.server/src/main/java/edu/gemini/seqexec/server/tcs/BinaryEnabledDisabled.java
@@ -1,0 +1,9 @@
+package edu.gemini.seqexec.server.tcs;
+
+/**
+ * Created by jluhrs on 10/19/15.
+ */
+public enum BinaryEnabledDisabled {
+    Disabled,
+    Enabled
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/java/edu/gemini/seqexec/server/tcs/BinaryOnOff.java
+++ b/bundle/edu.gemini.seqexec.server/src/main/java/edu/gemini/seqexec/server/tcs/BinaryOnOff.java
@@ -1,0 +1,9 @@
+package edu.gemini.seqexec.server.tcs;
+
+/**
+ * Created by jluhrs on 10/15/15.
+ */
+public enum BinaryOnOff {
+    Off,
+    On
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/java/edu/gemini/seqexec/server/tcs/BinaryYesNo.java
+++ b/bundle/edu.gemini.seqexec.server/src/main/java/edu/gemini/seqexec/server/tcs/BinaryYesNo.java
@@ -1,0 +1,9 @@
+package edu.gemini.seqexec.server.tcs;
+
+/**
+ * Created by jluhrs on 10/16/15.
+ */
+public enum BinaryYesNo {
+    No,
+    Yes
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/resources/Flamingos2.xml
+++ b/bundle/edu.gemini.seqexec.server/src/main/resources/Flamingos2.xml
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Records xmlns="http://www.gemini.edu/CaSchema">
+    <Top name="f2">f2</Top>
+    <Apply name="flamingos2::apply">
+        <top>f2</top>
+        <apply>apply</apply>
+        <car>applyC</car>
+        <description>IS Primary Apply Record</description>
+        <command name="flamingos2::dcconfig">
+            <description>Setup a DC Configuration</description>
+            <parameter name="biasMode">
+                <channel>observationSetup.D</channel>
+                <type>STRING</type>
+                <description>Bias mode (Imaging | Long_Slit | Mos)</description>
+            </parameter>
+            <parameter name="numReads">
+                <channel>observationSetup.B</channel>
+                <type>INTEGER</type>
+                <description>Number of non-destructive reads</description>
+                <isCAD>false</isCAD>
+            </parameter>
+            <parameter name="readoutMode">
+                <channel>observationSetup.C</channel>
+                <type>STRING</type>
+                <description>Readout mode (SCI | ENG)</description>
+            </parameter>
+            <parameter name="exposureTime">
+                <channel>observationSetup.A</channel>
+                <type>DOUBLE</type>
+                <description>Integration time</description>
+                <isCAD>false</isCAD>
+            </parameter>
+        </command>
+        <command name="flamingos2::continue">
+            <record>continue</record>
+            <description>Continue observation</description>
+        </command>
+        <command name="flamingos2::abort">
+            <record>abort</record>
+            <description>Abort observation</description>
+        </command>
+        <command name="flamingos2::config">
+            <description>Setup a Configuration</description>
+            <parameter name="useElectronicOffsetting">
+                <channel>wfs:followA.K</channel>
+                <type>INTEGER</type>
+                <description>0 Electronic Offsets</description>
+            </parameter>
+            <parameter name="filter">
+                <channel>instrumentSetup.F</channel>
+                <type>STRING</type>
+                <description>Discrete filter name</description>
+            </parameter>
+            <parameter name="windowCover">
+                <channel>instrumentSetup.C</channel>
+                <type>STRING</type>
+                <description>Window cover position (Open | Closed | Datum | Datum_Offset | Park)</description>
+            </parameter>
+            <parameter name="mos">
+                <channel>instrumentSetup.E</channel>
+                <type>STRING</type>
+                <description>Discrete MOS wheel position </description>
+            </parameter>
+            <parameter name="grism">
+                <channel>instrumentSetup.H</channel>
+                <type>STRING</type>
+                <description>Grism name</description>
+            </parameter>
+            <parameter name="mask">
+                <channel>instrumentSetup.J</channel>
+                <type>STRING</type>
+                <description>Mask name</description>
+            </parameter>
+            <parameter name="decker">
+                <channel>instrumentSetup.D</channel>
+                <type>STRING</type>
+                <description>Discrete decker wheel position (Open | Long_slit | MOS | Datum | Datum_Offset | Park)</description>
+            </parameter>
+            <parameter name="lyot">
+                <channel>instrumentSetup.G</channel>
+                <type>STRING</type>
+                <description>Lyot stop name</description>
+            </parameter>
+        </command>
+        <command name="flamingos2::stop">
+            <record>stop</record>
+            <description>Stop observation</description>
+        </command>
+        <command name="flamingos2::observe">
+            <description>Observe</description>
+            <parameter name="comment">
+                <channel>observe.G</channel>
+                <type>STRING</type>
+                <description>Comment</description>
+            </parameter>
+            <parameter name="label">
+                <channel>observe.A</channel>
+                <type>STRING</type>
+                <description>DHS data label</description>
+            </parameter>
+            <parameter name="pixLUTFile">
+                <channel>observe.H</channel>
+                <type>STRING</type>
+                <description>Pixel re-ordering file.</description>
+            </parameter>
+        </command>
+        <command name="flamingos2::pause">
+            <record>pause</record>
+            <description>Pause observation</description>
+        </command>
+        <command name="flamingos2::endObserve">
+            <record>endObserve</record>
+            <description>End Observe</description>
+        </command>
+    </Apply>
+    <Status name="flamingos2::status">
+        <top>f2</top>
+        <description>flamingos2 status</description>
+        <!--
+        <attribute name="ANALOG">
+            <channel>sad:ANALOG</channel>
+            <type>STRING</type>
+            <description>LS-332 Channel B ON | OFF indicator</description>
+        </attribute>
+        <attribute name="BARCODE">
+            <channel>sad:BARCODE</channel>
+            <type>STRING</type>
+            <description>Barcode number</description>
+        </attribute>
+        -->
+        <attribute name="biasGate">
+            <channel>sad:BIASGATE</channel>
+            <type>STRING</type>
+            <description>Bias Gate (V)</description>
+        </attribute>
+        <attribute name="biasPower">
+            <channel>sad:BIASPWR</channel>
+            <type>STRING</type>
+            <description>Bias Power (V)</description>
+        </attribute>
+        <attribute name="biasVcc">
+            <channel>sad:BIASVCC</channel>
+            <type>STRING</type>
+            <description>Bias Vcc (V)</description>
+        </attribute>
+        <attribute name="biasVreset">
+            <channel>sad:BIASVRES</channel>
+            <type>STRING</type>
+            <description>Bias Vreset (V)</description>
+        </attribute>
+        <attribute name="CAMVAC">
+            <channel>sad:CAMVAC</channel>
+            <type>STRING</type>
+            <description>Camera Dewar Pressure</description>
+        </attribute>
+        <attribute name="CD1_1">
+            <channel>sad:CD1_1</channel>
+            <type>STRING</type>
+            <description>Element of CD matrix</description>
+        </attribute>
+        <attribute name="CD1_2">
+            <channel>sad:CD1_2</channel>
+            <type>STRING</type>
+            <description>Element of CD matrix</description>
+        </attribute>
+        <attribute name="CD2_1">
+            <channel>sad:CD2_1</channel>
+            <type>STRING</type>
+            <description>Element of CD matrix</description>
+        </attribute>
+        <attribute name="CD2_2">
+            <channel>sad:CD2_2</channel>
+            <type>STRING</type>
+            <description>Element of CD matrix</description>
+        </attribute>
+        <attribute name="CHA_APWR">
+            <channel>sad:CHA_APWR</channel>
+            <type>STRING</type>
+            <description>Applied Power for LS-332 Channel A</description>
+        </attribute>
+        <attribute name="CHA_HTPW">
+            <channel>sad:CHA_HTPW</channel>
+            <type>STRING</type>
+            <description>Manually Added Percentage of Heater Power for LS-332 Channel A</description>
+        </attribute>
+        <attribute name="CHA_PID">
+            <channel>sad:CHA_PID</channel>
+            <type>STRING</type>
+            <description>PID Parameters in use for LS-332 Channel A</description>
+        </attribute>
+        <attribute name="CHA_RANG">
+            <channel>sad:CHA_RANG</channel>
+            <type>STRING</type>
+            <description>Heater Power Range Setting for LS-332 Channel A</description>
+        </attribute>
+        <attribute name="CHA_SETP">
+            <channel>sad:CHA_SETP</channel>
+            <type>STRING</type>
+            <description>Set Point Temperature for LS-332 Channel A</description>
+        </attribute>
+        <attribute name="CHB_APWR">
+            <channel>sad:CHB_APWR</channel>
+            <type>STRING</type>
+            <description>Applied Power for LS-332 Channel B</description>
+        </attribute>
+        <attribute name="CHB_HTPW">
+            <channel>sad:CHB_HTPW</channel>
+            <type>STRING</type>
+            <description>Manually Added Percentage of Heater Power for LS-332 Channel B</description>
+        </attribute>
+        <attribute name="CHB_PID">
+            <channel>sad:CHB_PID</channel>
+            <type>STRING</type>
+            <description>PID Parameters in use for LS-332 Channel B</description>
+        </attribute>
+        <attribute name="CHB_SETP">
+            <channel>sad:CHB_SETP</channel>
+            <type>STRING</type>
+            <description>Set Point Temperature for LS-332 Channel B</description>
+        </attribute>
+        <attribute name="CRPIX1">
+            <channel>sad:CRPIX1</channel>
+            <type>STRING</type>
+            <description>Pixel at which CRVAL1 applies</description>
+        </attribute>
+        <attribute name="CRPIX2">
+            <channel>sad:CRPIX2</channel>
+            <type>STRING</type>
+            <description>Pixel at which CRVAL2 applies</description>
+        </attribute>
+        <attribute name="CRVAL1">
+            <channel>sad:CRVAL1</channel>
+            <type>STRING</type>
+            <description>Reference pixel value</description>
+        </attribute>
+        <attribute name="CRVAL2">
+            <channel>sad:CRVAL2</channel>
+            <type>STRING</type>
+            <description>Reference pixel value</description>
+        </attribute>
+        <attribute name="CTYPE1">
+            <channel>sad:CTYPE1</channel>
+            <type>STRING</type>
+            <description>Coordinate 1 type</description>
+        </attribute>
+        <attribute name="CTYPE2">
+            <channel>sad:CTYPE2</channel>
+            <type>STRING</type>
+            <description>Coordinate 2 type</description>
+        </attribute>
+        <!--
+        <attribute name="CWAVE">
+            <channel>sad:CWAVE</channel>
+            <type>STRING</type>
+            <description>Central wavelength (micron)</description>
+        </attribute>
+        -->
+        <attribute name="DCKRSTEP">
+            <channel>sad:DCKRSTEP</channel>
+            <type>STRING</type>
+            <description>Current Decker Wheel Motor Step Count</description>
+        </attribute>
+        <attribute name="decker">
+            <channel>sad:DECKER</channel>
+            <type>STRING</type>
+            <description>Decker wheel named position</description>
+        </attribute>
+        <attribute name="DETID">
+            <channel>sad:DETID</channel>
+            <type>STRING</type>
+            <description>Detector Serial Number</description>
+        </attribute>
+        <attribute name="DETTYPE">
+            <channel>sad:DETTYPE</channel>
+            <type>STRING</type>
+            <description>Description of detector array type</description>
+        </attribute>
+        <attribute name="exposureTime">
+            <channel>sad:EXPTIME</channel>
+            <type>STRING</type>
+            <description>Current detector single image integration time in seconds</description>
+        </attribute>
+        <attribute name="FIL1STEP">
+            <channel>sad:FIL1STEP</channel>
+            <type>STRING</type>
+            <description>Current Filter Wheel 1 Motor Step Count</description>
+        </attribute>
+        <attribute name="FIL2STEP">
+            <channel>sad:FIL2STEP</channel>
+            <type>STRING</type>
+            <description>Current Filter Wheel 2 Motor Step Count</description>
+        </attribute>
+        <attribute name="FILTER1">
+            <channel>sad:FILTER1</channel>
+            <type>STRING</type>
+            <description>Filter wheel 1 named position</description>
+        </attribute>
+        <attribute name="FILTER2">
+            <channel>sad:FILTER2</channel>
+            <type>STRING</type>
+            <description>Filter wheel 2 named position</description>
+        </attribute>
+        <attribute name="filter">
+            <channel>sad:FILTER</channel>
+            <type>STRING</type>
+            <description>Virtual filter wheel current position (by name)</description>
+        </attribute>
+        <!--
+        <attribute name="useElectronicOffsetting">
+            <channel>wfs:followA.K</channel>
+            <type>INTEGER</type>
+            <description>Electronic Offsets on/off </description>
+        </attribute>
+        -->
+        <attribute name="focus">
+            <channel>sad:FOCUS</channel>
+            <type>STRING</type>
+            <description>Detector focus position name</description>
+        </attribute>
+        <attribute name="FOCUSTEP">
+            <channel>sad:FOCUSTEP</channel>
+            <type>STRING</type>
+            <description>Current Detector Focus Motor Step Count</description>
+        </attribute>
+        <attribute name="grism">
+            <channel>sad:GRISM</channel>
+            <type>STRING</type>
+            <description>Grism name</description>
+        </attribute>
+        <attribute name="GRSMSTEP">
+            <channel>sad:GRSMSTEP</channel>
+            <type>STRING</type>
+            <description>Current Grism Wheel Motor Step Count</description>
+        </attribute>
+        <attribute name="INHEALTH">
+            <channel>health</channel>
+            <type>STRING</type>
+            <description>Instrument health (GOOD | WARNING | BAD)</description>
+        </attribute>
+        <!--
+        <attribute name="INPORT">
+            <channel>issPort</channel>
+            <type>STRING</type>
+            <description>ISS port number</description>
+        </attribute>
+        -->
+        <attribute name="INSTATE">
+            <channel>state</channel>
+            <type>STRING</type>
+            <description>Instrument state</description>
+        </attribute>
+        <attribute name="lnrs">
+            <channel>sad:LNRS</channel>
+            <type>STRING</type>
+            <description>Current number of non-destructive reads</description>
+        </attribute>
+        <attribute name="lyot">
+            <channel>sad:LYOT</channel>
+            <type>STRING</type>
+            <description>Lyot name</description>
+        </attribute>
+        <attribute name="LYOTSTEP">
+            <channel>sad:LYOTSTEP</channel>
+            <type>STRING</type>
+            <description>Current Lyot Wheel Motor Step Count</description>
+        </attribute>
+        <attribute name="mask">
+            <channel>sad:MASKNAME</channel>
+            <type>STRING</type>
+            <description>MOS mask name</description>
+        </attribute>
+        <attribute name="mos">
+            <channel>sad:MOSPOS</channel>
+            <type>STRING</type>
+            <description>MOS wheel position (by name)	</description>
+        </attribute>
+        <attribute name="MOSSTEP">
+            <channel>sad:MOSSTEP</channel>
+            <type>STRING</type>
+            <description>Current MOS Wheel Motor Step Count</description>
+        </attribute>
+        <attribute name="MOSVAC">
+            <channel>sad:MOSVAC</channel>
+            <type>STRING</type>
+            <description>Mos Dewar Pressure</description>
+        </attribute>
+        <attribute name="INSTRUME">
+            <channel>name</channel>
+            <type>STRING</type>
+            <description>Instrument name (Flamingos-2)</description>
+        </attribute>
+        <!--
+        <attribute name="PA">
+            <channel>sad:PA</channel>
+            <type>STRING</type>
+            <description>Instrument Position Angle</description>
+        </attribute>
+        -->
+        <attribute name="PIXSCALE">
+            <channel>sad:PIXSCALE</channel>
+            <type>STRING</type>
+            <description>Plate scale in arcseconds per pixel</description>
+        </attribute>
+        <attribute name="TEMP_CH1">
+            <channel>sad:TEMP_CH1</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 1 Coldhead Stage 1 Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CH2">
+            <channel>sad:TEMP_CH2</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 2 Coldhead Stage 2 Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CH3">
+            <channel>sad:TEMP_CH3</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 3 MOS Bench Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CH4">
+            <channel>sad:TEMP_CH4</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 4 MOS Bench Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CH5">
+            <channel>sad:TEMP_CH5</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 5 Coldhead Stage 1 Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CH6">
+            <channel>sad:TEMP_CH6</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 6 Cold Finger Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CH7">
+            <channel>sad:TEMP_CH7</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 7 Camera Bench Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CH8">
+            <channel>sad:TEMP_CH8</channel>
+            <type>STRING</type>
+            <description>LS-218 Channel 8 Camera Bench Temperature</description>
+        </attribute>
+        <attribute name="TEMP_CHA">
+            <channel>sad:TEMP_CHA</channel>
+            <type>STRING</type>
+            <description>Temperature reported by LS-332 Channel A</description>
+        </attribute>
+        <attribute name="TEMP_CHB">
+            <channel>sad:TEMP_CHB</channel>
+            <type>STRING</type>
+            <description>Temperature reported by LS-332 Channel B</description>
+        </attribute>
+        <attribute name="WCSDIM">
+            <channel>sad:WCSDIM</channel>
+            <type>STRING</type>
+            <description>Dimensionality of image</description>
+        </attribute>
+        <!--
+        <attribute name="WDELTA">
+            <channel>sad:WDELTA</channel>
+            <type>STRING</type>
+            <description>Dispersion</description>
+        </attribute>
+        -->
+        <attribute name="windowCover">
+            <channel>sad:WINDOW</channel>
+            <type>STRING</type>
+            <description>Window cover current position (by name)</description>
+        </attribute>
+        <attribute name="WINSTEP">
+            <channel>sad:WINSTEP</channel>
+            <type>STRING</type>
+            <description>Current Window Motor Step Count</description>
+        </attribute>
+        <!--
+        <attribute name="WREFPIX">
+            <channel>sad:WREFPIX</channel>
+            <type>STRING</type>
+            <description>Reference pixel for wavelength scale</description>
+        </attribute>
+        -->
+    </Status>
+</Records>

--- a/bundle/edu.gemini.seqexec.server/src/main/resources/Tcs.xml
+++ b/bundle/edu.gemini.seqexec.server/src/main/resources/Tcs.xml
@@ -1,0 +1,1994 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Records xmlns="http://www.gemini.edu/CaSchema">
+    <Top name="tcs">tcs</Top>
+    <Top name="m2">m2</Top>
+    <Top name="ag">ag</Top>
+    <Top name="oiwfs">oiwfs</Top>
+    <Top name="ao">ao</Top>
+    <!--
+    <Top name="bto">bto</Top>
+    <Apply name="btoFsaApply">
+        <top>bto</top>
+        <apply>apply</apply>
+        <car>FSALoopCtrlC</car>
+        <description>FSA controller</description>
+        <command name="btoFsaLoopCtrl">
+            <record>apply</record>
+            <description>Bto Loop control</description>
+            <parameter name="loop">
+                <channel>FSALoopCtrl.A</channel>
+                <type>STRING</type>
+                <description>Loop control loop</description>
+            </parameter>
+        </command>
+    </Apply>
+    -->
+    <Apply name="tcsApply">
+        <top>tcs</top>
+        <apply>apply</apply>
+        <car>applyC</car>
+        <description>Primary TCS Apply Record</description>
+        <command name="pwfs1Observe">
+            <description>Start P1</description>
+            <parameter name="int">
+                <channel>pwfs1Observe.B</channel>
+                <type>DOUBLE</type>
+                <description>interval</description>
+            </parameter>
+            <parameter name="label">
+                <channel>pwfs1Observe.D</channel>
+                <type>STRING</type>
+                <description>DHS label</description>
+            </parameter>
+            <parameter name="path">
+                <channel>pwfs1Observe.F</channel>
+                <type>STRING</type>
+                <description>Path</description>
+            </parameter>
+            <parameter name="noexp">
+                <channel>pwfs1Observe.A</channel>
+                <type>INTEGER</type>
+                <description>Exposures</description>
+            </parameter>
+            <parameter name="output">
+                <channel>pwfs1Observe.E</channel>
+                <type>STRING</type>
+                <description>DHS output</description>
+            </parameter>
+            <parameter name="outopt">
+                <channel>pwfs1Observe.C</channel>
+                <type>STRING</type>
+                <description>Output options</description>
+            </parameter>
+            <parameter name="name">
+                <channel>pwfs1Observe.G</channel>
+                <type>STRING</type>
+                <description>Filename</description>
+            </parameter>
+        </command>
+        <command name="pwfs2Observe">
+            <description>Start P2</description>
+            <parameter name="name">
+                <channel>pwfs2Observe.G</channel>
+                <type>STRING</type>
+                <description>Filename</description>
+            </parameter>
+            <parameter name="path">
+                <channel>pwfs2Observe.F</channel>
+                <type>STRING</type>
+                <description>Path</description>
+            </parameter>
+            <parameter name="noexp">
+                <channel>pwfs2Observe.A</channel>
+                <type>INTEGER</type>
+                <description>Exposures</description>
+            </parameter>
+            <parameter name="outopt">
+                <channel>pwfs2Observe.C</channel>
+                <type>STRING</type>
+                <description>Output options</description>
+            </parameter>
+            <parameter name="output">
+                <channel>pwfs2Observe.E</channel>
+                <type>STRING</type>
+                <description>DHS output</description>
+            </parameter>
+            <parameter name="int">
+                <channel>pwfs2Observe.B</channel>
+                <type>DOUBLE</type>
+                <description>interval</description>
+            </parameter>
+            <parameter name="label">
+                <channel>pwfs2Observe.D</channel>
+                <type>STRING</type>
+                <description>DHS label</description>
+            </parameter>
+        </command>
+        <command name="oiwfsObserve">
+            <description>Start OIWFS</description>
+            <parameter name="output">
+                <channel>oiwfsObserve.E</channel>
+                <type>STRING</type>
+                <description>DHS output</description>
+            </parameter>
+            <parameter name="int">
+                <channel>oiwfsObserve.B</channel>
+                <type>DOUBLE</type>
+                <description>interval</description>
+            </parameter>
+            <parameter name="path">
+                <channel>oiwfsObserve.F</channel>
+                <type>STRING</type>
+                <description>Path</description>
+            </parameter>
+            <parameter name="label">
+                <channel>oiwfsObserve.D</channel>
+                <type>STRING</type>
+                <description>DHS label</description>
+            </parameter>
+            <parameter name="outopt">
+                <channel>oiwfsObserve.C</channel>
+                <type>STRING</type>
+                <description>Output options</description>
+            </parameter>
+            <parameter name="noexp">
+                <channel>oiwfsObserve.A</channel>
+                <type>INTEGER</type>
+                <description>Exposures</description>
+            </parameter>
+            <parameter name="name">
+                <channel>oiwfsObserve.G</channel>
+                <type>STRING</type>
+                <description>Filename</description>
+            </parameter>
+        </command>
+        <command name="m2GuideMode">
+            <description>M2 Guiding Mode</description>
+            <parameter name="coma">
+                <channel>m2GuideMode.B</channel>
+                <type>STRING</type>
+                <description>Apply Coma Correction</description>
+            </parameter>
+        </command>
+        <command name="offsetPoB1">
+            <description>Offset pointing origin B1</description>
+            <parameter name="y">
+                <channel>offsetPoB1.B</channel>
+                <type>DOUBLE</type>
+                <description>0 Y</description>
+            </parameter>
+            <parameter name="x">
+                <channel>offsetPoB1.A</channel>
+                <type>DOUBLE</type>
+                <description>0 X</description>
+            </parameter>
+        </command>
+        <command name="ngsPr3Park">
+            <record>ngsPr3Park</record>
+            <description>Canopus probe 3 park</description>
+        </command>
+        <command name="aoOiwfsSource">
+            <description>ALTAIR OIWFS source</description>
+            <parameter name="state">
+                <channel>aoOiwfsSource.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+            <parameter name="bandwidth">
+                <channel>aoOiwfsSource.B</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="aoFlatten">
+            <record>aoFlatten</record>
+            <description>Flatten AO light path</description>
+        </command>
+        <command name="aoFollow">
+            <description>GAOS probe following</description>
+            <parameter name="followState">
+                <channel>aoFollow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="aoPrepareCm">
+            <description>Prepare ALTAIR control matrix</description>
+            <parameter name="x">
+                <channel>aoPrepareCm.A</channel>
+                <type>STRING</type>
+                <description>Guide star x position</description>
+            </parameter>
+            <parameter name="seeing">
+                <channel>aoPrepareCm.C</channel>
+                <type>STRING</type>
+                <description>Seeing estimate</description>
+            </parameter>
+            <parameter name="windspeed">
+                <channel>aoPrepareCm.E</channel>
+                <type>STRING</type>
+                <description>Windspeed</description>
+            </parameter>
+            <parameter name="gsmag">
+                <channel>aoPrepareCm.D</channel>
+                <type>STRING</type>
+                <description>Guide star magnitude</description>
+            </parameter>
+            <parameter name="y">
+                <channel>aoPrepareCm.B</channel>
+                <type>STRING</type>
+                <description>Guide star y position</description>
+            </parameter>
+        </command>
+        <command name="tcs::continue">
+            <record>continue</record>
+            <description>Continue</description>
+        </command>
+        <command name="odgw3Park">
+            <description>ODGW 3 park</description>
+            <parameter name="command">
+                <channel>odgw3Park.A</channel>
+                <type>STRING</type>
+                <description>Park command</description>
+            </parameter>
+        </command>
+        <command name="ngsPr1Park">
+            <record>ngsPr1Park</record>
+            <description>Canopus probe 1 park</description>
+        </command>
+        <command name="pwfs2Guide">
+            <description>P2 guide configuration</description>
+            <parameter name="nodbchopb">
+                <channel>configPwfs2.E</channel>
+                <type>STRING</type>
+                <description>Nod B Chop B</description>
+            </parameter>
+            <parameter name="nodcchopa">
+                <channel>configPwfs2.G</channel>
+                <type>STRING</type>
+                <description>Nod C Chop A</description>
+            </parameter>
+            <parameter name="nodachopa">
+                <channel>configPwfs2.A</channel>
+                <type>STRING</type>
+                <description>Nod A Chop A</description>
+            </parameter>
+            <parameter name="nodbchopc">
+                <channel>configPwfs2.F</channel>
+                <type>STRING</type>
+                <description>Nod B Chop C</description>
+            </parameter>
+            <parameter name="nodachopb">
+                <channel>configPwfs2.B</channel>
+                <type>STRING</type>
+                <description>Nod A Chop B</description>
+            </parameter>
+            <parameter name="nodcchopb">
+                <channel>configPwfs2.H</channel>
+                <type>STRING</type>
+                <description>Nod C Chop B</description>
+            </parameter>
+            <parameter name="nodcchopc">
+                <channel>configPwfs2.I</channel>
+                <type>STRING</type>
+                <description>Nod C Chop C</description>
+            </parameter>
+            <parameter name="nodachopc">
+                <channel>configPwfs2.C</channel>
+                <type>STRING</type>
+                <description>Nod A Chop C</description>
+            </parameter>
+            <parameter name="nodbchopa">
+                <channel>configPwfs2.D</channel>
+                <type>STRING</type>
+                <description>Nod B Chop A</description>
+            </parameter>
+        </command>
+        <command name="pwfs2StopObserve">
+            <record>pwfs2StopObserve</record>
+            <description>Stop P2</description>
+        </command>
+        <command name="wavelG4">
+            <description>G4 wavelength</description>
+            <parameter name="wavel">
+                <channel>wavelG4.A</channel>
+                <type>DOUBLE</type>
+                <description>Wavelength (mu)</description>
+            </parameter>
+        </command>
+        <command name="odgw2Follow">
+            <description>ODGW 2 following</description>
+            <parameter name="followState">
+                <channel>odgw2Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="ngsPr2Follow">
+            <description>Canopus Guide Star 2 following</description>
+            <parameter name="followState">
+                <channel>ngs2Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="filter1">
+            <description>Target filter</description>
+            <parameter name="shortCircuit">
+                <channel>filter1.D</channel>
+                <type>STRING</type>
+                <description>shortCircuit</description>
+            </parameter>
+            <parameter name="bandwidth">
+                <channel>filter1.A</channel>
+                <type>STRING</type>
+                <description>Bandwidth</description>
+            </parameter>
+            <parameter name="maxv">
+                <channel>filter1.B</channel>
+                <type>STRING</type>
+                <description>Maximum velocity</description>
+            </parameter>
+            <parameter name="grab">
+                <channel>filter1.C</channel>
+                <type>STRING</type>
+                <description>Grab radius</description>
+            </parameter>
+        </command>
+        <command name="wavelG3">
+            <description>G3 wavelength</description>
+            <parameter name="wavel">
+                <channel>wavelG3.A</channel>
+                <type>DOUBLE</type>
+                <description>Wavelength (mu)</description>
+            </parameter>
+        </command>
+        <command name="odgw1Park">
+            <description>ODGW 1 park</description>
+            <parameter name="command">
+                <channel>odgw1Park.A</channel>
+                <type>STRING</type>
+                <description>Park command</description>
+            </parameter>
+        </command>
+        <command name="pwfs2Park">
+            <record>pwfs2Park</record>
+            <description>Park P2</description>
+        </command>
+        <command name="m1Guide">
+            <description>M1 Guiding</description>
+            <parameter name="state">
+                <channel>m1GuideMode.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="aoCorrect">
+            <description>ALTAIR Image correction</description>
+            <parameter name="matrix">
+                <channel>aoCorrect.B</channel>
+                <type>STRING</type>
+                <description>Matrix ID</description>
+            </parameter>
+            <parameter name="gains">
+                <channel>aoCorrect.C</channel>
+                <type>STRING</type>
+                <description>Re-use gains</description>
+            </parameter>
+            <parameter name="correct">
+                <channel>aoCorrect.A</channel>
+                <type>STRING</type>
+                <description>Correction On/OFF</description>
+            </parameter>
+        </command>
+        <command name="oiwfsPark">
+            <record>oiwfsPark</record>
+            <description>Park OIWFS</description>
+        </command>
+        <command name="m2Beam">
+            <description>Select M2 beam</description>
+            <parameter name="beam">
+                <channel>nod.A</channel>
+                <type>STRING</type>
+                <description>0 M2 Beam</description>
+            </parameter>
+        </command>
+        <command name="m2Guide">
+            <description>M2 Guiding</description>
+            <parameter name="state">
+                <channel>m2GuideControl.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="ngsPr1Follow">
+            <description>Canopus Guide Star 1 following</description>
+            <parameter name="followState">
+                <channel>ngs1Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="m2GuideConfig">
+            <description>M2 Guiding Config</description>
+            <parameter name="reset">
+                <channel>m2GuideConfig.G</channel>
+                <type>STRING</type>
+                <description>Reset</description>
+            </parameter>
+            <parameter name="beam">
+                <channel>m2GuideConfig.F</channel>
+                <type>STRING</type>
+                <description>Beam</description>
+            </parameter>
+            <parameter name="source">
+                <channel>m2GuideConfig.A</channel>
+                <type>STRING</type>
+                <description>Source</description>
+            </parameter>
+        </command>
+        <command name="wavelG1">
+            <description>G1 wavelength</description>
+            <parameter name="wavel">
+                <channel>wavelG1.A</channel>
+                <type>DOUBLE</type>
+                <description>Wavelength (mu)</description>
+            </parameter>
+        </command>
+        <command name="wavelSourceC">
+            <description>Source C wavelength</description>
+            <parameter name="wavel">
+                <channel>wavelSourceC.A</channel>
+                <type>DOUBLE</type>
+                <description>Wavelength (mu)</description>
+            </parameter>
+        </command>
+        <command name="scienceFold">
+            <description>Position science fold</description>
+            <parameter name="scfold">
+                <channel>scienceFold.A</channel>
+                <type>STRING</type>
+                <description>Position</description>
+            </parameter>
+        </command>
+        <command name="wavelSourceA">
+            <description>Source A wavelength</description>
+            <parameter name="wavel">
+                <channel>wavelSourceA.A</channel>
+                <type>DOUBLE</type>
+                <description>Wavelength (mu)</description>
+            </parameter>
+        </command>
+        <command name="p1Follow">
+            <description>PWFS1 probe following</description>
+            <parameter name="followState">
+                <channel>pwfs1Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="offsetPoA1">
+            <description>Offset pointing origin A1</description>
+            <parameter name="y">
+                <channel>offsetPoA1.B</channel>
+                <type>DOUBLE</type>
+                <description>0 Y</description>
+            </parameter>
+            <parameter name="x">
+                <channel>offsetPoA1.A</channel>
+                <type>DOUBLE</type>
+                <description>0 X</description>
+            </parameter>
+        </command>
+        <command name="odgw4Park">
+            <description>ODGW 4 park</description>
+            <parameter name="command">
+                <channel>odgw4Park.A</channel>
+                <type>STRING</type>
+                <description>Park command</description>
+            </parameter>
+        </command>
+        <command name="pwfs1StopObserve">
+            <record>pwfs1StopObserve</record>
+            <description>Stop P1</description>
+        </command>
+        <command name="chop">
+            <description>Chopping</description>
+            <parameter name="decs">
+                <channel>chop.B</channel>
+                <type>STRING</type>
+                <description>0 DECS On Off</description>
+            </parameter>
+            <parameter name="onoff">
+                <channel>chop.A</channel>
+                <type>STRING</type>
+                <description>0 Chop On Off</description>
+            </parameter>
+        </command>
+        <command name="mountGuide">
+            <description>Define mount guiding</description>
+            <parameter name="p2weight">
+                <channel>mountGuideMode.D</channel>
+                <type>DOUBLE</type>
+                <description>P2 weight</description>
+            </parameter>
+            <parameter name="source">
+                <channel>mountGuideMode.B</channel>
+                <type>STRING</type>
+                <description>Guide Source</description>
+            </parameter>
+            <parameter name="p1weight">
+                <channel>mountGuideMode.C</channel>
+                <type>DOUBLE</type>
+                <description>P1 weight</description>
+            </parameter>
+            <parameter name="mode">
+                <channel>mountGuideMode.A</channel>
+                <type>STRING</type>
+                <description>Mode</description>
+            </parameter>
+        </command>
+        <command name="tcs::endObserve">
+            <record>endObserve</record>
+            <description>End Observe</description>
+        </command>
+        <command name="chopConfig">
+            <description>Set Chop Config</description>
+            <parameter name="freq">
+                <channel>chopConfig.C</channel>
+                <type>STRING</type>
+                <description>0 Chop Frequency</description>
+            </parameter>
+            <parameter name="dutycycle">
+                <channel>chopConfig.D</channel>
+                <type>STRING</type>
+                <description>0 Chop Duty Cycle</description>
+            </parameter>
+        </command>
+        <command name="oiFollow">
+            <description>OIWFS probe following</description>
+            <parameter name="followState">
+                <channel>oiwfsFollow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="chopRelative">
+            <description>Set Chop Relative</description>
+            <parameter name="angle">
+                <channel>chopRelative.B</channel>
+                <type>STRING</type>
+                <description>0 Chop PA</description>
+            </parameter>
+            <parameter name="throw">
+                <channel>chopRelative.A</channel>
+                <type>STRING</type>
+                <description>0 Chop Throw</description>
+            </parameter>
+        </command>
+        <command name="wavelG2">
+            <description>G2 wavelength</description>
+            <parameter name="wavel">
+                <channel>wavelG2.A</channel>
+                <type>DOUBLE</type>
+                <description>Wavelength (mu)</description>
+            </parameter>
+        </command>
+        <command name="g4Guide">
+            <description>G4 guide configuration</description>
+            <parameter name="nodachopb">
+                <channel>configG4.B</channel>
+                <type>STRING</type>
+                <description>Nod A Chop B</description>
+            </parameter>
+            <parameter name="nodbchopc">
+                <channel>configG4.F</channel>
+                <type>STRING</type>
+                <description>Nod B Chop C</description>
+            </parameter>
+            <parameter name="nodbchopa">
+                <channel>configG4.D</channel>
+                <type>STRING</type>
+                <description>Nod B Chop A</description>
+            </parameter>
+            <parameter name="nodachopc">
+                <channel>configG4.C</channel>
+                <type>STRING</type>
+                <description>Nod A Chop C</description>
+            </parameter>
+            <parameter name="nodcchopb">
+                <channel>configG4.H</channel>
+                <type>STRING</type>
+                <description>Nod C Chop B</description>
+            </parameter>
+            <parameter name="nodachopa">
+                <channel>configG4.A</channel>
+                <type>STRING</type>
+                <description>Nod A Chop A</description>
+            </parameter>
+            <parameter name="nodcchopc">
+                <channel>configG4.I</channel>
+                <type>STRING</type>
+                <description>Nod C Chop C</description>
+            </parameter>
+            <parameter name="nodbchopb">
+                <channel>configG4.E</channel>
+                <type>STRING</type>
+                <description>Nod B Chop B</description>
+            </parameter>
+            <parameter name="nodcchopa">
+                <channel>configG4.G</channel>
+                <type>STRING</type>
+                <description>Nod C Chop A</description>
+            </parameter>
+        </command>
+        <command name="hrwfs">
+            <description>Position acqcam pickoff</description>
+            <parameter name="hrwfsPos">
+                <channel>hrwfs.A</channel>
+                <type>STRING</type>
+                <description>Position</description>
+            </parameter>
+        </command>
+        <command name="pwfs1Guide">
+            <description>P1 guide configuration</description>
+            <parameter name="nodachopb">
+                <channel>configPwfs1.B</channel>
+                <type>STRING</type>
+                <description>Nod A Chop B</description>
+            </parameter>
+            <parameter name="nodachopc">
+                <channel>configPwfs1.C</channel>
+                <type>STRING</type>
+                <description>Nod A Chop C</description>
+            </parameter>
+            <parameter name="nodcchopc">
+                <channel>configPwfs1.I</channel>
+                <type>STRING</type>
+                <description>Nod C Chop C</description>
+            </parameter>
+            <parameter name="nodachopa">
+                <channel>configPwfs1.A</channel>
+                <type>STRING</type>
+                <description>Nod A Chop A</description>
+            </parameter>
+            <parameter name="nodcchopa">
+                <channel>configPwfs1.G</channel>
+                <type>STRING</type>
+                <description>Nod C Chop A</description>
+            </parameter>
+            <parameter name="nodcchopb">
+                <channel>configPwfs1.H</channel>
+                <type>STRING</type>
+                <description>Nod C Chop B</description>
+            </parameter>
+            <parameter name="nodbchopa">
+                <channel>configPwfs1.D</channel>
+                <type>STRING</type>
+                <description>Nod B Chop A</description>
+            </parameter>
+            <parameter name="nodbchopb">
+                <channel>configPwfs1.E</channel>
+                <type>STRING</type>
+                <description>Nod B Chop B</description>
+            </parameter>
+            <parameter name="nodbchopc">
+                <channel>configPwfs1.F</channel>
+                <type>STRING</type>
+                <description>Nod B Chop C</description>
+            </parameter>
+        </command>
+        <command name="p2Follow">
+            <description>PWFS2 probe following</description>
+            <parameter name="followState">
+                <channel>pwfs2Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="tcs::pause">
+            <record>pause</record>
+            <description>Pause</description>
+        </command>
+        <command name="scienceFoldPark">
+            <record>scienceFoldPark</record>
+            <description>Park science fold</description>
+        </command>
+        <command name="wavelSourceB">
+            <description>Source B wavelength</description>
+            <parameter name="wavel">
+                <channel>wavelSourceB.A</channel>
+                <type>DOUBLE</type>
+                <description>Wavelength (mu)</description>
+            </parameter>
+        </command>
+        <command name="ngsPr3Follow">
+            <description>Canopus Guide Star 3 following</description>
+            <parameter name="followState">
+                <channel>ngs3Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="g3Guide">
+            <description>G3 guide configuration</description>
+            <parameter name="nodcchopc">
+                <channel>configG3.I</channel>
+                <type>STRING</type>
+                <description>Nod C Chop C</description>
+            </parameter>
+            <parameter name="nodbchopb">
+                <channel>configG3.E</channel>
+                <type>STRING</type>
+                <description>Nod B Chop B</description>
+            </parameter>
+            <parameter name="nodbchopa">
+                <channel>configG3.D</channel>
+                <type>STRING</type>
+                <description>Nod B Chop A</description>
+            </parameter>
+            <parameter name="nodachopb">
+                <channel>configG3.B</channel>
+                <type>STRING</type>
+                <description>Nod A Chop B</description>
+            </parameter>
+            <parameter name="nodachopa">
+                <channel>configG3.A</channel>
+                <type>STRING</type>
+                <description>Nod A Chop A</description>
+            </parameter>
+            <parameter name="nodcchopb">
+                <channel>configG3.H</channel>
+                <type>STRING</type>
+                <description>Nod C Chop B</description>
+            </parameter>
+            <parameter name="nodachopc">
+                <channel>configG3.C</channel>
+                <type>STRING</type>
+                <description>Nod A Chop C</description>
+            </parameter>
+            <parameter name="nodbchopc">
+                <channel>configG3.F</channel>
+                <type>STRING</type>
+                <description>Nod B Chop C</description>
+            </parameter>
+            <parameter name="nodcchopa">
+                <channel>configG3.G</channel>
+                <type>STRING</type>
+                <description>Nod C Chop A</description>
+            </parameter>
+        </command>
+        <command name="m2GuideReset">
+            <record>m2GuideReset</record>
+            <description>Reset M2 guide configuration</description>
+        </command>
+        <command name="aoStats">
+            <description>ALTAIR statistics</description>
+            <parameter name="trigtime">
+                <channel>aoStats.D</channel>
+                <type>STRING</type>
+                <description>Trigger time</description>
+            </parameter>
+            <parameter name="samples">
+                <channel>aoStats.B</channel>
+                <type>STRING</type>
+                <description>Samples</description>
+            </parameter>
+            <parameter name="filename">
+                <channel>aoStats.A</channel>
+                <type>STRING</type>
+                <description>DHS file name</description>
+            </parameter>
+            <parameter name="interval">
+                <channel>aoStats.C</channel>
+                <type>STRING</type>
+                <description>Interval</description>
+            </parameter>
+        </command>
+        <command name="oiwfsGuide">
+            <description>OIWFS guide configuration</description>
+            <parameter name="nodbchopb">
+                <channel>configOiwfs.E</channel>
+                <type>STRING</type>
+                <description>Nod B Chop B</description>
+            </parameter>
+            <parameter name="nodbchopc">
+                <channel>configOiwfs.F</channel>
+                <type>STRING</type>
+                <description>Nod B Chop C</description>
+            </parameter>
+            <parameter name="nodcchopb">
+                <channel>configOiwfs.H</channel>
+                <type>STRING</type>
+                <description>Nod C Chop B</description>
+            </parameter>
+            <parameter name="nodachopc">
+                <channel>configOiwfs.C</channel>
+                <type>STRING</type>
+                <description>Nod A Chop C</description>
+            </parameter>
+            <parameter name="nodachopa">
+                <channel>configOiwfs.A</channel>
+                <type>STRING</type>
+                <description>Nod A Chop A</description>
+            </parameter>
+            <parameter name="nodachopb">
+                <channel>configOiwfs.B</channel>
+                <type>STRING</type>
+                <description>Nod A Chop B</description>
+            </parameter>
+            <parameter name="nodcchopa">
+                <channel>configOiwfs.G</channel>
+                <type>STRING</type>
+                <description>Nod C Chop A</description>
+            </parameter>
+            <parameter name="nodcchopc">
+                <channel>configOiwfs.I</channel>
+                <type>STRING</type>
+                <description>Nod C Chop C</description>
+            </parameter>
+            <parameter name="nodbchopa">
+                <channel>configOiwfs.D</channel>
+                <type>STRING</type>
+                <description>Nod B Chop A</description>
+            </parameter>
+        </command>
+        <command name="odgw3Follow">
+            <description>ODGW 3 following</description>
+            <parameter name="followState">
+                <channel>odgw3Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="odgw1Follow">
+            <description>ODGW 1 following</description>
+            <parameter name="followState">
+                <channel>odgw1Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="offsetPoC1">
+            <description>Offset pointing origin C1</description>
+            <parameter name="y">
+                <channel>offsetPoC1.B</channel>
+                <type>DOUBLE</type>
+                <description>0 Y</description>
+            </parameter>
+            <parameter name="x">
+                <channel>offsetPoC1.A</channel>
+                <type>DOUBLE</type>
+                <description>0 X</description>
+            </parameter>
+        </command>
+        <command name="oiwfsStopObserve">
+            <record>oiwfsStopObserve</record>
+            <description>Stop OIWFS</description>
+        </command>
+        <command name="g1Guide">
+            <description>G1 guide configuration</description>
+            <parameter name="nodcchopb">
+                <channel>configG1.H</channel>
+                <type>STRING</type>
+                <description>Nod C Chop B</description>
+            </parameter>
+            <parameter name="nodcchopc">
+                <channel>configG1.I</channel>
+                <type>STRING</type>
+                <description>Nod C Chop C</description>
+            </parameter>
+            <parameter name="nodcchopa">
+                <channel>configG1.G</channel>
+                <type>STRING</type>
+                <description>Nod C Chop A</description>
+            </parameter>
+            <parameter name="nodachopb">
+                <channel>configG1.B</channel>
+                <type>STRING</type>
+                <description>Nod A Chop B</description>
+            </parameter>
+            <parameter name="nodbchopa">
+                <channel>configG1.D</channel>
+                <type>STRING</type>
+                <description>Nod B Chop A</description>
+            </parameter>
+            <parameter name="nodbchopc">
+                <channel>configG1.F</channel>
+                <type>STRING</type>
+                <description>Nod B Chop C</description>
+            </parameter>
+            <parameter name="nodbchopb">
+                <channel>configG1.E</channel>
+                <type>STRING</type>
+                <description>Nod B Chop B</description>
+            </parameter>
+            <parameter name="nodachopa">
+                <channel>configG1.A</channel>
+                <type>STRING</type>
+                <description>Nod A Chop A</description>
+            </parameter>
+            <parameter name="nodachopc">
+                <channel>configG1.C</channel>
+                <type>STRING</type>
+                <description>Nod A Chop C</description>
+            </parameter>
+        </command>
+        <command name="g2Guide">
+            <description>G2 guide configuration</description>
+            <parameter name="nodachopb">
+                <channel>configG2.B</channel>
+                <type>STRING</type>
+                <description>Nod A Chop B</description>
+            </parameter>
+            <parameter name="nodcchopa">
+                <channel>configG2.G</channel>
+                <type>STRING</type>
+                <description>Nod C Chop A</description>
+            </parameter>
+            <parameter name="nodbchopb">
+                <channel>configG2.E</channel>
+                <type>STRING</type>
+                <description>Nod B Chop B</description>
+            </parameter>
+            <parameter name="nodachopc">
+                <channel>configG2.C</channel>
+                <type>STRING</type>
+                <description>Nod A Chop C</description>
+            </parameter>
+            <parameter name="nodachopa">
+                <channel>configG2.A</channel>
+                <type>STRING</type>
+                <description>Nod A Chop A</description>
+            </parameter>
+            <parameter name="nodcchopc">
+                <channel>configG2.I</channel>
+                <type>STRING</type>
+                <description>Nod C Chop C</description>
+            </parameter>
+            <parameter name="nodbchopa">
+                <channel>configG2.D</channel>
+                <type>STRING</type>
+                <description>Nod B Chop A</description>
+            </parameter>
+            <parameter name="nodcchopb">
+                <channel>configG2.H</channel>
+                <type>STRING</type>
+                <description>Nod C Chop B</description>
+            </parameter>
+            <parameter name="nodbchopc">
+                <channel>configG2.F</channel>
+                <type>STRING</type>
+                <description>Nod B Chop C</description>
+            </parameter>
+        </command>
+        <command name="odgw2Park">
+            <description>ODGW 2 park</description>
+            <parameter name="command">
+                <channel>odgw2Park.A</channel>
+                <type>STRING</type>
+                <description>Park command</description>
+            </parameter>
+        </command>
+        <command name="hrwfsPark">
+            <record>hrwfsPark</record>
+            <description>Park acqcam pickoff</description>
+        </command>
+        <command name="tcs::observe">
+            <record>observe</record>
+            <description>Observe</description>
+        </command>
+        <command name="pwfs1Park">
+            <record>pwfs1Park</record>
+            <description>Park P1</description>
+        </command>
+        <command name="odgw4Follow">
+            <description>ODGW 4 following</description>
+            <parameter name="followState">
+                <channel>odgw4Follow.A</channel>
+                <type>STRING</type>
+                <description>State</description>
+            </parameter>
+        </command>
+        <command name="ngsPr2Park">
+            <record>ngsPr2Park</record>
+            <description>Canopus probe 2 park</description>
+        </command>
+    </Apply>
+    <!--
+    <Apply name="aolgsApply">
+        <top>ao</top>
+        <apply>wfcs:strap</apply>
+        <car>wfcs:strapGtCtl.BUSY</car>
+        <description>Strap controller</description>
+        <command name="strapCorrCtl">
+            <record>wfcs:strapCorrCtl</record>
+            <description>ALTAIR sfo</description>
+            <parameter name="onoff">
+                <channel>wfcs:strapCorrCtl.A</channel>
+                <type>STRING</type>
+                <description>Strap onoff loop control</description>
+            </parameter>
+        </command>
+        <command name="aoStrap">
+            <record>wfcs:strapGtCtl</record>
+            <description>ALTAIR strap</description>
+            <parameter name="gate">
+                <channel>wfcs:strapGtCtl.A</channel>
+                <type>STRING</type>
+                <description>Gate control</description>
+            </parameter>
+        </command>
+        <command name="aoSfoLoop">
+            <description>ALTAIR sfo</description>
+            <parameter name="onoff">
+                <channel>cc:lgszoomSfoLoop</channel>
+                <type>STRING</type>
+                <description>Sfo loop control</description>
+            </parameter>
+        </command>
+    </Apply>
+    -->
+    <Status name="tcsApply">
+        <top>tcs</top>
+        <attribute name="mess">
+            <channel>applyC.OMSS</channel>
+            <type>STRING</type>
+            <description>Command completion message</description>
+        </attribute>
+    </Status>
+    <Status name="aolgs">
+        <top>ao</top>
+        <!--
+        <attribute name="strapTPStat">
+            <channel>strapDevStatus.VALL</channel>
+            <type>STRING</type>
+            <description>STRAP Temp Ctl Status (1:OK, 0:not OK)</description>
+        </attribute>
+        <attribute name="strapgate">
+            <channel>strapDevStatus.VALH</channel>
+            <type>STRING</type>
+            <description>STRAP gate level</description>
+        </attribute>
+        -->
+        <attribute name="straploop">
+            <channel>wfcs:strapCorrCtl.VALA</channel>
+            <type>INTEGER</type>
+            <description>STRAP loop</description>
+        </attribute>
+        <!--
+        <attribute name="strapRTStat">
+            <channel>strapDevStatus.VALO</channel>
+            <type>STRING</type>
+            <description>STRAP RT Ctl Status (1:OK, 0:not OK)</description>
+        </attribute>
+        <attribute name="strapHVStat">
+            <channel>strapDevStatus.VALI</channel>
+            <type>STRING</type>
+            <description>STRAP HVolt Status (1:OK, 0:not OK)</description>
+        </attribute>
+        <attribute name="sfoloop">
+            <channel>cc:lgszoomSfoLoop</channel>
+            <type>STRING</type>
+            <description>Sfo loop</description>
+        </attribute>
+        -->
+    </Status>
+    <Status name="tcsstate">
+        <top>ao</top>
+        <attribute name="aowfsOn">
+            <channel>wfcs:loopRunning</channel>
+            <type>DOUBLE</type>
+            <description>AO loop on</description>
+        </attribute>
+        <attribute name="decson">
+            <channel>chopControl.VALB</channel>
+            <type>STRING</type>
+            <description>SCS DECS on flag</description>
+            <top>m2</top>
+        </attribute>
+        <attribute name="g3MapName">
+            <channel>guiderConfig.VALC</channel>
+            <type>STRING</type>
+            <description>Name of GeMS WFS for G3</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="port1Label">
+            <channel>port:port1</channel>
+            <type>STRING</type>
+            <description>ISS port 1 label</description>
+            <top>ag</top>
+        </attribute>
+        <!--
+        <attribute name="ngs1Follow">
+            <channel>ngsPr1FollowStat.VAL</channel>
+            <type>STRING</type>
+            <description>Canopus 1 in follow mode</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="ngs2Follow">
+            <channel>ngsPr2FollowStat.VAL</channel>
+            <type>STRING</type>
+            <description>Canopus 2 in follow mode</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="ngs3Follow">
+            <channel>ngsPr3FollowStat.VAL</channel>
+            <type>STRING</type>
+            <description>Canopus 3 in follow mode</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="odgw1Follow">
+            <channel>odgw1FollowStat.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 1 in follow mode</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="odgw2Follow">
+            <channel>odgw2FollowStat.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 2 in follow mode</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="odgw3Follow">
+            <channel>odgw3FollowStat.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 3 in follow mode</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="odgw4Follow">
+            <channel>odgw4FollowStat.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 4 in follow mode</description>
+            <top>tcs</top>
+        </attribute>
+        -->
+        <attribute name="p1nodachopa">
+            <channel>configPwfs1.VALA</channel>
+            <type>STRING</type>
+            <description>P1 nodachopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodachopb">
+            <channel>configPwfs1.VALB</channel>
+            <type>STRING</type>
+            <description>P1 nodachopb  </description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodachopc">
+            <channel>configPwfs1.VALC</channel>
+            <type>STRING</type>
+            <description>P1 nodachopc  </description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodbchopa">
+            <channel>configPwfs1.VALD</channel>
+            <type>STRING</type>
+            <description>P1 nodbchopa  </description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodbchopb">
+            <channel>configPwfs1.VALE</channel>
+            <type>STRING</type>
+            <description>P1 nodbchopb  </description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodbchopc">
+            <channel>configPwfs1.VALF</channel>
+            <type>STRING</type>
+            <description>P1 nodbchopc </description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodcchopa">
+            <channel>configPwfs1.VALG</channel>
+            <type>STRING</type>
+            <description>P1 nodcchopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodcchopb">
+            <channel>configPwfs1.VALH</channel>
+            <type>STRING</type>
+            <description>P1 nodcchopb</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1nodcchopc">
+            <channel>configPwfs1.VALI</channel>
+            <type>STRING</type>
+            <description>P1 nodcchopc</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodachopa">
+            <channel>configPwfs2.VALA</channel>
+            <type>STRING</type>
+            <description>P2 nodachopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodachopb">
+            <channel>configPwfs2.VALB</channel>
+            <type>STRING</type>
+            <description>P2 nodachopb</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodachopc">
+            <channel>configPwfs2.VALC</channel>
+            <type>STRING</type>
+            <description>P2 nodachopc</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodbchopa">
+            <channel>configPwfs2.VALD</channel>
+            <type>STRING</type>
+            <description>P2 nodbchopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodbchopb">
+            <channel>configPwfs2.VALE</channel>
+            <type>STRING</type>
+            <description>P2 nodbchopb</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodbchopc">
+            <channel>configPwfs2.VALF</channel>
+            <type>STRING</type>
+            <description>P2 nodbchopc</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodcchopa">
+            <channel>configPwfs2.VALG</channel>
+            <type>STRING</type>
+            <description>P2 nodcchopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodcchopb">
+            <channel>configPwfs2.VALH</channel>
+            <type>STRING</type>
+            <description>P2 nodcchopb</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2nodcchopc">
+            <channel>configPwfs2.VALI</channel>
+            <type>STRING</type>
+            <description>P2 nodcchopc</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodachopa">
+            <channel>configOiwfs.VALA</channel>
+            <type>STRING</type>
+            <description>OI nodachopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodachopb">
+            <channel>configOiwfs.VALB</channel>
+            <type>STRING</type>
+            <description>OI nodachopb</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodachopc">
+            <channel>configOiwfs.VALC</channel>
+            <type>STRING</type>
+            <description>OI nodachopc</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodbchopa">
+            <channel>configOiwfs.VALD</channel>
+            <type>STRING</type>
+            <description>OI nodbchopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodbchopb">
+            <channel>configOiwfs.VALE</channel>
+            <type>STRING</type>
+            <description>OI nodbchopb</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodbchopc">
+            <channel>configOiwfs.VALF</channel>
+            <type>STRING</type>
+            <description>OI nodbchopc</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodcchopa">
+            <channel>configOiwfs.VALG</channel>
+            <type>STRING</type>
+            <description>OI nodcchopa</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodcchopb">
+            <channel>configOiwfs.VALH</channel>
+            <type>STRING</type>
+            <description>OI nodcchopb</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oinodcchopc">
+            <channel>configOiwfs.VALI</channel>
+            <type>STRING</type>
+            <description>OI nodcchopc</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodachopa">
+            <channel>configG1.VALA</channel>
+            <type>STRING</type>
+            <description>G1 Nod A Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodachopb">
+            <channel>configG1.VALB</channel>
+            <type>STRING</type>
+            <description>G1 Nod A Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodachopc">
+            <channel>configG1.VALC</channel>
+            <type>STRING</type>
+            <description>G1 Nod A Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodbchopa">
+            <channel>configG1.VALD</channel>
+            <type>STRING</type>
+            <description>G1 Nod B Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodbchopb">
+            <channel>configG1.VALE</channel>
+            <type>STRING</type>
+            <description>G1 Nod B Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodbchopc">
+            <channel>configG1.VALF</channel>
+            <type>STRING</type>
+            <description>G1 Nod B Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodcchopa">
+            <channel>configG1.VALG</channel>
+            <type>STRING</type>
+            <description>G1 Nod C Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodcchopb">
+            <channel>configG1.VALH</channel>
+            <type>STRING</type>
+            <description>G1 Nod C Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1nodcchopc">
+            <channel>configG1.VALI</channel>
+            <type>STRING</type>
+            <description>G1 Nod C Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodachopa">
+            <channel>configG2.VALA</channel>
+            <type>STRING</type>
+            <description>G2 Nod A Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodachopb">
+            <channel>configG2.VALB</channel>
+            <type>STRING</type>
+            <description>G2 Nod A Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodachopc">
+            <channel>configG2.VALC</channel>
+            <type>STRING</type>
+            <description>G2 Nod A Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodbchopa">
+            <channel>configG2.VALD</channel>
+            <type>STRING</type>
+            <description>G2 Nod B Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodbchopb">
+            <channel>configG2.VALE</channel>
+            <type>STRING</type>
+            <description>G2 Nod B Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodbchopc">
+            <channel>configG2.VALF</channel>
+            <type>STRING</type>
+            <description>G2 Nod B Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodcchopa">
+            <channel>configG2.VALG</channel>
+            <type>STRING</type>
+            <description>G2 Nod C Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodcchopb">
+            <channel>configG2.VALH</channel>
+            <type>STRING</type>
+            <description>G2 Nod C Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2nodcchopc">
+            <channel>configG2.VALI</channel>
+            <type>STRING</type>
+            <description>G2 Nod C Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodachopa">
+            <channel>configG3.VALA</channel>
+            <type>STRING</type>
+            <description>G3 Nod A Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodachopb">
+            <channel>configG3.VALB</channel>
+            <type>STRING</type>
+            <description>G3 Nod A Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodachopc">
+            <channel>configG3.VALC</channel>
+            <type>STRING</type>
+            <description>G3 Nod A Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodbchopa">
+            <channel>configG3.VALD</channel>
+            <type>STRING</type>
+            <description>G3 Nod B Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodbchopb">
+            <channel>configG3.VALE</channel>
+            <type>STRING</type>
+            <description>G3 Nod B Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodbchopc">
+            <channel>configG3.VALF</channel>
+            <type>STRING</type>
+            <description>G3 Nod B Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodcchopa">
+            <channel>configG3.VALG</channel>
+            <type>STRING</type>
+            <description>G3 Nod C Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodcchopb">
+            <channel>configG3.VALH</channel>
+            <type>STRING</type>
+            <description>G3 Nod C Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3nodcchopc">
+            <channel>configG3.VALI</channel>
+            <type>STRING</type>
+            <description>G3 Nod C Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodachopa">
+            <channel>configG4.VALA</channel>
+            <type>STRING</type>
+            <description>G4 Nod A Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodachopb">
+            <channel>configG4.VALB</channel>
+            <type>STRING</type>
+            <description>G4 Nod A Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodachopc">
+            <channel>configG4.VALC</channel>
+            <type>STRING</type>
+            <description>G4 Nod A Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodbchopa">
+            <channel>configG4.VALD</channel>
+            <type>STRING</type>
+            <description>G4 Nod B Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodbchopb">
+            <channel>configG4.VALE</channel>
+            <type>STRING</type>
+            <description>G4 Nod B Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodbchopc">
+            <channel>configG4.VALF</channel>
+            <type>STRING</type>
+            <description>G4 Nod B Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodcchopa">
+            <channel>configG4.VALG</channel>
+            <type>STRING</type>
+            <description>G4 Nod C Chop A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodcchopb">
+            <channel>configG4.VALH</channel>
+            <type>STRING</type>
+            <description>G4 Nod C Chop B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g4nodcchopc">
+            <channel>configG4.VALI</channel>
+            <type>STRING</type>
+            <description>G4 Nod C Chop C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="chopon">
+            <channel>chopControl.VALA</channel>
+            <type>STRING</type>
+            <description>SCS Chop on flag</description>
+            <top>m2</top>
+        </attribute>
+        <attribute name="m2GuideCmdIn">
+            <channel>m2GuideControl.A</channel>
+            <type>STRING</type>
+            <description>M2 Guide control input</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="agInPosition">
+            <channel>agInPosCalc</channel>
+            <type>DOUBLE</type>
+            <description>A&amp;G in position</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="aoName">
+            <channel>aoName</channel>
+            <type>STRING</type>
+            <description>AO fold position</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="port3Label">
+            <channel>port:port3</channel>
+            <type>STRING</type>
+            <description>ISS port 3 label</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="cmprepy">
+            <channel>aoPrepareCm.VALA</channel>
+            <type>STRING</type>
+            <description>Prepared control matrix Y</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="aogsy">
+            <channel>drives:driveAOS.VALB</channel>
+            <type>DOUBLE</type>
+            <description>Guide star Y</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oiParked">
+            <channel>oi:probeParked</channel>
+            <type>INTEGER</type>
+            <description>OI probe parked</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="m2p2Guide">
+            <channel>drives:p2GuideConfig</channel>
+            <type>STRING</type>
+            <description>M2 P2 guide config</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="chopState">
+            <channel>sad:chopState</channel>
+            <type>STRING</type>
+            <description>Chop State</description>
+            <top>tcs</top>
+        </attribute>
+        <!--
+        <attribute name="ngs1Parked">
+            <channel>drives:ngsPr1Parked.VAL</channel>
+            <type>STRING</type>
+            <description>Canopus 1 probe parked</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="ngs2Parked">
+            <channel>drives:ngsPr1Parked.VAL</channel>
+            <type>STRING</type>
+            <description>Canopus 2 probe parked</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="ngs3Parked">
+            <channel>drives:ngsPr3Parked.VAL</channel>
+            <type>STRING</type>
+            <description>Canopus 3 probe parked</description>
+            <top>tcs</top>
+        </attribute>
+        -->
+        <attribute name="port5Label">
+            <channel>port:port5</channel>
+            <type>STRING</type>
+            <description>ISS port 5 label</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="chopFreq">
+            <channel>sad:chopFreq</channel>
+            <type>DOUBLE</type>
+            <description>Chop Frequency</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="aoSettled">
+            <channel>wfcs:settled</channel>
+            <type>DOUBLE</type>
+            <description>AO loop settled</description>
+        </attribute>
+        <attribute name="oiFollowS">
+            <channel>oi:followS</channel>
+            <type>STRING</type>
+            <description>OI follow mode</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="g4MapName">
+            <channel>guiderConfig.VALD</channel>
+            <type>STRING</type>
+            <description>Name of GeMS WFS for G4</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="agHwName">
+            <channel>drives:agHwName</channel>
+            <type>STRING</type>
+            <description>AcqCam pickoff</description>
+            <top>tcs</top>
+        </attribute>
+        <!--
+        <attribute name="pwfs2On">
+            <channel>drives:p2Integrating</channel>
+            <type>STRING</type>
+            <description>P2 integrating</description>
+            <top>tcs</top>
+        </attribute>
+        -->
+        <attribute name="odgw4Parked">
+            <channel>drives:odgw4Parked.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 4 parked</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="odgw3Parked">
+            <channel>drives:odgw3Parked.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 3 parked</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g2MapName">
+            <channel>guiderConfig.VALB</channel>
+            <type>STRING</type>
+            <description>Name of GeMS WFS for G2</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="xoffsetPoA1">
+            <channel>offsetPoA1.VALA</channel>
+            <type>DOUBLE</type>
+            <description>X offset</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="sourceAObjectName">
+            <channel>sad:sourceAObjectName</channel>
+            <type>STRING</type>
+            <description>Object name</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="conmatx">
+            <channel>conMatY</channel>
+            <type>DOUBLE</type>
+            <description>Control matrix star X</description>
+        </attribute>
+        <attribute name="conmaty">
+            <channel>conMatX</channel>
+            <type>DOUBLE</type>
+            <description>Control matrix star Y</description>
+        </attribute>
+        <attribute name="p1FollowS">
+            <channel>p1:followS</channel>
+            <type>STRING</type>
+            <description>P1 follow mode</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="nodState">
+            <channel>drives:nodState</channel>
+            <type>STRING</type>
+            <description>Nod State</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="odgw1Parked">
+            <channel>drives:odgw1Parked.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 1 parked</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="inPosition">
+            <channel>sad:inPosition</channel>
+            <type>STRING</type>
+            <description>TCS in position</description>
+            <top>tcs</top>
+        </attribute>
+        <!--
+        <attribute name="cmprepBusy">
+            <channel>prepareCm.BUSY</channel>
+            <type>STRING</type>
+            <description>PrepareCm busy</description>
+        </attribute>
+        -->
+        <attribute name="instrAA">
+            <channel>sad:instrAA</channel>
+            <type>DOUBLE</type>
+            <description>Instrument alignment angle</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g1Wavelength">
+            <channel>sad:g1Wavelength</channel>
+            <type>DOUBLE</type>
+            <description>G1 Wavelength</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="chopDutyCycle">
+            <channel>sad:chopDutyCycle</channel>
+            <type>DOUBLE</type>
+            <description>Chop Duty Cycle</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="g3Wavelength">
+            <channel>sad:g3Wavelength</channel>
+            <type>DOUBLE</type>
+            <description>G3 Wavelength</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="oiguideoutput">
+            <channel>dc:outGuide</channel>
+            <type>STRING</type>
+            <description>OI guide signal output</description>
+            <top>oiwfs</top>
+        </attribute>
+        <!--
+        <attribute name="oiwfsOn">
+            <channel>drives:oiIntegrating</channel>
+            <type>STRING</type>
+            <description>OI integrating</description>
+            <top>tcs</top>
+        </attribute>
+        -->
+        <attribute name="cmprepx">
+            <channel>aoPrepareCm.VALB</channel>
+            <type>STRING</type>
+            <description>Prepared control matrix X</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="m2aoGuide">
+            <channel>drives:aoGuideConfig</channel>
+            <type>STRING</type>
+            <description>M2 AO guide config</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p1Parked">
+            <channel>p1:probeParked</channel>
+            <type>INTEGER</type>
+            <description>P1 probe parked</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="sfName">
+            <channel>sfName</channel>
+            <type>STRING</type>
+            <description>Science fold position</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="aogsx">
+            <channel>drives:driveAOS.VALC</channel>
+            <type>DOUBLE</type>
+            <description>Guide star X</description>
+            <top>tcs</top>
+        </attribute>
+        <!--
+        <attribute name="m1Guide">
+            <channel>im:m1GuideOn</channel>
+            <type>STRING</type>
+            <description>M1 guide</description>
+            <top>tcs</top>
+        </attribute>
+        -->
+        <attribute name="m2p1Guide">
+            <channel>drives:p1GuideConfig</channel>
+            <type>STRING</type>
+            <description>M2 P1 guide config</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="lgsp1On">
+            <channel>lgsttSource.VALA</channel>
+            <type>INTEGER</type>
+            <description>LgsP1 mode</description>
+        </attribute>
+        <attribute name="agHwParked">
+            <channel>hwParked</channel>
+            <type>STRING</type>
+            <description>AcqCam parked      </description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="p2Parked">
+            <channel>p2:probeParked</channel>
+            <type>INTEGER</type>
+            <description>P2 probe parked</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="comaCorrect">
+            <channel>comaCorrect</channel>
+            <type>STRING</type>
+            <description>Apply Coma Corrections</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="odgw2Parked">
+            <channel>drives:odgw2Parked.VAL</channel>
+            <type>STRING</type>
+            <description>ODGW 2 parked</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="rotTrackFrame">
+            <channel>sad:rotTrackFrame</channel>
+            <type>STRING</type>
+            <description>Cass Rotator tracking frame</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="p2FollowS">
+            <channel>p2:followS</channel>
+            <type>STRING</type>
+            <description>P2 follow mode</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="g2Wavelength">
+            <channel>sad:g2Wavelength</channel>
+            <type>DOUBLE</type>
+            <description>G2 Wavelength</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="m1GuideSource">
+            <channel>m1GuideConfig.VALB</channel>
+            <type>STRING</type>
+            <description>M1 guide source</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="lgsoiOn">
+            <channel>lgsttSource.VALB</channel>
+            <type>INTEGER</type>
+            <description>LgsOI mode</description>
+        </attribute>
+        <!--
+        <attribute name="pwfs1On">
+            <channel>drives:p1Integrating</channel>
+            <type>STRING</type>
+            <description>P1 integrating</description>
+            <top>tcs</top>
+        </attribute>
+        -->
+        <attribute name="sourceAWavelength">
+            <channel>sad:sourceAWavelength.VAL</channel>
+            <type>DOUBLE</type>
+            <description>Source A Wavelength</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="sourceBWavelength">
+            <channel>sad:sourceBWavelength.VAL</channel>
+            <type>DOUBLE</type>
+            <description>Source B Wavelength</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="sourceCWavelength">
+            <channel>sad:sourceCWavelength.VAL</channel>
+            <type>DOUBLE</type>
+            <description>Source C Wavelength</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="port2Label">
+            <channel>port:port2</channel>
+            <type>STRING</type>
+            <description>ISS port 2 label</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="g1MapName">
+            <channel>guiderConfig.VALA</channel>
+            <type>STRING</type>
+            <description>Name of GeMS WFS for G1</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="chopAngle">
+            <channel>sad:chopPA</channel>
+            <type>DOUBLE</type>
+            <description>Chop PA</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="chopThrow">
+            <channel>sad:chopThrow</channel>
+            <type>DOUBLE</type>
+            <description>Chop Throw</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="sfParked">
+            <channel>sfParked</channel>
+            <type>STRING</type>
+            <description>Science Fold parked</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="g4Wavelength">
+            <channel>sad:g4Wavelength</channel>
+            <type>DOUBLE</type>
+            <description>G4 Wavelength</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="aoFollowS">
+            <channel>followS</channel>
+            <type>STRING</type>
+            <description>AO follow mode</description>
+        </attribute>
+        <!--
+        <attribute name="m2GuideState">
+            <channel>om:m2GuideState</channel>
+            <type>STRING</type>
+            <description>M2 guiding state</description>
+            <top>tcs</top>
+        </attribute>
+        -->
+        <attribute name="xoffsetPoA1">
+            <channel>offsetPoA1.VALA</channel>
+            <type>DOUBLE</type>
+            <description>X offset source A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="yoffsetPoA1">
+            <channel>offsetPoA1.VALB</channel>
+            <type>DOUBLE</type>
+            <description>Y offset source A</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="xoffsetPoB1">
+            <channel>offsetPoB1.VALA</channel>
+            <type>DOUBLE</type>
+            <description>X offset source B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="yoffsetPoB1">
+            <channel>offsetPoB1.VALB</channel>
+            <type>DOUBLE</type>
+            <description>Y offset source B</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="xoffsetPoC1">
+            <channel>offsetPoC1.VALA</channel>
+            <type>DOUBLE</type>
+            <description>X offset source C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="yoffsetPoC1">
+            <channel>offsetPoC1.VALB</channel>
+            <type>DOUBLE</type>
+            <description>Y offset source C</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="m2oiGuide">
+            <channel>drives:oiGuideConfig</channel>
+            <type>STRING</type>
+            <description>M2 OI guide config</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="absorbTipTilt">
+            <channel>absorbTipTiltFlag</channel>
+            <type>INTEGER</type>
+            <description>Absorb Tip/Tilt</description>
+            <top>tcs</top>
+        </attribute>
+        <attribute name="port4Label">
+            <channel>port:port4</channel>
+            <type>STRING</type>
+            <description>ISS port 4 label</description>
+            <top>ag</top>
+        </attribute>
+        <attribute name="chopBeam">
+            <channel>sad:chopBeam.VAL</channel>
+            <type>STRING</type>
+            <description>M2 beam</description>
+            <top>tcs</top>
+        </attribute>
+    </Status>
+</Records>

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ConfigUtil.scala
@@ -1,0 +1,36 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.spModel.config2.{ItemKey, Config}
+
+import java.beans.PropertyDescriptor
+
+import scala.reflect.ClassTag
+import scalaz._
+import Scalaz._
+
+/**
+ * Created by jluhrs on 8/17/15.
+ */
+object ConfigUtil {
+
+  type ExtractFailure = String // for now
+
+  // key syntax: parent / child
+  implicit class ItemKeyOps(k: ItemKey) {
+    def /(s: String): ItemKey = new ItemKey(k, s)
+    def /(p: PropertyDescriptor): ItemKey = /(p.getName)
+  }
+
+  // config syntax: cfg.extract(key).as[Type]
+  implicit class ConfigOps(c: Config) {
+    final class Extracted(key: ItemKey) {
+      def as[A](implicit clazz: ClassTag[A]): ExtractFailure \/ A =
+        for {
+          v <- Option(c.getItemValue(key)) \/> s"Missing config value for key ${key.getPath}"
+          b <- \/.fromTryCatchNonFatal(clazz.runtimeClass.cast(v).asInstanceOf[A]).leftMap(_.getMessage)
+        } yield b
+    }
+    def extract(key: ItemKey) = new Extracted(key)
+  }
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/DhsClient.scala
@@ -1,0 +1,164 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.Logger
+
+import argonaut._
+import Argonaut._
+import org.apache.commons.httpclient.{HttpMethod, HttpClient}
+import org.apache.commons.httpclient.methods.{EntityEnclosingMethod, PutMethod, PostMethod}
+
+import scala.io.Source
+
+import scalaz.concurrent.Task
+import scalaz.EitherT
+
+/**
+ * Created by jluhrs on 11/5/15.
+ */
+object DhsClient {
+
+  val baseURI = "http://cpodhsxx:9090/axis2/services/dhs/images"
+
+  type ObsId = String
+
+  sealed case class ErrorType(str: String)
+  object BadRequest extends ErrorType("BAD_REQUEST")
+  object DhsError extends ErrorType("DHS_ERROR")
+  object InternalServerError extends ErrorType("INTERNAL_SERVER_ERROR")
+
+  implicit def errorTypeDecode: DecodeJson[ErrorType] = DecodeJson[ErrorType]( c =>  c.as[String].map {
+      case BadRequest.str          => BadRequest
+      case DhsError.str            => DhsError
+      case InternalServerError.str => InternalServerError
+    }
+  )
+
+  final case class Error(t: ErrorType, msg: String) {
+    override def toString = "(" + t.str + ") " + msg
+  }
+
+  implicit def errorDecode: DecodeJson[Error] = DecodeJson[Error]( c => for {
+      t <- (c --\ "type").as[ErrorType]
+      msg <- (c --\ "message").as[String]
+    } yield Error(t, msg)
+  )
+
+  implicit def obsIdDecode: DecodeJson[TrySeq[ObsId]] = DecodeJson[TrySeq[ObsId]]( c => {
+    val r = c --\ "response"
+    val s = (r --\ "status").as[String]
+    s flatMap {
+      case "success" => (r --\ "result").as[String].map(TrySeq(_))
+      case "error"   => (r --\ "errors").as[List[Error]].map(
+        l => TrySeq.fail[ObsId](SeqexecFailure.Unexpected(l.mkString(", "))))
+    }
+  } )
+
+  implicit def unitDecode: DecodeJson[TrySeq[Unit]] = DecodeJson[TrySeq[Unit]]( c => {
+    val r = c --\ "response"
+    val s = (r --\ "status").as[String]
+    s flatMap {
+      case "success" => DecodeResult.ok(TrySeq(()))
+      case "error"   => (r --\ "errors").as[List[Error]].map(
+        l => TrySeq.fail[Unit](SeqexecFailure.Unexpected(l.mkString(", "))))
+    }
+  } )
+
+  type Contributor = String
+
+  sealed case class Lifetime(str: String)
+  object Permanent extends Lifetime("PERMANENT")
+  object Temporary extends Lifetime("TEMPORARY")
+  object Transient extends Lifetime("TRANSIENT")
+
+  final case class ImageParameters(lifetime: Lifetime, contributors: List[Contributor])
+
+  implicit def imageParametersEncode: EncodeJson[ImageParameters] = EncodeJson[ImageParameters]( p =>
+    ("lifetime" := p.lifetime.str) ->: ("contributors" := p.contributors) ->: Json.jEmptyObject )
+
+  // TODO: Implement the unsigned types, if needed.
+  sealed case class KeywordType protected (str: String)
+  object TypeInt8 extends KeywordType("INT8")
+  object TypeInt16 extends KeywordType("INT16")
+  object TypeInt32 extends KeywordType("INT32")
+  object TypeFloat extends KeywordType("FLOAT")
+  object TypeDouble extends KeywordType("DOUBLE")
+  object TypeBoolean extends KeywordType("BOOLEAN")
+  object TypeString extends KeywordType("STRING")
+
+
+  // The developer uses these classes to define all the typed keywords
+  sealed class Keyword[T] protected (val n: String, val t: KeywordType, val v: T)
+  final case class Int8Keyword(name: String, value: Byte) extends Keyword[Byte](name, TypeInt8, value)
+  final case class Int16Keyword(name: String, value: Short) extends Keyword[Short](name, TypeInt16, value)
+  final case class Int32Keyword(name: String, value: Int) extends Keyword[Int](name, TypeInt32, value)
+  final case class FloatKeyword(name: String, value: Float) extends Keyword[Float](name, TypeFloat, value)
+  final case class DoubleKeyword(name: String, value: Double) extends Keyword[Double](name, TypeDouble, value)
+  final case class BooleanKeyword(name: String, value: Boolean) extends Keyword[Boolean](name, TypeBoolean, value)
+  final case class StringKeyword(name: String, value: String) extends Keyword[String](name, TypeString, value)
+
+  // At the end, I want to just pass a list of keywords to be sent to the DHS. I cannot do this with Keyword[T],
+  // because I cannot mix different types in a List. But at the end I only care about the value as a String, so I
+  // use an internal representation, and offer a class to the developer (KeywordBag) to create the list from typed
+  // keywords.
+
+  final protected case class InternalKeyword(name: String, keywordType: KeywordType, value: String)
+
+  protected implicit def internalKeywordConvert[T](k: Keyword[T]): InternalKeyword = InternalKeyword(k.n, k.t, k.v.toString)
+
+  final case class KeywordBag(keywords: List[InternalKeyword]) {
+    def add[T](k: Keyword[T]): KeywordBag = KeywordBag(internalKeywordConvert(k) :: keywords)
+    def append(other: KeywordBag): KeywordBag =  KeywordBag(keywords ::: other.keywords)
+  }
+
+  //TODO: Add more apply methods if necessary
+  object KeywordBag {
+    def apply: KeywordBag = KeywordBag(List())
+    def apply[A](k1: Keyword[A]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1)))
+    def apply[A, B](k1: Keyword[A], k2: Keyword[B]): KeywordBag = KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2)))
+    def apply[A, B, C](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3)))
+    def apply[A, B, C, D](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4)))
+    def apply[A, B, C, D, E](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4), internalKeywordConvert(k5)))
+    def apply[A, B, C, D, E, F](k1: Keyword[A], k2: Keyword[B], k3: Keyword[C], k4: Keyword[D], k5: Keyword[E], k6: Keyword[F]): KeywordBag =
+      KeywordBag(List(internalKeywordConvert(k1), internalKeywordConvert(k2), internalKeywordConvert(k3),
+        internalKeywordConvert(k4), internalKeywordConvert(k5), internalKeywordConvert(k6)))
+  }
+
+  implicit def keywordEncode: EncodeJson[InternalKeyword] = EncodeJson[InternalKeyword]( k =>
+    ("name" := k.name) ->: ("type" := k.keywordType.str) ->: ("value" := k.value) ->: Json.jEmptyObject )
+
+  private def sendRequest[T](method: EntityEnclosingMethod, body: Json, errMsg: String)(implicit decoder: argonaut.DecodeJson[TrySeq[T]]): SeqAction[T] = EitherT ( Task.delay {
+      val client = new HttpClient()
+
+      method.addRequestHeader("Content-Type", "application/json")
+      method.setRequestBody(body.nospaces)
+
+      client.executeMethod(method)
+
+      val r = Source.fromInputStream(method.getResponseBodyAsStream).getLines().mkString.decodeOption[TrySeq[T]](decoder)
+
+      method.releaseConnection()
+
+      r.getOrElse(TrySeq.fail[T](SeqexecFailure.Execution(errMsg)))
+    } )
+
+  private def createImage(reqBody: Json): SeqAction[ObsId] =
+    sendRequest[ObsId](new PostMethod(baseURI), Json.jSingleObject("createImage", reqBody), "Unable to get label")
+
+  def createImage: SeqAction[ObsId] = createImage(Json.jEmptyObject)
+
+  def createImage(p: ImageParameters): SeqAction[ObsId] = createImage(p.asJson)
+
+  def setParameters(id: ObsId, p: ImageParameters): SeqAction[Unit] =
+    sendRequest[Unit](new PutMethod(baseURI + "/" + id), Json.jSingleObject("setParameters", p.asJson), "Unable to set parameters for image " + id)
+
+  def setKeywords(id: ObsId, keywords: KeywordBag, finalFlag: Boolean = false): SeqAction[Unit] =
+    sendRequest[Unit](new PutMethod(baseURI + "/" + id + "/keywords"),
+      Json.jSingleObject("setKeywords", ("final" := finalFlag) ->: ("keywords" := keywords.keywords) ->: Json.jEmptyObject ),
+      "Unable to write keywords for image " + id)
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/EpicsUtil.scala
@@ -1,0 +1,77 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.epics.acm.{CaService, CaCommandListener, CaCommandSender, CaParameter}
+import edu.gemini.seqexec.server.SeqexecFailure.{Timeout, SeqexecException}
+
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.Duration
+import scalaz.Scalaz._
+import scalaz._
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 10/5/15.
+ */
+trait EpicsCommand {
+  import EpicsCommand._
+
+  protected val cs: Option[CaCommandSender]
+
+  def post: SeqAction[Unit] = safe(EitherT(Task.async[TrySeq[Unit]](f => cs.map(_.postCallback {
+    new CaCommandListener {
+      override def onSuccess(): Unit = f(TrySeq(()).right)
+
+      override def onFailure(cause: Exception): Unit = f(cause.left)
+    }
+  } ).getOrElse(SeqexecFailure.Unexpected("Unable to trigger command.").left)
+  ) ) )
+
+  def mark: SeqAction[Unit] = safe(EitherT(Task.delay {
+      cs.map(_.mark().right).getOrElse(SeqexecFailure.Unexpected("Unable to mark command.").left)
+    })
+  )
+}
+
+trait EpicsSystem {
+  def init(service: CaService): TrySeq[Unit]
+}
+
+object EpicsCommand {
+  def safe[A](a: SeqAction[A]): SeqAction[A] = EitherT(a.run.attempt.map {
+    case -\/(t) => SeqexecException(t).left
+    case \/-(e) => e
+  })
+
+  def setParameter[T](p: Option[CaParameter[T]], v: T): SeqAction[Unit] =
+    safe(EitherT(Task.delay {
+      p.map(_.set(v).right).getOrElse(SeqexecFailure.Unexpected("Unable to set parameter.").left)
+    } ) )
+
+}
+
+object EpicsCodex {
+  //This code deals with decoding and encoding the EPICS values
+  trait EncodeEpicsValue[A, T] {
+    def encode(a: A): T
+  }
+
+  object EncodeEpicsValue {
+    def apply[A, T](f: A => T): EncodeEpicsValue[A, T] = new EncodeEpicsValue[A, T] {
+      override def encode(a: A): T = f(a)
+    }
+  }
+
+  def encode[A, T](a: A)(implicit e: EncodeEpicsValue[A, T]): T = e.encode(a)
+
+  trait DecodeEpicsValue[T, A] {
+    def decode(t: T): A
+  }
+
+  object DecodeEpicsValue {
+    def apply[T, A](f: T => A): DecodeEpicsValue[T, A] = new DecodeEpicsValue[T, A] {
+      override def decode(t: T): A = f(t)
+    }
+  }
+
+  def decode[T, A](t: T)(implicit e: DecodeEpicsValue[T, A]): A = e.decode(t)
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Executor.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Executor.scala
@@ -1,0 +1,157 @@
+package edu.gemini.seqexec.server
+
+import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.server.SeqexecFailure._
+import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
+import edu.gemini.spModel.obscomp.InstConstants.INSTRUMENT_NAME_PROP
+import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+
+import scala.language.{reflectiveCalls, higherKinds}
+import scalaz._
+import Scalaz._
+
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 4/28/15.
+ */
+
+object Step {
+  type Step = EitherT[Task, NonEmptyList[SeqexecFailure], StepResult]
+
+  def parConfig(config: List[SeqAction[ConfigResult]]):
+    EitherT[Task, NonEmptyList[SeqexecFailure], List[ConfigResult]] =
+      EitherT(Nondeterminism[Task].gather(config.map(_.run)).map(_.map(_.validationNel).sequenceU.disjunction))
+
+  def step(config: List[SeqAction[ConfigResult]], observe: SeqAction[ObserveResult]): Step =
+    for {
+      p <- parConfig(config)
+      q <- observe.leftMap(NonEmptyList(_))
+    } yield StepResult(p, q)
+
+  def step(config: Config): SeqexecFailure \/ (Set[System], Step) = {
+    val instName = config.getItemValue(new ItemKey(INSTRUMENT_KEY, INSTRUMENT_NAME_PROP))
+    val instrument = instName match {
+      case GmosSouth.name => Some(GmosSouth)
+      case Flamingos2.name => Some(Flamingos2(Flamingos2ControllerSim))
+      case _ => None
+    }
+
+    instrument map { a => {
+//        val systems = List(Tcs(TcsControllerEpics), a)
+        val systems = List(Tcs(TcsControllerSim), a)
+        (systems.toSet, step(systems.map(_.configure(config)), a.observe(config))).right
+      }
+    } getOrElse(UnrecognizedInstrument(instName.toString).left[(Set[System], Step)])
+  }
+
+}
+
+object Executor { self =>
+  import Step._
+
+  sealed trait Completion
+  case class  Ok(result: StepResult) extends Completion
+  case class  Failed(result: NonEmptyList[SeqexecFailure]) extends Completion
+  case object Skipped extends Completion
+
+  implicit val executor: ScheduledExecutorService = new ScheduledThreadPoolExecutor(10)
+  def shutdown(): Unit = executor.shutdown()
+
+  // Our current exec state is a list of completed steps and a list of remaining steps
+  case class ExecState(completed: List[Completion], remaining: List[Step]) {
+    def skip(n: Int): ExecState = {
+      val (skipped, rest) = remaining.splitAt(n)
+      ExecState(completed ++ skipped.as(Skipped), rest)
+    }
+    def ok(result: StepResult): ExecState =
+      ExecState(completed :+ Ok(result), remaining.tail) // not quite right
+    def nextStep: Option[Step] = remaining.headOption
+  }
+  object ExecState {
+    def initial(seq: List[Step]): ExecState = apply(Nil, seq)
+    def empty: ExecState = initial(Nil)
+  }
+    // The type of execution actions.
+  type ExecAction[A] = StateT[Task, ExecState, A]
+
+  // We now have the problem of lifting normal State/Task values into this transformer. The next
+  // few definitions do this.
+
+  // State accessors, lifted into ExecAction
+  def get: ExecAction[ExecState] = State.get.lift[Task]
+  def gets[A](f: ExecState => A): ExecAction[A] = State.gets(f).lift[Task]
+
+  // State mutators; private to discourage messing with the state outside of this module
+  private def modify(f: ExecState => ExecState): ExecAction[Unit] = State.modify(f).lift[Task]
+  private def put(s: ExecState): ExecAction[Unit] = State.put(s).lift[Task]
+
+  // Lift a normal task into ExecAction
+  def liftT[A](a: Task[A]): ExecAction[A] =
+    a.liftM[({ type λ[μ[+_], β] = StateT[μ ,ExecState, β] })#λ]
+
+  // Lift a failing value
+  def fail[A](e: SeqexecFailure): ExecAction[NonEmptyList[SeqexecFailure] \/ A] =
+    NonEmptyList(e).left[A].point[ExecAction]
+
+  // Actions of the form ExecAction[NonEmptyList[SeqexecFailure] \/ StepResult] are more
+  // easily expressed as EitherT[ExecAction, NonEmptyList[SeqexecFailure], StepResult] so
+  // we do that here, and provide unfolded versions for public consumption. This is a two-level
+  // monad transformer, which starts to get awkward because inference gets weaker.
+  object WithEitherT {
+
+    // This is isomorphic to the StateT above, but gives fast-fail semantics
+    private type ExecActionF[A] = EitherT[ExecAction, NonEmptyList[SeqexecFailure], A]
+
+    def fail[A](e: SeqexecFailure): ExecActionF[A] =
+      EitherT[ExecAction, NonEmptyList[SeqexecFailure], A](self.fail(e))
+
+    def liftA[A](a: ExecAction[A]): ExecActionF[A] =
+      EitherT[ExecAction, NonEmptyList[SeqexecFailure], A](a.map(_.right))
+
+    def liftE[A](a: ExecAction[NonEmptyList[SeqexecFailure] \/ A]): ExecActionF[A] =
+      EitherT[ExecAction, NonEmptyList[SeqexecFailure], A](a)
+
+    // Execute the next step, if any
+    def stepT(saveState: ExecState => Task[Unit]): ExecActionF[StepResult] =
+      for {
+        st <- liftA(gets(_.nextStep))
+        ds <- st.cata(t => liftE(liftT(t.run)), fail(Unexpected("No current step")))
+        _  <- liftA(modify(s => s.ok(ds))) // only happens on success above
+        _  <- liftA(get) >>= saveState.map(t => liftA(liftT(t)))
+      } yield ds
+
+    // Combine our boolean predicates ... we keep going as long as there is a next step AND the
+    // user hasn't pressed the stop button
+    def continue(go: Task[Boolean]): ExecActionF[Boolean] =
+      (liftA(liftT(go)) |@| liftA(gets(_.nextStep.nonEmpty)))(_ && _)
+
+    // Run to completion, or to error, as long as not cancelled or complete
+    def runT(go: Task[Boolean], saveState: ExecState => Task[Unit]): ExecActionF[Unit] =
+      stepT(saveState).whileM_(continue(go)) // cool eh?
+
+  }
+
+  // Execute the next step, if any
+  def step(saveState: ExecState => Task[Unit]): ExecAction[NonEmptyList[SeqexecFailure] \/ StepResult] =
+    WithEitherT.stepT(saveState).run
+
+  // Run to completion, or to error, as long as not cancelled
+  def run(go: Task[Boolean], saveState: ExecState => Task[Unit]): ExecAction[NonEmptyList[SeqexecFailure] \/ Unit] =
+    WithEitherT.runT(go, saveState).run
+
+  // Skip some number of steps
+  def skip(n: Int): ExecAction[Unit] =
+    modify(_.skip(n))
+
+  // Get the current position in the sequence; (2, 4) means we're on step 2 of 4
+  def position: ExecAction[(Int, Int)] =
+    gets { case ExecState(cs, ss) => (cs.length + 1, cs.length + ss.length) }
+
+}
+
+case class StepResult(configResults: List[ConfigResult], observeResult: ObserveResult)
+

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ExecutorImpl.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ExecutorImpl.scala
@@ -1,0 +1,86 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.seqexec.shared.{SeqFailure, SeqExecService}
+import edu.gemini.spModel.core.Peer
+
+import scalaz._
+import Scalaz._
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.server.Executor._
+import edu.gemini.seqexec.server.SeqexecFailure._
+import edu.gemini.spModel.config2.ConfigSequence
+
+import scalaz.concurrent.Task
+
+/** An executor that maintains state in a pair of `TaskRef`s. */
+class ExecutorImpl private (cancelRef: TaskRef[Set[SPObservationID]], stateRef: TaskRef[Map[SPObservationID, Executor.ExecState]]) {
+
+  private var loc = new Peer("localhost", 8443, null)
+
+  def host(): Peer = loc
+  def host(l: Peer): Unit = { loc = l }
+
+  private def recordState(id: SPObservationID)(s: ExecState): Task[Unit] =
+    stateRef.modify(_ + (id -> s))
+
+  private def go(id: SPObservationID): Task[Boolean] = 
+    cancelRef.get.map(!_(id))
+
+  def read(oid: SPObservationID): SeqexecFailure \/ ConfigSequence =
+      SeqExecService.client(loc).sequence(oid).leftMap(SeqexecFailure.ODBSeqError(_))
+
+  def sequence(sequenceConfig: ConfigSequence):  SeqexecFailure \/ (Set[System], List[Step.Step]) = {
+    val a = sequenceConfig.getAllSteps.toList.map(Step.step).sequenceU
+    a map { _.unzip match {
+      case (l, s) => (l.suml, s)
+    }}
+  }
+
+  // todo: it is an error to run a sequence with an existing ExecState != s
+  private def runSeq(id: SPObservationID, s: ExecState): Task[(ExecState, NonEmptyList[SeqexecFailure] \/ Unit)] =
+    cancelRef.modify(_ - id) *> recordState(id)(s) *> run(go(id), recordState(id))(s)
+
+  def start(id: SPObservationID): SeqexecFailure \/ Unit = for {
+    a <- read(id)
+    b <- start(id, a)
+  } yield b.unsafePerformAsync(_ => ())
+
+  private def start(id: SPObservationID, sequenceConfig: ConfigSequence): SeqexecFailure \/ Task[(ExecState, NonEmptyList[SeqexecFailure] \/ Unit)] = {
+    sequence(sequenceConfig) map {
+      case (s, l) =>
+        // TODO: We have the set of systems used by the sequence. Check that they are available.
+        runSeq(id, ExecState.initial(l))
+    }
+  }
+
+  def continue(id: SPObservationID): SeqexecFailure \/ Unit = continueTask(id) map (_.unsafePerformAsync(???))
+  private def continueTask(id: SPObservationID): SeqexecFailure \/ Task[(Option[ExecState], NonEmptyList[SeqexecFailure] \/ Unit)] =
+    getState(id).unsafePerformSync map {runSeq(id, _).map(_.leftMap(_.some))}
+
+  def state(id: SPObservationID): SeqexecFailure \/ ExecState = getState(id).unsafePerformSync
+
+  private def getState(id: SPObservationID): Task[SeqexecFailure \/ ExecState] =
+    stateRef.get.map(_.get(id) \/> InvalidOp("Sequence has not started."))
+
+  def stop(id: SPObservationID): SeqexecFailure \/ Unit = stopTask(id).unsafePerformSync
+
+  private def stopTask(id: SPObservationID): Task[SeqexecFailure \/ Unit] =
+    getState(id) >>= {
+      case \/-(s) => cancelRef.modify(s => s + id).as(\/-(()))
+      case -\/(e) => Task.now(-\/(e))
+    }
+
+  def stateDescription(state: ExecState): String = {
+    "Completed " + state.completed.length + " steps out of " + (state.completed.length + state.remaining.length) +
+      ( state.completed.zipWithIndex.map(a => (a._1, a._2+1)) map {
+        case (Ok(StepResult(_,ObserveResult(label))), idx) => s"Step $idx completed with label $label"
+        case (Failed(result), idx) => s"Step $idx failed with error " + result.map(SeqexecFailure.explain).toList.mkString("\n", "\n", "")
+        case (Skipped, idx)        => s"Step $idx skipped"
+      }
+    ).mkString("\n", "\n", "")
+  }
+
+}
+
+object ExecutorImpl extends ExecutorImpl(TaskRef.newTaskRef[Set[SPObservationID]](Set.empty).unsafePerformSync, TaskRef.newTaskRef[Map[SPObservationID, Executor.ExecState]](Map.empty).unsafePerformSync)

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2.scala
@@ -1,0 +1,129 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.seqexec.server.DhsClient.{StringKeyword, KeywordBag, ObsId}
+import edu.gemini.seqexec.server.Flamingos2Controller._
+import edu.gemini.seqexec.server.ConfigUtil._
+import edu.gemini.spModel.config2.{ItemKey, Config}
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Decker
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Filter
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.ReadoutMode
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Reads
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.WindowCover
+import edu.gemini.spModel.obscomp.InstConstants.OBSERVE_TYPE_PROP
+
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
+import edu.gemini.spModel.seqcomp.SeqConfigNames._
+import edu.gemini.spModel.obscomp.InstConstants.DARK_OBSERVE_TYPE
+
+import scala.concurrent.duration.SECONDS
+import scala.concurrent.duration.Duration
+import scalaz.concurrent.Task
+import scalaz.{EitherT, \/, \/-}
+
+
+/**
+ * Created by jluhrs on 11/16/15.
+ */
+final case class Flamingos2(f2Controller: Flamingos2Controller) extends Instrument {
+
+  import Flamingos2._
+
+  override val name: String = Flamingos2.name
+
+  override val sfName: String = Flamingos2.sfName
+
+  override def observe(config: Config): SeqAction[ObserveResult] = for {
+    id <- DhsClient.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List("flamingos2", "dhs-http")))
+    _ <- f2Controller.observe(id)
+    _ <- closeImage(id)
+  } yield ObserveResult(id)
+
+  override def configure(config: Config): SeqAction[ConfigResult] =
+    fromSequenceConfig(config).flatMap(f2Controller.applyConfig).map(_ => ConfigResult(this))
+
+  private def closeImage(id: ObsId): SeqAction[Unit] = DhsClient.setKeywords(id,
+    KeywordBag(StringKeyword("instrument", "flamingos2"), StringKeyword("OBSERVER", "Javier Luhrs")), finalFlag = true)
+
+}
+
+object Flamingos2 {
+  val name: String = INSTRUMENT_NAME_PROP
+
+  val sfName: String = "f2"
+
+  def fpuFromFPUnit(fpu: FPUnit):FocalPlaneUnit = fpu match {
+    case FPUnit.FPU_NONE => FocalPlaneUnit.Open
+    case FPUnit.SUBPIX_PINHOLE => FocalPlaneUnit.GridSub1Pix
+    case FPUnit.PINHOLE => FocalPlaneUnit.Grid2Pix
+    case FPUnit.LONGSLIT_1 => FocalPlaneUnit.Slit1Pix
+    case FPUnit.LONGSLIT_2 => FocalPlaneUnit.Slit2Pix
+    case FPUnit.LONGSLIT_3 => FocalPlaneUnit.Slit3Pix
+    case FPUnit.LONGSLIT_4 => FocalPlaneUnit.Slit4Pix
+    case FPUnit.LONGSLIT_6 => FocalPlaneUnit.Slit6Pix
+    case FPUnit.LONGSLIT_8 => FocalPlaneUnit.Slit8Pix
+    case FPUnit.CUSTOM_MASK => FocalPlaneUnit.Custom("")
+  }
+
+  def readsFromReadMode(readMode: ReadMode): Flamingos2Controller.Reads = readMode match {
+    case ReadMode.BRIGHT_OBJECT_SPEC => Reads.READS_1
+    case ReadMode.MEDIUM_OBJECT_SPEC => Reads.READS_4
+    case ReadMode.FAINT_OBJECT_SPEC  => Reads.READS_8
+  }
+
+  implicit def biasFromDecker(dk: Decker): BiasMode = dk match {
+    case Decker.IMAGING   => BiasMode.Imaging
+    case Decker.LONG_SLIT => BiasMode.LongSlit
+    case Decker.MOS       => BiasMode.MOS
+  }
+
+  def fpuConfig(config: Config): \/[String, FocalPlaneUnit] = {
+    val a = INSTRUMENT_KEY / FPU_PROP
+    val b = INSTRUMENT_KEY / FPU_MASK_PROP
+
+    config.extract(a).as[FPUnit].flatMap(x =>
+      if(x != FPUnit.CUSTOM_MASK) \/-(fpuFromFPUnit(x))
+      else config.extract(b).as[String].map(FocalPlaneUnit.Custom)
+    )
+  }
+
+  def windowCoverFromObserveType(observeType: String): WindowCover = observeType match {
+    case DARK_OBSERVE_TYPE    => WindowCover.CLOSE
+    case _                    => WindowCover.OPEN
+  }
+
+  def ccConfigFromSequenceConfig(config: Config): TrySeq[CCConfig] = ( for {
+      // WINDOW_COVER_PROP is optional. If not present, then window cover position is inferred from observe type.
+      p <- config.extract(INSTRUMENT_KEY / WINDOW_COVER_PROP).as[WindowCover] match {
+            case a: \/-[WindowCover] => a
+            case _         => config.extract(OBSERVE_KEY / OBSERVE_TYPE_PROP).as[String]
+                              .map(windowCoverFromObserveType)
+          }
+      q <- config.extract(INSTRUMENT_KEY / DECKER_PROP).as[Decker]
+      r <- fpuConfig(config)
+      s <- config.extract(INSTRUMENT_KEY / FILTER_PROP).as[Filter]
+      t <- config.extract(INSTRUMENT_KEY / LYOT_WHEEL_PROP).as[LyotWheel]
+      u <- config.extract(INSTRUMENT_KEY / DISPERSER_PROP).as[Disperser]
+
+    } yield CCConfig(p, q, r, s, t, u) ).leftMap(SeqexecFailure.Unexpected)
+
+  def dcConfigFromSequenceConfig(config: Config): TrySeq[DCConfig] = ( for {
+    p <- config.extract(OBSERVE_KEY / EXPOSURE_TIME_PROP).as[java.lang.Double].map(x => Duration(x, SECONDS))
+    // Reads is usually inferred from the read mode, but it can be explicit.
+    q <- config.extract(OBSERVE_KEY / READS_PROP).as[Reads] match {
+          case a: \/-[Reads] => a
+          case _         => config.extract(INSTRUMENT_KEY / READMODE_PROP).as[ReadMode]
+                            .map(readsFromReadMode)
+        }
+    // Readout mode defaults to SCIENCE if not present.
+    r <- \/-(config.extract(INSTRUMENT_KEY / READOUT_MODE_PROP).as[ReadoutMode].getOrElse(ReadoutMode.SCIENCE))
+    s <- config.extract(INSTRUMENT_KEY / DECKER_PROP).as[Decker]
+  } yield DCConfig(p, q, r, s) ).leftMap(SeqexecFailure.Unexpected)
+
+  def fromSequenceConfig(config: Config): SeqAction[Flamingos2Config] = EitherT( Task ( for {
+      p <- ccConfigFromSequenceConfig(config)
+      q <- dcConfigFromSequenceConfig(config)
+    } yield Flamingos2Config(p, q)
+  ) )
+
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Controller.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Controller.scala
@@ -1,0 +1,84 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.seqexec.server.DhsClient.ObsId
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Created by jluhrs on 11/16/15.
+ */
+trait Flamingos2Controller {
+  import Flamingos2Controller._
+
+  // I'm not sure if getConfig will be used. It made sense for TCS, because parts of the TCS configuration cannot be
+  // inferred from the sequence, and because Seqexec needs to temporarily change parts of the TCS configuration only to
+  // later revert those changes to the previous values. But for most (if not all) instruments, the sequence completely
+  // defines the instrument configuration.
+  def getConfig: SeqAction[Flamingos2Config]
+
+  def applyConfig(config: Flamingos2Config): SeqAction[Unit]
+
+  def observe(obsid: ObsId): SeqAction[ObsId]
+}
+
+object Flamingos2Controller {
+
+  type WindowCover = edu.gemini.spModel.gemini.flamingos2.Flamingos2.WindowCover
+
+  type Decker = edu.gemini.spModel.gemini.flamingos2.Flamingos2.Decker
+
+  sealed trait FocalPlaneUnit
+  object FocalPlaneUnit {
+    object Open extends FocalPlaneUnit
+    object GridSub1Pix extends FocalPlaneUnit
+    object Grid2Pix extends FocalPlaneUnit
+    object Slit1Pix extends FocalPlaneUnit
+    object Slit2Pix extends FocalPlaneUnit
+    object Slit3Pix extends FocalPlaneUnit
+    object Slit4Pix extends FocalPlaneUnit
+    object Slit6Pix extends FocalPlaneUnit
+    object Slit8Pix extends FocalPlaneUnit
+    final case class Custom(mask: String) extends FocalPlaneUnit
+  }
+
+  type Filter = edu.gemini.spModel.gemini.flamingos2.Flamingos2.Filter
+
+  type Lyot = edu.gemini.spModel.gemini.flamingos2.Flamingos2.LyotWheel
+
+  type Grism = edu.gemini.spModel.gemini.flamingos2.Flamingos2.Disperser
+
+  type ExposureTime = Duration
+
+  type Reads = edu.gemini.spModel.gemini.flamingos2.Flamingos2.Reads
+
+  type ReadoutMode = edu.gemini.spModel.gemini.flamingos2.Flamingos2.ReadoutMode
+
+  sealed trait BiasMode
+  object BiasMode {
+    object Imaging extends BiasMode
+    object LongSlit extends BiasMode
+    object MOS extends BiasMode
+  }
+
+  final case class CCConfig(w: WindowCover, d: Decker, fpu: FocalPlaneUnit, f: Filter, l: Lyot, g: Grism) {
+    def setWindowCover(windowCover: WindowCover) = this.copy(w = windowCover)
+    def setDecker(decker: Decker) = this.copy(d = decker)
+    def setFPU(focalPlaneUnit: FocalPlaneUnit) = this.copy(fpu = focalPlaneUnit)
+    def setFilter(filter: Filter) = this.copy(f = filter)
+    def setLyot(lyot: Lyot) = this.copy(l = lyot)
+    def setGrism(grism: Grism) = this.copy(g = grism)
+  }
+
+  final case class DCConfig(t: ExposureTime, n: Reads, r: ReadoutMode, b: BiasMode) {
+    def setExposureTime(exposureTime: ExposureTime) = this.copy(t = exposureTime)
+    def setNumReads(numReads: Reads) =  this.copy(n = numReads)
+    def setReadoutMode(readoutMode: ReadoutMode) = this.copy(r = readoutMode)
+    def setBiasMode(biasMode: BiasMode) = this.copy(b = biasMode)
+  }
+
+  final case class Flamingos2Config(cc: CCConfig, dc: DCConfig) {
+    def setCCConfig(ccConfig: CCConfig) = this.copy(cc = ccConfig)
+    def setDCConfig(dcConfig: DCConfig) = this.copy(dc = dcConfig)
+  }
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerEpics.scala
@@ -1,0 +1,146 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.Logger
+
+import edu.gemini.seqexec.server.DhsClient.ObsId
+import edu.gemini.seqexec.server.Flamingos2Controller._
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Decker
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.Filter
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.ReadoutMode
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2.WindowCover
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
+
+import scalaz.Scalaz._
+
+import scalaz.EitherT
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 11/16/15.
+ */
+object Flamingos2ControllerEpics extends Flamingos2Controller {
+  private val Log = Logger.getLogger(getClass.getName)
+
+  import EpicsCodex._
+
+  override def getConfig: SeqAction[Flamingos2Config] = ???
+
+  implicit val encodeReadoutMode: EncodeEpicsValue[ReadoutMode, String] = EncodeEpicsValue((a: ReadoutMode)
+    => a match {
+      case ReadoutMode.SCIENCE     => "SCI"
+      case ReadoutMode.ENGINEERING => "ENG"
+    }
+  )
+
+  implicit val encodeBiasMode: EncodeEpicsValue[BiasMode, String] = EncodeEpicsValue((a: BiasMode)
+    => a match {
+      case BiasMode.Imaging  => "Imaging"
+      case BiasMode.LongSlit => "Long_Slit"
+      case BiasMode.MOS      => "Mos"
+    }
+  )
+
+  def setDCConfig(dc: DCConfig): SeqAction[Unit] = for {
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setExposureTime(dc.t.toSeconds)
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setNumReads(dc.n.getCount)
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setReadoutMode(encode(dc.r))
+    _ <- Flamingos2Epics.instance.dcConfigCmd.setBiasMode(encode(dc.b))
+  } yield ()
+
+  implicit val encodeWindowCoverPosition: EncodeEpicsValue[WindowCover, String] = EncodeEpicsValue((a: WindowCover)
+    => a match {
+      case WindowCover.OPEN  => "Open"
+      case WindowCover.CLOSE => "Closed"
+    }
+  )
+
+  implicit val encodeDeckerPosition: EncodeEpicsValue[Decker, String] = EncodeEpicsValue((a: Decker)
+    => a match {
+      case Decker.IMAGING   => "Open"
+      case Decker.LONG_SLIT => "Long_Slit"
+      case Decker.MOS       => "Mos"
+    }
+  )
+
+  implicit val encodeFPUPosition: EncodeEpicsValue[FocalPlaneUnit, (String, String)] = EncodeEpicsValue((a: FocalPlaneUnit)
+    => a match {
+      case FocalPlaneUnit.Open        => ("Open", "null")
+      case FocalPlaneUnit.GridSub1Pix => ("sub1-pix_grid", "null")
+      case FocalPlaneUnit.Grid2Pix    => ("2-pix_grid", "null")
+      case FocalPlaneUnit.Slit1Pix    => ("1pix-slit", "null")
+      case FocalPlaneUnit.Slit2Pix    => ("2pix-slit", "null")
+      case FocalPlaneUnit.Slit3Pix    => ("3pix-slit", "null")
+      case FocalPlaneUnit.Slit4Pix    => ("4pix-slit", "null")
+      case FocalPlaneUnit.Slit6Pix    => ("6pix-slit", "null")
+      case FocalPlaneUnit.Slit8Pix    => ("8pix-slit", "null")
+      case FocalPlaneUnit.Custom(s)   => ("null", s)
+    }
+  )
+
+  implicit val encodeFilterPosition: EncodeEpicsValue[Filter, String] = EncodeEpicsValue((a: Filter)
+    => a match {
+      case Filter.OPEN    => "Open"
+      case Filter.Y       => "Y_G0811"
+      case Filter.F1056   => "F1056"
+      case Filter.F1063   => "F1063"
+      case Filter.J_LOW   => "J-lo_G0801"
+      case Filter.J       => "J_G0802"
+      case Filter.H       => "H_G0803"
+      case Filter.K_LONG  => "K-long_G0812"
+      case Filter.K_SHORT => "Ks_G0804"
+      case Filter.JH      => "JH_G0809"
+      case Filter.HK      => "HK_G0806"
+      case Filter.DARK    => "DK_G0807"
+    }
+  )
+
+  implicit val encodeLyotPosition: EncodeEpicsValue[Lyot, String] = EncodeEpicsValue((a: Lyot)
+    => a match {
+      case LyotWheel.OPEN       => "f/16_G5830"
+      case LyotWheel.HIGH       => "null"
+      case LyotWheel.LOW        => "null"
+      case LyotWheel.GEMS_OVER  => "GEMS_over_G5836"
+      case LyotWheel.GEMS_UNDER => "GEMS_under_G5835"
+      case LyotWheel.GEMS       => "Gems_G5835"
+      case LyotWheel.H1         => "Hart1_G5833"
+      case LyotWheel.H2         => "Hart2_G5834"
+    }
+  )
+
+  implicit val encodeGrismPosition: EncodeEpicsValue[Grism, String] = EncodeEpicsValue((a: Grism)
+    => a match {
+      case Disperser.NONE  => "Open"
+      case Disperser.R1200HK => "HK_G5802"
+      case Disperser.R1200JH => "JH_G5801"
+      case Disperser.R3000 => "R3K_G5803"
+    }
+  )
+
+  def setCCConfig(cc: CCConfig): SeqAction[Unit] = {
+    val fpu = encode(cc.fpu)
+    for {
+      _ <- Flamingos2Epics.instance.configCmd.setWindowCover(encode(cc.w))
+      _ <- Flamingos2Epics.instance.configCmd.setDecker(encode(cc.d))
+      _ <- Flamingos2Epics.instance.configCmd.setMOS(fpu._1)
+      _ <- Flamingos2Epics.instance.configCmd.setMask(fpu._2)
+      _ <- Flamingos2Epics.instance.configCmd.setFilter(encode(cc.f))
+      _ <- Flamingos2Epics.instance.configCmd.setLyot(encode(cc.l))
+      _ <- Flamingos2Epics.instance.configCmd.setGrism(encode(cc.g))
+    } yield ()
+  }
+
+  override def applyConfig(config: Flamingos2Config): SeqAction[Unit] = for {
+    _ <- EitherT(Task(Log.info("Start Flamingos2 configuration").right))
+    _ <- setDCConfig(config.dc)
+    _ <- setCCConfig(config.cc)
+    _ <- Flamingos2Epics.instance.post
+    _ <- EitherT(Task(Log.info("Completed Flamingos2 configuration").right))
+  } yield ()
+
+  override def observe(obsid: ObsId): SeqAction[ObsId] = for {
+    _ <- EitherT(Task(Log.info("Start Flamingos2 observation").right))
+    _ <- Flamingos2Epics.instance.observeCmd.setLabel(obsid)
+    _ <- Flamingos2Epics.instance.observeCmd.post
+    _ <- EitherT(Task(Log.info("Completed Flamingos2 observation").right))
+  } yield obsid
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerSim.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2ControllerSim.scala
@@ -1,0 +1,28 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.Logger
+
+import edu.gemini.seqexec.server.DhsClient.ObsId
+import edu.gemini.seqexec.server.Flamingos2Controller.Flamingos2Config
+
+import scalaz.EitherT
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 11/24/15.
+ */
+object Flamingos2ControllerSim extends Flamingos2Controller {
+  private val Log = Logger.getLogger(getClass.getName)
+
+  override def getConfig: SeqAction[Flamingos2Config] = ???
+
+  override def observe(obsid: ObsId): SeqAction[ObsId] = EitherT( Task {
+    Log.info("Taking Flamingos-2 observation with label " + obsid)
+    TrySeq(obsid)
+  } )
+
+  override def applyConfig(config: Flamingos2Config): SeqAction[Unit] = EitherT( Task {
+    Log.info("Applying Flamingos-2 configuration " + config)
+    TrySeq(())
+  } )
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Flamingos2Epics.scala
@@ -1,0 +1,129 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.Logger
+
+import scalaz._
+import Scalaz._
+
+import edu.gemini.epics.acm.{XMLBuilder, CaService}
+
+/**
+ * Created by jluhrs on 11/13/15.
+ */
+final class Flamingos2Epics(epicsService: CaService) {
+
+  import Flamingos2Epics._
+  import EpicsCommand.setParameter
+
+  def post: SeqAction[Unit] = configCmd.post
+
+  object dcConfigCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("flamingos2::dcconfig"))
+
+    val biasMode = cs.map(_.getString("biasMode"))
+    def setBiasMode(v: String): SeqAction[Unit] = setParameter(biasMode, v)
+
+    val numReads = cs.map(_.getInteger("numReads"))
+    def setNumReads(v: Integer): SeqAction[Unit] = setParameter(numReads, v)
+
+    val readoutMode = cs.map(_.getString("readoutMode"))
+    def setReadoutMode(v: String): SeqAction[Unit] = setParameter(readoutMode, v)
+
+    val exposureTime = cs.map(_.getDouble("exposureTime"))
+    def setExposureTime(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](exposureTime, v)
+
+  }
+
+  object abortCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("flamingos2::abort"))
+  }
+
+  object stopCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("flamingos2::stop"))
+  }
+
+  object observeCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("flamingos2::observe"))
+
+    val label = cs.map(_.getString("label"))
+    def setLabel(v: String): SeqAction[Unit] = setParameter(label, v)
+  }
+
+  object configCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("flamingos2::config"))
+
+    val useElectronicOffsetting = cs.map(_.getInteger("useElectronicOffsetting"))
+    def setUseElectronicOffsetting(v: Integer): SeqAction[Unit] = setParameter(useElectronicOffsetting, v)
+
+    val filter = cs.map(_.getString("filter"))
+    def setFilter(v: String): SeqAction[Unit] = setParameter(filter, v)
+
+    val mos = cs.map(_.getString("mos"))
+    def setMOS(v: String): SeqAction[Unit] = setParameter(mos, v)
+
+    val grism = cs.map(_.getString("grism"))
+    def setGrism(v: String): SeqAction[Unit] = setParameter(grism, v)
+
+    val mask = cs.map(_.getString("mask"))
+    def setMask(v: String): SeqAction[Unit] = setParameter(mask, v)
+
+    val decker = cs.map(_.getString("decker"))
+    def setDecker(v: String): SeqAction[Unit] = setParameter(decker, v)
+
+    val lyot = cs.map(_.getString("lyot"))
+    def setLyot(v: String): SeqAction[Unit] = setParameter(lyot, v)
+
+    val windowCover = cs.map(_.getString("windowCover"))
+    def setWindowCover(v: String): SeqAction[Unit] = setParameter(windowCover, v)
+
+  }
+
+  val f2State = epicsService.getStatusAcceptor("flamingos2::dcstatus")
+
+  def exposureTime: Option[String] = Option(f2State.getStringAttribute("exposureTime").value)
+
+  //def useElectronicOffsetting: Option[Integer] = Option(f2State.getIntegerAttribute("useElectronicOffsetting").value)
+
+  def filter: Option[String] = Option(f2State.getStringAttribute("filter").value)
+
+  def mos: Option[String] = Option(f2State.getStringAttribute("mos").value)
+
+  def grism: Option[String] = Option(f2State.getStringAttribute("grism").value)
+
+  def mask: Option[String] = Option(f2State.getStringAttribute("mask").value)
+
+  def decker: Option[String] = Option(f2State.getStringAttribute("decker").value)
+
+  def lyot: Option[String] = Option(f2State.getStringAttribute("lyot").value)
+
+  def windowCover: Option[String] = Option(f2State.getStringAttribute("windowCover").value)
+
+}
+
+object Flamingos2Epics extends EpicsSystem {
+  
+  val Log = Logger.getLogger(getClass.getName)
+  val CA_CONFIG_FILE = "/Flamingos2.xml"
+  
+  // Still using a var, but at least now it's hidden. Attempts to access the single instance will
+  // now result in an Exception with a meaningful message, instead of a NullPointerException
+  private var instanceInternal = Option.empty[Flamingos2Epics]
+  lazy val instance: Flamingos2Epics = instanceInternal.getOrElse(
+    throw new Exception("Attempt to reference Flamingos2Epics single instance before initialization."))
+
+  override def init(service: CaService): TrySeq[Unit] = {
+    try {
+      (new XMLBuilder).fromStream(this.getClass.getResourceAsStream(CA_CONFIG_FILE))
+        .buildAll()
+
+      instanceInternal = Some(new Flamingos2Epics(service))
+
+      TrySeq(())
+    } catch {
+      case c: Throwable =>
+        Log.warning("Flamingos2Epics: Problem initializing EPICS service: " + c.getMessage + "\n"
+          + c.getStackTrace.mkString("\n"))
+        SeqexecFailure.SeqexecException(c).left
+    }
+  }
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/GmosSouth.scala
@@ -1,0 +1,52 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.{Level, Logger}
+
+import edu.gemini.spModel.config2.Config
+import edu.gemini.spModel.gemini.gmos.InstGmosSouth.INSTRUMENT_NAME_PROP
+import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+
+import scalaz.EitherT
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 4/27/15.
+ */
+object GmosSouth extends Instrument {
+
+  override val name: String = INSTRUMENT_NAME_PROP
+
+  override val sfName: String = "gmos"
+
+  val Log = Logger.getLogger(getClass.getName)
+
+  var imageCount = 0
+
+  override def configure(config: Config): SeqAction[ConfigResult] = EitherT(Task {
+    val items = config.getAll(INSTRUMENT_KEY).itemEntries()
+
+    //    Log.log(Level.INFO, "Configuring " + name + " with :" + ItemEntryUtil.showItems(items))
+    Log.log(Level.INFO, "Configuring " + name)
+    Thread.sleep(2000)
+    Log.log(Level.INFO, name + " configured")
+
+    TrySeq(ConfigResult(this))
+  })
+
+  override def observe(config: Config): SeqAction[ObserveResult] = for {
+    id <- DhsClient.createImage(DhsClient.ImageParameters(DhsClient.Permanent, List("gmos", "dhs-http")))
+    _ <- EitherT ( Task {
+      Log.log(Level.INFO, name + ": starting observation " + id)
+      Thread.sleep(5000)
+      Log.log(Level.INFO, name + ": observation completed")
+      TrySeq(())
+    } )
+    _ <- DhsClient.setKeywords(id, DhsClient.KeywordBag(
+      DhsClient.StringKeyword("instrument", "gmos"),
+      DhsClient.Int32Keyword("INPORT", 3),
+      DhsClient.DoubleKeyword("WAVELENG", 3.14159),
+      DhsClient.BooleanKeyword("PROP_MD", value = true)
+    ))
+  } yield ObserveResult(id)
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Instrument.scala
@@ -1,0 +1,41 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.{Level, Logger}
+
+import edu.gemini.seqexec.server.DhsClient.ObsId
+import edu.gemini.spModel.config2.Config
+import edu.gemini.spModel.gemini.gmos.InstGmosSouth._
+import edu.gemini.spModel.seqcomp.SeqConfigNames._
+
+import scalaz.EitherT
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 4/22/15.
+ */
+trait Instrument extends System {
+  // The name used for this instrument in the science fold configuration
+  val sfName: String
+  def observe(config: Config): SeqAction[ObserveResult]
+}
+
+//Placeholder for observe response
+case class ObserveResult(dataId: ObsId)
+
+object UnknownInstrument extends Instrument {
+
+  override val name: String = "UNKNOWN"
+
+  override val sfName: String = "unknown"
+
+  var imageCount = 0
+
+  override def configure(config: Config): SeqAction[ConfigResult] = EitherT ( Task {
+    TrySeq(ConfigResult(this))
+  } )
+
+  override def observe(config: Config): SeqAction[ObserveResult] = EitherT ( Task {
+    imageCount += 1
+    TrySeq(ObserveResult(f"S20150519S$imageCount%04d"))
+  } )
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ItemEntryUtil.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ItemEntryUtil.scala
@@ -1,0 +1,32 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.spModel.`type`.{DisplayableSpType, LoggableSpType, SequenceableSpType}
+import edu.gemini.spModel.config2.ItemEntry
+
+/**
+ * Created by jluhrs on 4/27/15.
+ */
+object ItemEntryUtil {
+
+  def showItems(ks: Array[ItemEntry]): String = {
+
+    def width(ks: Array[ItemEntry]): Int = ks match {
+      case Array() => 0
+      case _ => ks.maxBy(_.getKey.toString.length).toString.length
+    }
+
+    def seqValue(o: Object): String = o match {
+      case s: SequenceableSpType => s.sequenceValue()
+      case d: DisplayableSpType  => d.displayValue()
+      case l: LoggableSpType     => l.logValue()
+      case _ => o.toString
+    }
+
+    val pad = width(ks)
+    (ks.sortWith((u, v) => u.getKey.compareTo(v.getKey) < 0) map { p =>
+      val paddedKey = s"%-${pad}s".format(p.getKey.toString)
+      s"$paddedKey -> ${seqValue(p.getItemValue)}"
+    }).mkString(s"\n", "\n", "")
+  }
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecFailure.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/SeqexecFailure.scala
@@ -1,0 +1,44 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.seqexec.shared.SeqFailure
+import edu.gemini.seqexec.shared.SeqFailure._
+
+/**
+ * Created by jluhrs on 5/18/15.
+ */
+sealed trait SeqexecFailure
+
+object SeqexecFailure {
+
+  /** Seqexec does not know how to deal with instrument in sequence. */
+  case class UnrecognizedInstrument(name: String) extends SeqexecFailure
+
+  /** Something went wrong while running a sequence. **/
+  case class Execution(errMsg: String) extends SeqexecFailure
+
+  /** Exception thrown while running a sequence. */
+  case class SeqexecException(ex: Throwable) extends SeqexecFailure
+
+  /** Invalid operation on a Sequence */
+  case class InvalidOp(errMsg: String) extends SeqexecFailure
+
+  /** Indicates an unexpected problem while performing a Seqexec operation. */
+  case class Unexpected(msg: String) extends SeqexecFailure
+
+  /** Timeout */
+  case class Timeout(msg: String) extends SeqexecFailure
+
+  /** Sequence loading errors */
+  case class ODBSeqError(fail: SeqFailure) extends SeqexecFailure
+
+  def explain(f: SeqexecFailure): String = f match {
+    case UnrecognizedInstrument(name) => s"Unrecognized instrument: $name"
+    case Execution(errMsg)            => s"Sequence execution failed with error $errMsg"
+    case SeqexecException(ex)         => "Application exception: " + ex.getMessage
+    case InvalidOp(msg)               => s"Invalid operation: $msg"
+    case Unexpected(msg)              => s"Unexpected error: $msg"
+    case Timeout(msg)                 => s"Timeout while waiting for $msg"
+    case ODBSeqError(fail)             => SeqFailure.explain(fail)
+  }
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/System.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/System.scala
@@ -1,0 +1,17 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.spModel.config2.Config
+
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 4/22/15.
+ */
+trait System {
+  val name: String
+
+  def configure(config: Config): SeqAction[ConfigResult]
+}
+
+//Placeholder for config response
+case class ConfigResult(sys: System)

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TaskRef.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TaskRef.scala
@@ -1,0 +1,32 @@
+package edu.gemini.seqexec.server
+
+import scalaz.concurrent.Task
+
+/** A concurrent mutable cell for type A. */
+sealed trait TaskRef[A] {
+
+  /** Atomic modification. */
+  def modify(f: A => A): Task[Unit]
+  
+  /** Return the current value. */
+  def get: Task[A]
+
+  /** Replace the current value. */
+  def put(a: A): Task[Unit] = 
+    modify(_ => a)
+
+}
+
+object TaskRef {
+
+  /** Create a new TaskRef. */
+  def newTaskRef[A](a: A): Task[TaskRef[A]] =
+    Task.delay {
+      @volatile var value = a
+      new TaskRef[A] { ref =>
+        def get = Task.delay(value)
+        def modify(f: A => A) = Task.delay(ref.synchronized(value = f(value)))
+      }
+    }
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Tcs.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/Tcs.scala
@@ -1,0 +1,139 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.Logger
+
+import edu.gemini.seqexec.server.ConfigUtil._
+import edu.gemini.seqexec.server.TcsController._
+import edu.gemini.spModel.config2.{Config, ItemKey}
+import edu.gemini.spModel.core.{Angle, OffsetP, OffsetQ}
+import edu.gemini.spModel.guide.StandardGuideOptions
+import edu.gemini.spModel.seqcomp.SeqConfigNames.{TELESCOPE_CONFIG_NAME, TELESCOPE_KEY}
+import edu.gemini.spModel.target.obsComp.TargetObsCompConstants._
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+import scalaz.concurrent.Task
+import scalaz._, Scalaz._
+import squants.space.{ Millimeters, LengthConversions } 
+
+/**
+ * Created by jluhrs on 4/23/15.
+ */
+final case class Tcs(tcsController: TcsController) extends System {
+
+  import Tcs._
+  import MountGuideOption._
+
+  override val name: String = TELESCOPE_CONFIG_NAME
+
+  private def computeGuideOff(s0: TcsConfig, s1: Requested[TcsConfig]): GuideConfig = {
+
+    val g0 = s1.self.gc.mountGuide match {
+      case MountGuideOff => s0.gc.setMountGuide(MountGuideOff)
+      case _             => s0.gc
+    }
+    
+    val g1 = s1.self.gc.m1Guide match {
+      case M1GuideOff => g0.setM1Guide(M1GuideOff)
+      case _          => g0
+    }
+
+    val g2 = s1.self.gc.m2Guide match {
+      case M2GuideOff => g1.setM2Guide(M2GuideOff)
+      case _          => g1
+    }
+
+    g2 // final result
+
+  }
+
+  private def guideOff(s0: TcsConfig, s1: Requested[TcsConfig]): SeqAction[Unit] =
+    tcsController.guide {
+      if (s0.tc.offsetA === s1.self.tc.offsetA) computeGuideOff(s0, s1)
+      else GuideConfig(MountGuideOff, M1GuideOff, M2GuideOff)
+    }
+
+  private def configure(config: Config, tcsState: TcsConfig): SeqAction[ConfigResult] = {
+    val tcsConfig = fromSequenceConfig(config)(tcsState)
+    Log.info("Applying TCS configuration " + tcsConfig)
+
+    for {
+      _ <- guideOff(tcsState, Requested(tcsConfig))
+      _ <- tcsController.applyConfig(tcsConfig.tc, tcsConfig.gtc, tcsConfig.ge, tcsConfig.agc)
+      _ <- tcsController.guide(tcsConfig.gc)
+    } yield ConfigResult(this)
+  }
+
+  override def configure(config: Config): SeqAction[ConfigResult] = {
+    tcsController.getConfig.flatMap(configure(config, _))
+  }
+}
+
+object Tcs {
+  private val Log = Logger.getLogger(getClass.getName)
+
+  // Shouldn't these be defined somewhere ?
+  val GUIDE_WITH_PWFS1_PROP = "guideWithPWFS1"
+  val GUIDE_WITH_PWFS2_PROP = "guideWithPWFS2"
+  val P_OFFSET_PROP = "p"
+  val Q_OFFSET_PROP = "q"
+
+  // Conversions from ODB model values to TCS configuration values
+  implicit def probeTrackingConfigFromGuideWith(guideWith: StandardGuideOptions.Value): ProbeTrackingConfig = guideWith match {
+    case StandardGuideOptions.Value.park => ProbeTrackingConfig.Parked
+    case StandardGuideOptions.Value.freeze => ProbeTrackingConfig.Off
+    case StandardGuideOptions.Value.guide => ProbeTrackingConfig.On(NodChopTrackingConfig.Normal)
+  }
+
+  implicit def guideSensorOptionFromGuideWith(guideWith: StandardGuideOptions.Value): GuiderSensorOption = {
+    if (guideWith.isActive) GuiderSensorOn
+    else GuiderSensorOff
+  }
+
+  def build[T, P: ClassTag](f: P => Endo[T], k: ItemKey, config: Config): Endo[T] =
+    config.extract(k).as[P].foldMap(f)
+
+  def build[T, P: ClassTag, Q: ClassTag](f: (P, Q) => Endo[T], k1: ItemKey, k2: ItemKey, config: Config): Endo[T] =
+    (config.extract(k1).as[P] tuple config.extract(k2).as[Q]).foldMap(f.tupled)
+
+  // Parameter specific build functions
+  def buildPwfs1Config(guideWithPWFS1: StandardGuideOptions.Value): Endo[TcsConfig] = Endo { s0 =>
+    s0.setGuidersTrackingConfig(s0.gtc.setPwfs1TrackingConfig(guideWithPWFS1)).
+      setGuidersEnabled(s0.ge.setPwfs1GuiderSensorOption(guideWithPWFS1))
+  }
+
+  def buildPwfs2Config(guideWithPWFS2: StandardGuideOptions.Value): Endo[TcsConfig] = Endo { s0 =>
+    s0.setGuidersTrackingConfig(s0.gtc.setPwfs2TrackingConfig(guideWithPWFS2)).
+      setGuidersEnabled(s0.ge.setPwfs1GuiderSensorOption(guideWithPWFS2))
+  }
+
+  def buildOiwfsConfig(guideWithOIWFS: StandardGuideOptions.Value): Endo[TcsConfig] = Endo { s0 =>
+    s0.setGuidersTrackingConfig(s0.gtc.setOiwfsTrackingConfig(guideWithOIWFS)).
+      setGuidersEnabled(s0.ge.setOiwfsGuiderSensorOption(guideWithOIWFS))
+  }
+
+  def buildOffsetConfig(pstr: String, qstr: String): Endo[TcsConfig] = Endo { s0 =>
+    // Is there a way to express this value with squants quantities ?
+    val FOCAL_PLANE_SCALE = 1.61144; //[arcsec/mm]
+
+    try {
+      val p = pstr.toDouble
+      val q = qstr.toDouble
+      val x = (-p * s0.iaa.self.cos - q * s0.iaa.self.sin) / FOCAL_PLANE_SCALE
+      val y = (p * s0.iaa.self.sin - q * s0.iaa.self.cos) / FOCAL_PLANE_SCALE
+      s0.setTelescopeConfig(s0.tc.setOffsetA(FocalPlaneOffset(OffsetX(Millimeters(x)), OffsetY(Millimeters(y)))))
+    } catch {
+      case _: Throwable => s0
+    }
+  }
+
+  def fromSequenceConfig(config: Config)(s0: TcsConfig): TcsConfig =
+    List(
+      build(buildPwfs1Config,  TELESCOPE_KEY / GUIDE_WITH_PWFS1_PROP, config),
+      build(buildPwfs2Config,  TELESCOPE_KEY / GUIDE_WITH_PWFS2_PROP, config),
+      build(buildOiwfsConfig,  TELESCOPE_KEY / GUIDE_WITH_OIWFS_PROP, config),
+      build(buildOffsetConfig, TELESCOPE_KEY / P_OFFSET_PROP, TELESCOPE_KEY / Q_OFFSET_PROP, config)
+    ).suml.apply(s0)
+
+}
+

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsController.scala
@@ -1,0 +1,310 @@
+package edu.gemini.seqexec.server
+
+import edu.gemini.spModel.core.Wavelength
+
+import scalaz._, Scalaz._
+
+import squants.{Length, Angle}
+
+/**
+ * Created by jluhrs on 7/30/15.
+ *
+ * Interface to change and retrieve the TCS state.
+ * Most of the code deals with representing the state of the TCS subsystems.
+ */
+
+trait TcsController {
+  import TcsController._
+
+  def getConfig: SeqAction[TcsConfig]
+
+  def guide(gc: GuideConfig): SeqAction[Unit]
+
+  def applyConfig(tc: TelescopeConfig, gtc: GuidersTrackingConfig, ge: GuidersEnabled, agc: AGConfig): SeqAction[Unit]
+
+}
+
+object TcsController {
+
+  case class Requested[T](self: T) extends AnyVal
+
+  /** Enumerated type for Tip/Tilt Source. */
+  sealed trait TipTiltSource
+  object TipTiltSource {
+    case object PWFS1 extends TipTiltSource
+    case object PWFS2 extends TipTiltSource
+    case object OIWFS extends TipTiltSource
+    case object GAOS  extends TipTiltSource
+  }
+
+  /** Enumerated type for M1 Source. */
+  sealed trait M1Source
+  object M1Source {
+    case object PWFS1 extends M1Source
+    case object PWFS2 extends M1Source
+    case object OIWFS extends M1Source
+    case object GAOS  extends M1Source
+    case object HRWFS extends M1Source
+  }
+
+  /** Enumerated type for Coma option. */
+  sealed trait ComaOption
+  object ComaOption {
+    case object ComaOn  extends ComaOption
+    case object ComaOff extends ComaOption
+  }
+
+  /** Data type for M2 guide config. */
+  sealed trait M2GuideConfig
+  case object M2GuideOff extends M2GuideConfig
+  final case class M2GuideOn(coma: ComaOption, source: Set[TipTiltSource]) extends M2GuideConfig {
+    def setComa(v: ComaOption) = M2GuideOn(v, source)
+    def setSource(v: Set[TipTiltSource]) = M2GuideOn(coma, v)
+  }
+
+  /** Data type for M2 guide config. */
+  sealed trait M1GuideConfig
+  case object M1GuideOff extends M1GuideConfig
+  final case class M1GuideOn(source: M1Source) extends M1GuideConfig
+
+  /** Enumerated type for beams A, B, and C. */
+  sealed trait Beam
+  object Beam {
+    case object A extends Beam
+    case object B extends Beam
+    case object C extends Beam
+  }
+
+  /** 
+   * Data type for combined configuration of nod position (telescope orientation) and chop position 
+   * (M2 orientation)
+   */
+  final case class NodChop(nod: Beam, chop: Beam)
+  object NodChop {
+    implicit def EqualNodChop: Equal[NodChop] = 
+      Equal.equalA
+  }
+
+  /** Enumerated type for nod/chop tracking. */
+  sealed trait NodChopTrackingOption
+  object NodChopTrackingOption {
+    
+    case object NodChopTrackingOn  extends NodChopTrackingOption
+    case object NodChopTrackingOff extends NodChopTrackingOption
+
+    def fromBoolean(on: Boolean): NodChopTrackingOption =
+      if (on) NodChopTrackingOn else NodChopTrackingOff
+
+  }
+  import NodChopTrackingOption._ // needed below
+
+  // TCS can be configured to update a guide probe position only for certain nod-chop positions.
+  sealed trait NodChopTrackingConfig {
+    def get(nodchop: NodChop): NodChopTrackingOption
+  }
+  sealed trait ActiveNodChopTracking extends NodChopTrackingConfig {
+  
+    // If x is of type ActiveNodChopTracking then ∃ a:NodChop ∍ x.get(a) == NodChopTrackingOn
+    // How could I reflect that in the code?
+
+  }
+  object NodChopTrackingConfig {
+
+    object None extends NodChopTrackingConfig {
+      def get(nodchop: NodChop): NodChopTrackingOption = 
+        NodChopTrackingOff
+    }
+
+    object Normal extends ActiveNodChopTracking {
+      def get(nodchop: NodChop): NodChopTrackingOption =
+        NodChopTrackingOption.fromBoolean(nodchop.nod == nodchop.chop)
+    }
+
+    final case class Special(s: OneAnd[Set, NodChop]) extends ActiveNodChopTracking {
+      def get(nodchop: NodChop): NodChopTrackingOption =
+        NodChopTrackingOption.fromBoolean(s.element(nodchop))
+    }
+
+  }
+
+  // A probe tracking configuration is specified by its nod-chop tracking table
+  // and its follow flag. The first tells TCS when to update the target track
+  // followed by the probe, and the second tells the probe if it must follow
+  // the target track.
+
+  /** Enumerated type for follow on/off. */
+  sealed trait FollowOption
+  object FollowOption {
+    case object FollowOff extends FollowOption
+    case object FollowOn  extends FollowOption
+  }
+  import FollowOption._
+
+  /** Data type for probe tracking config. */
+  sealed abstract class ProbeTrackingConfig(
+    val follow: FollowOption,
+    val getNodChop: NodChopTrackingConfig
+  )
+  object ProbeTrackingConfig {
+    case object Parked extends ProbeTrackingConfig(FollowOff, NodChopTrackingConfig.None)
+    case object Off extends ProbeTrackingConfig(FollowOff, NodChopTrackingConfig.None)
+    final case class On(ndconfig: ActiveNodChopTracking) extends ProbeTrackingConfig(FollowOn, ndconfig)
+  }
+
+  /** Enumerated type for HRWFS pickup position. */
+  sealed trait HrwfsPickupPosition
+  object HrwfsPickupPosition {
+    case object IN     extends HrwfsPickupPosition
+    case object OUT    extends HrwfsPickupPosition
+    case object Parked extends HrwfsPickupPosition
+  }
+
+  /** Enumerated type for light source. */
+  sealed trait LightSource
+  object LightSource {
+    case object Sky  extends LightSource
+    case object AO   extends LightSource
+    case object GCAL extends LightSource
+  }
+
+  /** Data type for science fold position. */
+  sealed trait ScienceFoldPosition
+  object ScienceFoldPosition {
+    case object Parked extends ScienceFoldPosition
+    final case class Position(source: LightSource, sink: Instrument) extends ScienceFoldPosition
+  }
+
+  /** Enumerated type for offloading of tip/tilt corrections from M2 to mount. */
+  sealed trait MountGuideOption
+  object MountGuideOption {
+    case object MountGuideOff extends MountGuideOption
+    case object MountGuideOn  extends MountGuideOption
+  }
+  import MountGuideOption._
+
+  /** Data type for guide config. */
+  final case class GuideConfig(mountGuide: MountGuideOption, m1Guide: M1GuideConfig, m2Guide: M2GuideConfig) {
+    def setMountGuide(v: MountGuideOption) = GuideConfig(v, m1Guide, m2Guide)
+    def setM1Guide(v: M1GuideConfig) = GuideConfig(mountGuide, v, m2Guide)
+    def setM2Guide(v: M2GuideConfig) = GuideConfig(mountGuide, m1Guide, v)
+  }
+
+  // TCS expects offsets as two length quantities (in millimeters) in the focal plane
+  final case class OffsetX(self: Length) extends AnyVal
+  object OffsetX {
+    implicit val EqualOffsetX: Equal[OffsetX] =
+      Equal.equalA // natural equality here
+  }
+
+  final case class OffsetY(self: Length) extends AnyVal
+  object OffsetY {
+    implicit val EqualOffsetY: Equal[OffsetY] =
+      Equal.equalA // natural equality here
+  }
+
+  final case class FocalPlaneOffset(x: OffsetX, y: OffsetY)
+  object FocalPlaneOffset {
+    implicit val EqualFocalPlaneOffset: Equal[FocalPlaneOffset] =
+      Equal.equalBy(o => (o.x, o.y))
+  }
+
+  final case class OffsetA(self: FocalPlaneOffset) extends AnyVal
+  object OffsetA {
+    implicit val EqualOffsetA: Equal[OffsetA] =
+      Equal.equalBy(_.self)
+  }
+
+  final case class OffsetB(self: FocalPlaneOffset) extends AnyVal
+  object OffsetB {
+    implicit val EqualOffsetB: Equal[OffsetB] =
+      Equal.equalBy(_.self)
+  }
+
+  final case class OffsetC(self: FocalPlaneOffset) extends AnyVal
+  object OffsetC {
+    implicit val EqualOffsetC: Equal[OffsetC] =
+      Equal.equalBy(_.self)
+  }
+
+  // The WavelengthX classes cannot be value classes, because Wavelength is now a value class, and they cannot be
+  // nested.
+  final case class WavelengthA(self: Wavelength)
+  final case class WavelengthB(self: Wavelength)
+  final case class WavelengthC(self: Wavelength)
+
+  final case class TelescopeConfig(
+    offsetA: OffsetA, offsetB: OffsetB, offsetC: OffsetC,
+    wavelA:  WavelengthA, wavelB: WavelengthB, wavelC: WavelengthC,
+    m2beam: Beam
+  ) {
+
+    // TODO: these in terms of .copy
+    def setOffsetA(v: FocalPlaneOffset) = TelescopeConfig(OffsetA(v), offsetB, offsetC, wavelA, wavelB, wavelC, m2beam)
+    def setOffsetB(v: FocalPlaneOffset) = TelescopeConfig(offsetA, OffsetB(v), offsetC, wavelA, wavelB, wavelC, m2beam)
+    def setOffsetC(v: FocalPlaneOffset) = TelescopeConfig(offsetA, offsetB, OffsetC(v), wavelA, wavelB, wavelC, m2beam)
+    def setWavelengthA(v: Wavelength) = TelescopeConfig(offsetA, offsetB, offsetC, WavelengthA(v), wavelB, wavelC, m2beam)
+    def setWavelengthB(v: Wavelength) = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, WavelengthB(v), wavelC, m2beam)
+    def setWavelengthC(v: Wavelength) = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, wavelB, WavelengthC(v), m2beam)
+    def setBeam(v: Beam) = TelescopeConfig(offsetA, offsetB, offsetC, wavelA, wavelB, wavelC, v)
+  }
+
+  final case class ProbeTrackingConfigP1(self: ProbeTrackingConfig) extends AnyVal
+  final case class ProbeTrackingConfigP2(self: ProbeTrackingConfig) extends AnyVal
+  final case class ProbeTrackingConfigOI(self: ProbeTrackingConfig) extends AnyVal
+  final case class ProbeTrackingConfigAO(self: ProbeTrackingConfig) extends AnyVal
+
+  final case class GuidersTrackingConfig(
+    pwfs1: ProbeTrackingConfigP1, 
+    pwfs2: ProbeTrackingConfigP2,
+    oiwfs: ProbeTrackingConfigOI, 
+    aowfs: ProbeTrackingConfigAO
+  ) {
+    def setPwfs1TrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(ProbeTrackingConfigP1(v), pwfs2, oiwfs, aowfs)
+    def setPwfs2TrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(pwfs1, ProbeTrackingConfigP2(v), oiwfs, aowfs)
+    def setOiwfsTrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(pwfs1, pwfs2, ProbeTrackingConfigOI(v), aowfs)
+    def setAowfsTrackingConfig(v: ProbeTrackingConfig) = GuidersTrackingConfig(pwfs1, pwfs2, oiwfs, ProbeTrackingConfigAO(v))
+  }
+
+  sealed trait GuiderSensorOption
+  object GuiderSensorOff extends GuiderSensorOption
+  object GuiderSensorOn extends GuiderSensorOption
+
+  final case class GuiderSensorOptionP1(self: GuiderSensorOption) extends AnyVal
+  final case class GuiderSensorOptionP2(self: GuiderSensorOption) extends AnyVal
+  final case class GuiderSensorOptionOI(self: GuiderSensorOption) extends AnyVal
+  final case class GuiderSensorOptionAO(self: GuiderSensorOption) extends AnyVal
+
+  // A enabled guider means it is taking images and producing optical error measurements.
+  final case class GuidersEnabled(
+    pwfs1: GuiderSensorOptionP1, 
+    pwfs2: GuiderSensorOptionP2,
+    oiwfs: GuiderSensorOptionOI, 
+    aowfs: GuiderSensorOptionAO
+  ) {
+    def setPwfs1GuiderSensorOption(v: GuiderSensorOption) = GuidersEnabled(GuiderSensorOptionP1(v), pwfs2, oiwfs, aowfs)
+    def setPwfs2GuiderSensorOption(v: GuiderSensorOption) = GuidersEnabled(pwfs1, GuiderSensorOptionP2(v), oiwfs, aowfs)
+    def setOiwfsGuiderSensorOption(v: GuiderSensorOption) = GuidersEnabled(pwfs1, pwfs2, GuiderSensorOptionOI(v), aowfs)
+    def setAowfsGuiderSensorOption(v: GuiderSensorOption) = GuidersEnabled(pwfs1, pwfs2, oiwfs, GuiderSensorOptionAO(v))
+  }
+
+  final case class AGConfig(sfPos: ScienceFoldPosition, hrwfsPos: HrwfsPickupPosition)
+
+  final case class InstrumentAlignAngle(self: Angle) extends AnyVal
+
+  final case class TcsConfig(
+    gc:  GuideConfig, 
+    tc:  TelescopeConfig, 
+    gtc: GuidersTrackingConfig, 
+    ge:  GuidersEnabled,
+    agc: AGConfig, 
+    iaa: InstrumentAlignAngle
+  ) {
+    def setGuideConfig(v: GuideConfig) = TcsConfig(v, tc, gtc, ge, agc, iaa)
+    def setTelescopeConfig(v: TelescopeConfig) = TcsConfig(gc, v, gtc, ge, agc, iaa)
+    def setGuidersTrackingConfig(v: GuidersTrackingConfig) = TcsConfig(gc, tc, v, ge, agc, iaa)
+    def setGuidersEnabled(v: GuidersEnabled) = TcsConfig(gc, tc, gtc, v, agc, iaa)
+    def setAGConfig(v: AGConfig) = TcsConfig(gc, tc, gtc, ge, v, iaa)
+    def setIAA(v: InstrumentAlignAngle) = TcsConfig(gc, tc, gtc, ge, agc, v)
+  }
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerEpics.scala
@@ -1,0 +1,377 @@
+package edu.gemini.seqexec.server
+
+import java.util
+import java.util.logging.Logger
+import edu.gemini.seqexec.server.tcs.{BinaryYesNo, BinaryOnOff}
+import squants.time.Seconds
+
+import collection.JavaConversions._
+
+import edu.gemini.seqexec.server.TcsController._
+import edu.gemini.epics.acm.{CaAttributeListener, CaService, XMLBuilder}
+import edu.gemini.spModel.core.Wavelength
+import squants.space.{Degrees, Microns, Millimeters}
+
+import scalaz._
+import Scalaz._
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 9/7/15.
+ */
+object TcsControllerEpics extends TcsController {
+  private val Log = Logger.getLogger(getClass.getName)
+
+  import EpicsCodex._
+  import FollowOption._
+  import MountGuideOption._
+
+  // Code to retrieve the current configuration from TCS. Include a lot of decoders
+  implicit private val decodeMountGuideOption: DecodeEpicsValue[Integer, MountGuideOption] = DecodeEpicsValue((d: Integer)
+  => if (d == 0) MountGuideOff else MountGuideOn)
+
+  implicit private val decodeM1GuideSource: DecodeEpicsValue[String, M1Source] = DecodeEpicsValue((s: String)
+  => s.trim match {
+      case "PWFS1" => M1Source.PWFS1
+      case "PWFS2" => M1Source.PWFS2
+      case "OIWFS" => M1Source.OIWFS
+      case "GAOS" => M1Source.GAOS
+      case _ => M1Source.PWFS1
+    })
+
+  private def decodeM1Guide(r: BinaryOnOff, s: M1Source): M1GuideConfig =
+    if (r == BinaryOnOff.Off) M1GuideOff
+    else M1GuideOn(s)
+
+  private def decodeGuideSourceOption(s: String): Boolean = s.trim == "ON"
+
+  implicit private val decodeComaOption: DecodeEpicsValue[String, ComaOption] = DecodeEpicsValue((s: String)
+  => if (s.trim == "Off") ComaOption.ComaOff else ComaOption.ComaOn)
+
+  private def decodeM2Guide(s: BinaryOnOff, u: ComaOption, v: Set[TipTiltSource]): M2GuideConfig =
+    if (s == BinaryOnOff.Off) M2GuideOff
+    else M2GuideOn(u, v)
+
+  private def getGuideConfig: TrySeq[GuideConfig] = {
+    for {
+      mountGuide <- TcsEpics.instance.absorbTipTilt.map(decode[Integer, MountGuideOption])
+      m1Source <- TcsEpics.instance.m1GuideSource.map(decode[String, M1Source])
+      m1Guide <- TcsEpics.instance.m1Guide.map(decodeM1Guide(_, m1Source))
+      m2p1Guide <- TcsEpics.instance.m2p1Guide.map(decodeGuideSourceOption)
+      m2p2Guide <- TcsEpics.instance.m2p2Guide.map(decodeGuideSourceOption)
+      m2oiGuide <- TcsEpics.instance.m2oiGuide.map(decodeGuideSourceOption)
+      m2aoGuide <- TcsEpics.instance.m2aoGuide.map(decodeGuideSourceOption)
+      m2Coma <- TcsEpics.instance.comaCorrect.map(decode[String, ComaOption])
+      m2Guide <- TcsEpics.instance.m2GuideState.map(decodeM2Guide(_, m2Coma, List((m2p1Guide, TipTiltSource.PWFS1),
+        (m2p2Guide, TipTiltSource.PWFS2), (m2oiGuide, TipTiltSource.OIWFS),
+        (m2aoGuide, TipTiltSource.GAOS)).foldLeft(Set[TipTiltSource]())((s: Set[TipTiltSource], v: (Boolean, TipTiltSource)) => if (v._1) s + v._2 else s)))
+    } yield TrySeq(GuideConfig(mountGuide, m1Guide, m2Guide))
+  }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read guide configuration from TCS.")))
+
+  implicit private val decodeBeam: DecodeEpicsValue[String, Beam] = DecodeEpicsValue((op: String)
+  => op match {
+      case "A" => Beam.A
+      case "B" => Beam.B
+      case "C" => Beam.C
+      case _ => Beam.A
+    }
+  )
+
+  private def getTelescopeConfig: TrySeq[TelescopeConfig] = {
+    for {
+      xOffsetA <- TcsEpics.instance.xoffsetPoA1
+      yOffsetA <- TcsEpics.instance.yoffsetPoA1
+      xOffsetB <- TcsEpics.instance.xoffsetPoB1
+      yOffsetB <- TcsEpics.instance.yoffsetPoB1
+      xOffsetC <- TcsEpics.instance.xoffsetPoC1
+      yOffsetC <- TcsEpics.instance.yoffsetPoC1
+      wavelengthA <- TcsEpics.instance.sourceAWavelength
+      wavelengthB <- TcsEpics.instance.sourceBWavelength
+      wavelengthC <- TcsEpics.instance.sourceCWavelength
+      m2Beam <- TcsEpics.instance.chopBeam.map(decode[String, Beam])
+    } yield TrySeq(TelescopeConfig(
+      OffsetA(FocalPlaneOffset(OffsetX(Millimeters[Double](xOffsetA)), OffsetY(Millimeters[Double](yOffsetA)))),
+      OffsetB(FocalPlaneOffset(OffsetX(Millimeters[Double](xOffsetB)), OffsetY(Millimeters[Double](yOffsetB)))),
+      OffsetC(FocalPlaneOffset(OffsetX(Millimeters[Double](xOffsetC)), OffsetY(Millimeters[Double](yOffsetC)))),
+      WavelengthA(Wavelength(Microns[Double](wavelengthA))),
+      WavelengthB(Wavelength(Microns[Double](wavelengthB))),
+      WavelengthC(Wavelength(Microns[Double](wavelengthC))),
+      m2Beam
+    ))
+  }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read telescope configuration from TCS.")))
+
+  private def decodeNodChopOption(s: String): Boolean = s.trim == "On"
+
+  private def getNodChopTrackingConfig(g: TcsEpics.ProbeGuideConfig): Option[NodChopTrackingConfig] =
+    for {
+      aa <- g.nodachopa.map(decodeNodChopOption)
+      ab <- g.nodachopb.map(decodeNodChopOption)
+      ac <- g.nodachopc.map(decodeNodChopOption)
+      ba <- g.nodbchopa.map(decodeNodChopOption)
+      bb <- g.nodbchopb.map(decodeNodChopOption)
+      bc <- g.nodbchopc.map(decodeNodChopOption)
+      ca <- g.nodcchopa.map(decodeNodChopOption)
+      cb <- g.nodcchopb.map(decodeNodChopOption)
+      cc <- g.nodcchopc.map(decodeNodChopOption)
+
+      // This last production is slightly tricky. 
+      o  <- if (List(aa, ab, ac, ba, bb, bc, ca, cb, cc).exists(_ == true)) {
+              if (List(aa, bb, cc).forall(_ == true) && List(ab, ac, ba, bc, ca, cb).forall(_ == false)) {
+                Some(NodChopTrackingConfig.Normal)
+              } else {
+                List(
+                  (aa, NodChop(Beam.A, Beam.A)), (ab, NodChop(Beam.A, Beam.B)), (ac, NodChop(Beam.A, Beam.C)), 
+                  (ba, NodChop(Beam.B, Beam.A)), (bb, NodChop(Beam.B, Beam.B)), (bc, NodChop(Beam.B, Beam.C)), 
+                  (ca, NodChop(Beam.C, Beam.A)), (cb, NodChop(Beam.C, Beam.B)), (cc, NodChop(Beam.C, Beam.C))
+                ) collect {
+                  case (true, a) => a
+                } match {
+                  case h :: t => Some(NodChopTrackingConfig.Special(OneAnd(h, t.toSet)))
+                  case Nil    => None // the list is empty
+                }
+              }
+            } else Some(NodChopTrackingConfig.None)   
+
+    } yield o
+
+  private def calcProbeTrackingConfig(f: FollowOption, t: NodChopTrackingConfig): ProbeTrackingConfig = (f, t) match {
+    case (_, NodChopTrackingConfig.None) => ProbeTrackingConfig.Off
+    case (FollowOn, NodChopTrackingConfig.Normal) => ProbeTrackingConfig.On(NodChopTrackingConfig.Normal)
+    case (FollowOn, v: NodChopTrackingConfig.Special) => ProbeTrackingConfig.On(v)
+    case _ => ProbeTrackingConfig.Off
+  }
+
+  implicit private val decodeFollowOption: DecodeEpicsValue[String, FollowOption] = DecodeEpicsValue((s: String)
+  => if (s.trim == "Off") FollowOff else FollowOn)
+
+  private def getGuidersTrackingConfig: TrySeq[GuidersTrackingConfig] = {
+    for {
+      p1 <- getNodChopTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideConfig)
+      p2 <- getNodChopTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideConfig)
+      oi <- getNodChopTrackingConfig(TcsEpics.instance.oiwfsProbeGuideConfig)
+      p1Follow <- TcsEpics.instance.p1FollowS.map(decode[String, FollowOption])
+      p2Follow <- TcsEpics.instance.p2FollowS.map(decode[String, FollowOption])
+      oiFollow <- TcsEpics.instance.oiFollowS.map(decode[String, FollowOption])
+    } yield TrySeq(GuidersTrackingConfig(ProbeTrackingConfigP1(calcProbeTrackingConfig(p1Follow, p1)),
+      ProbeTrackingConfigP2(calcProbeTrackingConfig(p2Follow, p2)),
+      ProbeTrackingConfigOI(calcProbeTrackingConfig(oiFollow, oi)),
+      ProbeTrackingConfigAO(ProbeTrackingConfig.Off)))
+  }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read probes guide from TCS.")))
+
+  implicit private val decodeGuideSensorOption: DecodeEpicsValue[BinaryYesNo, GuiderSensorOption] = DecodeEpicsValue((s: BinaryYesNo)
+  => if (s == BinaryYesNo.No) GuiderSensorOff else GuiderSensorOn)
+  implicit private val decodeAltairSensorOption: DecodeEpicsValue[Double, GuiderSensorOption] = DecodeEpicsValue((s: Double)
+  => if (s == 0.0) GuiderSensorOff else GuiderSensorOn)
+
+  private def getGuidersEnabled: TrySeq[GuidersEnabled] = {
+    for {
+      p1On <- TcsEpics.instance.pwfs1On.map(decode[BinaryYesNo, GuiderSensorOption])
+      p2On <- TcsEpics.instance.pwfs2On.map(decode[BinaryYesNo, GuiderSensorOption])
+      oiOn <- TcsEpics.instance.oiwfsOn.map(decode[BinaryYesNo, GuiderSensorOption])
+      aoOn <- TcsEpics.instance.aowfsOn.map(decode[Double, GuiderSensorOption])
+    } yield TrySeq(GuidersEnabled(GuiderSensorOptionP1(p1On), GuiderSensorOptionP2(p2On), GuiderSensorOptionOI(oiOn),
+      GuiderSensorOptionAO(aoOn)))
+  }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read guider detectors state from TCS.")))
+
+  // Decoding and encoding the science fold position require some common definitions, therefore I put them inside an
+  // object
+  private object CodexScienceFoldPosition {
+
+    import LightSource._
+    import ScienceFoldPosition._
+
+    private val AO_PREFIX = "ao2"
+    private val GCAL_PREFIX = "gcal2"
+
+    // I have the feeling this operation will be needed in other places
+    private def findInstrument(name: String): Instrument =
+      List(GmosSouth).find(x => name.startsWith(x.sfName)).getOrElse(UnknownInstrument)
+
+    implicit val decodeScienceFoldPosition: DecodeEpicsValue[String, Position] = DecodeEpicsValue((t: String)
+    => if (t.startsWith(AO_PREFIX)) Position(AO, findInstrument(t.substring(AO_PREFIX.length)))
+      else if (t.startsWith(GCAL_PREFIX)) Position(GCAL, findInstrument(t.substring(GCAL_PREFIX.length)))
+      else Position(Sky, findInstrument(t)))
+
+    implicit val encodeScienceFoldPosition: EncodeEpicsValue[Position, String] = EncodeEpicsValue((a: Position)
+    => a.source match {
+        case Sky => a.sink.sfName
+        case AO => AO_PREFIX + a.sink.sfName
+        case GCAL => GCAL_PREFIX + a.sink.sfName
+      }
+    )
+  }
+
+  import CodexScienceFoldPosition._
+
+  private def getScienceFoldPosition: Option[ScienceFoldPosition] = for {
+    sfPos <- TcsEpics.instance.sfName.map(decode[String, ScienceFoldPosition.Position])
+    sfParked <- TcsEpics.instance.sfParked.map {
+      _ != 0
+    }
+  } yield if (sfParked) ScienceFoldPosition.Parked
+    else sfPos
+
+  implicit val decodeHwrsPickupPosition: DecodeEpicsValue[String, HrwfsPickupPosition] = DecodeEpicsValue((t: String)
+  => if (t.trim == "IN") HrwfsPickupPosition.IN
+    else HrwfsPickupPosition.OUT)
+
+  private def getHrwfsPickupPosition: Option[HrwfsPickupPosition] = for {
+    hwPos <- TcsEpics.instance.agHwName.map(decode[String, HrwfsPickupPosition])
+    hwParked <- TcsEpics.instance.agHwParked.map {
+      _ != 0
+    }
+  } yield if (hwParked) HrwfsPickupPosition.Parked
+    else hwPos
+
+  private def getAGConfig: TrySeq[AGConfig] = {
+    for {
+      sf <- getScienceFoldPosition
+      hrwfs <- getHrwfsPickupPosition
+    } yield TrySeq(AGConfig(sf, hrwfs))
+  }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read AG state from TCS.")))
+
+  private def getIAA: TrySeq[InstrumentAlignAngle] = {
+    for {
+      iaa <- TcsEpics.instance.instrAA
+    } yield TrySeq(InstrumentAlignAngle(Degrees[Double](iaa)))
+  }.getOrElse(TrySeq.fail(SeqexecFailure.Unexpected("Unable to read IAA from TCS.")))
+
+  override def getConfig: SeqAction[TcsConfig] = EitherT ( Task {
+    for {
+      gc <- getGuideConfig
+      tc <- getTelescopeConfig
+      gtc <- getGuidersTrackingConfig
+      ge <- getGuidersEnabled
+      agc <- getAGConfig
+      iaa <- getIAA
+    } yield TcsConfig(gc, tc, gtc, ge, agc, iaa)
+  } )
+
+  // Here starts the code that set the TCS configuration. There are a lot of encoders.
+  implicit private val encodeBeam: EncodeEpicsValue[Beam, String] = EncodeEpicsValue((op: Beam)
+  => op match {
+      case Beam.A => "A"
+      case Beam.B => "B"
+      case Beam.C => "C"
+    })
+
+  private def setTelescopeConfig(c: TelescopeConfig): SeqAction[Unit] = for {
+    _ <- TcsEpics.instance.offsetACmd.setX(c.offsetA.self.x.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetACmd.setY(c.offsetA.self.y.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetBCmd.setX(c.offsetB.self.x.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetBCmd.setY(c.offsetB.self.y.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetCCmd.setX(c.offsetC.self.x.self.toMillimeters)
+    _ <- TcsEpics.instance.offsetCCmd.setY(c.offsetC.self.y.self.toMillimeters)
+    _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelA.self.toMicrons)
+    _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
+    _ <- TcsEpics.instance.wavelSourceA.setWavel(c.wavelB.self.toMicrons)
+    _ <- TcsEpics.instance.m2Beam.setBeam(encode(c.m2beam))
+  } yield TrySeq(())
+
+  implicit private val encodeNodChopOption: EncodeEpicsValue[NodChopTrackingOption, String] = 
+    EncodeEpicsValue { (op: NodChopTrackingOption) => 
+      op match {
+        case NodChopTrackingOption.NodChopTrackingOn  => "on"
+        case NodChopTrackingOption.NodChopTrackingOff => "off"
+      }
+    }
+
+  private def setProbeTrackingConfig(s: TcsEpics.ProbeGuideCmd, c: ProbeTrackingConfig) = for {
+    _ <- s.setNodachopa(encode(c.getNodChop.get(NodChop(Beam.A, Beam.A))))
+    _ <- s.setNodachopb(encode(c.getNodChop.get(NodChop(Beam.A, Beam.B))))
+    _ <- s.setNodachopc(encode(c.getNodChop.get(NodChop(Beam.A, Beam.C))))
+    _ <- s.setNodbchopa(encode(c.getNodChop.get(NodChop(Beam.B, Beam.A))))
+    _ <- s.setNodbchopb(encode(c.getNodChop.get(NodChop(Beam.B, Beam.B))))
+    _ <- s.setNodbchopc(encode(c.getNodChop.get(NodChop(Beam.B, Beam.C))))
+    _ <- s.setNodcchopa(encode(c.getNodChop.get(NodChop(Beam.C, Beam.A))))
+    _ <- s.setNodcchopb(encode(c.getNodChop.get(NodChop(Beam.C, Beam.B))))
+    _ <- s.setNodcchopc(encode(c.getNodChop.get(NodChop(Beam.C, Beam.C))))
+  } yield TrySeq(())
+
+  private def setGuiderWfs(on: TcsEpics.WfsObserveCmd, off: EpicsCommand, c: GuiderSensorOption): SeqAction[Unit] =
+    c match {
+      case GuiderSensorOff => off.mark
+      case GuiderSensorOn => on.setNoexp(-1) // Set number of exposures to non-stop (-1)
+    }
+
+  private def setGuidersWfs(c: GuidersEnabled): SeqAction[Unit] = for {
+    _ <- setGuiderWfs(TcsEpics.instance.pwfs1ObserveCmd, TcsEpics.instance.pwfs1StopObserveCmd, c.pwfs1.self)
+    _ <- setGuiderWfs(TcsEpics.instance.pwfs2ObserveCmd, TcsEpics.instance.pwfs2StopObserveCmd, c.pwfs2.self)
+    _ <- setGuiderWfs(TcsEpics.instance.oiwfsObserveCmd, TcsEpics.instance.oiwfsStopObserveCmd, c.oiwfs.self)
+  } yield TrySeq(())
+
+  private def setProbesTrackingConfig(c: GuidersTrackingConfig): SeqAction[Unit] = for {
+    _ <- setProbeTrackingConfig(TcsEpics.instance.pwfs1ProbeGuideCmd, c.pwfs1.self)
+    _ <- setProbeTrackingConfig(TcsEpics.instance.pwfs2ProbeGuideCmd, c.pwfs2.self)
+    _ <- setProbeTrackingConfig(TcsEpics.instance.oiwfsProbeGuideCmd, c.oiwfs.self)
+  } yield TrySeq(())
+
+  def setScienceFoldConfig(sfPos: ScienceFoldPosition): SeqAction[Unit] = sfPos match {
+    case ScienceFoldPosition.Parked => TcsEpics.instance.scienceFoldParkCmd.mark
+    case p: ScienceFoldPosition.Position => TcsEpics.instance.scienceFoldPosCmd.setScfold(encode(p))
+  }
+
+  implicit private val encodeHrwfsPickupPosition: EncodeEpicsValue[HrwfsPickupPosition, String] = EncodeEpicsValue((op: HrwfsPickupPosition)
+  => op match {
+      case HrwfsPickupPosition.IN => "IN"
+      case HrwfsPickupPosition.OUT => "OUT"
+      case HrwfsPickupPosition.Parked => "park-pos."
+    })
+
+  def setHRPickupConfig(hrwfsPos: HrwfsPickupPosition): SeqAction[Unit] = hrwfsPos match {
+    case HrwfsPickupPosition.Parked => TcsEpics.instance.hrwfsParkCmd.mark
+    case _ => TcsEpics.instance.hrwfsPosCmd.setHrwfsPos(encode(hrwfsPos))
+  }
+
+  private def setAGConfig(c: AGConfig): SeqAction[Unit] = for {
+    _ <- setScienceFoldConfig(c.sfPos)
+    _ <- setHRPickupConfig(c.hrwfsPos)
+  } yield TrySeq(())
+
+
+  implicit private val encodeMountGuideConfig: EncodeEpicsValue[MountGuideOption, String] = EncodeEpicsValue((op: MountGuideOption)
+  => op match {
+      case MountGuideOn => "on"
+      case MountGuideOff => "off"
+    })
+
+  private def setMountGuide(c: MountGuideOption): SeqAction[Unit] = TcsEpics.instance.mountGuideCmd.setMode(encode(c))
+
+  implicit private val encodeM1GuideConfig: EncodeEpicsValue[M1GuideConfig, String] = EncodeEpicsValue((op: M1GuideConfig)
+  => op match {
+      case M1GuideOn(_) => "on"
+      case M1GuideOff => "off"
+    })
+
+  private def setM1Guide(c: M1GuideConfig): SeqAction[Unit] = TcsEpics.instance.m1GuideCmd.setState(encode(c))
+
+  implicit private val encodeM2GuideConfig: EncodeEpicsValue[M2GuideConfig, String] = EncodeEpicsValue((op: M2GuideConfig)
+  => op match {
+      case M2GuideOn(_, _) => "on"
+      case M2GuideOff => "off"
+    })
+
+  private def setM2Guide(c: M2GuideConfig): SeqAction[Unit] = TcsEpics.instance.m2GuideCmd.setState(encode(c))
+
+  implicit private val decodeInPosition: DecodeEpicsValue[String, Boolean] = DecodeEpicsValue(x => x.trim == "TRUE")
+
+  override def applyConfig(tc: TelescopeConfig, gtc: GuidersTrackingConfig, ge: GuidersEnabled, agc: AGConfig): SeqAction[Unit] =
+    for {
+      _ <- setTelescopeConfig(tc)
+      _ <- setProbesTrackingConfig(gtc)
+      _ <- setGuidersWfs(ge)
+      _ <- setAGConfig(agc)
+      _ <- TcsEpics.instance.post
+      _ <- EitherT(Task(Log.info("TCS configuration command post").right))
+      _ <- TcsEpics.instance.waitInPosition(Seconds(30))
+      _ <- EitherT(Task(Log.info("TCS inposition").right))
+    } yield TrySeq(())
+
+  override def guide(gc: GuideConfig): SeqAction[Unit] = for {
+    _ <- setMountGuide(gc.mountGuide)
+    _ <- setM1Guide(gc.m1Guide)
+    _ <- setM2Guide(gc.m2Guide)
+    _ <- TcsEpics.instance.post
+  } yield TrySeq(())
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerSim.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsControllerSim.scala
@@ -1,0 +1,75 @@
+package edu.gemini.seqexec.server
+
+import java.util.logging.{Level, Logger}
+
+import edu.gemini.seqexec.server.TaskRef._
+import edu.gemini.seqexec.server.TcsController._
+import edu.gemini.spModel.core.Wavelength
+import squants.space.{Degrees, Nanometers, Millimeters}
+
+import scalaz.EitherT
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 8/3/15.
+ */
+object TcsControllerSim extends TcsController {
+  import MountGuideOption._
+
+  val guideState = newTaskRef(GuideConfig(MountGuideOff, M1GuideOff, M2GuideOff))
+  val telescopeState = newTaskRef(TelescopeConfig(
+    OffsetA(FocalPlaneOffset(OffsetX(Millimeters(0.0)), OffsetY(Millimeters(0.0)))),
+    OffsetB(FocalPlaneOffset(OffsetX(Millimeters(0.0)), OffsetY(Millimeters(0.0)))),
+    OffsetC(FocalPlaneOffset(OffsetX(Millimeters(0.0)), OffsetY(Millimeters(0.0)))),
+    WavelengthA(Wavelength(Nanometers(445))),
+    WavelengthB(Wavelength(Nanometers(445))),
+    WavelengthC(Wavelength(Nanometers(445))),
+    Beam.A))
+  val guidersTrackState = newTaskRef(GuidersTrackingConfig(
+    ProbeTrackingConfigP1(ProbeTrackingConfig.Parked),
+    ProbeTrackingConfigP2(ProbeTrackingConfig.Parked),
+    ProbeTrackingConfigOI(ProbeTrackingConfig.Parked),
+    ProbeTrackingConfigAO(ProbeTrackingConfig.Parked)))
+  val guidersActivityState = newTaskRef(GuidersEnabled(
+    GuiderSensorOptionP1(GuiderSensorOff),
+    GuiderSensorOptionP2(GuiderSensorOff),
+    GuiderSensorOptionOI(GuiderSensorOff),
+    GuiderSensorOptionAO(GuiderSensorOff)))
+  val agState = newTaskRef(AGConfig(ScienceFoldPosition.Parked, HrwfsPickupPosition.Parked))
+  val iaaState = newTaskRef(InstrumentAlignAngle(Degrees(0.0)))
+  private val Log = Logger.getLogger(getClass.getName)
+
+  override def getConfig: SeqAction[TcsConfig] = EitherT( for {
+      a <- guideState.flatMap(_.get)
+      b <- telescopeState.flatMap(_.get)
+      c <- guidersTrackState.flatMap(_.get)
+      d <- guidersActivityState.flatMap(_.get)
+      e <- agState.flatMap(_.get)
+      f <- iaaState.flatMap(_.get)
+    } yield TrySeq(TcsConfig(a, b, c, d, e, f))
+  )
+
+  override def applyConfig(tc: TelescopeConfig, gtc: GuidersTrackingConfig, ge: GuidersEnabled, agc: AGConfig): SeqAction[Unit] =
+    EitherT ( for {
+        _ <- Task {
+          Log.log(Level.INFO, "Applying TCS configuration")
+          Thread.sleep(2000)
+        }
+        _ <- telescopeState.flatMap(_.put(tc))
+        _ <- guidersTrackState.flatMap(_.put(gtc))
+        _ <- guidersActivityState.flatMap(_.put(ge))
+        _ <- agState.flatMap(_.put(agc))
+      } yield TrySeq(())
+    )
+
+  override def guide(gc: GuideConfig): SeqAction[Unit] =
+    EitherT ( for {
+        _ <- Task {
+          Log.log(Level.INFO, "Applying guiding configuration")
+          Thread.sleep(1000)
+        }
+        _ <- guideState.flatMap(_.put(gc))
+      } yield TrySeq(())
+    )
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TcsEpics.scala
@@ -1,0 +1,451 @@
+package edu.gemini.seqexec.server
+
+import java.util
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+import java.util.{Timer, TimerTask}
+import java.util.logging.Logger
+import edu.gemini.seqexec.server.EpicsCommand._
+import edu.gemini.seqexec.server.tcs.{BinaryYesNo, BinaryOnOff}
+
+import collection.JavaConversions._
+
+import squants.Time
+
+import edu.gemini.epics.acm._
+
+import scalaz._
+import Scalaz._
+import scalaz.concurrent.Task
+
+/**
+ * TcsEpics wraps the non-functional parts of the EPICS ACM library to interact with TCS. It has all the objects used
+ * to read TCS status values and execute TCS commands.
+ *
+ * Created by jluhrs on 10/1/15.
+ */
+
+final class TcsEpics(epicsService: CaService) {
+
+  import TcsEpics._
+  import EpicsCommand.setParameter
+
+  // This is a bit ugly. Commands are triggered from the main apply record, so I just choose an arbitrary command here.
+  // Triggering that command will trigger all the marked commands.
+  def post: SeqAction[Unit] = m1GuideCmd.post
+
+  object m1GuideCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("m1Guide"))
+    val state = cs.map(_.getString("state"))
+
+    def setState(v: String): SeqAction[Unit] = setParameter(state, v)
+  }
+
+  object m2GuideCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("m2Guide"))
+    val state = cs.map(_.getString("state"))
+
+    def setState(v: String): SeqAction[Unit] = setParameter[String](state, v)
+  }
+
+  object mountGuideCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("mountGuide"))
+
+    val source = cs.map(_.getString("source"))
+
+    def setSource(v: String): SeqAction[Unit] = setParameter(source, v)
+
+    val p1weight = cs.map(_.getDouble("p1weight"))
+
+    def setP1Weight(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](p1weight, v)
+
+    val p2weight = cs.map(_.getDouble("p2weight"))
+
+    def setP2Weight(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](p2weight, v)
+
+    val mode = cs.map(_.getString("mode"))
+
+    def setMode(v: String): SeqAction[Unit] = setParameter(mode, v)
+  }
+
+  object offsetACmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("offsetPoA1"))
+
+    val x = cs.map(_.getDouble("x"))
+
+    def setX(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](x, v)
+
+    val y = cs.map(_.getDouble("y"))
+
+    def setY(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](y, v)
+  }
+
+  object offsetBCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("offsetPoB1"))
+
+    val x = cs.map(_.getDouble("x"))
+
+    def setX(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](x, v)
+
+    val y = cs.map(_.getDouble("y"))
+
+    def setY(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](y, v)
+  }
+
+  object offsetCCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("offsetPoC1"))
+
+    val x = cs.map(_.getDouble("x"))
+
+    def setX(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](x, v)
+
+    val y = cs.map(_.getDouble("y"))
+
+    def setY(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](y, v)
+  }
+
+  object wavelSourceA extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("wavelSourceA"))
+
+    val wavel = cs.map(_.getDouble("wavel"))
+
+    def setWavel(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](wavel, v)
+  }
+
+  object wavelSourceB extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("wavelSourceB"))
+
+    val wavel = cs.map(_.getDouble("wavel"))
+
+    def setWavel(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](wavel, v)
+  }
+
+  object wavelSourceC extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("wavelSourceC"))
+
+    val wavel = cs.map(_.getDouble("wavel"))
+
+    def setWavel(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](wavel, v)
+  }
+
+  object m2Beam extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("m2Beam"))
+
+    val beam = cs.map(_.getString("beam"))
+
+    def setBeam(v: String): SeqAction[Unit] = setParameter(beam, v)
+  }
+
+  object pwfs1ProbeGuideCmd extends ProbeGuideCmd("pwfs1Guide", epicsService)
+
+  object pwfs2ProbeGuideCmd extends ProbeGuideCmd("pwfs2Guide", epicsService)
+
+  object oiwfsProbeGuideCmd extends ProbeGuideCmd("oiwfsGuide", epicsService)
+
+  object pwfs1Park extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("pwfs1Park"))
+  }
+
+  object pwfs2Park extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("pwfs2Park"))
+  }
+
+  object oiwfsPark extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("oiwfsPark"))
+  }
+
+  object pwfs1StopObserveCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("pwfs1StopObserve"))
+  }
+
+  object pwfs2StopObserveCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("pwfs2StopObserve"))
+  }
+
+  object oiwfsStopObserveCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("oiwfsStopObserve"))
+  }
+
+  object pwfs1ObserveCmd extends WfsObserveCmd("pwfs1Observe", epicsService)
+
+  object pwfs2ObserveCmd extends WfsObserveCmd("pwfs2Observe", epicsService)
+
+  object oiwfsObserveCmd extends WfsObserveCmd("oiwfsObserve", epicsService)
+
+  object hrwfsParkCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("hrwfsPark"))
+  }
+
+  object hrwfsPosCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("hrwfs"))
+
+    val hrwfsPos = cs.map(_.getString("hrwfsPos"))
+
+    def setHrwfsPos(v: String): SeqAction[Unit] = setParameter(hrwfsPos, v)
+  }
+
+  object scienceFoldParkCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("scienceFoldPark"))
+  }
+
+  object scienceFoldPosCmd extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender("scienceFold"))
+
+    val scfold = cs.map(_.getString("scfold"))
+
+    def setScfold(v: String): SeqAction[Unit] = setParameter(scfold, v)
+  }
+
+  val tcsState = epicsService.getStatusAcceptor("tcsstate")
+
+  def absorbTipTilt: Option[Integer] = Option(tcsState.getIntegerAttribute("absorbTipTilt").value)
+
+  def m1GuideSource: Option[String] = Option(tcsState.getStringAttribute("m1GuideSource").value)
+
+  private val m1GuideAttr: Option[CaAttribute[BinaryOnOff]] = Option(tcsState.addEnum("m1Guide",
+    TCS_TOP + "im:m1GuideOn", classOf[BinaryOnOff], "M1 guide"))
+
+  def m1Guide: Option[BinaryOnOff] = m1GuideAttr.flatMap(v => Option(v.value))
+
+  def m2p1Guide: Option[String] = Option(tcsState.getStringAttribute("m2p1Guide").value)
+
+  def m2p2Guide: Option[String] = Option(tcsState.getStringAttribute("m2p2Guide").value)
+
+  def m2oiGuide: Option[String] = Option(tcsState.getStringAttribute("m2oiGuide").value)
+
+  def m2aoGuide: Option[String] = Option(tcsState.getStringAttribute("m2aoGuide").value)
+
+  def comaCorrect: Option[String] = Option(tcsState.getStringAttribute("comaCorrect").value)
+
+  private val m2GuideStateAttr: Option[CaAttribute[BinaryOnOff]] = Option(tcsState.addEnum("m2GuideState",
+    TCS_TOP + "om:m2GuideState", classOf[BinaryOnOff], "M2 guiding state"))
+
+  def m2GuideState: Option[BinaryOnOff] = m2GuideStateAttr.flatMap(v => Option(v.value))
+
+  def xoffsetPoA1: Option[Double] = Option(tcsState.getDoubleAttribute("xoffsetPoA1").value).map(_.doubleValue)
+
+  def yoffsetPoA1: Option[Double] = Option(tcsState.getDoubleAttribute("yoffsetPoA1").value).map(_.doubleValue)
+
+  def xoffsetPoB1: Option[Double] = Option(tcsState.getDoubleAttribute("xoffsetPoB1").value).map(_.doubleValue)
+
+  def yoffsetPoB1: Option[Double] = Option(tcsState.getDoubleAttribute("yoffsetPoB1").value).map(_.doubleValue)
+
+  def xoffsetPoC1: Option[Double] = Option(tcsState.getDoubleAttribute("xoffsetPoC1").value).map(_.doubleValue)
+
+  def yoffsetPoC1: Option[Double] = Option(tcsState.getDoubleAttribute("yoffsetPoC1").value).map(_.doubleValue)
+
+  def sourceAWavelength: Option[Double] = Option(tcsState.getDoubleAttribute("sourceAWavelength").value).map(_.doubleValue)
+
+  def sourceBWavelength: Option[Double] = Option(tcsState.getDoubleAttribute("sourceBWavelength").value).map(_.doubleValue)
+
+  def sourceCWavelength: Option[Double] = Option(tcsState.getDoubleAttribute("sourceCWavelength").value).map(_.doubleValue)
+
+  def chopBeam: Option[String] = Option(tcsState.getStringAttribute("chopBeam").value)
+
+  def p1FollowS: Option[String] = Option(tcsState.getStringAttribute("p1FollowS").value)
+
+  def p2FollowS: Option[String] = Option(tcsState.getStringAttribute("p2FollowS").value)
+
+  def oiFollowS: Option[String] = Option(tcsState.getStringAttribute("oiFollowS").value)
+
+  private val pwfs1OnAttr: Option[CaAttribute[BinaryYesNo]] = Option(tcsState.addEnum("pwfs1On",
+    TCS_TOP + "drives:p1Integrating", classOf[BinaryYesNo], "P1 integrating"))
+
+  def pwfs1On: Option[BinaryYesNo] = pwfs1OnAttr.flatMap(v => Option(v.value))
+
+  private val pwfs2OnAttr: Option[CaAttribute[BinaryYesNo]] = Option(tcsState.addEnum("pwfs2On",
+    TCS_TOP + "drives:p2Integrating", classOf[BinaryYesNo], "P2 integrating"))
+
+  def pwfs2On: Option[BinaryYesNo] = pwfs2OnAttr.flatMap(v => Option(v.value))
+
+  private val oiwfsOnAttr: Option[CaAttribute[BinaryYesNo]] = Option(tcsState.addEnum("oiwfsOn",
+    TCS_TOP + "drives:oiIntegrating", classOf[BinaryYesNo], "P2 integrating"))
+
+  def oiwfsOn: Option[BinaryYesNo] = oiwfsOnAttr.flatMap(v => Option(v.value))
+
+  def aowfsOn: Option[Double] = Option(tcsState.getDoubleAttribute("aowfsOn").value).map(_.doubleValue)
+
+  def sfName: Option[String] = Option(tcsState.getStringAttribute("sfName").value)
+
+  //def sfParked: Option[Integer] = Option(tcsState.getIntegerAttribute("sfParked").value)
+  def sfParked: Option[Integer] = Some(0)
+
+  def agHwName: Option[String] = Option(tcsState.getStringAttribute("agHwName").value)
+
+  //  def agHwParked: Option[Integer] = Option(tcsState.getIntegerAttribute("agHwParked").value)
+  def agHwParked: Option[Integer] = Some(1)
+
+  def instrAA: Option[Double] = Option(tcsState.getDoubleAttribute("instrAA").value).map(_.doubleValue)
+
+  private val inPositionAttr: CaAttribute[String] = tcsState.getStringAttribute("inPosition")
+
+  def inPosition: Option[String] = Option(inPositionAttr.value)
+
+  object pwfs1ProbeGuideConfig extends ProbeGuideConfig("p1", tcsState)
+
+  object pwfs2ProbeGuideConfig extends ProbeGuideConfig("p2", tcsState)
+
+  object oiwfsProbeGuideConfig extends ProbeGuideConfig("oi", tcsState)
+
+  def waitInPosition(timeout: Time): SeqAction[Unit] =
+    EpicsCommand.safe(EitherT(Task.async[TrySeq[Unit]]((f) => {
+
+      val resultGuard = new AtomicInteger(1)
+      val lock = new ReentrantLock()
+      def locked(f: => Unit): Unit = {
+        lock.lock()
+        try {
+          f
+        } finally {
+          lock.unlock()
+        }
+      }
+
+      if (!inPositionAttr.values().isEmpty && inPositionAttr.value == "TRUE") {
+        f(TrySeq(()).right)
+      } else {
+
+        val timer = new Timer
+        val statusListener = new CaAttributeListener[String] {
+
+          override def onValueChange(newVals: util.List[String]): Unit = {
+            if (!newVals.isEmpty && newVals.get(0) == "TRUE" && resultGuard.getAndDecrement() == 1) {
+              locked {
+                inPositionAttr.removeListener(this)
+                timer.cancel()
+              }
+
+              f(TrySeq(()).right)
+            }
+          }
+
+          override def onValidityChange(newValidity: Boolean): Unit = {}
+        }
+
+        locked {
+          if (timeout.toMilliseconds.toLong > 0) {
+            timer.schedule(new TimerTask {
+              override def run(): Unit = if (resultGuard.getAndDecrement() == 1) {
+                locked {
+                  inPositionAttr.removeListener(statusListener)
+                }
+
+                f(TrySeq.fail(SeqexecFailure.Timeout("waiting for TCS inposition flag.")).right)
+
+              }
+            }, timeout.toMilliseconds.toLong)
+          }
+          inPositionAttr.addListener(statusListener)
+        }
+      }
+    })))
+
+
+
+}
+
+object TcsEpics extends EpicsSystem {
+
+  val Log = Logger.getLogger(getClass.getName)
+  val CA_CONFIG_FILE = "/Tcs.xml"
+  val TCS_TOP = "tc1:"
+
+
+  // Still using a var, but at least now it's hidden. Attempts to access the single instance will
+  // now result in an Exception with a meaningful message, instead of a NullPointerExecption
+  private var instanceInternal = Option.empty[TcsEpics]
+  lazy val instance: TcsEpics = instanceInternal.getOrElse(
+    throw new Exception("Attempt to reference TcsEpics single instance before initialization."))
+
+  override def init(service: CaService): TrySeq[Unit] = {
+    try {
+      (new XMLBuilder).fromStream(this.getClass.getResourceAsStream(CA_CONFIG_FILE))
+        .withCaService(service)
+        .withTop("tcs", TcsEpics.TCS_TOP)
+        .withTop("ag", "tag:")
+        .withTop("m2", "tc1:m2:")
+        .withTop("ao", "tc1:ao:")
+        .withTop("oiwfs", "toiwfs:")
+        .buildAll()
+
+        instanceInternal = Some(new TcsEpics(service))
+
+        TrySeq(())
+
+    } catch {
+      case c: Throwable =>
+        Log.warning("TcsEpics: Problem initializing EPICS service: " + c.getMessage + "\n"
+          + c.getStackTrace.mkString("\n"))
+        TrySeq.fail(SeqexecFailure.SeqexecException(c))
+    }
+  }
+
+  sealed class ProbeGuideCmd(csName: String, epicsService: CaService) extends EpicsCommand {
+    override val cs = Option(epicsService.getCommandSender(csName))
+
+    val nodachopa = cs.map(_.getString("nodachopa"))
+    def setNodachopa(v: String): SeqAction[Unit] = setParameter(nodachopa, v)
+
+    val nodachopb = cs.map(_.getString("nodachopb"))
+    def setNodachopb(v: String): SeqAction[Unit] = setParameter(nodachopb, v)
+
+    val nodachopc = cs.map(_.getString("nodachopc"))
+    def setNodachopc(v: String): SeqAction[Unit] = setParameter(nodachopc, v)
+
+    val nodbchopa = cs.map(_.getString("nodbchopa"))
+    def setNodbchopa(v: String): SeqAction[Unit] = setParameter(nodbchopa, v)
+
+    val nodbchopb = cs.map(_.getString("nodbchopb"))
+    def setNodbchopb(v: String): SeqAction[Unit] = setParameter(nodbchopb, v)
+
+    val nodbchopc = cs.map(_.getString("nodbchopc"))
+    def setNodbchopc(v: String): SeqAction[Unit] = setParameter(nodbchopc, v)
+
+    val nodcchopa = cs.map(_.getString("nodcchopa"))
+    def setNodcchopa(v: String): SeqAction[Unit] = setParameter(nodcchopa, v)
+
+    val nodcchopb = cs.map(_.getString("nodcchopb"))
+    def setNodcchopb(v: String): SeqAction[Unit] = setParameter(nodcchopb, v)
+
+    val nodcchopc = cs.map(_.getString("nodcchopc"))
+    def setNodcchopc(v: String): SeqAction[Unit] = setParameter(nodcchopc, v)
+  }
+
+  sealed class WfsObserveCmd(csName: String, epicsService: CaService) extends EpicsCommand {
+    override val cs= Option(epicsService.getCommandSender(csName))
+
+    val noexp = cs.map(_.getInteger("noexp"))
+    def setNoexp(v: Integer): SeqAction[Unit] = setParameter(noexp, v)
+
+    val int = cs.map(_.getDouble("int"))
+    def setInt(v: Double): SeqAction[Unit] = setParameter[java.lang.Double](int, v)
+
+    val outopt = cs.map(_.getString("outopt"))
+    def setOutopt(v: String): SeqAction[Unit] = setParameter(outopt, v)
+
+    val label = cs.map(_.getString("label"))
+    def setLabel(v: String): SeqAction[Unit] = setParameter(label, v)
+
+    val output = cs.map(_.getString("output"))
+    def setOutput(v: String): SeqAction[Unit] = setParameter(output, v)
+
+    val path = cs.map(_.getString("path"))
+    def setPath(v: String): SeqAction[Unit] = setParameter(path, v)
+
+    val name = cs.map(_.getString("name"))
+    def setName(v: String): SeqAction[Unit] = setParameter(name, v)
+  }
+
+  class ProbeGuideConfig(protected val prefix: String, protected val tcsState: CaStatusAcceptor) {
+    def nodachopa: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodachopa").value)
+    def nodachopb: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodachopb").value)
+    def nodachopc: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodachopc").value)
+    def nodbchopa: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodbchopa").value)
+    def nodbchopb: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodbchopb").value)
+    def nodbchopc: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodbchopc").value)
+    def nodcchopa: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodcchopa").value)
+    def nodcchopb: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodcchopb").value)
+    def nodcchopc: Option[String] = Option(tcsState.getStringAttribute(prefix+"nodcchopc").value)
+  }
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/osgi/Activator.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/osgi/Activator.scala
@@ -1,0 +1,48 @@
+package edu.gemini.seqexec.server.osgi
+
+import edu.gemini.epics.acm.CaService
+import edu.gemini.seqexec.server.{Flamingos2Epics, SeqexecFailure, TcsEpics}
+import org.osgi.framework.{BundleActivator, BundleContext, ServiceRegistration}
+import scalaz._
+import Scalaz._
+
+object Activator {
+  val CommandScope = "osgi.command.scope"
+  val CommandFunction = "osgi.command.function"
+}
+
+class Activator extends BundleActivator {
+
+  import Activator._
+
+  private var reg: Option[ServiceRegistration[Commands]] = None
+
+  override def start(ctx: BundleContext): Unit = {
+    println("edu.gemini.seqexec.client start")
+
+    val dict = new java.util.Hashtable[String, Object]()
+    dict.put(CommandScope, "seq")
+    dict.put(CommandFunction, Array("seq"))
+
+    Option(CaService.getInstance()) match {
+      case None => throw new Exception("Unable to start EPICS service.")
+      case Some(s) => {
+        List(TcsEpics, Flamingos2Epics).traverseU(_.init(s)).leftMap {
+          case SeqexecFailure.SeqexecException(ex) => throw ex
+          case c: SeqexecFailure => throw new Exception(SeqexecFailure.explain(c))
+        }
+      }
+    }
+
+    reg = Some(ctx.registerService(classOf[Commands], Commands(), dict))
+  }
+
+  override def stop(ctx: BundleContext): Unit = {
+    println("edu.gemini.seqexec.client stop")
+
+    CaService.getInstance().unbind()
+
+    reg.foreach(_.unregister())
+    reg = None
+  }
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/osgi/Commands.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/osgi/Commands.scala
@@ -1,0 +1,193 @@
+package edu.gemini.seqexec.server.osgi
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.server._
+import edu.gemini.seqexec.shared.{SeqExecService, SeqFailure}
+import edu.gemini.spModel.`type`.{DisplayableSpType, LoggableSpType, SequenceableSpType}
+import edu.gemini.spModel.config2.{ConfigSequence, ItemKey}
+import edu.gemini.spModel.core.Peer
+
+import scalaz._
+import Scalaz._
+
+
+sealed trait Commands {
+  def seq(cmd: String, args: Array[String]): String
+}
+
+object Commands {
+  val Usage =
+    "Usage: seq host [host:port] | show obsId count|static|dynamic | run obsId"
+  val ShowUsage =
+    """Usage:
+      |  seq show obsId count
+      |  seq show obsId static [calibration|instrument|telescope ...]
+      |  seq show obsId dynamic step# [calibration|instrument|telescope ...]
+      |  seq run obsId
+      |  seq stop obsId
+      |  seq continue obsId
+      |  seq status obsId
+      |      |
+      |  Example
+      |    seq show GS-2014B-Q-2-355 static
+      |    -> shows all static values for observation 355
+      |
+      |    seq show GS-2014B-Q-2-355 static instrument
+      |    -> shows all static instrument values for observation 355
+      |
+      |    seq show GS-2014B-Q-2-355 dynamic 4 instrument
+      |    -> shows dynamic instrument values for dataset 4 of obs 355
+    """.stripMargin
+
+  def apply(): Commands = new Commands {
+
+    def host(): String =
+      s"Default seq host set to ${ExecutorImpl.host.host} ${ExecutorImpl.host.port}"
+
+    def host(loc0: Peer): String = {
+      ExecutorImpl.host(loc0)
+      host()
+    }
+
+    def show(oid: SPObservationID, cs: ConfigSequence, args: List[String]): String = {
+      def seqValue(o: Object): String = o match {
+        case s: SequenceableSpType => s.sequenceValue()
+        case d: DisplayableSpType => d.displayValue()
+        case l: LoggableSpType => l.logValue()
+        case _ => o.toString
+      }
+
+      def width(ks: Array[ItemKey]): Int = ks match {
+        case Array() => 0
+        case _ => ks.maxBy(_.toString.length).toString.length
+      }
+
+      def showKeys(title: String, step: Int, ks: Array[ItemKey]): String = {
+        val pad = width(ks)
+        ks.sortWith((u, v) => u.compareTo(v) < 0).map { k =>
+          val paddedKey = s"%-${pad}s".format(k.toString)
+          s"$paddedKey -> ${seqValue(cs.getItemValue(step, k))}"
+        }.mkString(s"$title\n", "\n", "")
+      }
+
+      def sysFilter(system: String): ItemKey => Boolean =
+        _.splitPath().get(0) == system
+
+      def ifStepValid(step: String)(body: Int => String): String =
+        \/.fromTryCatchNonFatal(step.toInt - 1).fold(
+        _ => s"Specify an integer step, not '$step'.", {
+          case i if i < 0 => "Specify a positive step number."
+          case i if i >= cs.size() => s"$oid only has ${cs.size} steps."
+          case i => body(i)
+        })
+
+
+      args match {
+        case List("count") =>
+          s"$oid sequence has ${cs.size()} steps."
+
+        case List("static") =>
+          showKeys(s"$oid Static Values", 0, cs.getStaticKeys)
+
+        case List("static", system) =>
+          val ks = cs.getStaticKeys.filter(sysFilter(system))
+          showKeys(s"$oid Static Values ($system only)", 0, ks)
+
+        case List("dynamic", step) =>
+          ifStepValid(step) { s =>
+            showKeys(s"$oid Dynamic Values (Step ${s + 1})", s, cs.getIteratedKeys)
+          }
+
+        case List("dynamic", step, system) =>
+          ifStepValid(step) { s =>
+            val ks = cs.getIteratedKeys.filter(sysFilter(system))
+            showKeys(s"$oid Dynamic Values (Step ${s + 1}, $system only)", s, ks)
+          }
+
+        case _ =>
+          ShowUsage
+      }
+    }
+
+    def seq(cmd: String, args: Array[String]): String =
+      cmd :: args.toList match {
+        case List("host") =>
+          host()
+
+        case List("host", peer) =>
+          parseLoc(peer).map(host).merge
+
+        case "show" :: obsId :: showArgs =>
+          (for {
+            oid <- parseId(obsId)
+            seq <- ExecutorImpl.read(oid).leftMap(SeqexecFailure.explain(_))
+          } yield show(oid, seq, showArgs)).merge
+
+        case List("run", obsId) =>
+          (for {
+            oid <- parseId(obsId)
+            _ <- ExecutorImpl.start(oid).leftMap(SeqexecFailure.explain(_))
+          } yield s"Sequence $obsId started." ) .merge
+
+        case List("stop", obsId) =>
+          (for {
+            oid <- parseId(obsId)
+            _ <- ExecutorImpl.stop(oid).leftMap(SeqexecFailure.explain(_))
+          } yield s"Stop requested for $obsId." ) .merge
+
+        case List("continue", obsId) => (
+          for {
+            oid <- parseId(obsId)
+            _ <- ExecutorImpl.continue(oid).leftMap(SeqexecFailure.explain(_))
+          } yield s"Resume requested for $obsId." ) .merge
+
+        case List("state", obsId) => (
+          for {
+            oid <- parseId(obsId)
+            s <- ExecutorImpl.state(oid).leftMap(SeqexecFailure.explain(_))
+          } yield ExecutorImpl.stateDescription(s) ) .merge
+
+        case _ =>
+          Usage
+      }
+  }
+
+  def parseId(s: String): String \/ SPObservationID =
+    \/.fromTryCatchNonFatal {
+      new SPObservationID(s)
+    }.leftMap(_ => s"Sorry, '$s' isn't a valid observation id.")
+
+  def parseLoc(s: String): String \/ Peer =
+    Option(Peer.tryParse(s)) \/> s"Sorry, expecting host:port not '$s'."
+
+  // a better version of this available in the latest scalaz
+  implicit class MergeOp[A](d: A \/ A) {
+    def merge: A = d.fold(identity, identity)
+  }
+
+  implicit object KeyOrdering extends scala.Ordering[ItemKey] {
+    override def compare(x: ItemKey, y: ItemKey) = x.compareTo(y)
+  }
+
+  // TODO: this, better
+  def onComplete[A](id: SPObservationID)(result: Throwable \/ A): Unit =
+    println(id + ": " + result)
+
+  // TODO: this, much, much better
+  def onCompleteRun (id: SPObservationID)(result: Throwable \/ (Executor.ExecState, \/[NonEmptyList[SeqexecFailure], Unit])): Unit = {
+    println(id + ": ")
+    result match {
+      case -\/(ex) => println(ex.getMessage)
+      case \/-((st, r)) =>
+        println(st.completed.map {
+          case Executor.Ok(StepResult(_, ObserveResult(id))) => id
+          case _                                             => ""
+        }.filter(!_.isEmpty).mkString("\n"))
+        r match {
+          case -\/(errs) => println(errs.toList.map(SeqexecFailure.explain).mkString(","))
+          case _         => ()
+        }
+    }
+
+  }
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/package.scala
@@ -1,0 +1,50 @@
+package edu.gemini.seqexec
+
+import edu.gemini.seqexec.server.SeqexecFailure.{SeqexecException, Unexpected}
+import edu.gemini.seqexec.server.System
+
+import scala.language.higherKinds
+import scalaz._
+import Scalaz._
+
+import scalaz.concurrent.Task
+
+/**
+ * Created by jluhrs on 5/18/15.
+ */
+package object server {
+
+  type TrySeq[A] = SeqexecFailure \/ A
+
+  object TrySeq {
+    def apply[A](a: A): TrySeq[A]             = a.right[SeqexecFailure]
+    def fail[A](p: SeqexecFailure): TrySeq[A] = p.left[A]
+  }
+
+  type SeqAction[A] = EitherT[Task, SeqexecFailure, A]
+
+  object SeqAction {
+    def apply[A](a: => A): SeqAction[A]          = SeqAction(a)
+    def fail[A](p: SeqexecFailure): SeqAction[A] = EitherT(Task.delay(TrySeq.fail(p)))
+  }
+
+  implicit class SeqActionOps[A](a: SeqAction[A]) {
+    def runSeqAction: TrySeq[A] = a.run.unsafePerformSyncAttempt.leftMap[SeqexecFailure](SeqexecException).join
+  }
+
+  implicit class MoreDisjunctionOps[A,B](ab: A \/ B) {
+    def validationNel: ValidationNel[A, B] =
+      ab match {
+        case -\/(a) => Failure(NonEmptyList(a))
+        case \/-(b) => Success(b)
+      }
+  }
+
+    // This is built into scalaz 7.1
+  implicit class MoreMonadOps[M[+_], A](ma: M[A])(implicit M: Monad[M]) {
+    def whileM_(p: M[Boolean]): M[Unit] =
+      M.ifM(p, M.bind(ma)(_ => whileM_(p)), M.point(()))
+  }
+
+}
+

--- a/bundle/edu.gemini.seqexec.shared/README.md
+++ b/bundle/edu.gemini.seqexec.shared/README.md
@@ -1,0 +1,5 @@
+
+## edu.gemini.seqexec.shared
+
+Shared ODB and seqexec API.
+

--- a/bundle/edu.gemini.seqexec.shared/build.sbt
+++ b/bundle/edu.gemini.seqexec.shared/build.sbt
@@ -1,0 +1,23 @@
+import OcsKeys._
+
+// note: inter-project dependencies are declared at the top, in projects.sbt
+
+name := "edu.gemini.seqexec.shared"
+
+// version set in ThisBuild
+
+libraryDependencies ++= Seq(
+  "org.scalaz" %% "scalaz-core" % ScalaZVersion)
+
+osgiSettings
+
+ocsBundleSettings
+
+OsgiKeys.bundleActivator := Some("edu.gemini.seqexec.shared.osgi.Activator")
+
+OsgiKeys.bundleSymbolicName := name.value
+
+OsgiKeys.dynamicImportPackage := Seq("")
+
+OsgiKeys.exportPackage := Seq(
+  "edu.gemini.seqexec.shared")

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecServer.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecServer.scala
@@ -1,0 +1,23 @@
+package edu.gemini.seqexec.shared
+
+import edu.gemini.pot.sp.{ISPObservation, SPObservationID}
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.seqexec.shared.SeqFailure.MissingObservation
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
+import edu.gemini.spModel.config2.ConfigSequence
+
+import scalaz._
+import Scalaz._
+
+/** Sequence Executor service server-side implementation. */
+final class SeqExecServer(odb: IDBDatabaseService) extends SeqExecService {
+  def lookup(oid: SPObservationID): TrySeq[ISPObservation] =
+    Option(odb.lookupObservationByID(oid)) \/> MissingObservation(oid)
+
+  override def sequence(oid: SPObservationID): TrySeq[ConfigSequence] =
+    lookup(oid).map { obs =>
+      ConfigBridge.extractSequence(obs, null, IDENTITY_MAP, true)
+    }
+
+}

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecService.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqExecService.scala
@@ -1,0 +1,34 @@
+package edu.gemini.seqexec.shared
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.shared.SeqFailure.SeqException
+
+
+import edu.gemini.spModel.config2.ConfigSequence
+import edu.gemini.spModel.core.Peer
+import edu.gemini.util.trpc.client.TrpcClient
+
+import scalaz._
+import Scalaz._
+
+/**
+ * Sequence Executor Service API.
+ */
+trait SeqExecService {
+
+  /** Fetches the sequence associated with the given observation id, if it
+    * exists. */
+  def sequence(oid: SPObservationID): TrySeq[ConfigSequence]
+}
+
+object SeqExecService {
+  def client(peer: Peer): SeqExecService = new SeqExecService {
+    val trpc = TrpcClient(peer).withoutKeys
+
+    private def call[A](op: SeqExecService => TrySeq[A]): TrySeq[A] =
+      trpc { remote => op(remote[SeqExecService]) }.valueOr(ex => SeqException(ex).left)
+
+    override def sequence(oid: SPObservationID): TrySeq[ConfigSequence] =
+      call(_.sequence(oid))
+  }
+}

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqFailure.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/SeqFailure.scala
@@ -1,0 +1,19 @@
+package edu.gemini.seqexec.shared
+
+import edu.gemini.pot.sp.SPObservationID
+
+sealed trait SeqFailure
+
+object SeqFailure {
+  case class MissingObservation(oid: SPObservationID) extends SeqFailure
+  case class SeqException(ex: Throwable) extends SeqFailure
+
+  def explain(sf: SeqFailure): String = sf match {
+    case MissingObservation(oid) =>
+      s"The database doesn't have observation $oid"
+
+    case SeqException(ex)        =>
+      s"Exception: ${ex.getMessage}"
+  }
+}
+

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/osgi/Activator.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/osgi/Activator.scala
@@ -1,0 +1,38 @@
+package edu.gemini.seqexec.shared.osgi
+
+import java.util
+
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.seqexec.shared.{SeqExecService, SeqExecServer}
+import org.osgi.framework.{ServiceRegistration, BundleContext, BundleActivator}
+
+import edu.gemini.util.osgi.Tracker._
+import org.osgi.util.tracker.ServiceTracker
+
+
+object Activator {
+  val PublishTrpc = "trpc"
+}
+
+class Activator extends BundleActivator {
+  private var tracker: Option[ServiceTracker[_,_]] = None
+
+  override def start(ctx: BundleContext): Unit = {
+    import Activator._
+
+    tracker = Some(track[IDBDatabaseService, ServiceRegistration[_]](ctx) { (odb) =>
+      val seqServer = new SeqExecServer(odb)
+
+      val props = new util.Hashtable[String, Object]()
+      props.put(PublishTrpc, "true")
+      ctx.registerService(classOf[SeqExecService], seqServer, props)
+    } { _.unregister() })
+
+    tracker.foreach(_.open())
+  }
+
+  override  def stop(ctx: BundleContext): Unit = {
+    tracker.foreach(_.close())
+    tracker = None
+  }
+}

--- a/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/package.scala
+++ b/bundle/edu.gemini.seqexec.shared/src/main/scala/edu/gemini/seqexec/shared/package.scala
@@ -1,0 +1,7 @@
+package edu.gemini.seqexec
+
+import scalaz._
+
+package object shared {
+  type TrySeq[A] = SeqFailure \/ A
+}

--- a/project/OcsApp.scala
+++ b/project/OcsApp.scala
@@ -47,6 +47,10 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_qpt_client
   )
 
+  lazy val app_seqexec_server = project.in(file("app/seqexec-server")).dependsOn(
+    bundle_edu_gemini_seqexec_server
+  )
+
   lazy val app_spdb = project.in(file("app/spdb")).dependsOn(
     bundle_edu_gemini_catalog,
     bundle_edu_gemini_p2checker,
@@ -75,6 +79,10 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_itc
   )
 
+//  lazy val app_seqexec = project.in(file("app/seqexec")).dependsOn(
+//    bundle_edu_gemini_seqexec_client
+//  )
+
   lazy val app_weather = project.in(file("app/weather")).dependsOn(
     bundle_edu_gemini_shared_ca,
     bundle_edu_gemini_spdb_reports_collection
@@ -101,6 +109,7 @@ trait OcsApp { this: OcsBundle =>
     bundle_edu_gemini_qpt_server,
     bundle_edu_gemini_qpt_shared,
     bundle_edu_gemini_qv_plugin,
+    bundle_edu_gemini_seqexec_server,
     bundle_edu_gemini_services_client,
     bundle_edu_gemini_services_server,
     bundle_edu_gemini_shared_ca,

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -234,6 +234,30 @@ trait OcsBundle {
       bundle_jsky_elevation_plot
     )
 
+  lazy val bundle_edu_gemini_seqexec_server = 
+    project.in(file("bundle/edu.gemini.seqexec.server")).dependsOn(
+      bundle_edu_gemini_pot,
+      bundle_edu_gemini_seqexec_shared,
+      bundle_edu_gemini_shared_util,
+      bundle_edu_gemini_spModel_core,
+      bundle_edu_gemini_spModel_pio,
+      bundle_edu_gemini_util_trpc,
+      bundle_edu_gemini_epics_acm,
+      bundle_jsky_coords,
+      bundle_jsky_util
+    )
+
+  lazy val bundle_edu_gemini_seqexec_shared = 
+    project.in(file("bundle/edu.gemini.seqexec.shared")).dependsOn(
+      bundle_edu_gemini_pot,
+      bundle_edu_gemini_shared_util,
+      bundle_edu_gemini_spModel_core,
+      bundle_edu_gemini_spModel_pio,
+      bundle_edu_gemini_util_trpc,
+      bundle_jsky_coords,
+      bundle_jsky_util
+    )
+
   lazy val bundle_edu_gemini_services_client = 
     project.in(file("bundle/edu.gemini.services.client")).dependsOn(
       bundle_edu_gemini_pot,


### PR DESCRIPTION
Rats, this is a bad PR. The edu.gemini.seqexec.shared bundle should exist in spdb, I miss-understood the logic beneath.

That module should stay in ocs and be removed from ocs3, sorry.

Reverts gemini-hlsw/ocs#897