### PR TITLE
REL-2323B: Altar additional strategies

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -50,7 +50,7 @@ sealed case class MultiProbeStrategy(key: AgsStrategyKey, strategies: List[AgsSt
     def ctxToFixedList: List[ObsContext] = {
       val ctxFixed = {
         val instFixed = ctx.getInstrument match {
-          case pac : PosAngleConstraintAware =>
+          case pac : SPInstObsComp with PosAngleConstraintAware =>
             val newPac = pac.clone.asInstanceOf[SPInstObsComp with PosAngleConstraintAware]
             newPac.setPosAngleConstraint(PosAngleConstraint.FIXED)
             newPac

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -95,14 +95,12 @@ sealed case class MultiProbeStrategy(key: AgsStrategyKey, strategies: List[AgsSt
         case AgsStrategy.Assignment(gp: SingleProbeStrategy.VProbe, t) => gp.calculator(cCtx).calc(t.coordinates)
       }.sum
 
-      // We can use default value of 0.0 as the guide probes for which targets with magnitudes exist should be
-      // consistent across all selections.
       val brightestMag = sel.assignments.collect {
         case AgsStrategy.Assignment(_, t) if qualitiesByTarget.get(t).exists(_ === bestQuality) =>
           probeBands.extract(t).map(_.value)
       }.collect {
         case Some(v) => v
-      }.minimum.getOrElse(0.0)
+      }.minimum.getOrElse(Double.MaxValue)
 
       (qualityIdx, vignettingIdx, bestQuality, brightestMag)
     }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -55,7 +55,7 @@ class MultiProbeStrategy(val key: AgsStrategyKey, paStrategy: AgsStrategy, paSym
   val probeBands = RBandsList
 
   override val guideProbes: List[GuideProbe] =
-    strategies.flatMap(_.guideProbes)
+    strategies.flatMap(_.guideProbes).distinct
 }
 
 case object GmosNorthOiwfsAltair extends MultiProbeStrategy(AgsStrategyKey.GmosNorthAltairOiwfsKey, Strategy.GmosNorthOiwfs, List(Strategy.AltairAowfs))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -70,7 +70,7 @@ sealed case class MultiProbeStrategy(key: AgsStrategyKey, strategies: List[AgsSt
     def ctxSelect(cCtx: ObsContext): Future[(ObsContext, Option[AgsStrategy.Selection])] =
       Future.fold(strategies.map(_.select(cCtx, mt)))(cCtx -> noStrategy) {
         case ((_, resOpt), curOpt) =>
-          cCtx -> curOpt.map(cur => AgsStrategy.Selection(cur.posAngle, resOpt.fold(cur.assignments)(cur.assignments ++ _.assignments))).orElse(resOpt)
+          cCtx -> curOpt.map(cur => AgsStrategy.Selection(cur.posAngle, resOpt.fold(cur.assignments)(cur.assignments ++ _.assignments)))
       }
 
     // We need a way to compare AGS selections to determine which is the best across the list of generated

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -6,57 +6,57 @@ import edu.gemini.ags.api.{AgsAnalysis, AgsMagnitude, AgsStrategy}
 import edu.gemini.catalog.api.CatalogQuery
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.core.{RBandsList, SiderealTarget}
-import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
+import edu.gemini.spModel.guide.{GuideProbe, ValidatableGuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 
 import scala.concurrent.Future
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scalaz._
+import Scalaz._
+
 
 /**
  * Represents an AGS strategy consisting of multiple substrategies.
  *
  * Currently, this is only used to represent combinations of SingleProbeStrategies.
- *
- * Since select returns a position angle, this allows us to use the position angle of the paStrategy and ignore
- * the position angles of the (fully or approximately) rotation-symmetric (around the base pos) strategies returned
- * by select.
  */
-class MultiProbeStrategy(val key: AgsStrategyKey, paStrategy: AgsStrategy, paSymmetricStrategies: List[AgsStrategy]) extends AgsStrategy {
-  val strategies = paStrategy :: paSymmetricStrategies
+case class MultiProbeStrategy(key: AgsStrategyKey, strategies: NonEmptyList[AgsStrategy]) extends AgsStrategy {
 
   override def magnitudes(ctx: ObsContext, mt: MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =
-    strategies.flatMap(_.magnitudes(ctx, mt))
+    strategies.toList.flatMap(_.magnitudes(ctx, mt))
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
-    strategies.flatMap(_.analyze(ctx, mt))
+    strategies.toList.flatMap(_.analyze(ctx, mt))
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
 
   override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] =
-    strategies.flatMap(_.catalogQueries(ctx, mt))
+    strategies.toList.flatMap(_.catalogQueries(ctx, mt))
 
   override def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]] =
-    Future.traverse(strategies)(_.candidates(ctx, mt)).map(_.flatten)
+    Future.traverse(strategies.toList)(_.candidates(ctx, mt)).map(_.flatten)
 
   override def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
-    Future.fold(strategies.map(_.estimate(ctx, mt)))(1.0)((p,est) => p * est.probability).map(Estimate(_))
+    Future.fold(strategies.toList.map(_.estimate(ctx, mt)))(1.0)((p,est) => p * est.probability).map(Estimate(_))
 
   // As described in the comment for the class, we pick the position angle for the FIRST strategy, since it is the
   // only one that can have a patrol field that is not (at least approximately) symmetric under rotation around the base.
   override def select(ctx: ObsContext, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]] = {
-    Future.fold(strategies.map(_.select(ctx, mt)))(None: Option[AgsStrategy.Selection])((resOpt,curOpt) =>
+    Future.fold(strategies.toList.map(_.select(ctx, mt)))(None: Option[AgsStrategy.Selection])((resOpt,curOpt) =>
       curOpt.map(cur => AgsStrategy.Selection(cur.posAngle, resOpt.fold(cur.assignments)(cur.assignments ++ _.assignments))).orElse(resOpt)
     )
   }
 
-  // Default is R bands.
-  val probeBands = RBandsList
+  // From the left, take the band that is the superset of the most bands.
+  // This should but may not contain all bands, as BandsList is a sealed trait.
+  override lazy val probeBands = strategies.toList.map(_.probeBands).reduceLeft((sup,cur) => {
+    if (sup.bands.toSet.subsetOf(cur.bands.toSet)) cur else sup
+  })
 
-  override val guideProbes: List[GuideProbe] =
-    strategies.flatMap(_.guideProbes).distinct
+  override lazy val guideProbes: List[GuideProbe] =
+    strategies.toList.flatMap(_.guideProbes).distinct
 }
 
-case object GmosNorthOiwfsAltair extends MultiProbeStrategy(AgsStrategyKey.GmosNorthAltairOiwfsKey, Strategy.GmosNorthOiwfs, List(Strategy.AltairAowfs))
-case object GmosNorthOiwfsPwfs1 extends MultiProbeStrategy(AgsStrategyKey.GmosNorthPwfs1OiwfsKey, Strategy.GmosNorthOiwfs, List(Strategy.Pwfs1North))
+case object GmosNorthOiwfsAltair extends MultiProbeStrategy(AgsStrategyKey.GmosNorthAltairOiwfsKey, NonEmptyList(Strategy.GmosNorthOiwfs, Strategy.AltairAowfs))
+case object GmosNorthOiwfsPwfs1 extends MultiProbeStrategy(AgsStrategyKey.GmosNorthPwfs1OiwfsKey, NonEmptyList(Strategy.GmosNorthOiwfs, Strategy.Pwfs1North))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -2,15 +2,18 @@ package edu.gemini.ags.impl
 
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
 import edu.gemini.ags.api.AgsStrategy.Estimate
-import edu.gemini.ags.api.{AgsAnalysis, AgsMagnitude, AgsStrategy}
+import edu.gemini.ags.api.{AgsAnalysis, AgsGuideQuality, AgsMagnitude, AgsStrategy}
 import edu.gemini.catalog.api.CatalogQuery
+import edu.gemini.skycalc.Angle
 import edu.gemini.spModel.ags.AgsStrategyKey
-import edu.gemini.spModel.core.{RBandsList, SiderealTarget}
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.guide.{GuideProbe, ValidatableGuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.obscomp.SPInstObsComp
+import edu.gemini.spModel.telescope.{PosAngleConstraint, PosAngleConstraintAware}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-
 import scalaz._
 import Scalaz._
 
@@ -20,43 +23,114 @@ import Scalaz._
  *
  * Currently, this is only used to represent combinations of SingleProbeStrategies.
  */
-case class MultiProbeStrategy(key: AgsStrategyKey, strategies: NonEmptyList[AgsStrategy]) extends AgsStrategy {
+class MultiProbeStrategy(val key: AgsStrategyKey, val strategies: List[AgsStrategy]) extends AgsStrategy {
 
   override def magnitudes(ctx: ObsContext, mt: MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =
-    strategies.toList.flatMap(_.magnitudes(ctx, mt))
+    strategies.flatMap(_.magnitudes(ctx, mt))
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
-    strategies.toList.flatMap(_.analyze(ctx, mt))
+    strategies.flatMap(_.analyze(ctx, mt))
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
 
   override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] =
-    strategies.toList.flatMap(_.catalogQueries(ctx, mt))
+    strategies.flatMap(_.catalogQueries(ctx, mt))
 
   override def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]] =
-    Future.traverse(strategies.toList)(_.candidates(ctx, mt)).map(_.flatten)
+    Future.traverse(strategies)(_.candidates(ctx, mt)).map(_.flatten)
 
   override def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
-    Future.fold(strategies.toList.map(_.estimate(ctx, mt)))(1.0)((p,est) => p * est.probability).map(Estimate(_))
+    Future.fold(strategies.map(_.estimate(ctx, mt)))(1.0)((p,est) => p * est.probability).map(Estimate(_))
 
-  // As described in the comment for the class, we pick the position angle for the FIRST strategy, since it is the
-  // only one that can have a patrol field that is not (at least approximately) symmetric under rotation around the base.
+  // This is a bit hacked, as it requires invoking select for each of the substrategies, which are structured to
+  // pick the best assignment for the current position angle constraint. This, of course, might result in different
+  // position angles for substrategies if we naively call select on each, so instead, we hack the context to
+  // handle each position angle constraint and then pick the best one.
   override def select(ctx: ObsContext, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]] = {
-    Future.fold(strategies.toList.map(_.select(ctx, mt)))(None: Option[AgsStrategy.Selection])((resOpt,curOpt) =>
-      curOpt.map(cur => AgsStrategy.Selection(cur.posAngle, resOpt.fold(cur.assignments)(cur.assignments ++ _.assignments))).orElse(resOpt)
-    )
+    // We hack the obs context to be a list of obs contexts with all possible position angles, and with fixed
+    // position angle constraint so that guide probes will not be allowed to take on different angles in select calls.
+    def ctxToFixedList: List[ObsContext] = {
+      val ctxFixed = {
+        val instFixed = ctx.getInstrument match {
+          case pac : PosAngleConstraintAware =>
+            val newPac = pac.clone.asInstanceOf[SPInstObsComp with PosAngleConstraintAware]
+            newPac.setPosAngleConstraint(PosAngleConstraint.FIXED)
+            newPac
+          case oth : SPInstObsComp => oth
+        }
+        ctx.withInstrument(instFixed)
+      }
+      (ctx.getPosAngleConstraint match {
+        case PosAngleConstraint.FIXED                                            => List(0)
+        case PosAngleConstraint.FIXED_180 | PosAngleConstraint.PARALLACTIC_ANGLE => List(0, 180)
+        case PosAngleConstraint.UNBOUNDED                                        => Range(0, 360, 15).toList
+      }).map(a => ctxFixed.withPositionAngle(ctx.getPositionAngle.add(a, Angle.Unit.DEGREES)))
+    }
+
+    // We have a List[ObsContext], and we want to get a Future[Option[AgsStrategy.Selection]]
+    // We can take the List[ObsContext] to a Future[List[Option[AgsStrategy.Selection]]].
+    // Then we simply filter out the empty Options, and of the remaining, fold to get the best selection.
+    // We MAY want to make a comparator for AgsStrategy.Selection. I'm just not sure the best way to do this.
+    // Assign values to GuideQualities, add together, pick the maximum, and then break ties by vignetting?
+    val noStrategy: Option[AgsStrategy.Selection] = None
+    def ctxSelect(cCtx: ObsContext): Future[(ObsContext, Option[AgsStrategy.Selection])] = {
+      val lOfF = strategies.map(_.select(cCtx, mt).map(opt => (ctx, opt)))
+      Future.fold(lOfF)(ctx -> noStrategy) { case ((_, resOpt), (_, curOpt)) =>
+        cCtx -> curOpt.map(cur => AgsStrategy.Selection(cur.posAngle, resOpt.fold(cur.assignments)(cur.assignments ++ _.assignments))).orElse(resOpt)
+      }
+    }
+
+    // Now we convert to a future of lists of (ObsContext, Option[AgsStrategy.Selection]), and pick the best one,
+    // if one exists. This entails picking the best quality, followed by vignetting, followed by magnitude.
+    // To calculate this for multiple selections:
+    // 1. Quality index is the quality converted to an int, and then summed over all targets. Lowest wins.
+    // 2. Vignetting index is vignetting for each vignetting guide probe, summed across all. Lowest wins.
+    // 3. Best quality across all targets. Used because for magnitude, we only want best quality class in comparison.
+    // 4. Magnitude is magnitude of the brightest star in the assignment in the best quality class.
+    def selValue(cCtx: ObsContext, sel: AgsStrategy.Selection): (Int, Double, Int, Double) = {
+      val qualitiesByTarget = sel.assignments.collect {
+        case AgsStrategy.Assignment(gp: ValidatableGuideProbe, t) => t -> analyze(cCtx, mt, gp, t)
+      }.collect {
+        case (t, Some(v)) => t -> AgsGuideQuality.All.indexOf(v.quality)
+      }.toMap
+      val (bestQuality, qualityIdx) = {
+        val qualities = qualitiesByTarget.values
+        (qualities.min, qualities.sum)
+      }
+
+      val vignettingIdx = sel.assignments.collect {
+        case AgsStrategy.Assignment(gp: SingleProbeStrategy.VProbe,t) => gp.calculator(cCtx).calc(t.coordinates)
+      }.sum
+
+      // We can use default value of 0.0 as the guide probes for which targets with magnitudes exist should be
+      // consistent across all selections.
+      val brightestMag = sel.assignments.collect {
+        case AgsStrategy.Assignment(_, t) if qualitiesByTarget.get(t).exists(_ === bestQuality) =>
+          probeBands.extract(t).map(_.value)
+      }.collect {
+        case Some(v) => v
+      }.minimum.getOrElse(0.0)
+
+      (qualityIdx, vignettingIdx, bestQuality, brightestMag)
+    }
+
+    // Turn into a Future of List[(ObsContext, Option[AgsStrategy.Selection]), collect the results that have
+    // a defined selection while calculating their value, and then return the one (if one exists) of minimum value.
+    Future.sequence(ctxToFixedList.map(ctxSelect))
+      .map(_.collect { case (cCtx, Some(sel)) => (cCtx, sel, selValue(cCtx, sel)) }.minimumBy(_._3).map(_._2))
   }
+
 
   // From the left, take the band that is the superset of the most bands.
   // This should but may not contain all bands, as BandsList is a sealed trait.
-  override lazy val probeBands = strategies.toList.map(_.probeBands).reduceLeft((sup,cur) => {
+  override lazy val probeBands = strategies.map(_.probeBands).reduceLeft((sup,cur) => {
     if (sup.bands.toSet.subsetOf(cur.bands.toSet)) cur else sup
   })
 
   override lazy val guideProbes: List[GuideProbe] =
-    strategies.toList.flatMap(_.guideProbes).distinct
+    strategies.flatMap(_.guideProbes).distinct
 }
 
-case object GmosNorthOiwfsAltair extends MultiProbeStrategy(AgsStrategyKey.GmosNorthAltairOiwfsKey, NonEmptyList(Strategy.GmosNorthOiwfs, Strategy.AltairAowfs))
-case object GmosNorthOiwfsPwfs1 extends MultiProbeStrategy(AgsStrategyKey.GmosNorthPwfs1OiwfsKey, NonEmptyList(Strategy.GmosNorthOiwfs, Strategy.Pwfs1North))
+case object GmosNorthOiwfsAltair extends MultiProbeStrategy(AgsStrategyKey.GmosNorthAltairOiwfsKey, List(Strategy.GmosNorthOiwfs, Strategy.AltairAowfs))
+case object GmosNorthOiwfsPwfs1 extends MultiProbeStrategy(AgsStrategyKey.GmosNorthPwfs1OiwfsKey, List(Strategy.GmosNorthOiwfs, Strategy.Pwfs1North))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/MultiProbeStrategy.scala
@@ -1,0 +1,62 @@
+package edu.gemini.ags.impl
+
+import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
+import edu.gemini.ags.api.AgsStrategy.Estimate
+import edu.gemini.ags.api.{AgsAnalysis, AgsMagnitude, AgsStrategy}
+import edu.gemini.catalog.api.CatalogQuery
+import edu.gemini.spModel.ags.AgsStrategyKey
+import edu.gemini.spModel.core.{RBandsList, SiderealTarget}
+import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
+import edu.gemini.spModel.obs.context.ObsContext
+
+import scala.concurrent.Future
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+ * Represents an AGS strategy consisting of multiple substrategies.
+ *
+ * Currently, this is only used to represent combinations of SingleProbeStrategies.
+ *
+ * Since select returns a position angle, this allows us to use the position angle of the paStrategy and ignore
+ * the position angles of the (fully or approximately) rotation-symmetric (around the base pos) strategies returned
+ * by select.
+ */
+class MultiProbeStrategy(val key: AgsStrategyKey, paStrategy: AgsStrategy, paSymmetricStrategies: List[AgsStrategy]) extends AgsStrategy {
+  val strategies = paStrategy :: paSymmetricStrategies
+
+  override def magnitudes(ctx: ObsContext, mt: MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =
+    strategies.flatMap(_.magnitudes(ctx, mt))
+
+  override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
+    strategies.flatMap(_.analyze(ctx, mt))
+
+  override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
+    AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar, probeBands)
+
+  override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] =
+    strategies.flatMap(_.catalogQueries(ctx, mt))
+
+  override def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]] =
+    Future.traverse(strategies)(_.candidates(ctx, mt)).map(_.flatten)
+
+  override def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
+    Future.fold(strategies.map(_.estimate(ctx, mt)))(1.0)((p,est) => p * est.probability).map(Estimate(_))
+
+  // As described in the comment for the class, we pick the position angle for the FIRST strategy, since it is the
+  // only one that can have a patrol field that is not (at least approximately) symmetric under rotation around the base.
+  override def select(ctx: ObsContext, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]] = {
+    Future.fold(strategies.map(_.select(ctx, mt)))(None: Option[AgsStrategy.Selection])((resOpt,curOpt) =>
+      curOpt.map(cur => AgsStrategy.Selection(cur.posAngle, resOpt.fold(cur.assignments)(cur.assignments ++ _.assignments))).orElse(resOpt)
+    )
+  }
+
+  // Default is R bands.
+  val probeBands = RBandsList
+
+  override val guideProbes: List[GuideProbe] =
+    strategies.flatMap(_.guideProbes)
+}
+
+case object GmosNorthOiwfsAltair extends MultiProbeStrategy(AgsStrategyKey.GmosNorthAltairOiwfsKey, Strategy.GmosNorthOiwfs, List(Strategy.AltairAowfs))
+case object GmosNorthOiwfsPwfs1 extends MultiProbeStrategy(AgsStrategyKey.GmosNorthPwfs1OiwfsKey, Strategy.GmosNorthOiwfs, List(Strategy.Pwfs1North))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -41,6 +41,8 @@ object Strategy {
     Flamingos2Oiwfs,
     GemsStrategy,
     GmosNorthOiwfs,
+    GmosNorthOiwfsAltair,
+    GmosNorthOiwfsPwfs1,
     GmosSouthOiwfs,
     GnirsOiwfs,
     NiciOiwfs,
@@ -84,9 +86,9 @@ object Strategy {
       val ao = ctx.getAOComponent.asScalaOpt
       if (ao.exists(_.isInstanceOf[InstAltair])) {
         ao.get.asInstanceOf[InstAltair].getMode match {
-          case AltairParams.Mode.LGS_P1 => List(Pwfs1North)
+          case AltairParams.Mode.LGS_P1 => List(Pwfs1North, GmosNorthOiwfsPwfs1)
           case AltairParams.Mode.LGS_OI => List(GmosNorthOiwfs)
-          case _                        => List(AltairAowfs, Pwfs1North, GmosNorthOiwfs)
+          case _                        => List(AltairAowfs, GmosNorthOiwfsAltair)
         }
       } else oiStategies(ctx, GmosNorthOiwfs)
     }),
@@ -110,6 +112,7 @@ object Strategy {
     s match {
       case SingleProbeStrategy(_, params, _) => isAvailable(params.guideProbe)
       case ScienceTargetStrategy(_, gp, _)   => isAvailable(gp)
+      case m: MultiProbeStrategy             => m.strategies.forall(guidersAvailable(ctx))
       case GemsStrategy                      => isAvailable(Canopus.Wfs.cwfs3) // any canopus would serve
       case _                                 => false
     }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -1,6 +1,7 @@
 package edu.gemini.ags.impl
 
 import edu.gemini.ags.api.AgsStrategy
+import edu.gemini.ags.impl.MultiProbeStrategy._
 import edu.gemini.catalog.votable.ConeSearchBackend
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.ags.AgsStrategyKey

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -124,6 +124,18 @@ public class GeneralRule implements IRule {
         //TODO: Rule to check if the WFS is in the patrol field, whatever that means
         //private static final String WFS_OUT_PATROL_FIELD_TEMPLATE = "%s outside of the patrol field";
 
+        private String formatGuiderString(final Iterator<GuideProbe> iter) {
+            if (iter == null || !iter.hasNext())
+                return "";
+
+            final StringBuilder buf = new StringBuilder();
+            buf.append(iter.next().getKey());
+            while (iter.hasNext()) {
+                buf.append(", ").append(iter.next().getKey());
+            }
+            return buf.toString();
+        }
+
         private void reportAltairLgsGuideIssues(P2Problems problems, Set<GuideProbe> guiders, AltairParams.Mode mode, ISPObsComponent targetComp) {
             final ImList<GuideProbe> usedGuiders = mode.guiders();
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -125,24 +125,26 @@ public class GeneralRule implements IRule {
         //private static final String WFS_OUT_PATROL_FIELD_TEMPLATE = "%s outside of the patrol field";
 
         private void reportAltairLgsGuideIssues(P2Problems problems, Set<GuideProbe> guiders, AltairParams.Mode mode, ISPObsComponent targetComp) {
-            final GuideProbe guider = mode.guider();
-            if (!guiders.contains(guider)) {
-                problems.addError(PREFIX+"LGS_WFS", String.format(LGS_WFS, mode.displayValue(), guider), targetComp);
-            } else if (guiders.size() > 1) {
+            final ImList<GuideProbe> usedGuiders = mode.guiders();
+
+            // Check to see if we are using any guiders that are not in the set of guiders in the parameter list.
+            // Then check to see if there are any unused guiders in the set of guiders parameter list.
+            // TODO: Not sure if we want to display one P2 error per used guider, or one message with all used guiders.
+            final ImList<GuideProbe> badGuiders = usedGuiders.filter(gp -> !guiders.contains(gp));
+            if (badGuiders.nonEmpty()) {
+                final String badGuiderNames = formatGuiderString(badGuiders.iterator());
+                problems.addError(PREFIX + "LGS_WFS", String.format(LGS_WFS, mode.displayValue(), badGuiderNames), targetComp);
+                //badGuiders.foreach(g -> problems.addError(PREFIX + "LGS_WFS", String.format(LGS_WFS, mode.displayValue(), g), targetComp));
+            } else if (guiders.size() - usedGuiders.size() > 1) {
                 final Set<GuideProbe> otherGuiders = new TreeSet<>(GuideProbe.KeyComparator.instance);
                 otherGuiders.addAll(guiders);
-                otherGuiders.remove(guider);
+                badGuiders.foreach(otherGuiders::remove);
 
                 // Format the guider names
-                final StringBuilder buf = new StringBuilder();
-                final Iterator<GuideProbe> it = otherGuiders.iterator();
-                buf.append(it.next().getKey());
-                while (it.hasNext()) {
-                    buf.append(", ").append(it.next().getKey());
-                }
-
-                final String msg = String.format(NO_AO_OTHER, guider.getKey(), buf.toString());
-                problems.addError(PREFIX+"NO_AO_OTHER", msg, targetComp);
+                final String guiderNames     = formatGuiderString(otherGuiders.iterator());
+                final String usedGuiderNames = formatGuiderString(usedGuiders.iterator());
+                problems.addError(PREFIX+"NO_AO_OTHER", String.format(NO_AO_OTHER, usedGuiderNames, guiderNames), targetComp);
+                //usedGuiders.foreach(g -> problems.addError(PREFIX+"NO_AO_OTHER", String.format(NO_AO_OTHER, g.getKey(), guiderNames), targetComp));
             }
         }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairParams.java
@@ -6,6 +6,8 @@
 //
 package edu.gemini.spModel.gemini.altair;
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
@@ -244,24 +246,24 @@ public final class AltairParams {
      */
     public enum Mode implements DisplayableSpType, SequenceableSpType {
 
-        NGS     ("NGS",     GuideStarType.NGS, FieldLens.OUT, AltairAowfsGuider.instance),
-        NGS_FL  ("NGS+FL",  GuideStarType.NGS, FieldLens.IN,  AltairAowfsGuider.instance),
-        LGS     ("LGS",     GuideStarType.LGS, FieldLens.IN,  AltairAowfsGuider.instance),
-        LGS_P1  ("LGS+P1",  GuideStarType.LGS, FieldLens.IN,  PwfsGuideProbe.pwfs1),
-        LGS_OI  ("LGS+OI",  GuideStarType.LGS, FieldLens.IN,  GmosOiwfsGuideProbe.instance)
+        NGS     ("NGS",     GuideStarType.NGS, FieldLens.OUT, DefaultImList.create(AltairAowfsGuider.instance)),
+        NGS_FL  ("NGS+FL",  GuideStarType.NGS, FieldLens.IN,  DefaultImList.create(AltairAowfsGuider.instance)),
+        LGS     ("LGS",     GuideStarType.LGS, FieldLens.IN,  DefaultImList.create(AltairAowfsGuider.instance, GmosOiwfsGuideProbe.instance)),
+        LGS_P1  ("LGS+P1",  GuideStarType.LGS, FieldLens.IN,  DefaultImList.create(PwfsGuideProbe.pwfs1, GmosOiwfsGuideProbe.instance)),
+        LGS_OI  ("LGS+OI",  GuideStarType.LGS, FieldLens.IN,  DefaultImList.create(GmosOiwfsGuideProbe.instance))
         ;
 
         public static final Mode DEFAULT = NGS;
         private final String _displayValue;
         private final GuideStarType _guideStarType;
         private final FieldLens _fieldLens;
-        private final GuideProbe _guider;
+        private final ImList<GuideProbe> _guiders;
 
-        Mode(String displayValue, GuideStarType guideStarType, FieldLens fieldLens, GuideProbe guider) {
+        Mode(final String displayValue, final GuideStarType guideStarType, final FieldLens fieldLens, final ImList<GuideProbe> guiders) {
             _displayValue = displayValue;
             _guideStarType = guideStarType;
             _fieldLens = fieldLens;
-            _guider = guider;
+            _guiders = guiders;
         }
 
         public String displayValue() {
@@ -280,8 +282,8 @@ public final class AltairParams {
             return _guideStarType;
         }
 
-        public GuideProbe guider() {
-            return _guider;
+        public ImList<GuideProbe> guiders() {
+            return _guiders;
         }
 
         /**
@@ -293,5 +295,3 @@ public final class AltairParams {
     }
 
 }
-
-

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
@@ -366,7 +366,7 @@ public final class InstAltair extends AbstractDataObject implements PropertyProv
     private static Set<GuideProbe> allMinus(final ImList<GuideProbe> guideProbes) {
         final Set<GuideProbe> guiders = new TreeSet<>(GuideProbe.KeyComparator.instance);
         guiders.addAll(GuideProbeMap.instance.values());
-        guiders.removeAll(guideProbes);
+        guideProbes.foreach(guiders::remove);
         return guiders;
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/InstAltair.java
@@ -9,6 +9,7 @@ package edu.gemini.spModel.gemini.altair;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.ao.AOConstants;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.data.ISPDataObject;
@@ -362,16 +363,16 @@ public final class InstAltair extends AbstractDataObject implements PropertyProv
     private static final Collection<GuideProbe> ANTI_GUIDERS    =
             GuideProbeUtil.instance.createCollection(PwfsGuideProbe.pwfs1, PwfsGuideProbe.pwfs2);
 
-    private static Set<GuideProbe> allMinus(GuideProbe guideProbe) {
+    private static Set<GuideProbe> allMinus(final ImList<GuideProbe> guideProbes) {
         final Set<GuideProbe> guiders = new TreeSet<>(GuideProbe.KeyComparator.instance);
         guiders.addAll(GuideProbeMap.instance.values());
-        guiders.remove(guideProbe);
+        guiders.removeAll(guideProbes);
         return guiders;
     }
 
     public Collection<GuideProbe> getConsumedGuideProbes() {
         if (getGuideStarType() == GuideStarType.LGS) {
-            return allMinus(getMode().guider());
+            return allMinus(getMode().guiders());
         } else {
             return ANTI_GUIDERS;
         }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ags/AgsStrategyKey.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ags/AgsStrategyKey.scala
@@ -29,6 +29,16 @@ object AgsStrategyKey {
     val id = "GMOS-N_OIWFS"
   }
 
+  case object GmosNorthAltairOiwfsKey extends AgsStrategyKey {
+    val id = "ALTAIR_GMOS-N_OIWFS"
+    override def displayName = "Altair + GMOS-N OIWFS"
+  }
+
+  case object GmosNorthPwfs1OiwfsKey extends AgsStrategyKey {
+    val id = "GN_PWFS1_GMOS-N_OIWFS"
+    override def displayName = "GN PWFS1 + GMOS-N OIWFS"
+  }
+
   case object GmosSouthOiwfsKey extends AgsStrategyKey {
     val id = "GMOS-S_OIWFS"
   }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
@@ -128,7 +128,8 @@ public class AltairForm extends JPanel {
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsRadioButton ----
-        lgsRadioButton.setText("Laser Guide Star + AOWFS");
+        lgsRadioButton.setText("Laser Guide Star + AOWFS TTF"); 
+        lgsRadioButton.setToolTipText("LGS using AOWFS to measure Tip, Tilt, and Focus");
         add(lgsRadioButton, new GridBagConstraints(1, 10, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
@@ -138,7 +139,8 @@ public class AltairForm extends JPanel {
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsP1RadioButton ----
-        lgsP1RadioButton.setText("Laser Guide Star + PWFS1");
+        lgsP1RadioButton.setText("Laser Guide Star + PWFS1 TTF"); 
+        lgsP1RadioButton.setToolTipText("LGS using PWFS1 to measure Tip, Tilt, and Focus");
         add(lgsP1RadioButton, new GridBagConstraints(1, 11, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
@@ -150,7 +152,8 @@ public class AltairForm extends JPanel {
         //---- lgsP1RadioButton ----
         // LAYOUT NOTE: bring both elements to the top left and let the last element
         // consume all remaining space (fill weight = 1.0 for x and y)
-        lgsOiRadioButton.setText("Laser Guide Star + OIWFS");
+        lgsOiRadioButton.setText("Laser Guide Star + OIWFS TTF"); 
+        lgsOiRadioButton.setToolTipText("LGS using OIWFS to measure Tip, Tilt, and Focus");
         add(lgsOiRadioButton, new GridBagConstraints(1, 12, 1, 1, 0.0, 0.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/altair/AltairForm.java
@@ -17,11 +17,6 @@ public class AltairForm extends JPanel {
         ndFilterInButton = new JRadioButton();
         ndFilterOutButton = new JRadioButton();
         JLabel guideStarType = new JLabel();
-        ngsRadioButton = new JRadioButton();
-        ngsWithFieldLensRadioButton = new JRadioButton();
-        lgsRadioButton = new JRadioButton();
-        lgsP1RadioButton = new JRadioButton();
-        lgsOiRadioButton = new JRadioButton();
         JLabel withFlLabel1 = new JLabel();
         JLabel withFlLabel2 = new JLabel();
         JLabel withFlLabel3 = new JLabel();
@@ -116,19 +111,19 @@ public class AltairForm extends JPanel {
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- ngsRadioButton ----
-        ngsRadioButton.setText("Natural Guide Star");
+        ngsRadioButton = new JRadioButton("Natural Guide Star");
         add(ngsRadioButton, new GridBagConstraints(1, 8, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(11, 11, 0, 0), 0, 0));
 
         //---- ngsWithFieldLensRadioButton ----
-        ngsWithFieldLensRadioButton.setText("Natural Guide Star with Field Lens");
+        ngsWithFieldLensRadioButton = new JRadioButton("Natural Guide Star with Field Lens");
         add(ngsWithFieldLensRadioButton, new GridBagConstraints(1, 9, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsRadioButton ----
-        lgsRadioButton.setText("Laser Guide Star + AOWFS TTF"); 
+        lgsRadioButton = new JRadioButton("Laser Guide Star + AOWFS TTF");
         lgsRadioButton.setToolTipText("LGS using AOWFS to measure Tip, Tilt, and Focus");
         add(lgsRadioButton, new GridBagConstraints(1, 10, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
@@ -139,7 +134,7 @@ public class AltairForm extends JPanel {
                 new Insets(0, 11, 0, 0), 0, 0));
 
         //---- lgsP1RadioButton ----
-        lgsP1RadioButton.setText("Laser Guide Star + PWFS1 TTF"); 
+        lgsP1RadioButton = new JRadioButton("Laser Guide Star + PWFS1 TTF");
         lgsP1RadioButton.setToolTipText("LGS using PWFS1 to measure Tip, Tilt, and Focus");
         add(lgsP1RadioButton, new GridBagConstraints(1, 11, 1, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE,
@@ -152,7 +147,7 @@ public class AltairForm extends JPanel {
         //---- lgsP1RadioButton ----
         // LAYOUT NOTE: bring both elements to the top left and let the last element
         // consume all remaining space (fill weight = 1.0 for x and y)
-        lgsOiRadioButton.setText("Laser Guide Star + OIWFS TTF"); 
+        lgsOiRadioButton = new JRadioButton("Laser Guide Star + OIWFS TTF");
         lgsOiRadioButton.setToolTipText("LGS using OIWFS to measure Tip, Tilt, and Focus");
         add(lgsOiRadioButton, new GridBagConstraints(1, 12, 1, 1, 0.0, 0.0,
                 GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,


### PR DESCRIPTION
Partial (minimal) migration from previous REL-2323 PR to allow for WDBA changes as per REL-2518.

Now that the coding is complete, I am updating this description:

The main detail added by this PR is the inclusion of the `MultiProbeStrategy` class, which allows combining different AGS strategies together to allow them to select in concert, which is required by REL-2323 (which adds Altair + GMOS OI, and GMOS OI + PWFS1).

The challenge in this lies in the position angle constraint, which makes this non-trivial and not straightforward. For example, if the position angle constraint is FIXED + 180, if we naively run `select` on each substrategy, then it is possible that one strategy will select at the PA, and the other strategy will select at the PA + 180, which is clearly invalid.

Thus, in order to avoid having to touch the other AGS strategies, what I did was hack the `ObsContext` when the position angle constraint is not FIXED: I create a list of `ObsContext` with all possible position angles allowed by the position angle constraint, and make sure that the position angle constraint for each one is FIXED so that selecting on the `ObsContext` forces the substrategies to use the same PA.

We then mess around with the `Futures` to get the appropriate format, and rank each valid selection using a score that corresponds to the way targets are chosen for `SingleProbeStrategy` and pick the best.

Note that the position angle constraint is used in very few places in the code, so I did not have to use this technique in methods like `estimate`, where it is never examined.