### PR TITLE
OCSADV-383-E: ephemeris robot improved logging output

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFiles.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFiles.scala
@@ -84,7 +84,7 @@ object EphemerisFiles {
       dir.resolve(filename(hid))
 
     def error(action: String, hid: HorizonsDesignation, ex: Throwable): FileError =
-      FileError(s"Error $action ephemeris file '${filename(hid)}'", Some(hid), Some(ex))
+      FileError(s"Error $action ephemeris file", Some(hid), Some(ex))
 
     def fileOp[T](action: String, hid: HorizonsDesignation)(op: Path => T): TryExport[T] =
       TryExport.fromTryCatch(error(action, hid, _)) { op(path(hid)) }
@@ -102,7 +102,7 @@ object EphemerisFiles {
       def parseString(content: String): TryExport[T] =
         TryExport.fromDisjunction {
           parser(content).leftMap { s =>
-            FileError(s"Could not parse ephemeris data in '${filename(hid)}': $s", Some(hid), None)
+            FileError(s"Could not parse ephemeris data: $s", Some(hid), None)
           }
         }
 

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/FileStatus.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/FileStatus.scala
@@ -1,0 +1,31 @@
+package edu.gemini.dbTools.ephemeris
+
+import scalaz._, Scalaz._
+
+/** Ephemeris file status before an update. */
+sealed trait FileStatus
+
+object FileStatus {
+  /** FileStatus indicating that the corresponding ephemeris file is out of
+    * date or contains insufficient coverage for the night in general.
+    */
+  case object Expired extends FileStatus
+
+  /** FileStatus indicating that the ephemeris file corresponds to an
+    * observation that is no longer of interest (for example because it has
+    * been deleted or observed).
+    */
+  case object Extra extends FileStatus
+
+  /** FileStatus indicating that the ephemeris file is missing.
+    */
+  case object Missing extends FileStatus
+
+  /** FileStatus indicating that the ephemeris file is up-to-date for the
+    * night.
+    */
+  case object UpToDate extends FileStatus
+
+  implicit val OrderFileStatus: Order[FileStatus] =
+    Order.orderBy(_.toString)
+}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisCron.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisCron.scala
@@ -1,6 +1,7 @@
 package edu.gemini.dbTools.ephemeris
 
 import edu.gemini.dbTools.ephemeris.ExportError.OdbError
+import edu.gemini.dbTools.ephemeris.FileStatus._
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.skycalc.TwilightBoundType.NAUTICAL
 import edu.gemini.skycalc.TwilightBoundedNight
@@ -9,7 +10,7 @@ import edu.gemini.spModel.core.osgi.SiteProperty
 import org.osgi.framework.BundleContext
 
 import java.io.File
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import java.security.Principal
 import java.time.Instant
 import java.util.logging.{Level, Logger}
@@ -24,6 +25,8 @@ object TcsEphemerisCron {
     * files will be written.
     */
   val DirectoryProp = "edu.gemini.dbTools.tcs.ephemeris.directory"
+
+  import TcsEphemerisExport.FileUpdate  // (FileStatus, ExportError \/ Path)
 
   /** Cron job entry point.  See edu.gemini.spdb.cron.osgi.Activator. */
   def run(ctx: BundleContext)(tmpDir: File, log: Logger, env: java.util.Map[String, String], user: java.util.Set[Principal]): Unit = {
@@ -46,31 +49,128 @@ object TcsEphemerisCron {
     // Updates the TCS ephemeris file directory to contain only ephemeris files
     // corresponding to non-sidereal observations of interest in the ODB.  Each
     // file is updated for the current observing night.
-    val action: TryExport[HorizonsDesignation ==>> (ExportError \/ Path)] =
+    val action: TryExport[HorizonsDesignation ==>> FileUpdate] =
       for {
-        obs <- nonSid
-        res <- TcsEphemerisExport(exportDir.toPath, night, site).update(obs)
+        hid <- nonSid
+        res <- TcsEphemerisExport(exportDir.toPath, night, site).update(hid)
       } yield res
 
     log.info(s"Starting ephemeris lookup for $site, writing into $exportDir")
     try {
       action.run.unsafePerformIO() match {
         case -\/(err)     =>
-          err.log(log, "Could not refresh ephemeris data: ")
+          log.log(Level.WARNING, "Could not refresh ephemeris data: " + err.message, err.exception.orNull)
 
         case \/-(updates) =>
-          updates.toList.foreach { case (hid, res) =>
-            res match {
-              case -\/(err)  => err.log(log)
-              case \/-(path) => log.log(Level.INFO, s"$hid: updated at ${Files.getLastModifiedTime(path)}")
-            }
-          }
+          val (errors, successes) = splitResults(updates)
+          if (!successes.isEmpty) log.log(Level.INFO, successReport(successes)) // hmm, no nonEmpty?
+          if (!errors.isEmpty) log.log(Level.WARNING, errorReport(errors))
       }
     } finally {
       ctx.ungetService(odbRef)
     }
     log.info("Finish ephemeris lookup.")
   }
+
+  // **** Report Formatting ****
+
+  private implicit class ThrowableOps(t: Throwable) {
+    // Produces a String describing the stack trace but ignoring the error
+    // message itself.  The idea is that stack traces that are identical except
+    // for details mentioned in the error message will all map to the same
+    // String.
+    def stackString: String = {
+      val buf = new StringBuilder(s"${t.getClass.getName}\n")
+      t.getStackTrace.foreach { e =>
+        buf ++= s"\tat ${e.getClassName}.${e.getMethodName}(${e.getFileName}:${e.getLineNumber})\n"
+      }
+
+      Option(t.getCause).foreach { c =>
+        buf ++= "Caused By:\n"
+        buf ++= c.stackString
+      }
+
+      buf.toString()
+    }
+  }
+
+  // Errors keyed by stack trace String in order to group similar stack traces.
+  type ErrorMap   = ==>>[String,      NonEmptyList[(HorizonsDesignation, FileStatus, ExportError)]]
+
+  // Success cases grouped by the status of the file before update, so we can
+  // simply list the files that were deleted, created, updated, or skipped.
+  type SuccessMap = ==>>[FileStatus,  NonEmptyList[(HorizonsDesignation, Path)                   ]]
+
+  // Take the map of results from TcsEphemerisExport and process it into a
+  // map of errors and a map of successes.
+  private def splitResults(res: HorizonsDesignation ==>> FileUpdate): (ErrorMap, SuccessMap) =
+    res.foldrWithKey((==>>.empty: ErrorMap, ==>>.empty: SuccessMap)) { case (hid, (fileStatus, errorOrPath), (errorMap, successMap)) =>
+      errorOrPath match {
+        case -\/(err)  =>
+          val key       = err.exception.map(_.stackString) | ""
+          val head      = (hid, fileStatus, err)
+          val errorMap2 = errorMap.alter(key, o => Some(o.fold(NonEmptyList(head)) { nel =>
+            NonEmptyList.nel(head, nel.toIList)
+          }))
+          (errorMap2, successMap)
+
+        case \/-(path) =>
+          val head        = (hid, path)
+          val successMap2 = successMap.alter(fileStatus, o => Some(o.fold(NonEmptyList(head)) { nel =>
+            NonEmptyList.nel(head, nel.toIList)
+          }))
+          (errorMap, successMap2)
+      }
+    }
+
+  // Maps the list to Strings where each entry is as wide as the widest entry,
+  // right padding with space as necessary.
+  private def pad[A](as: List[A]): List[String] = {
+    val s = as.map(_.toString)
+    val m = s.maxBy(_.length).length
+    val f = s"%-${m}s"
+    s.map { s0 => f.format(s0) }
+  }
+
+  // The error report will list all the cases that generated the same stack
+  // trace followed by "Caused By" and then the stack trace. Further, we try
+  // to combine all the cases with the same user-oriented error message and
+  // then just list the corresponding horizons ids below.
+  private def errorReport(em: ErrorMap): String =
+    em.toList.map { case (stack, cases) =>
+      // Group the cases by ExportError message.
+      val empty    = ==>>.empty[String, List[(HorizonsDesignation, FileStatus)]]
+      val messages = cases.foldRight(empty) { case ((h, f, e), m) =>
+        m.alter(e.message, lo => Some((h, f) :: (lo | Nil)))
+      }
+
+      // Show the message followed by a formatted list of horizons ids
+      val header   = messages.toList.map { case (msg, lst) =>
+        val (hs, fs) = lst.unzip
+        pad(hs).zip(fs).map { case (h, s) => s"\t$h ($s)" }.mkString(s"$msg\n", "\n", "\n")
+      }.mkString("\n")
+
+      // After the header, add the stack trace if any.
+      val causedBy = (stack == "") ? "" | s"Caused By:\n$stack"
+      s"$header\n$causedBy"
+    }.mkString(s"\n${"-" * 80}\n", "\n", "")
+
+  // The success report will group the files by what happened, indicating
+  // whether they were updated, deleted, created or skipped.
+  private def successReport(sm: SuccessMap): String =
+    sm.toList.map { case (fs, updates) =>
+      val title = fs match {
+        case Expired  => "* Updated"
+        case Extra    => "* Deleted"
+        case Missing  => "* Created"
+        case UpToDate => "* Skipped (already up-to-date)"
+      }
+      val (hids, paths) = updates.toList.unzip
+      val hidsS         = pad(hids)
+      val lines         = hidsS.zip(paths).map { case (h,p) => s"\t$h => $p" }
+      s"${lines.mkString(s"$title\n", "\n", "\n")}"
+    }.mkString("\n", "\n", "")
+
 }
 
 

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/EphemerisFilesTest.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/EphemerisFilesTest.scala
@@ -46,9 +46,8 @@ object EphemerisFilesTest extends Specification with ScalaCheck with Arbitraries
   def testRight[T](makeAction: EphemerisFiles => TryExport[T]): T =
     execTest(makeAction) {
       case -\/(err) =>
-        val (msg, ex) = err.report
-        log.log(Level.WARNING, msg, ex.orNull)
-        throw ex.getOrElse(new RuntimeException())
+        log.log(Level.WARNING, err.message, err.exception.orNull)
+        throw err.exception | new RuntimeException()
 
       case \/-(t) =>
         t


### PR DESCRIPTION
This PR changes the ephemeris robot logging output to

* separate successful updates from error cases
* group successful updates by what happened to the file (created, updated, deleted, or skipped)
* group error cases by common stack trace and message

In a subsequent PR, the idea is that error (and success?) reports will be emailed to interested parties so that they know when there is an issue with gathering ephemeris data for the night.

As an example of a successful update, all three ephemeris files were updated in this report (file paths are default values because I haven't specified a more appropriate directory):

````
* Updated
	AsteroidOldStyle(4) => /Users/swalker/.ocs15/spdb_2016A-test.1.1.1_swalker/data/edu.gemini.spdb.reports.collection/cron/AsteroidOld_4.eph
	Comet(1P)           => /Users/swalker/.ocs15/spdb_2016A-test.1.1.1_swalker/data/edu.gemini.spdb.reports.collection/cron/Comet_1P.eph
	MajorBody(606)      => /Users/swalker/.ocs15/spdb_2016A-test.1.1.1_swalker/data/edu.gemini.spdb.reports.collection/cron/MajorBody_606.eph
````

Here is an example of an error case for when the network is down.  Instead of a separate stack trace for each ephemeris file, they are grouped into a single report.  (I've replaced some of the stack trace with [SNIP] so that it doesn't get too long.)

````
--------------------------------------------------------------------------------
Error communicating with horizons service: ssd.jpl.nasa.gov
	AsteroidOldStyle(4) (Missing)
	Comet(1P)           (Missing)
	MajorBody(606)      (Missing)

Caused By:
edu.gemini.horizons.api.HorizonsException
	at edu.gemini.horizons.api.HorizonsException.create(HorizonsException.java:28)
	at edu.gemini.horizons.server.backend.HorizonsService2$$anonfun$horizonsRequest$2$$anonfun$apply$21.apply(HS2.scala:318)
	at edu.gemini.horizons.server.backend.HorizonsService2$$anonfun$horizonsRequest$2$$anonfun$apply$21.apply(HS2.scala:315)
	at scalaz.effect.IO$$anonfun$catchSomeLeft$1$$anonfun$apply$11.apply(IO.scala:92)
	[SNIP]
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused By:
java.net.UnknownHostException
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:184)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	[SNIP]
````
