### PR TITLE
REL-2751 disable target node rename

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -71,24 +71,17 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
         return toc;
     }
 
-    /**
-     * Override getTitle to return the name of the base position if set.
-     */
     public String getTitle() {
-        // By default, append the name of the base position.  If a title
-        // has been directly set though, use that instead.
-        final String title = super.getTitle();
-        if (!isTitleChanged()) {
-            final TargetEnvironment env = getTargetEnvironment();
-            final SPTarget tp = env.getBase();
-            if (tp != null) {
-                final String initName  = tp.getName();
-                final String finalName = initName == null || initName.trim().isEmpty() ? "<Untitled>" : initName;
-                return helper.targetTag(tp.getTarget()) + ": " + finalName;
-            }
+        // Always compute the name; the UI disallows changes.
+        final TargetEnvironment env = getTargetEnvironment();
+        final SPTarget tp = env.getBase();
+        if (tp != null) {
+            final String initName  = tp.getName();
+            final String finalName = initName == null || initName.trim().isEmpty() ? "<Untitled>" : initName;
+            return helper.targetTag(tp.getTarget()) + ": " + finalName;
+        } else {
+            return super.getTitle();
         }
-
-        return title;
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/EditItemTitleAction.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/EditItemTitleAction.java
@@ -2,6 +2,7 @@ package jsky.app.ot.viewer.action;
 
 import edu.gemini.pot.sp.ISPNode;
 import edu.gemini.spModel.data.ISPDataObject;
+import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import jsky.app.ot.viewer.SPViewer;
 import jsky.util.gui.DialogUtil;
 
@@ -41,6 +42,10 @@ public final class EditItemTitleAction extends AbstractViewerAction {
 
     @Override
     public boolean computeEnabledState() throws Exception {
-        return isEditableContext() && getContextNode(ISPNode.class) != null;
+        if (isEditableContext()) {
+            ISPNode n = getContextNode(ISPNode.class);
+            return !(n.getDataObject() instanceof TargetObsComp);
+        }
+        return false;
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/EditItemTitleAction.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/EditItemTitleAction.java
@@ -44,7 +44,7 @@ public final class EditItemTitleAction extends AbstractViewerAction {
     public boolean computeEnabledState() throws Exception {
         if (isEditableContext()) {
             ISPNode n = getContextNode(ISPNode.class);
-            return !(n.getDataObject() instanceof TargetObsComp);
+            return (n != null) && !(n.getDataObject() instanceof TargetObsComp);
         }
         return false;
     }


### PR DESCRIPTION
One of the hugely irritating things about the POT model is that nodes have arbitrary settable names that in many cases should be computed, and the computed name ends up being set as a side-effect. So we end up in the position of looking at the name and trying to decide whether it had been computed and should thus be re-computed if properties change; or was set by hand and should thus be left alone.

So in 16B the target naming scheme has changed to reflect the new model, which makes all the old target names appear to have been set by hand via the "Edit Item Title…" menu item in the OT. This means if you change the target the label in the tree view in the OT doesn't change. Possible fixes are:

- Encode a representation of the old naming scheme forever in OCS so we can figure out whether the name was computed in a prior version, or
- Just disable custom names for target environments (since nobody actually does that) and compute them every time.

As you may have guessed, I chose option B. Any thoughts?