### PR TITLE
REL-2662: Add support for new Altair dichroic to OT

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairConstants.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairConstants.java
@@ -1,9 +1,3 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-//
 package edu.gemini.spModel.gemini.altair;
 
 public final class AltairConstants {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
@@ -27,14 +27,13 @@ public final class AltairParams {
      */
     public enum Wavelength implements DisplayableSpType, SequenceableSpType {
 
-        // TODO: Ideally, we would change WAVELENGTH_B to BS_850_2500 and A to BS_850_5000.
-        WAVELENGTH_B("850 nm - 2.5 μm science",        "BS_850_2500"),
-        WAVELENGTH_A("750 nm - 5 μm science",          "BS_850_5000"),
+        BS_850_2500("850 nm - 2.5 μm science",         "BS_850_2500"),
+        BS_850_5000("750 nm - 5 μm science",           "BS_850_5000"),
         BS_589("589 nm notch (400 nm - 1 μm science)", "BS_589");
 
 
         /* The default Wavelength index value */
-        public static final Wavelength DEFAULT = WAVELENGTH_B;
+        public static final Wavelength DEFAULT = BS_850_2500;
         private final String _displayValue;
         private final String _sequenceValue;
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
@@ -28,7 +28,7 @@ public final class AltairParams {
     public enum Wavelength implements DisplayableSpType, SequenceableSpType {
 
         BS_850_2500("850 nm - 2.5 μm science",         "BS_850_2500"),
-        BS_850_5000("750 nm - 5 μm science",           "BS_850_5000"),
+        BS_850_5000("850 nm - 5 μm science",           "BS_850_5000"),
         BS_589("589 nm notch (400 nm - 1 μm science)", "BS_589");
 
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
@@ -27,8 +27,11 @@ public final class AltairParams {
      */
     public enum Wavelength implements DisplayableSpType, SequenceableSpType {
 
-        WAVELENGTH_A("750 nm - 5 μm science", "WAVELENGTH_A"),
-        WAVELENGTH_B("850 nm - 2.5 μm science", "WAVELENGTH_B");
+        // TODO: Ideally, we would change WAVELENGTH_B to BS_850_2500 and A to BS_850_5000.
+        WAVELENGTH_B("850 nm - 2.5 μm science",        "BS_850_2500"),
+        WAVELENGTH_A("750 nm - 5 μm science",          "BS_850_5000"),
+        BS_589("589 nm notch (400 nm - 1 μm science)", "BS_589");
+
 
         /* The default Wavelength index value */
         public static final Wavelength DEFAULT = WAVELENGTH_B;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
@@ -74,7 +74,7 @@ public final class InstAltair extends AbstractDataObject implements PropertyProv
         MODE_PROP = initProp(AltairConstants.MODE_PROP, query_yes, iter_no);
     }
 
-    private static final String VERSION = "2006B-1";
+    private static final String VERSION = "2016B-1";
     private Wavelength _wavelength = Wavelength.DEFAULT;
     private ADC _adc = ADC.DEFAULT;
     private CassRotator _cassRotator = CassRotator.DEFAULT;

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/altair/test/InstAltairCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/altair/test/InstAltairCase.java
@@ -46,8 +46,8 @@ public final class InstAltairCase {
         assertTrue(altOrig.getTitle().equals(title));
 
         // defined in InstAltair
-        altOrig.setWavelength(Wavelength.WAVELENGTH_B);
-        assertTrue(altOrig.getWavelength() == Wavelength.WAVELENGTH_B);
+        altOrig.setWavelength(Wavelength.WAVELENGTH_A);
+        assertTrue(altOrig.getWavelength() == Wavelength.WAVELENGTH_A);
         altOrig.setAdc(ADC.ON);
         assertTrue(altOrig.getAdc() == ADC.ON);
         altOrig.setAdc(ADC.OFF);
@@ -73,10 +73,10 @@ public final class InstAltairCase {
 
         // Create change
         outObject.setAdc(ADC.ON);
-        outObject.setWavelength(Wavelength.WAVELENGTH_B);
+        outObject.setWavelength(Wavelength.WAVELENGTH_A);
 
         final InstAltair inObject = ser(outObject);
         assertSame("ADC", ADC.ON, inObject.getAdc());
-        assertSame("Wavelength", Wavelength.WAVELENGTH_B, inObject.getWavelength());
+        assertSame("Wavelength", Wavelength.WAVELENGTH_A, inObject.getWavelength());
     }
 }

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/altair/test/InstAltairCase.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/altair/test/InstAltairCase.java
@@ -46,8 +46,8 @@ public final class InstAltairCase {
         assertTrue(altOrig.getTitle().equals(title));
 
         // defined in InstAltair
-        altOrig.setWavelength(Wavelength.WAVELENGTH_A);
-        assertTrue(altOrig.getWavelength() == Wavelength.WAVELENGTH_A);
+        altOrig.setWavelength(Wavelength.BS_850_5000);
+        assertTrue(altOrig.getWavelength() == Wavelength.BS_850_5000);
         altOrig.setAdc(ADC.ON);
         assertTrue(altOrig.getAdc() == ADC.ON);
         altOrig.setAdc(ADC.OFF);
@@ -73,10 +73,10 @@ public final class InstAltairCase {
 
         // Create change
         outObject.setAdc(ADC.ON);
-        outObject.setWavelength(Wavelength.WAVELENGTH_A);
+        outObject.setWavelength(Wavelength.BS_850_5000);
 
         final InstAltair inObject = ser(outObject);
         assertSame("ADC", ADC.ON, inObject.getAdc());
-        assertSame("Wavelength", Wavelength.WAVELENGTH_A, inObject.getWavelength());
+        assertSame("Wavelength", Wavelength.BS_850_5000, inObject.getWavelength());
     }
 }

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -5,7 +5,6 @@ import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.core.HorizonsDesignation.MajorBody
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.obscomp.SPProgram
-import edu.gemini.spModel.pio.codec.ParamSetCodec
 import edu.gemini.spModel.pio.xml.PioXmlFactory
 import edu.gemini.spModel.pio.{Document, ParamSet, Pio, Version}
 import edu.gemini.spModel.target.{SPTargetPio, SourcePio, TargetParamSetCodecs}
@@ -13,7 +12,6 @@ import edu.gemini.spModel.target.env.GuideGroup
 
 import scala.collection.JavaConverters._
 import PioSyntax._
-import edu.gemini.spModel.gemini.altair.AltairConstants
 
 import scalaz._
 import Scalaz._

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
@@ -54,13 +54,13 @@ public class AltairForm extends JPanel {
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- wavelength850_2500_Button ----
-        wavelength850_2500_Button = new JRadioButton(AltairParams.Wavelength.WAVELENGTH_B.displayValue());
+        wavelength850_2500_Button = new JRadioButton(AltairParams.Wavelength.BS_850_2500.displayValue());
         add(wavelength850_2500_Button, new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- wavelength850_5000_Button ----
-        wavelength850_5000_Button = new JRadioButton(AltairParams.Wavelength.WAVELENGTH_A.displayValue());
+        wavelength850_5000_Button = new JRadioButton(AltairParams.Wavelength.BS_850_5000.displayValue());
         add(wavelength850_5000_Button, new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
@@ -10,8 +10,6 @@ public class AltairForm extends JPanel {
         JLabel adcLabel = new JLabel();
         JLabel beamSplitterLabel = new JLabel();
         adcCheck = new JCheckBox();
-        eight50Button = new JRadioButton();
-        oneButton = new JRadioButton();
         JLabel cassRotatorLabel = new JLabel();
         cassRotatorFollowingButton = new JRadioButton();
         cassRotatorFixedButton = new JRadioButton();
@@ -55,15 +53,21 @@ public class AltairForm extends JPanel {
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
-        //---- eight50Button ----
-        eight50Button.setText(AltairParams.Wavelength.WAVELENGTH_B.displayValue());
-        add(eight50Button, new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
+        //---- wavelength850_2500_Button ----
+        wavelength850_2500_Button = new JRadioButton(AltairParams.Wavelength.WAVELENGTH_B.displayValue());
+        add(wavelength850_2500_Button, new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
-        //---- oneButton ----
-        oneButton.setText(AltairParams.Wavelength.WAVELENGTH_A.displayValue());
-        add(oneButton, new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0,
+        //---- wavelength850_5000_Button ----
+        wavelength850_5000_Button = new JRadioButton(AltairParams.Wavelength.WAVELENGTH_A.displayValue());
+        add(wavelength850_5000_Button, new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0,
+                GridBagConstraints.WEST, GridBagConstraints.NONE,
+                new Insets(0, 11, 0, 0), 0, 0));
+
+        //---- wavelength589_Button ----
+        wavelength589_Button = new JRadioButton(AltairParams.Wavelength.BS_589.displayValue());
+        add(wavelength589_Button, new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
@@ -71,75 +75,75 @@ public class AltairForm extends JPanel {
         cassRotatorLabel.setToolTipText("");
         cassRotatorLabel.setVerifyInputWhenFocusTarget(true);
         cassRotatorLabel.setText("Cass Rotator");
-        add(cassRotatorLabel, new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0,
+        add(cassRotatorLabel, new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- cassRotatorFollowingButton ----
         cassRotatorFollowingButton.setText("Following");
-        add(cassRotatorFollowingButton, new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0,
+        add(cassRotatorFollowingButton, new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- cassRotatorFixedButton ----
         cassRotatorFixedButton.setText("Fixed");
-        add(cassRotatorFixedButton, new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0,
+        add(cassRotatorFixedButton, new GridBagConstraints(1, 5, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- ndFilterLabel ----
         ndFilterLabel.setText("ND Filter");
-        add(ndFilterLabel, new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0,
+        add(ndFilterLabel, new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- ndFilterInButton ----
         ndFilterInButton.setText("In");
-        add(ndFilterInButton, new GridBagConstraints(1, 5, 1, 1, 0.0, 0.0,
+        add(ndFilterInButton, new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- ndFilterOutButton ----
         ndFilterOutButton.setText("Out");
-        add(ndFilterOutButton, new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0,
+        add(ndFilterOutButton, new GridBagConstraints(1, 7, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- guideStarType ----
         guideStarType.setText("Guide Star Type");
-        add(guideStarType, new GridBagConstraints(0, 7, 1, 1, 0.0, 0.0,
+        add(guideStarType, new GridBagConstraints(0, 8, 1, 1, 0.0, 0.0,
                 GridBagConstraints.EAST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- ngsRadioButton ----
         ngsRadioButton.setText("Natural Guide Star");
-        add(ngsRadioButton, new GridBagConstraints(1, 7, 1, 1, 0.0, 0.0,
+        add(ngsRadioButton, new GridBagConstraints(1, 8, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- ngsWithFieldLensRadioButton ----
         ngsWithFieldLensRadioButton.setText("Natural Guide Star with Field Lens");
-        add(ngsWithFieldLensRadioButton, new GridBagConstraints(1, 8, 1, 1, 0.0, 0.0,
+        add(ngsWithFieldLensRadioButton, new GridBagConstraints(1, 9, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsRadioButton ----
         lgsRadioButton.setText("Laser Guide Star + AOWFS");
-        add(lgsRadioButton, new GridBagConstraints(1, 9, 1, 1, 0.0, 0.0,
+        add(lgsRadioButton, new GridBagConstraints(1, 10, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
         withFlLabel1.setText("(with Field Lens)");
-        add(withFlLabel1, new GridBagConstraints(2, 9, 1, 1, 1.0, 0.0,
+        add(withFlLabel1, new GridBagConstraints(2, 10, 1, 1, 1.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsP1RadioButton ----
         lgsP1RadioButton.setText("Laser Guide Star + PWFS1");
-        add(lgsP1RadioButton, new GridBagConstraints(1, 10, 1, 1, 0.0, 0.0,
+        add(lgsP1RadioButton, new GridBagConstraints(1, 11, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
         withFlLabel2.setText("(with Field Lens)");
-        add(withFlLabel2, new GridBagConstraints(2, 10, 1, 1, 1.0, 0.0,
+        add(withFlLabel2, new GridBagConstraints(2, 11, 1, 1, 1.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
@@ -147,18 +151,19 @@ public class AltairForm extends JPanel {
         // LAYOUT NOTE: bring both elements to the top left and let the last element
         // consume all remaining space (fill weight = 1.0 for x and y)
         lgsOiRadioButton.setText("Laser Guide Star + OIWFS");
-        add(lgsOiRadioButton, new GridBagConstraints(1, 11, 1, 1, 0.0, 0.0,
+        add(lgsOiRadioButton, new GridBagConstraints(1, 12, 1, 1, 0.0, 0.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
         withFlLabel3.setText("(with Field Lens)");
-        add(withFlLabel3, new GridBagConstraints(2, 11, 1, 1, 1.0, 1.0,
+        add(withFlLabel3, new GridBagConstraints(2, 12, 1, 1, 1.0, 1.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- beamSplitterButtonGroup ----
         ButtonGroup beamSplitterButtonGroup = new ButtonGroup();
-        beamSplitterButtonGroup.add(eight50Button);
-        beamSplitterButtonGroup.add(oneButton);
+        beamSplitterButtonGroup.add(wavelength850_2500_Button);
+        beamSplitterButtonGroup.add(wavelength850_5000_Button);
+        beamSplitterButtonGroup.add(wavelength589_Button);
 
         //---- cassRotatorButtonGroup ----
         ButtonGroup cassRotatorButtonGroup = new ButtonGroup();
@@ -181,8 +186,9 @@ public class AltairForm extends JPanel {
     }
 
     final JCheckBox    adcCheck;
-    final JRadioButton eight50Button;
-    final JRadioButton oneButton;
+    final JRadioButton wavelength850_2500_Button;
+    final JRadioButton wavelength850_5000_Button;
+    final JRadioButton wavelength589_Button;
     final JRadioButton cassRotatorFollowingButton;
     final JRadioButton cassRotatorFixedButton;
     final JRadioButton ndFilterInButton;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/EdCompInstAltair.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/EdCompInstAltair.java
@@ -63,9 +63,9 @@ public final class EdCompInstAltair extends OtItemEditor<ISPObsComponent, InstAl
         _w.adcCheck.setSelected(inst.getAdc() == ADC.ON);
 
         final Wavelength wl = inst.getWavelength();
-        if (wl == Wavelength.WAVELENGTH_B) {
+        if (wl == Wavelength.BS_850_2500) {
             _w.wavelength850_2500_Button.setSelected(true);
-        } else if (wl == Wavelength.WAVELENGTH_A) {
+        } else if (wl == Wavelength.BS_850_5000) {
             _w.wavelength850_5000_Button.setSelected(true);
         } else {
             _w.wavelength589_Button.setSelected(true);
@@ -114,9 +114,9 @@ public final class EdCompInstAltair extends OtItemEditor<ISPObsComponent, InstAl
         if (w == _w.adcCheck) {
             getDataObject().setAdc(_w.adcCheck.isSelected() ? ADC.ON : ADC.OFF);
         } else if (w == _w.wavelength850_5000_Button) {
-            getDataObject().setWavelength(Wavelength.WAVELENGTH_A);
+            getDataObject().setWavelength(Wavelength.BS_850_5000);
         } else if (w == _w.wavelength850_2500_Button) {
-            getDataObject().setWavelength(Wavelength.WAVELENGTH_B);
+            getDataObject().setWavelength(Wavelength.BS_850_2500);
         } else if (w == _w.wavelength589_Button) {
             getDataObject().setWavelength(Wavelength.BS_589);
         } else if (w == _w.cassRotatorFollowingButton) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/EdCompInstAltair.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/EdCompInstAltair.java
@@ -31,8 +31,9 @@ public final class EdCompInstAltair extends OtItemEditor<ISPObsComponent, InstAl
      */
     public EdCompInstAltair() {
         _w = new AltairForm();
-        _w.eight50Button.addActionListener(this);
-        _w.oneButton.addActionListener(this);
+        _w.wavelength850_2500_Button.addActionListener(this);
+        _w.wavelength850_5000_Button.addActionListener(this);
+        _w.wavelength589_Button.addActionListener(this);
         _w.adcCheck.addActionListener(this);
         _w.cassRotatorFollowingButton.addActionListener(this);
         _w.cassRotatorFixedButton.addActionListener(this);
@@ -63,9 +64,11 @@ public final class EdCompInstAltair extends OtItemEditor<ISPObsComponent, InstAl
 
         final Wavelength wl = inst.getWavelength();
         if (wl == Wavelength.WAVELENGTH_B) {
-            _w.eight50Button.setSelected(true);
+            _w.wavelength850_2500_Button.setSelected(true);
+        } else if (wl == Wavelength.WAVELENGTH_A) {
+            _w.wavelength850_5000_Button.setSelected(true);
         } else {
-            _w.oneButton.setSelected(true);
+            _w.wavelength589_Button.setSelected(true);
         }
 
         final CassRotator cr = inst.getCassRotator();
@@ -110,10 +113,12 @@ public final class EdCompInstAltair extends OtItemEditor<ISPObsComponent, InstAl
         final Object w = evt.getSource();
         if (w == _w.adcCheck) {
             getDataObject().setAdc(_w.adcCheck.isSelected() ? ADC.ON : ADC.OFF);
-        } else if (w == _w.oneButton) {
+        } else if (w == _w.wavelength850_5000_Button) {
             getDataObject().setWavelength(Wavelength.WAVELENGTH_A);
-        } else if (w == _w.eight50Button) {
+        } else if (w == _w.wavelength850_2500_Button) {
             getDataObject().setWavelength(Wavelength.WAVELENGTH_B);
+        } else if (w == _w.wavelength589_Button) {
+            getDataObject().setWavelength(Wavelength.BS_589);
         } else if (w == _w.cassRotatorFollowingButton) {
             getDataObject().setCassRotator(CassRotator.FOLLOWING);
         } else if (w == _w.cassRotatorFixedButton) {


### PR DESCRIPTION
A new Altair dichroic (wavelength) has been added, and support is required for the OT / WDBA.

This PR adds this new wavelength, and additionally, changes the names of the enum members of the old `AltairParams.Wavelength` to more accurately represent the reality of the current situation, since `WAVELENGTH_A` and `WAVELENGTH_B` no longer have the same meaning.

Additionally, `To2016B` was updated to account for these enum name changes.
I have tested it with programs with Altair components exported from 2015B and 2016A, and the import appears to be working correctly.