### PR TITLE
OCSADV-383: add error report mailer

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/ReportMailer.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/ReportMailer.scala
@@ -1,0 +1,84 @@
+package edu.gemini.dbTools.ephemeris
+
+import edu.gemini.spModel.core.Site
+
+import java.util.Properties
+import java.util.logging.{Level, Logger}
+import javax.mail.{Transport, Session}
+import javax.mail.Message.RecipientType.TO
+import javax.mail.internet.{InternetAddress, MimeMessage}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+
+import scalaz._, Scalaz._
+import scalaz.effect.IO
+import scalaz.effect.IO._
+
+/** Mailer for ephemeris error reports.
+ */
+sealed abstract class ReportMailer(site: Site, val smtpHost: String, val recipients: List[InternetAddress]) {
+
+  def notifyError(report: String): IO[Unit] =
+    createMessage(report).flatMap(send)
+
+  private def createMessage(report: String): IO[MimeMessage] = IO {
+    val sender = new InternetAddress()
+    sender.setAddress("noreply@gemini.edu")
+    sender.setPersonal(s"Gemini ODB (${site.abbreviation})")
+
+    val props = new Properties()
+    props.put("mail.transport.protocol", "smtp")
+    props.put("mail.smtp.host",          smtpHost)
+
+    val text =
+      s"""
+         |There was an error running the ephemeris update service at ${site.displayName}:
+         |
+         |$report
+         |
+       """.stripMargin
+
+    val mm = new MimeMessage(Session.getInstance(props, null))
+    mm.setFrom(sender)
+    recipients.foreach(mm.addRecipient(TO, _))
+    mm.setSubject(s"${site.abbreviation} Ephemeris Update Error")
+    mm.setContent(text, "text/plain")
+    mm
+  }
+
+  protected def send(m: MimeMessage): IO[Unit]
+}
+
+object ReportMailer {
+  val Log = Logger.getLogger(getClass.getName)
+
+  def apply(site: Site, smtpHost: String, recipients: List[InternetAddress]): ReportMailer =
+    new ReportMailer(site, smtpHost, recipients) {
+      override def send(msg: MimeMessage): IO[Unit] =
+        IO {
+          val rs = recipients.mkString(", ")
+          Future(Transport.send(msg)).onComplete {
+            case Success(_) => Log.info(s"Successfully sent mail to $rs.")
+            case Failure(e) => Log.log(Level.WARNING, s"Failed to send mail to $rs.", e)
+          }
+        }
+    }
+
+  def forTesting(site: Site): ReportMailer =
+    new ReportMailer(site, "bogus.mail.host", Nil) {
+      override def send(msg: MimeMessage): IO[Unit] =
+        for {
+          _ <- log("")
+          _ <- log(s"From: ${msg.getFrom.mkString(", ")}")
+          _ <- log(s"To: ${recipients.mkString(", ")}")
+          _ <- log(s"Subject: ${msg.getSubject}")
+          _ <- log("")
+          _ <- msg.getContent.toString.lines.toList.traverseU(log)
+        } yield ()
+
+      def log(msg: String): IO[Unit] =
+        putStrLn(s"TestMailer: $msg")
+    }
+}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisCron.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/TcsEphemerisCron.scala
@@ -14,9 +14,12 @@ import java.nio.file.Path
 import java.security.Principal
 import java.time.Instant
 import java.util.logging.{Level, Logger}
+import javax.mail.internet.InternetAddress
 
 import scalaz.Scalaz._
 import scalaz._
+import scalaz.effect.IO
+import scalaz.effect.IO.ioUnit
 
 /** TCS ephemeris export cron job. */
 object TcsEphemerisCron {
@@ -24,13 +27,45 @@ object TcsEphemerisCron {
   /** If specified, this property identifies the directory where ephemeris
     * files will be written.
     */
-  val DirectoryProp = "edu.gemini.dbTools.tcs.ephemeris.directory"
+  val DirectoryProp  = "edu.gemini.dbTools.tcs.ephemeris.directory"
+
+  /** A config property that lists email recipients for error reports. */
+  val RecipientsProp = "edu.gemini.dbTools.tcs.ephemeris.recipients"
+
+  /** A config property that specifies the SMTP server to use. */
+  val SmtpProp       = "cron.odbMail.SITE_SMTP_SERVER"
 
   import TcsEphemerisExport.FileUpdate  // (FileStatus, ExportError \/ Path)
 
+  // Creates a mailer for sending error reports, extracting smtp and recipients
+  // from bundle properties.
+  private def reportMailer(ctx: BundleContext, site: Site, log: Logger): ReportMailer = {
+    def parseRecipients(s: String): String \/ List[InternetAddress] =
+      \/.fromTryCatchNonFatal {
+        InternetAddress.parse(s, false).toList
+      }.leftMap(_ => s"Could not parse address list '$s'").ensure("Empty address list.") { _.nonEmpty }
+
+    val mailer = for {
+      rprop <- Option(ctx.getProperty(RecipientsProp)) \/> s"Missing $RecipientsProp"
+      rs    <- parseRecipients(rprop)
+      host  <- Option(ctx.getProperty(SmtpProp))       \/> s"Missing $SmtpProp"
+    } yield ReportMailer(site, host, rs)
+
+    mailer match {
+      case -\/(msg) =>
+        // If anything is missing use a test mailer.
+        log.warning(s"TcsEphemerisCron using test mailer ($msg).")
+        ReportMailer.forTesting(site)
+      case \/-(m)   =>
+        log.info(s"TcsEphemerisCron using host '${m.smtpHost}' and recipients '${m.recipients.mkString(",")}'")
+        m
+    }
+  }
+
   /** Cron job entry point.  See edu.gemini.spdb.cron.osgi.Activator. */
-  def run(ctx: BundleContext)(tmpDir: File, log: Logger, env: java.util.Map[String, String], user: java.util.Set[Principal]): Unit = {
-    val site = Option(SiteProperty.get(ctx)) | sys.error(s"Property `${SiteProperty.NAME}` not specified.")
+  def run(ctx: BundleContext)(tmpDir: File, logger: Logger, env: java.util.Map[String, String], user: java.util.Set[Principal]): Unit = {
+    val site   = Option(SiteProperty.get(ctx)) | sys.error(s"Property `${SiteProperty.NAME}` not specified.")
+    val mailer = reportMailer(ctx, site, logger)
 
     val exportDir = Option(ctx.getProperty(DirectoryProp)).fold(tmpDir) { pathString =>
       new File(pathString)
@@ -55,21 +90,38 @@ object TcsEphemerisCron {
         res <- TcsEphemerisExport(exportDir.toPath, night, site).update(hid)
       } yield res
 
-    log.info(s"Starting ephemeris lookup for $site, writing into $exportDir")
-    try {
-      action.run.unsafePerformIO() match {
-        case -\/(err)     =>
-          log.log(Level.WARNING, "Could not refresh ephemeris data: " + err.message, err.exception.orNull)
+    def log(level: Level, msg: String, ex: Option[Throwable] = None): IO[Unit] =
+      IO { logger.log(level, msg, ex.orNull) }
 
+    def logAndMail(results: ExportError \/ (HorizonsDesignation ==>> FileUpdate)): IO[Unit] =
+      results match {
+        case -\/(err)     =>
+          val msg = "Could not refresh ephemeris data: " + err.message
+          for {
+            _ <- log(Level.WARNING, msg, err.exception)
+            _ <- mailer.notifyError(msg)
+          } yield ()
         case \/-(updates) =>
-          val (errors, successes) = splitResults(updates)
-          if (!successes.isEmpty) log.log(Level.INFO, successReport(successes)) // hmm, no nonEmpty?
-          if (!errors.isEmpty) log.log(Level.WARNING, errorReport(errors))
+          val (em, sm) = splitResults(updates)
+          val sr       = (!sm.isEmpty) option successReport(sm)
+          val er       = (!em.isEmpty) option errorReport(em)
+          for {
+            _ <- sr.fold(ioUnit) { log(Level.INFO, _)    }
+            _ <- er.fold(ioUnit) { log(Level.WARNING, _) }
+            _ <- er.fold(ioUnit) { mailer.notifyError    }
+          } yield ()
       }
+
+    try {
+      (for {
+        _   <- log(Level.INFO, s"Starting ephemeris lookup for $site, writing into $exportDir")
+        res <- action.run
+        _   <- logAndMail(res)
+        _   <- log(Level.INFO, "Finish ephemeris lookup.")
+      } yield ()).unsafePerformIO()
     } finally {
       ctx.ungetService(odbRef)
     }
-    log.info("Finish ephemeris lookup.")
   }
 
   // **** Report Formatting ****
@@ -153,7 +205,7 @@ object TcsEphemerisCron {
       // After the header, add the stack trace if any.
       val causedBy = (stack == "") ? "" | s"Caused By:\n$stack"
       s"$header\n$causedBy"
-    }.mkString(s"\n${"-" * 80}\n", "\n", "")
+    }.mkString(s"\n", s"\n${"-" * 80}\n", "")
 
   // The success report will group the files by what happened, indicating
   // whether they were updated, deleted, created or skipped.


### PR DESCRIPTION
This installment adds an error report mailer (which is a shameless copy of `KeyMailer`) and uses it to send an email if there is a problem with creating/refreshing/deleting ephemeris files.