### PR TITLE
REL-2746-A add semester to obs context

### DIFF
--- a/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
+++ b/bundle/edu.gemini.ags.servlet/src/main/java/edu/gemini/ags/servlet/ToContext.java
@@ -1,5 +1,6 @@
 package edu.gemini.ags.servlet;
 
+import edu.gemini.shared.util.immutable.None;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.DDMMSS;
 import edu.gemini.skycalc.HHMMSS;
@@ -210,7 +211,7 @@ public enum ToContext {
 
         final TargetObsComp toc = new TargetObsComp();
         toc.setTargetEnvironment(env);
-        return ObsContext.create(env, inst, site, conds, Collections.emptySet(), altair, new Some<>(sb));
+        return ObsContext.create(env, inst, site, conds, Collections.emptySet(), altair, new Some<>(sb), None.instance());
     }
 
     private InstAltair getAltair(HttpServletRequest req) throws RequestException {

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsRegistrarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsRegistrarSpec.scala
@@ -25,7 +25,7 @@ class AgsRegistrarSpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new InstPhoenix <| {_.setPosAngle(0.0)}
 
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), null, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), null, null, null, JNone.instance(), JNone.instance())
 
       AgsRegistrar.defaultStrategy(ctx) should beSome(SingleProbeStrategy(Pwfs2SouthKey,PwfsParams(Site.GS, PwfsGuideProbe.pwfs2),ConeSearchBackend))
     }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsGuideSearchOptionsSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsGuideSearchOptionsSpec.scala
@@ -25,7 +25,7 @@ class GemsGuideSearchOptionsSpec extends Specification {
   val inst = new Gsaoi
   inst.setPosAngle(0.0)
   inst.setIssPort(IssPort.SIDE_LOOKING)
-  val ctx = ObsContext.create(targetEnvironment, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+  val ctx = ObsContext.create(targetEnvironment, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance(), JNone.instance())
   val posAngles = new java.util.HashSet[Angle]()
 
   "GemsGuideSearchOptions" should {
@@ -56,7 +56,7 @@ class GemsGuideSearchOptionsSpec extends Specification {
       criteria(1).criterion.magConstraint should beEqualTo(MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(17.0), Some(SaturationConstraint(8))))
     }
     "provide search options for gsaoi in both tip tilt modes" in {
-      val ctx = ObsContext.create(targetEnvironment, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+      val ctx = ObsContext.create(targetEnvironment, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance(), JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.both
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -341,7 +341,7 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
     val baseTarget = new SPTarget(coords.getRaDeg, coords.getDecDeg)
     val env = TargetEnvironment.create(baseTarget)
     val offsets = new java.util.HashSet[Offset]
-    val obsContext = ObsContext.create(env, inst, JNone.instance[Site], conditions, offsets, new Gems, JNone.instance())
+    val obsContext = ObsContext.create(env, inst, JNone.instance[Site], conditions, offsets, new Gems, JNone.instance(), JNone.instance())
     val baseRA = Angle.fromDegrees(coords.getRaDeg)
     val baseDec = Angle.fromDegrees(coords.getDecDeg)
     val base = new HmsDegCoordinates.Builder(baseRA.toOldModel, baseDec.toOldModel).build

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
@@ -36,7 +36,7 @@ class GemsVoTableCatalogSpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.SIDE_LOOKING)}
       val conditions = SPSiteQuality.Conditions.BEST
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], conditions, null, null, JNone.instance(), JNone.instance())
       val base = Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
@@ -60,7 +60,7 @@ class GemsVoTableCatalogSpec extends Specification {
       val inst = new Gsaoi
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance(), JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
 
@@ -79,7 +79,7 @@ class GemsVoTableCatalogSpec extends Specification {
       val inst = new Gsaoi
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance(), JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
@@ -41,7 +41,7 @@ trait UCAC3Regression {
     val env = TargetEnvironment.create(baseTarget)
     val offsets = new java.util.HashSet[edu.gemini.skycalc.Offset]
 
-    val obsContext = ObsContext.create(env, new Gsaoi, new JSome(Site.GS), conditions, offsets, new Gems, JNone.instance()).withPositionAngle(Angle.zero.toOldModel)
+    val obsContext = ObsContext.create(env, new Gsaoi, new JSome(Site.GS), conditions, offsets, new Gems, JNone.instance(), JNone.instance()).withPositionAngle(Angle.zero.toOldModel)
     val gemsResults = GemsResultsAnalyzer.analyze(obsContext, posAngles.asJava, results.asJava, None)
     areGuideStarListsEqual(expectedGuideStars, gemsResults.asScala.toList)
   }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
@@ -213,7 +213,7 @@ class MascotGuideStarSpec extends Specification {
       val inst = new Gsaoi()
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance(), JNone.instance())
 
       val result = MascotGuideStar.findBestAsterismInQueryResult(loadedTargets, ctx, MascotGuideStar.CWFS, 180.0, 10.0)
 
@@ -230,7 +230,7 @@ class MascotGuideStarSpec extends Specification {
       val inst = new Gsaoi()
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance(), JNone.instance())
 
       val result = MascotGuideStar.findBestAsterismInQueryResult(UCAC3Regression.replaceRBands(loadedTargets), ctx, MascotGuideStar.CWFS, 180.0, 10.0)
 
@@ -250,7 +250,7 @@ class MascotGuideStarSpec extends Specification {
         val inst = new Gsaoi()
         inst.setPosAngle(0.0)
         inst.setIssPort(IssPort.SIDE_LOOKING)
-        val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+        val ctx = ObsContext.create(env, inst, JNone.instance(), SPSiteQuality.Conditions.BEST, null, null, JNone.instance(), JNone.instance())
 
         val targets = t.result.targets.rows
         val result = MascotGuideStar.findBestAsterismInQueryResult(targets, ctx, MascotGuideStar.CWFS, 180.0, 10.0)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
@@ -61,8 +61,8 @@ object AgsTest extends TargetsHelper {
     }
     inst.setPosAngleDegrees(0.0)
 
-    val ctx = if (site.isDefined) ObsContext.create(targetEnv, inst, site.asGeminiOpt, BEST, java.util.Collections.emptySet(), null, JNone.instance())
-              else ObsContext.create(targetEnv, inst, BEST, java.util.Collections.emptySet(), null, JNone.instance())
+    val ctx = if (site.isDefined) ObsContext.create(targetEnv, inst, site.asGeminiOpt, BEST, java.util.Collections.emptySet(), null, JNone.instance(), JNone.instance())
+              else ObsContext.create(targetEnv, inst, BEST, java.util.Collections.emptySet(), null, JNone.instance(), JNone.instance())
     AgsTest(
       ctx,
       guideProbe,

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -47,7 +47,7 @@ class GemsStrategySpec extends Specification {
       val canopus = Canopus.Wfs.values().toList
       val pwfs1 = List(PwfsGuideProbe.pwfs1)
 
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), SPSiteQuality.Conditions.BEST, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), SPSiteQuality.Conditions.BEST, null, new Gems, JNone.instance(), JNone.instance())
 
       val estimate = TestGemsStrategy("/gemsstrategyquery.xml").estimate(ctx, ProbeLimitsTable.loadOrThrow())
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
@@ -59,7 +59,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions , null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions , null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.instrument
 
       val posAngles = Set.empty[Angle]
@@ -79,7 +79,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -147,7 +147,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -225,7 +225,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.BEST.cc(SPSiteQuality.CloudCover.PERCENT_50)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -290,7 +290,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).wv(SPSiteQuality.WaterVapor.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -365,7 +365,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).wv(SPSiteQuality.WaterVapor.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -442,7 +442,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
@@ -506,7 +506,7 @@ class GemsStrategySpec extends Specification {
       val env = TargetEnvironment.create(target)
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val conditions = SPSiteQuality.Conditions.BEST.cc(SPSiteQuality.CloudCover.PERCENT_50)
-      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance(), JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -71,7 +71,7 @@ class SingleProbeStrategySpec extends Specification {
 
       val strategy = SingleProbeStrategy(AltairAowfsKey, SingleProbeStrategyParams.AltairAowfsParams, TestVoTableBackend("/ocsadv245.xml"))
       val aoComp = new InstAltair <| {_.setMode(AltairParams.Mode.NGS)}
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.BEST, null, aoComp, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.BEST, null, aoComp, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -87,7 +87,7 @@ class SingleProbeStrategySpec extends Specification {
 
       val strategy = SingleProbeStrategy(AltairAowfsKey, SingleProbeStrategyParams.AltairAowfsParams, TestVoTableBackend("/ocsadv-245-lgs.xml"))
       val aoComp = new InstAltair <| {_.setMode(AltairParams.Mode.LGS)}
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), null, aoComp, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), null, aoComp, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -105,7 +105,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Pwfs1NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs1), TestVoTableBackend("/niri_pwfs1.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -123,7 +123,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/niri_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -141,7 +141,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), TestVoTableBackend("/gmosn_oiwfs.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -171,7 +171,7 @@ class SingleProbeStrategySpec extends Specification {
 
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
+      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance(), JNone.instance())
       val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff", GmosOiwfsGuideProbe.instance, PossibleIqDegradation)
     }
@@ -199,7 +199,7 @@ class SingleProbeStrategySpec extends Specification {
 
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
+      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance(), JNone.instance())
       val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff Bright", GmosOiwfsGuideProbe.instance)
     }
@@ -231,7 +231,7 @@ class SingleProbeStrategySpec extends Specification {
 
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
-      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
+      val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance(), JNone.instance())
       val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff Flip Bright", GmosOiwfsGuideProbe.instance)
     }
@@ -247,7 +247,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gmosn_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.WORST
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -265,7 +265,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Flamingos2OiwfsKey, SingleProbeStrategyParams.Flamingos2OiwfsParams, TestVoTableBackend("/f2_oiwfs.xml"))
 
       val conditions = SPSiteQuality.Conditions.WORST
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -283,7 +283,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Pwfs2SouthKey, SingleProbeStrategyParams.PwfsParams(Site.GS, PwfsGuideProbe.pwfs2), TestVoTableBackend("/f2_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -301,7 +301,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(GmosSouthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GS), TestVoTableBackend("/gmoss_oiwfs.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -320,7 +320,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Pwfs2SouthKey, SingleProbeStrategyParams.PwfsParams(Site.GS, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gmoss_pwfs2.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -338,7 +338,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gnirs_1.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.cc(SPSiteQuality.CloudCover.PERCENT_70).sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -356,7 +356,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy = SingleProbeStrategy(Pwfs2NorthKey, SingleProbeStrategyParams.PwfsParams(Site.GN, PwfsGuideProbe.pwfs2), TestVoTableBackend("/gnirs_2.xml"))
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.cc(SPSiteQuality.CloudCover.PERCENT_70).sb(SPSiteQuality.SkyBackground.ANY)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance(), JNone.instance())
 
       val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
 
@@ -374,7 +374,7 @@ class SingleProbeStrategySpec extends Specification {
 
       // Conditions will not let it go through
       val conditions = SPSiteQuality.Conditions.WORST
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance(), JNone.instance())
 
       val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
 
@@ -395,7 +395,7 @@ class SingleProbeStrategySpec extends Specification {
 
       // Conditions not that bad
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance(), JNone.instance())
 
       val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
 
@@ -417,7 +417,7 @@ class SingleProbeStrategySpec extends Specification {
 
       // Conditions not that bad
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance(), JNone.instance())
 
       val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
 
@@ -438,7 +438,7 @@ class SingleProbeStrategySpec extends Specification {
 
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70).iq(SPSiteQuality.ImageQuality.PERCENT_85)
       // Note, no site defined
-      val ctx = ObsContext.create(env, inst, JNone.instance(), conditions, null, null, JNone.instance())
+      val ctx = ObsContext.create(env, inst, JNone.instance(), conditions, null, null, JNone.instance(), JNone.instance())
 
       val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -79,7 +79,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
         gmos <- arbitrary[InstGmosNorth]
         offs <- arbitrary[java.util.Set[SkyCalcOffset]]
         pac  <- Gen.oneOf(FIXED, FIXED_180)
-        ctx   = ObsContext.create(env, gmos <| (_.setPosAngleConstraint(pac)), Conditions.NOMINAL, offs, null, ImOption.empty())
+        ctx   = ObsContext.create(env, gmos <| (_.setPosAngleConstraint(pac)), Conditions.NOMINAL, offs, null, ImOption.empty(), ImOption.empty())
         gs   <- genGuideStars(ctx)
       } yield (ctx, gs)
     }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -119,7 +119,7 @@ class VignettingTest {
     config.inst.setPosAngleDegrees(posAngle)
     val targetEnv = TargetEnvironment.create(base)
     val offsetSet = offsets.map(_.toOldModel).toSet.asJava
-    val ctx       = ObsContext.create(targetEnv, config.inst, Some(config.site).asGeminiOpt, BEST, offsetSet, null, JNone.instance())
+    val ctx       = ObsContext.create(targetEnv, config.inst, Some(config.site).asGeminiOpt, BEST, offsetSet, null, JNone.instance(), JNone.instance())
     val strategy  = AgsRegistrar.currentStrategy(ctx).get.asInstanceOf[SingleProbeStrategy]
 
     def nextCandidate(candidates: List[SiderealTarget], expected: List[SiderealTarget]): Unit = {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/AgsStrategyTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/AgsStrategyTest.java
@@ -25,7 +25,7 @@ public class AgsStrategyTest {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance(), None.instance());
     }
 
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
@@ -48,7 +48,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance(), None.instance());
     }
 
     /**
@@ -148,7 +148,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
 
         InstGmosNorth ign = (InstGmosNorth) baseContext.getInstrument();
         ign.setFPUnit(GmosNorthType.FPUnitNorth.IFU_2);
-        ObsContext    ctx = ObsContext.create(env, ign, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        ObsContext    ctx = ObsContext.create(env, ign, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance(), None.instance());
 
         assertFalse("Point outside of fov, after IFU selected.",
                 GmosOiwfsGuideProbe.instance.validate(

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArrayTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArrayTest.java
@@ -43,7 +43,7 @@ public class GsaoiDetectorArrayTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.SIDE_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance(), None.instance());
     }
 
     private void assertEmpty(Coordinates[] coordsArray) {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiOdgwGroupTest.java
@@ -40,7 +40,7 @@ public class GsaoiOdgwGroupTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.SIDE_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance(), None.instance());
     }
 
     // Selection and adding essentially wrap the GsaoiDetectorArray.getId

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/guide/BoundaryValidatorTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/guide/BoundaryValidatorTest.java
@@ -37,7 +37,7 @@ public class BoundaryValidatorTest {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance(), None.instance());
 
 
         //Assert.notFalse(BoundaryValidator.instance.validate(coords, ctxt, GmosOiwfsGuideProbe.instance), "Expected valid, got 'false' ");
@@ -59,7 +59,7 @@ public class BoundaryValidatorTest {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        ObsContext ctxt = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance(), None.instance());
 
 
        // Assert.notFalse(BoundaryValidator.instance.validate(coords, ctxt, PwfsGuideProbe.pwfs1), "Expected valid, got 'false' ");

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
@@ -200,6 +200,6 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
         site  = inst.getSite.asScala.headOption.asGeminiOpt
         cond <- arbitrary[Conditions]
         offs <- arbitrary[java.util.Set[SkyCalcOffset]]
-      } yield ObsContext.create(ags.asGeminiOpt, env, inst, site, cond, offs, null, None.instance())
+      } yield ObsContext.create(ags.asGeminiOpt, env, inst, site, cond, offs, null, None.instance(), None.instance())
     }
 }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
@@ -123,6 +123,13 @@ object ProgramId {
       case s: StandardProgramId => Some(s)
       case _                    => None
     }
+
+  def fromSPProgramID(sp: SPProgramID): ProgramId =
+    parse(sp.stringValue());
+
+  def fromStandardSPProgramID(sp: SPProgramID): Option[ProgramId] =
+    parseStandardId(sp.stringValue());
+
 }
 
 

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/CatalogQueryDemo.scala
@@ -40,7 +40,7 @@ object CatalogQueryDemo extends SwingApplication {
     val inst = new InstGmosSouth <| {_.setPosAngle(0.0)}
 
     val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.PERCENT_80).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
-    val ctx = ObsContext.create(env, inst, new JSome(Site.GN), conditions, null, null, JNone.instance())
+    val ctx = ObsContext.create(env, inst, new JSome(Site.GN), conditions, null, null, JNone.instance(), JNone.instance())
 
     instance.showOn(ctx)
   }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -110,7 +110,7 @@ case class ObservationInfo(ctx: Option[ObsContext],
       val altair = strategy.collect {
         case SupportedStrategy(_, _, Some(m)) => new InstAltair() <| {_.setMode(m)}
       }
-      ObsContext.create(env, i, site.flatten.asGeminiOpt, cond, offsets.map(_.toOldModel).asJava, altair.orNull, JNone.instance()).withPositionAngle(positionAngle.toOldModel)
+      ObsContext.create(env, i, site.flatten.asGeminiOpt, cond, offsets.map(_.toOldModel).asJava, altair.orNull, JNone.instance(), JNone.instance()).withPositionAngle(positionAngle.toOldModel)
     }
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -4,7 +4,7 @@ import edu.gemini.pot.sp._
 
 import edu.gemini.shared.util.immutable.{None => JNone, Option => JOption}
 import edu.gemini.shared.util.immutable.ScalaConverters._
-import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.core.{ProgramId, Site}
 import edu.gemini.spModel.data.{ISPDataObject, IOffsetPosListProvider}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
@@ -197,7 +197,8 @@ case class TpeContext(node: Option[ISPNode]) {
     i <- instrument.dataObject
     ao = (gems.dataObject orElse altair.dataObject).orNull
     obs = s.getDataObject.asInstanceOf[SPObservation]
-  } yield ObsContext.create(obs.getAgsStrategyOverride, t, i, site, c, offsets.scienceOffsetsJava, ao, obs.getSchedulingBlock)
+    sem = Option(s.getProgramID).flatMap(ProgramId.fromStandardSPProgramID).flatMap(_.semester).asGeminiOpt
+  } yield ObsContext.create(obs.getAgsStrategyOverride, t, i, site, c, offsets.scienceOffsetsJava, ao, obs.getSchedulingBlock, sem)
 
   def obsContextJavaWithConditions(c: Conditions): JOption[ObsContext] =
     obsContextWithConditions(c).asGeminiOpt


### PR DESCRIPTION
REL-2746 requires the target editor to know the program semester (if any) so it needs to be in the `ObsContext`. This is sufficiently noisy to warrant its own PR.

I could have done this with an overload and default arg but `ObsContext` doesn't do this elsewhere and I didn't want to introduce a new pattern. So this PR is mostly busywork.