### PR TITLE
REL-2745 add scheduling block editor at observation level

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -38,12 +38,14 @@ final class NonSiderealTargetRules extends IRule {
 
   def checkNoSchedulingBlock(es: ObservationElements): IP2Problems =
     new P2Problems <| { p2p =>
-      for {
-        toc <- es.getTargetObsComp.asScalaOpt
-               if toc.getTargetEnvironment.getTargets.asScalaList.exists(_.isNonSidereal)
-      } p2p.addWarning(ERR_NO_SCHEDULING_BLOCK,
-          s"Observation ${es.getObservationNode.getObservationID} has nonsidereal targets but no scheduling block.",
+      es.getTargetObsComp.asScalaOpt.map { toc =>
+        if (toc.getTargetEnvironment.getTargets.asScalaList.exists(_.isNonSidereal) &&
+            es.getSchedulingBlock.isEmpty) {
+        p2p.addWarning(ERR_NO_SCHEDULING_BLOCK,
+          s"Observation ${Option(es.getObservationNode.getObservationID).getOrElse(es.getObservation.getTitle)} has nonsidereal targets but no scheduling block.",
           es.getObservationNode)
+        }
+      }
     }
 
   def checkSchedulingBlockOutsideSemester(es: ObservationElements): IP2Problems =

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -38,7 +38,7 @@ final class NonSiderealTargetRules extends IRule {
 
   def checkNoSchedulingBlock(es: ObservationElements): IP2Problems =
     new P2Problems <| { p2p =>
-      es.getTargetObsComp.asScalaOpt.map { toc =>
+      es.getTargetObsComp.asScalaOpt.foreach { toc =>
         if (toc.getTargetEnvironment.getTargets.asScalaList.exists(_.isNonSidereal) &&
             es.getSchedulingBlock.isEmpty) {
         p2p.addWarning(ERR_NO_SCHEDULING_BLOCK,

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
@@ -9,11 +9,13 @@ import edu.gemini.shared.util.TimeValue;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.dataset.DataflowStatus;
 import edu.gemini.spModel.dataset.DatasetQaState;
 import edu.gemini.spModel.dataset.DatasetQaStateSums;
 import edu.gemini.spModel.obs.*;
 import edu.gemini.spModel.obs.ObservationStatus;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummary;
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummaryService;
 import edu.gemini.spModel.obsclass.ObsClass;
@@ -41,6 +43,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeListener;
 import java.text.DateFormat;
+import java.text.Format;
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.logging.Level;
@@ -322,6 +326,12 @@ public final class EdObservation2 extends OtItemEditor<ISPObservation, SPObserva
 
         _updateObsTimeCorrectionTable();
         _updateTotalUsedTime(false);
+
+        final Option<Site> site = ObsContext.getSiteFromObservation(getNode());
+        final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
+        numberFormatter.setMaximumFractionDigits(2);
+        numberFormatter.setMaximumIntegerDigits(3);
+        _editorPanel.schedulingBlock.init(this, site, numberFormatter);
 
         // GUI editable state depends on the observation status
         OT.updateEditableState(getNode());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ObsForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ObsForm.java
@@ -5,6 +5,7 @@ import com.jgoodies.forms.factories.FormFactory;
 import com.jgoodies.forms.layout.*;
 import edu.gemini.spModel.obs.ObsPhase2Status;
 import edu.gemini.spModel.obs.ObsQaState;
+import jsky.app.ot.gemini.parallacticangle.ParallacticAngleControls;
 import jsky.util.gui.DropDownListBoxWidget;
 import jsky.util.gui.NumberBoxWidget;
 import jsky.util.gui.SingleSelectComboBox;
@@ -50,6 +51,9 @@ public class ObsForm extends JPanel {
         JLabel phase2StatusLabel = new JLabel();
         phase2StatusBox = new SingleSelectComboBox<>();
         execStatusPanel = new JPanel();
+
+        final JLabel schedulingBlockLabel = new JLabel();
+        schedulingBlock = new ParallacticAngleControls(false);
 
         JLabel label3 = new JLabel();
         qaStateBox = new DropDownListBoxWidget<>();
@@ -231,6 +235,12 @@ public class ObsForm extends JPanel {
             panel1.add(tooCardPanel, cc.xywh(7, 1, 5, 1, CellConstraints.FILL, CellConstraints.FILL));
         }
         add(panel1, cc.xywh(3, row, 9, 1));
+
+        row += 2;
+
+        schedulingBlockLabel.setText("Scheduling ");
+        add(schedulingBlockLabel, cc.xy(1, row));
+        add(schedulingBlock.peer(), cc.xywh(3, row, 9, 1));
 
         row += 2;
 
@@ -528,4 +538,7 @@ public class ObsForm extends JPanel {
     JPanel tooLabelOnlyPanel;
     JLabel tooSinglePriorityLabel;
     // JFormDesigner - End of variables declaration  //GEN-END:variables
+
+    ParallacticAngleControls schedulingBlock;
+
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -103,7 +103,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
                                          SPComponentType.INSTRUMENT_GNIRS).contains(instType)
 
       if (supportsParallacticAngle) {
-        val parallacticAngleControls = new ParallacticAngleControls
+        val parallacticAngleControls = new ParallacticAngleControls(true)
 
         listenTo(parallacticAngleControls)
         reactions += {
@@ -176,7 +176,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     // Turn off the parallactic angle changing event handling as it triggers an AGS lookup.
     ui.parallacticAngleControlsOpt.foreach(p => {
       deafTo(p)
-      p.init(e.asInstanceOf[ParallacticAngleControls.Editor], s, numberFormatter)
+      p.init(e, s, numberFormatter)
     })
 
     // Reset the combo box so that all of the options are enabled by default.


### PR DESCRIPTION
This PR hacks a copy of the parametric angle time doodad into the top-level observation editor. It's not great but it provides needed functionality for today's test release.

![image](https://cloud.githubusercontent.com/assets/1200131/14825466/f43c181c-0b8e-11e6-9597-b97bb97eba68.png)

Also fixed a P2 warning about missing scheduling blocks that didn't actually check to see if there was a scheduling block or not.