### PR TITLE
REL-2726 make ERR_NO_EPHEMERIS_FOR_BLOCK an error

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -71,7 +71,7 @@ final class NonSiderealTargetRules extends IRule {
         nst <- tar.getNonSiderealTarget.toList
         sb  <- es.getObservation.getSchedulingBlock.asScalaOpt
                if nst.coords(sb.start).isEmpty
-      } p2p.addWarning(ERR_NO_EPHEMERIS_FOR_BLOCK,
+      } p2p.addError(ERR_NO_EPHEMERIS_FOR_BLOCK,
           s"Target ${nst.name} has no defined coordinates for its scheduling block.",
           ocn)
     }


### PR DESCRIPTION
This makes `ERR_NO_EPHEMERIS_FOR_BLOCK` an error rather than a warning.