### PR TITLE
REL-2700 improve horizons lookups

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -40,7 +40,7 @@ object HorizonsService2 {
   /** A partial-name search specification for HORIZONS. */
   sealed abstract class Search[A](val queryString: String) extends Product with Serializable
   object Search {
-    final case class Comet(partial: String)     extends Search[HorizonsDesignation.Comet](s"COMNAM=$partial*;CAP")
+    final case class Comet(partial: String)     extends Search[HorizonsDesignation.Comet](s"NAME=$partial*;CAP")
     final case class Asteroid(partial: String)  extends Search[HorizonsDesignation.Asteroid](s"ASTNAM=$partial*")
     final case class MajorBody(partial: String) extends Search[HorizonsDesignation.MajorBody](s"$partial")
   }
@@ -182,17 +182,20 @@ object HorizonsService2 {
   // Parse the result of the given search
   private def parseResponse[A](s: Search[A], lines: List[String]): \/[String, List[Row[A]]] =
     parseHeader[Row[A]](lines) { case (header, tail) =>
+
+      lines.foreach(println)
+
       s match {
 
         case Search.Comet(_) =>
 
           // Common case is that we have many results, or none.
           lazy val case0 =
-            parseMany[Row[HorizonsDesignation.Comet]](header, tail, """  +Small-body Search Results  """.r) { os =>
+            parseMany[Row[HorizonsDesignation.Comet]](header, tail, """  +Small-body Index Search Results  """.r) { os =>
               (os.lift(2) |@| os.lift(3)).tupled.map {
                 case ((ods, ode), (ons, one)) => { row =>
                   val desig = row.substring(ods, ode).trim
-                  val name  = row.substring(ons, one).trim
+                  val name  = row.substring(ons     ).trim // last column, so no end index because rows are ragged
                   Row(HorizonsDesignation.Comet(desig), name)
                 }
               }

--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -182,9 +182,6 @@ object HorizonsService2 {
   // Parse the result of the given search
   private def parseResponse[A](s: Search[A], lines: List[String]): \/[String, List[Row[A]]] =
     parseHeader[Row[A]](lines) { case (header, tail) =>
-
-      lines.foreach(println)
-
       s match {
 
         case Search.Comet(_) =>

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/HorizonsDesignation.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/HorizonsDesignation.scala
@@ -30,9 +30,9 @@ object HorizonsDesignation {
 
   /**
    * Designation for a comet, in the current apparition. Example: `C/1973 E1` for Kohoutek, yielding
-   * the query string `DES=C/1973 E1;CAP`.
+   * the query string `NAME=C/1973 E1;CAP`.
    */
-  final case class Comet(des: String) extends HorizonsDesignation(s"DES=$des;CAP")
+  final case class Comet(des: String) extends HorizonsDesignation(s"NAME=$des;CAP")
   object Comet {
     val des: Comet @> String = Lens.lensu((a, b) => a.copy(des = b), _.des)
   }
@@ -41,9 +41,9 @@ object HorizonsDesignation {
 
   /**
    * Designation for an asteroid under modern naming conventions. Example: `1971 UC1` for
-   * 1896 Beer, yielding a query string `DES=1971 UC1`.
+   * 1896 Beer, yielding a query string `ASTNAM=1971 UC1`.
    */
-  final case class AsteroidNewStyle(des: String) extends Asteroid(s"DES=$des")
+  final case class AsteroidNewStyle(des: String) extends Asteroid(s"ASTNAM=$des")
   object AsteroidNewStyle {
     val des: AsteroidNewStyle @> String = Lens.lensu((a, b) => a.copy(des = b), _.des)
   }


### PR DESCRIPTION
This PR fixes two issues with the current HORIZONS lookup:
- It allows you to search for comets by designation `67P` for example.
- It changes ephemeris lookup to search by designation, but *not* use the `DES` keyword, which doesn't always yield unique results. A non-wildcard search for `NAME=des;CAP` for comets and `ASTNAM=des` for asteroids seems to work.