### PR TITLE
REL-2747 REL-2757 fix scheduling dialog

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -595,7 +595,8 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
         }
         if (!_schedulingBlock.isEmpty()) {
             Pio.addLongParam(factory, paramSet, SCHEDULING_BLOCK_START_PROP, getSchedulingBlock().getValue().start());
-            Pio.addLongParam(factory, paramSet, SCHEDULING_BLOCK_DURATION_PROP, getSchedulingBlock().getValue().durationOrZero());
+            if (getSchedulingBlock().getValue().duration().nonEmpty())
+                Pio.addLongParam(factory, paramSet, SCHEDULING_BLOCK_DURATION_PROP, getSchedulingBlock().getValue().durationOrZero());
         }
 
         Pio.addParam(factory, paramSet, QA_STATE_PROP, getOverriddenObsQaState().name());
@@ -660,8 +661,10 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
         // Set the scheduling block if it exists for both start and duration properties.
         v = Pio.getValue(paramSet, SCHEDULING_BLOCK_START_PROP);
         String v2 = Pio.getValue(paramSet, SCHEDULING_BLOCK_DURATION_PROP);
-        if (v == null || v2 == null) {
+        if (v == null) {
             setSchedulingBlock(None.instance());
+        } else if (v2 == null) {
+            setSchedulingBlock(new Some<>(SchedulingBlock.unsafeFromStrings(v)));
         } else {
             setSchedulingBlock(new Some<>(SchedulingBlock.unsafeFromStrings(v, v2)));
         }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
@@ -30,7 +30,7 @@ object SchedulingBlock {
     apply(start, Some(duration))
 
   def apply(start: Long, duration: Option[Long]): SchedulingBlock =
-    new Impl(start, duration.filter(_ > 0))
+    new Impl(start, duration.filter(_ >= 0))
 
   def unsafeFromStrings(startString: String, durationString: String): SchedulingBlock =
     apply(startString.toLong, durationString.toLong)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
@@ -35,4 +35,7 @@ object SchedulingBlock {
   def unsafeFromStrings(startString: String, durationString: String): SchedulingBlock =
     apply(startString.toLong, durationString.toLong)
 
+  def unsafeFromStrings(startString: String): SchedulingBlock =
+    apply(startString.toLong)
+
 }

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -89,10 +89,7 @@ object To2016B extends Migration {
     for {
       (o, b) <- obsAndBases(d) if o.value("schedulingBlockStart").isEmpty
       date   <- b.value("validAt").map(SPTargetPio.parseDate)
-    } {
-      Pio.addLongParam(fact, o, "schedulingBlockStart", date.getTime)
-      Pio.addLongParam(fact, o, "schedulingBlockDuration", 0L)
-    }
+    } Pio.addLongParam(fact, o, "schedulingBlockStart", date.getTime)
 
   def isTooProgram(d: Document): Boolean =
     d.findContainers(SPProgram.SP_TYPE).exists { c =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleDialog.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleDialog.scala
@@ -132,7 +132,6 @@ class ParallacticAngleDialog(
 
     // The duration field information.
     private val durationLabel = new Label("Duration")
-
     if (showDuration) layout(durationLabel) = new Constraints() {
       anchor     = GridBagPanel.Anchor.NorthWest
       gridx      = 2


### PR DESCRIPTION
This fixes several problems with the parallactic angle / scheduling controls and dialog:
- The relative time menu now correctly sets the start time, not the duration.
- When used in "scheduling" mode in the observation editor only the start date and time are shown; duration is not mentioned.
- It was formerly not possible to set the duration back to "remaining time", nor was it possible to set a duration of zero.