### PR TITLE
REL-2599: Fixed F2 long slit geometry offsetting

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2ScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2ScienceAreaGeometry.scala
@@ -84,13 +84,14 @@ object F2ScienceAreaGeometry extends ScienceAreaGeometry {
   private def longSlitFOV(plateScale: Double, scienceAreaWidth: Double): Shape = {
     val slitHeight = LongSlitFOVHeight * plateScale
     val slitSouth  = LongSlitFOVSouthPos * plateScale
+    val slitNorth  = LongSlitFOVNorthPos * plateScale
 
     val x = -scienceAreaWidth / 2.0
     val y = slitSouth - slitHeight
-    new Rectangle2D.Double(x, y, x + scienceAreaWidth, y + slitHeight)
+    new Rectangle2D.Double(x, y, x + scienceAreaWidth, y + slitHeight + slitNorth)
   }
 
-  // Geometry features for F2, in arcseconds.
+  // Geometry features for F2, in mm.
   val LongSlitFOVHeight   = 164.10
   val LongSlitFOVSouthPos = 112.00
   val LongSlitFOVNorthPos =  52.10


### PR DESCRIPTION
Previously, the old F2 geometry feature was offsetting the geometry of long slits by `LongSlitFOVNorthPos` in a sort of hacky way that was missed when we extracted the geometry into its own class. This accounts for the offsetting properly so that the geometry of F2 long slits is now the same as it was in 2015B.

See the JIRA task for graphics showing how things looked in 2015B and how things incorrectly looked in 2016A:
http://jira.gemini.edu:8080/browse/REL-2599