### PR TITLE
REL-2745-B fixed spacing problem

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ObsForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ObsForm.java
@@ -131,6 +131,8 @@ public class ObsForm extends JPanel {
                 FormFactory.DEFAULT_ROWSPEC,
                 FormFactory.LINE_GAP_ROWSPEC,
                 FormFactory.DEFAULT_ROWSPEC,
+                FormFactory.LINE_GAP_ROWSPEC,
+                FormFactory.DEFAULT_ROWSPEC,
                 FormFactory.PARAGRAPH_GAP_ROWSPEC,
                 FormFactory.DEFAULT_ROWSPEC,
                 FormFactory.LINE_GAP_ROWSPEC,


### PR DESCRIPTION
I neglected to add space in the layout for the scheduling block, so part of the time correction UI was getting pushed off the bottom.