### PR TITLE
REL-2767 show setup time for nonsidereal targets in TPE

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -193,12 +193,12 @@ object TpeEphemerisFeature {
     }
   }
 
-  def remainingTime(ispObservation: ISPObservation): Long =
-    PlannedTimeCalculator.instance
-      .calc(ispObservation)
-      .steps.asScala
+  def remainingTime(ispObservation: ISPObservation): Long = {
+    val c = PlannedTimeCalculator.instance.calc(ispObservation)
+    c.setup.time + c.steps.asScala
       .filterNot(_.executed)
       .map(_.totalTime)
       .sum
+  }
 
 }


### PR DESCRIPTION
This does three unrelated things that happened to appear in the same issue:
- It adds the setup time to the path shown in the TPE.
- It adds a "Now +5 min" option to the sched block and PA controls.
- It removes the "Now + Setup" and "Now + Reacq" options from the sched block controls.