### PR TITLE
OCSADV-383-H: requested updates

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/NonSiderealObservation.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/NonSiderealObservation.scala
@@ -20,7 +20,7 @@ object NonSiderealObservation {
     * queue for immediate observation.  The program itself must be active and
     * the observation status must be `READY` or `ONGOING`.
     */
-  def findScheduleableIn(p: ISPProgram): List[NonSiderealObservation] =
+  def findRelevantIn(p: ISPProgram): List[NonSiderealObservation] =
     if (includeProgram(p)) activeObservations(p).flatMap(obsRef)
     else Nil
 
@@ -34,8 +34,8 @@ object NonSiderealObservation {
     import ObservationStatus._
     p.getAllObservations.asScala.filter { obs =>
       computeFor(obs) match {
-        case READY | ONGOING => true
-        case _               => false
+        case OBSERVED | INACTIVE => false
+        case _                   => true
       }
     }.toList
   }

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/NonSiderealObservationFunctor.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/NonSiderealObservationFunctor.scala
@@ -18,13 +18,13 @@ object NonSiderealObservationFunctor {
 }
 
 private class NonSiderealObservationFunctor extends DBAbstractQueryFunctor{
-  import NonSiderealObservation.findScheduleableIn
+  import NonSiderealObservation.findRelevantIn
 
   var results: List[NonSiderealObservation] = Nil
 
   override def execute(db: IDBDatabaseService, node: ISPNode, principals: JSet[Principal]): Unit =
     node match {
-      case p: ISPProgram => results = findScheduleableIn(p) ++ results
+      case p: ISPProgram => results = findRelevantIn(p) ++ results
       case _             => // do nothing
     }
 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/NonSiderealObservationTest.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/NonSiderealObservationTest.scala
@@ -11,7 +11,7 @@ object NonSiderealObservationTest extends TestSupport {
   "NonSiderealObservation.findScheduleable" should {
     "include every ready nonsidereal observation in an active program" ! forAllPrograms { (odb, progs) =>
       progs.forall { prog =>
-        val obsList = NonSiderealObservation.findScheduleableIn(prog)
+        val obsList = NonSiderealObservation.findRelevantIn(prog)
         obsList.size == prog.getAllObservations.size
       }
     }
@@ -19,13 +19,13 @@ object NonSiderealObservationTest extends TestSupport {
     "include no observations in an inactive program" ! forAllPrograms { (odb, progs) =>
       progs.forall { prog =>
         genInactiveProgram.sample.get.apply(odb.getFactory, prog)
-        NonSiderealObservation.findScheduleableIn(prog).isEmpty
+        NonSiderealObservation.findRelevantIn(prog).isEmpty
       }
     }
 
     "find matching observation information" ! forAllPrograms { (odb, progs) =>
       progs.forall { prog =>
-        val expected = NonSiderealObservation.findScheduleableIn(prog).toSet
+        val expected = NonSiderealObservation.findRelevantIn(prog).toSet
         val actual   = (Set.empty[NonSiderealObservation]/:prog.getAllObservations.asScala) { (s, o) =>
           val oid = o.getObservationID
           val tc  = SPTreeUtil.findTargetEnvNode(o)
@@ -44,7 +44,7 @@ object NonSiderealObservationTest extends TestSupport {
     "skip sidereal targets" ! forAllPrograms { (odb, progs) =>
       progs.forall { prog =>
         genSiderealEdit.sample.get.apply(odb.getFactory, prog)
-        val nsSize  = NonSiderealObservation.findScheduleableIn(prog).size
+        val nsSize  = NonSiderealObservation.findRelevantIn(prog).size
         val allSize = prog.getAllObservations.size
         ((allSize == 0) && (nsSize == 0)) || (allSize - 1 == nsSize)
       }
@@ -53,7 +53,7 @@ object NonSiderealObservationTest extends TestSupport {
     "skip inactive observations" ! forAllPrograms { (odb, progs) =>
       progs.forall { prog =>
         genInactiveObsStatus.sample.get.apply(odb.getFactory, prog)
-        val nsSize  = NonSiderealObservation.findScheduleableIn(prog).size
+        val nsSize  = NonSiderealObservation.findRelevantIn(prog).size
         val allSize = prog.getAllObservations.size
         ((allSize == 0) && (nsSize == 0)) || (allSize - 1 == nsSize)
       }

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/TestSupport.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/TestSupport.scala
@@ -73,10 +73,7 @@ trait TestSupport extends ProgramTestSupport {
   val genInactiveObsStatus: Gen[ProgEdit] =
     for {
       f <- maybePickObservation
-      s <- Gen.oneOf(ObservationStatus.values().filter {
-        case ObservationStatus.READY | ObservationStatus.ONGOING => false
-        case _                                                   => true
-      })
+      s <- Gen.oneOf(ObservationStatus.OBSERVED, ObservationStatus.INACTIVE)
     } yield { (_: ISPFactory, p: ISPProgram) =>
       f(p).foreach { obs =>
         val dob = obs.getDataObject.asInstanceOf[SPObservation]

--- a/bundle/edu.gemini.util.skycalc/src/main/java/edu/gemini/skycalc/TwilightBoundType.java
+++ b/bundle/edu.gemini.util.skycalc/src/main/java/edu/gemini/skycalc/TwilightBoundType.java
@@ -1,6 +1,9 @@
 package edu.gemini.skycalc;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Definition for how the range from sunset to sunrise should be defined for
@@ -23,6 +26,9 @@ public final class TwilightBoundType implements Comparable<TwilightBoundType>, S
 
     public static final TwilightBoundType ASTRONOMICAL =
             new TwilightBoundType("Astronomical", 18.0);
+
+    public static final List<TwilightBoundType> ALL =
+            Collections.unmodifiableList(Arrays.asList(OFFICIAL, CIVIL, NAUTICAL, ASTRONOMICAL));
 
     private String _name;
     private double _horizAngle; // angle below the horizon


### PR DESCRIPTION
This PR addresses a few requests from science:

* [REL-2752](http://jira.gemini.edu:8080/browse/REL-2752) - include all non-sidereal observations except those with "observed" or "inactive" status.  Previously, only "ready" and "ongoing" were included.

* [REL-2753](http://jira.gemini.edu:8080/browse/REL-2753) - write ephemeris data with 24 hour coverage to facilitate testing.  Specifically a twilight bounds type parameter may be specified to control how a given night is defined ("official" twilight, civil twilight, nautical twilight, or astronomical twilight).  If not set, the robot will default to full day coverage where the day is defined to end on the nearest even minute after the next sunrise and start exactly 24 hours before.

* (no JIRA issue) - write ephemeris values that align with precise minutes.  The timestamp written to the ephemeris file was specified to not include seconds or fractional seconds, yet the actual data would correspond to the precise night start time and one minute intervals thereafter.  This change collects data at precise minute boundaries that correspond to the timestamps.