### PR TITLE
REL-2720: More adjustments to position angle field

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
@@ -80,7 +80,6 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
      * A key was pressed in the given TextBoxWidget.
      */
     public void textBoxKeyPress(final TextBoxWidget tbwe) {
-        System.out.println("--- textBoxKeyPress");
         if (getDataObject() != null) {
             _ignoreChanges = true;
             try {
@@ -102,7 +101,6 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
 
     // Copy the data model pos angle value to the pos angle text field.
     private void updatePosAngle(final boolean ignoreFocus) {
-        System.out.println("--- Updating pos angle: ignoreFocus=" + ignoreFocus + " _ignoreChanges=" + _ignoreChanges);
         if (!_ignoreChanges) {
             // Ignore model changes to the pos angle if the pos angle text box has the focus.
             // This is to avoid changing the text box value when BAGS selects an auto group at +180.
@@ -131,7 +129,6 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
     }
 
     public void propertyChange(final PropertyChangeEvent evt) {
-        System.out.println("--- PropertyChange");
         updatePosAngle(false);
         updateExpTime();
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdCompInstBase.java
@@ -7,6 +7,8 @@ import jsky.util.gui.TextBoxWidget;
 
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -47,10 +49,17 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
                 // As a result, make sure everything is synched when editing starts / stops.
                 getPosAngleTextBox().addFocusListener(new FocusAdapter() {
                     @Override public void focusLost(final FocusEvent e) {
-                        updatePosAngle();
+                        updatePosAngle(false);
                     }
                     @Override public void focusGained(final FocusEvent e) {
-                        updatePosAngle();
+                        updatePosAngle(false);
+                    }
+                });
+                getPosAngleTextBox().addKeyListener(new KeyAdapter() {
+                    @Override public void keyPressed(final KeyEvent e) {
+                        super.keyPressed(e);
+                        if (e.getKeyCode() == KeyEvent.VK_ENTER)
+                            updatePosAngle(true);
                     }
                 });
             }
@@ -71,6 +80,7 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
      * A key was pressed in the given TextBoxWidget.
      */
     public void textBoxKeyPress(final TextBoxWidget tbwe) {
+        System.out.println("--- textBoxKeyPress");
         if (getDataObject() != null) {
             _ignoreChanges = true;
             try {
@@ -91,13 +101,15 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
     }
 
     // Copy the data model pos angle value to the pos angle text field.
-    private void updatePosAngle() {
+    private void updatePosAngle(final boolean ignoreFocus) {
+        System.out.println("--- Updating pos angle: ignoreFocus=" + ignoreFocus + " _ignoreChanges=" + _ignoreChanges);
         if (!_ignoreChanges) {
             // Ignore model changes to the pos angle if the pos angle text box has the focus.
             // This is to avoid changing the text box value when BAGS selects an auto group at +180.
             final TextBoxWidget posAngleTextBox = getPosAngleTextBox();
-            if (posAngleTextBox != null && getDataObject() != null && !posAngleTextBox.hasFocus()) {
+            if (posAngleTextBox != null && getDataObject() != null && (ignoreFocus || !posAngleTextBox.hasFocus())) {
                 final String newAngle = getDataObject().getPosAngleDegreesStr();
+                System.out.println("--- newAngle=" + newAngle);
                 if (!newAngle.equals(posAngleTextBox.getText())) {
                     posAngleTextBox.setText(newAngle);
                 }
@@ -119,7 +131,8 @@ public abstract class EdCompInstBase<T extends SPInstObsComp> extends OtItemEdit
     }
 
     public void propertyChange(final PropertyChangeEvent evt) {
-        updatePosAngle();
+        System.out.println("--- PropertyChange");
+        updatePosAngle(false);
         updateExpTime();
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -19,7 +19,7 @@ import jsky.app.ot.util.OtColor
 
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
-import scala.swing.event.{FocusGained, FocusLost, SelectionChanged, ValueChanged}
+import scala.swing.event._
 import scala.util.Try
 import scalaz._
 import Scalaz._
@@ -70,6 +70,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     // We want the parallactic angle controls to be notified every time the position angle changes.
     // A warning icon will be displayed if the two values are not the same according to the chosen formatter.
     listenTo(positionAngleTextField)
+    listenTo(positionAngleTextField.keys)
     reactions += {
       case ValueChanged(`positionAngleTextField`) =>
         ui.parallacticAngleControlsOpt.foreach(_.positionAngleChanged(positionAngleTextField.text))
@@ -77,6 +78,9 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
         copyPosAngleToInstrument()
 
       case FocusGained(`positionAngleTextField`, _, _) | FocusLost(`positionAngleTextField`, _, _) =>
+        copyPosAngleToTextField()
+
+      case KeyPressed(`positionAngleTextField`, Key.Enter, _, _) =>
         copyPosAngleToTextField()
     }
 


### PR DESCRIPTION
As BAGS can use the "Flip 180" position angle feature in order to calculate a position angle +180 of the position angle currently being typed into the position angle field, we have special handling in place as per an earlier PR for this feature to prevent the contents of the PA field from being changed until the focus is gained / lost.

Andy reopened the JIRA task stating that this change should also occur when ENTER is pressed in the field, so this small PR adds that functionality.