### PR TITLE
REL-2315: IFU Expanded Description

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -566,7 +566,9 @@
 
 			</tr>
 			<tr>
-				<td colspan="2" height="50" valign="bottom"><b>Analysis Method for Integral Field Unit (IFU) spectroscopy:</b></td>
+				<td colspan="2" height="50" valign="bottom"><b>Analysis Method for Integral Field Unit (IFU) spectroscopy:</b><br />
+				<i>Note: A single IFU element is a 0.2 arcsec diameter hexagon
+                <span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/node/10431','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false"><span>more info</span></a></i><span>)</span></td>
 			</tr>
 			<tr>
 				<td/>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -568,7 +568,9 @@
 
 			</tr>
 			<tr>
-				<td colspan="2" height="50" valign="bottom"><b>Analysis Method for Integral Field Unit (IFU) spectroscopy:</b></td>
+				<td colspan="2" height="50" valign="bottom"><b>Analysis Method for Integral Field Unit (IFU) spectroscopy:</b><br />
+                    <i>Note: A single IFU element is a 0.2 arcsec diameter hexagon
+                        <span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/node/10431','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false"><span>more info</span></a></i><span>)</span></td>
 			</tr>
 			<tr>
 				<td/>


### PR DESCRIPTION
Added a short note under the "Analysis Method for Integral Field Unit (IFU) spectroscopy" section of the GMOS-N and GMOS-S ITC webpages.  The format of the note and the corresponding link was copied from other notes and links on the same page.