### PR TITLE
OCSADV-383-I: RA/Dec formatting updates

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Angle.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Angle.scala
@@ -421,8 +421,8 @@ object Angle {
 
     val x = a + carryB
 
-    if (x == max) s"0${sep}00$sep${df.format(0)}"
-    else f"$x%d$sep$m$sep$s"
+    if (x == max) s"00${sep}00$sep${df.format(0)}"
+    else f"$x%02d$sep$m$sep$s"
   }
 
   def signedDegrees(d: Double): Double =

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Declination.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Declination.scala
@@ -128,7 +128,7 @@ object Declination {
    */
   def formatSexigesimal(dec: Declination, sep: String = ":", fractionalDigits: Int = 2): String = {
     val a0       = dec.toDegrees
-    val (a, sgn) = if (a0 < 0) (a0.abs, "-") else (a0, "")
+    val (a, sgn) = if (a0 < 0) (a0.abs, "-") else (a0, "+")
     s"$sgn${Angle.formatSexigesimal(Angle.fromDegrees(a), sep, fractionalDigits)}"
   }
 

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/FormatTest.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/FormatTest.scala
@@ -12,36 +12,36 @@ class FormatTest extends FlatSpec {
   }
 
   "HMS second formatting" should "not carry over if under 60" in {
-    testHms("0:00:59.9998", 4, "0:00:59.9998")
+    testHms("0:00:59.9998", 4, "00:00:59.9998")
   }
 
   it should "carry over if rounding up to 60" in {
-    testHms("0:00:59.9998", 3, "0:01:00.000")
+    testHms("0:00:59.9998", 3, "00:01:00.000")
   }
 
   it should "carry over to hours if rounding up minutes as well" in {
-    testHms("0:59:59.9998", 1, "1:00:00.0")
+    testHms("0:59:59.9998", 1, "01:00:00.0")
   }
 
   it should "wrap around to 0 if rounding up hours to 24" in {
-    testHms("23:59:59.9998", 2, "0:00:00.00")
+    testHms("23:59:59.9998", 2, "00:00:00.00")
   }
 
   it should "handle 0 fractional digits" in {
-    testHms("1:02:03.567", 0, "1:02:04")
+    testHms("1:02:03.567", 0, "01:02:04")
   }
 
   it should "handle 0 fractional digits with rounding" in {
-    testHms("1:02:59.567", 0, "1:03:00")
+    testHms("1:02:59.567", 0, "01:03:00")
   }
 
   it should "handle negative fractional digits" in {
-    testHms("1:02:03.567", -1, "1:02:04")
+    testHms("1:02:03.567", -1, "01:02:04")
   }
 
   "DMS second formatting" should "wrap around to 0 if rounding up degrees to 360" in {
     assert(Angle.parseDMS("359:59:59.9998").exists { a =>
-      Angle.formatDMS(a) == "0:00:00.00"
+      Angle.formatDMS(a) == "00:00:00.00"
     })
   }
 
@@ -57,28 +57,28 @@ class FormatTest extends FlatSpec {
   }
 
   "Declination second formatting" should "carry not carry over if under 60" in {
-    testDec("-0:00:59.9998", 4, "-0:00:59.9998")
+    testDec("-0:00:59.9998", 4, "-00:00:59.9998")
   }
 
   it should "carry over if rounding up to 60" in {
-    testDec("-0:00:59.9998", 3, "-0:01:00.000")
+    testDec("-0:00:59.9998", 3, "-00:01:00.000")
   }
 
   it should "carry over to degrees if rounding up minutes as well" in {
-    testDec("-0:59:59.9998", 2, "-1:00:00.00")
+    testDec("-0:59:59.9998", 2, "-01:00:00.00")
   }
 
   it should "handle 0 fractional digits" in {
-    testDec("-0:00:59.99", 0, "-0:01:00")
+    testDec("-0:00:59.99", 0, "-00:01:00")
   }
 
   it should "handle negative fractional digits" in {
-    testDec("-0:00:59.99", -2, "-0:01:00")
+    testDec("-0:00:59.99", -2, "-00:01:00")
   }
 
   "HMS formatting" should "allow a custom separator" in {
     assert(Angle.parseHMS("1:02:03.456").exists { a =>
-      Angle.formatHMS(a, " ", 1) == "1 02 03.5"
+      Angle.formatHMS(a, " ", 1) == "01 02 03.5"
     })
   }
 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFileFormat.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFileFormat.scala
@@ -57,7 +57,7 @@ object EphemerisFileFormat {
       val coordsS   = formatCoords(coords)
       val raTrackS  = f"$raTrack%9.5f"
       val decTrackS = f"$decTrack%9.5f"
-      s" $timeS $jdS     $coordsS $raTrackS $decTrackS"
+      s" $timeS $jdS    $coordsS $raTrackS $decTrackS"
     }
 
     lines.mkString(s"$SOE\n", "\n", (lines.isEmpty ? "" | "\n") + s"$EOE\n")


### PR DESCRIPTION
This PR introduces a few minor RA/Dec formatting updates to help with TCS parsing.

* zero pads single digit hour/degree values
* adds a + sign to positive declinations
* removes a space from the whitespace separating the julian date from the RA