### PR TITLE
REL-2731 add notes for conic target migration

### DIFF
--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
@@ -33,13 +33,12 @@ trait Migration {
   val ParamSetTarget             = "spTarget"
   val ParamSetTemplateParameters = "Template Parameters"
 
-  // Extract all the target paramsets, be they part of an observation or
-  // template parameters.
-  protected def allTargets(d: Document): List[ParamSet] = {
+  // Extract all the target paramsets
+  protected def allTargets(d: Document, includeTemplates: Boolean = true): List[ParamSet] = {
     val names = Set(ParamSetBase, ParamSetTarget)
 
     val templateTargets = for {
-      cs  <- d.findContainers(SPComponentType.TEMPLATE_PARAMETERS)
+      cs  <- d.findContainers(SPComponentType.TEMPLATE_PARAMETERS) if includeTemplates
       tps <- cs.allParamSets if tps.getName == ParamSetTemplateParameters
       ps  <- tps.allParamSets if names(ps.getName)
     } yield ps
@@ -52,7 +51,6 @@ trait Migration {
 
     templateTargets ++ obsTargets
   }
-
 
   /** (obs paramset, target paramset) paramset pairs **/
   protected def obsAndBases(d: Document): List[(ParamSet, ParamSet)] =

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2015B/To2015B.scala
@@ -178,7 +178,7 @@ object To2015B extends Migration {
   private def appendMagNote(target: ParamSet, s: String): Unit =
     appendNote(target, s, MagnitudeNoteTitle, MagnitudeNoteText)
 
-  private def appendNote(target: ParamSet, s: String, title: String, text: String => String): Unit = {
+  def appendNote(target: ParamSet, s: String, title: String, text: String => String, append: Boolean = true): Unit = {
     // Find the parent that should hold the note.
     @tailrec
     def noteParent(node: PioNode): Option[Container] = {
@@ -192,10 +192,12 @@ object To2015B extends Migration {
 
     noteParent(target).foreach { parent =>
       val pset  = noteText(parent, title, text)
-      val param   = pset.getParam(PARAM_NOTE_TEXT)
-      val curText = param.getValue
-      val tName   = target.value(PARAM_NAME).getOrElse(VALUE_NAME_UNTITLED)
-      param.setValue(s"$curText  $tName $s\n")
+      if (append) {
+        val param   = pset.getParam(PARAM_NOTE_TEXT)
+        val curText = param.getValue
+        val tName   = target.value(PARAM_NAME).getOrElse(VALUE_NAME_UNTITLED)
+        param.setValue(s"$curText  $tName $s\n")
+      }
     }
   }
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -219,7 +219,7 @@ object To2016B extends Migration {
       s"""
          |Starting with 2016B, the Observing Tool supports all nonsidereal targets with ephemerides
          |automatically downloaded from JPL HORIZONS.  This observation used the following orbital
-         |elements for which have been migrated to a single-point ephemeris.
+         |elements which have been migrated to a single-point ephemeris.
          |
          |     Name: $name
          |    Epoch: $epoch

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -5,6 +5,7 @@ import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.core.HorizonsDesignation.MajorBody
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.obscomp.SPProgram
+import edu.gemini.spModel.io.impl.migration.to2015B.To2015B
 import edu.gemini.spModel.pio.xml.PioXmlFactory
 import edu.gemini.spModel.pio.{Document, ParamSet, Pio, Version}
 import edu.gemini.spModel.target.{SPTargetPio, SourcePio, TargetParamSetCodecs}
@@ -28,7 +29,7 @@ object To2016B extends Migration {
   }
 
   val conversions: List[Document => Unit] = List(
-    updateGuideEnvironment, updateSchedulingBlocks, updateTargets, updateAltair // order matters!
+    updateGuideEnvironment, updateSchedulingBlocks, updateTargets, updateTargetNotes, updateAltair // order matters!
   )
 
   val fact = new PioXmlFactory
@@ -125,6 +126,14 @@ object To2016B extends Migration {
 
     }
 
+  // Add notes to obs targets only, since template targets have no orbital elements
+  def updateTargetNotes(d: Document): Unit =
+    allTargets(d, false).foreach { t =>
+      conicTargetNote(t).foreach { case (title, body) =>
+        To2015B.appendNote(t, "", title, _ => body, false)
+      }
+    }
+
   // Properties common to all target types
   def common(ps: ParamSet): State[Target, Unit] =
     for {
@@ -192,6 +201,39 @@ object To2016B extends Migration {
       case "NEPTUNE" => 899
       case _         => sys.error("Unknown named target: " + name)
     })
+
+  // Construct a note describing the old conic target
+  def conicTargetNote(ps: ParamSet): Option[(String, String)] =
+    for {
+      name  <- ps.value("name")
+      mpc   <- ps.value("system").map(_ == "MPC minor planet")
+      epoch <- ps.value("epoch")
+      in    <- ps.value("inclination")
+      om    <- ps.value("anode")
+      w     <- ps.value("perihelion")
+      aq    <- ps.value("aq")
+      ec    <- ps.value("e")
+      matp  <- ps.value(mpc ? "lm" | "epochOfPeri")
+    } yield (
+      s"Migration: $name",
+      s"""
+         |Starting with 2016B, the Observing Tool supports all nonsidereal targets with ephemerides
+         |automatically downloaded from JPL HORIZONS.  This observation used the following orbital
+         |elements for which have been migrated to a single-point ephemeris.
+         |
+         |     Name: $name
+         |    Epoch: $epoch
+         |       IN: $in
+         |       OM: $om
+         |        W: $w
+         |       ${mpc ? " A" | "QR"}: $aq
+         |       EC: $ec
+         |       ${mpc ? "MA" | "TP"}: $matp
+         |
+         |Re-resolve the target to set the unique target identifier and to update to the most recent
+         |ephemeris.
+       """.stripMargin
+      )
 
   def updateAltair(d: Document): Unit = {
     for {

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -1,10 +1,11 @@
 package edu.gemini.spModel.io.impl.migration.to2016B
 
-import edu.gemini.pot.sp.{SPComponentType, ISPProgram}
+import edu.gemini.pot.sp.{ISPObservation, ISPNode, SPComponentType, ISPProgram}
 import edu.gemini.spModel.core.HorizonsDesignation.MajorBody
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.io.impl.migration.MigrationTest
 import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
+import edu.gemini.spModel.obscomp.{SPNote, ProgramNote}
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import org.specs2.mutable.Specification
@@ -109,6 +110,30 @@ class TargetMigrationTest extends Specification with MigrationTest {
       )
     }
 
+    "Add a migration note for MPC Minor Planet 'beer'" in withTestProgram2("targetMigration.xml") { p =>
+      findNoteTextByPath(p, "mpc-minor-planet", "Migration: beer").exists(_ contains "W: 180.0542620681246")
+    }
+
+    "Add a migration note for JPL Major Body 'Halley'" in withTestProgram2("targetMigration.xml") { p =>
+      findNoteTextByPath(p, "jpl-minor-body", "Migration: halley").exists(_ contains "EC: 0.9671429084623044")
+    }
+
   }
+
+  def findNoteTextByPath(n: ISPNode, title: String, more: String*): Option[String] =
+    findByPath(n, title, more: _*).map(_.getDataObject).collect {
+      case n: SPNote => n.getNote
+    }
+
+  def findByPath(n: ISPNode, title: String, more: String*): Option[ISPNode] =
+    findByName(n, title).flatMap { node =>
+      more.toList match {
+        case Nil    => Some(node)
+        case t :: m => findByPath(node, t, m: _*)
+      }
+    }
+
+  def findByName(n: ISPNode, title: String): Option[ISPNode] =
+    n.findDescendant(_.getDataObject.getTitle == title)
 
 }


### PR DESCRIPTION
This updates the `To2016B` migration logic to add notes for imported conic targets:

```
Starting with 2016B, the Observing Tool supports all nonsidereal targets with ephemerides
automatically downloaded from JPL HORIZONS.  This observation used the following orbital
elements which have been migrated to a single-point ephemeris.

     Name: Pluto
    Epoch: 2457217.5
       IN: 17.36609399010031
       OM: 110.2100007229519
        W: 114.2248220688449
        A: 39.74409337717218
       EC: 0.2543036816945946
       MA: 0.0

Re-resolve the target to set the unique target identifier and to update to the most recent
ephemeris.
```

I'm ignoring targets in template groups because they targets coming from the PIT won't have orbital elements. I'm not sure if this is the right approach.