### PR TITLE
REL-2765: Made changes for ephemeris output.

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -275,7 +275,8 @@ def sraaphorst(version: Version) = AppConfig(
     "edu.gemini.auxfile.other.dest"        -> "/gemsoft/var/data/finder/GSqueue/Finders-Test/@SEMESTER@/@PROG_ID@",
     "edu.gemini.auxfile.fits.host"         -> "gsconfig.gemini.edu",
     "edu.gemini.dataman.gsa.summit.host"   -> "cpofits-lv1new.cl.gemini.edu",
-    "edu.gemini.dbTools.archive.directory" -> "/Users/sraaphor/tmp/archiver"
+    "edu.gemini.dbTools.archive.directory" -> "/Users/sraaphor/tmp/archiver",
+    "osgi.shell.telnet.ip"                 -> "172.16.77.56"
   )
 ) extending List(with_gogo(version), sraaphorst_credentials(version))
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -9,11 +9,7 @@ import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.wdba.glue.api.WdbaGlueException;
 import edu.gemini.spModel.target.env.GuideGroup;
 
-/**
- *
- */
 public class TccFieldConfig extends ParamSet {
-    //private static final Logger LOG = LogUtil.getLogger(TccFieldConfig.class);
     private ObservationEnvironment _oe;
     private String _name;
 
@@ -87,9 +83,7 @@ public class TccFieldConfig extends ParamSet {
         if (!gg.getName().isEmpty()) return gg.getName().getValue();
 
         final Option<Tuple2<GuideGroup, Integer>> res = env.getGroups().zipWithIndex().find(tup -> tup._1() == gg);
-        return res.map(new Function1<Tuple2<GuideGroup,Integer>,String>() {
-            @Override public String apply(Tuple2<GuideGroup, Integer> tup) { return "Guide Group " + (tup._2() + 1); }
-        }).getOrElse("");
+        return res.map(tup -> "Guide Group " + (tup._2() + 1)).getOrElse("");
     }
 
     private void addTargets(TargetEnvironment env) throws WdbaGlueException {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
@@ -25,20 +25,6 @@ public final class TcsConfig extends ParamSet {
     }
 
     /**
-     * Returns the name of the ephemeris file associated with the given
-     * horizons designation.
-     */
-    public static String ephemerisFile(final HorizonsDesignation hd) {
-        try {
-            // See TcsEphemerisExport.
-            return URLEncoder.encode(hd.show() + ".eph", StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException ex) {
-            LOG.log(Level.SEVERE, "UTF-8 is not supported!", ex);
-            throw new RuntimeException(ex);
-        }
-    }
-
-    /**
      * build will use the <code>(@link TargetEnv}</code> to construct
      * an XML document.
      */
@@ -51,17 +37,6 @@ public final class TcsConfig extends ParamSet {
         String chopState = is.getChopState();
         if (chopState != null) {
             putParameter(TccNames.CHOP, chopState);
-        }
-
-        // Add a parameter that identifies the ephemeris file to look for if
-        // this is a non-sidereal target.
-        final scala.Option<NonSiderealTarget> nsOption = _oe.getTargetEnvironment().getBase().getNonSiderealTarget();
-        if (nsOption.isDefined()) {
-            final NonSiderealTarget ns = nsOption.get();
-            final scala.Option<HorizonsDesignation> hdOption = ns.horizonsDesignation();
-            if (hdOption.isDefined()) {
-                putParameter(TccNames.EPHEMERIS, ephemerisFile(hdOption.get()));
-            }
         }
         return true;
     }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TcsConfig.java
@@ -1,18 +1,6 @@
 package edu.gemini.wdba.tcc;
 
-import edu.gemini.spModel.core.HorizonsDesignation;
-import edu.gemini.spModel.core.NonSiderealTarget;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 public final class TcsConfig extends ParamSet {
-
-    private static final Logger LOG = Logger.getLogger(TcsConfig.class.getName());
-
     private ObservationEnvironment _oe;
 
     public TcsConfig(ObservationEnvironment oe) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
@@ -21,14 +21,6 @@ final class TcsConfigTest extends TestBase {
   }
 
   @Test
-  def testNonSiderealWithHorizonsDesignation(): Unit = {
-    val titan = HorizonsDesignation.MajorBody(606)
-    setBase(NonSiderealTarget("Titan", ==>>.empty, Some(titan), List.empty, None, None))
-    val m   = getTcsConfigurationMap(getSouthResults)
-    assertEquals(TcsConfig.ephemerisFile(titan), m.get(TccNames.EPHEMERIS))
-  }
-
-  @Test
   def testNonSiderealWithoutHorizonsDesignation(): Unit = {
     setBase(NonSiderealTarget("Titan", ==>>.empty, None, List.empty, None, None))
     val m = getTcsConfigurationMap(getSouthResults)

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
@@ -1,6 +1,6 @@
 package edu.gemini.wdba.tcc
 
-import edu.gemini.spModel.core.{Declination, Angle, RightAscension, Coordinates, SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target}
+import edu.gemini.spModel.core.{Declination, Angle, RightAscension, Coordinates, SiderealTarget, NonSiderealTarget, Target}
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import edu.gemini.spModel.util.SPTreeUtil
 import org.junit.Assert._


### PR DESCRIPTION
Previously, the WDBA XML generated a single ephemeris filename per observation if the science target was nonsidereal. This should have been done per target, with the filename associated with each nonsidereal target instead of with the observation root node.

This fixes this so that the ephemeris parameter is associated with each target if applicable.

I am not certain that we want to commit this until the change for nonsidereal targets is made throughout the OCS: as things currently stand, everything is simply done for the science target, such as the fetching of ephemeris files. I am still submitting this PR for consideration and for review by @swalker2m 