### PR TITLE
REL-2707: Set locale to en_US

### DIFF
--- a/app/itc/build.sbt
+++ b/app/itc/build.sbt
@@ -32,7 +32,9 @@ def common(version: Version) = AppConfig(
     "-Dcom.sun.management.jmxremote.port=2407",
     "-Dcom.sun.management.jmxremote.ssl=false",
     "-Djava.awt.headless=true",
-    "-Dnetworkaddress.cache.ttl=60"
+    "-Dnetworkaddress.cache.ttl=60",
+    "-Duser.language=en",
+    "-Duser.country=US"
   ),
   props = Map(
     "edu.gemini.spdb.mode"                       -> "local",

--- a/app/ot/build.sbt
+++ b/app/ot/build.sbt
@@ -41,7 +41,9 @@ def common(version: Version) = AppConfig(
   id = "common",
   vmargs = List(
     "-Xmx1024M",
-    "-XX:MaxPermSize=196M"
+    "-XX:MaxPermSize=196M",
+    "-Duser.language=en",
+    "-Duser.country=US"
   ),
   props = Map(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",

--- a/app/p1-monitor/build.sbt
+++ b/app/p1-monitor/build.sbt
@@ -30,7 +30,9 @@ def common(ov: Version, pv: Version) = AppConfig(
   id = "common",
   vmargs = List(
     "-Xmx512M",
-    "-Djava.util.logging.config.file=conf/log.properties"
+    "-Djava.util.logging.config.file=conf/log.properties",
+    "-Duser.language=en",
+    "-Duser.country=US"
   ),
   props = Map(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",

--- a/app/p1pdfmaker/build.sbt
+++ b/app/p1pdfmaker/build.sbt
@@ -27,7 +27,9 @@ def common(pv: Version) = AppConfig(
   vmargs = List(
     "-Xmx512M",
     "-Dedu.gemini.ui.workspace.impl.Workspace.fonts.shrunk=true",
-    "-Dfile.encoding=UTF-8"
+    "-Dfile.encoding=UTF-8",
+    "-Duser.language=en",
+    "-Duser.country=US"
   ),
   props = Map(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",

--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -30,7 +30,9 @@ def common(pv: Version) = AppConfig(
   vmargs = List(
     "-Xmx512M",
     "-Dedu.gemini.ui.workspace.impl.Workspace.fonts.shrunk=true",
-    "-Dfile.encoding=UTF-8"
+    "-Dfile.encoding=UTF-8",
+    "-Duser.language=en",
+    "-Duser.country=US"
   ),
   props = Map(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",

--- a/app/qpt/build.sbt
+++ b/app/qpt/build.sbt
@@ -34,7 +34,9 @@ ocsAppManifest := {
 def common(version: Version) = AppConfig(
   id = "common",
   vmargs = List(
-    "-Xmx1024M"
+    "-Xmx1024M",
+    "-Duser.language=en",
+    "-Duser.country=US"
   ),
   props = Map(
     "org.osgi.framework.storage.clean"                 -> "onFirstInit",

--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -50,7 +50,9 @@ def common(version: Version) = AppConfig(
     "-Dcom.sun.management.jmxremote.port=2407",
     "-Dcom.sun.management.jmxremote.ssl=false",
     "-Djava.awt.headless=true",
-    "-Dnetworkaddress.cache.ttl=60"
+    "-Dnetworkaddress.cache.ttl=60",
+    "-Duser.language=en",
+    "-Duser.country=US"
   ),
   props = Map(
     "edu.gemini.auxfile.chunkSize"                     -> "32768",


### PR DESCRIPTION
This PR adds explicit flags to all the applications setting the locale to `en_US`. I tested this by changing my locale to something else and after the launch spdb started with `en_US`

We could also set the locale using `Locale.setDefault` on the launcher but this option seems less intrusive