### PR TITLE
REL-1204: Modify NIRI + Altair max guide star distance

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/altair/Altair.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/altair/Altair.java
@@ -55,9 +55,6 @@ public class Altair implements AOSystem {
 
     public void validateInputParameters(final AltairParameters p) {
         // validation
-        if (p.guideStarSeparation() < 0 || p.guideStarSeparation() > 25)
-            throw new IllegalArgumentException(" Altair Guide star distance must be between 0 and 25 arcsecs.");
-
         if (p.wfsMode().equals(AltairParams.GuideStarType.LGS) && p.guideStarMagnitude() > 19.5)
             throw new IllegalArgumentException(" Altair Guide star Magnitude must be <= 19.5 in R for LGS mode. ");
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -323,6 +323,12 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
             throw new RuntimeException("An IFU analysis method is selected but no IFU is selected.\nPlease select the IFU or" +
                     " select another analysis method.");
         }
+
+        // TODO: Implement once GMOS can be used with Altair
+//        if (gp.altair().isDefined()) {
+//            if (gp.altair().get().guideStarSeparation() < 0 || gp.altair().get().guideStarSeparation() > 45)
+//                throw new RuntimeException("Altair Guide star distance must be between 0 and 45 arcsecs for GMOS.\n");
+//        }
     }
 
     @Override

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
@@ -111,6 +111,11 @@ public final class Gnirs extends Instrument implements SpectroscopyInstrument {
             throw new RuntimeException("Central wavelength must be between 1.03um and 6.0um.");
         }
 
+        if (gp.altair().isDefined()) {
+            if ((gp.altair().get().guideStarSeparation() < 0 || gp.altair().get().guideStarSeparation() > 25))
+                throw new RuntimeException("Altair Guide star distance must be between 0 and 25 arcsecs for GNIRS.\n");
+        }
+
         //set read noise by exporsure time
         if (odp.exposureTime() <= 1.0) {
             _wellDepth      = DEEP_WELL;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
@@ -70,6 +70,11 @@ public final class Nifs extends Instrument implements SpectroscopyInstrument {
             throw new RuntimeException("Central wavelength must be between 1.00um and 6.0um.");
         }
 
+        if (gp.altair().isDefined()) {
+            if (gp.altair().get().guideStarSeparation() < 0 || gp.altair().get().guideStarSeparation() > 25)
+                throw new RuntimeException("Altair Guide star distance must be between 0 and 25 arcsecs for NIFS.\n");
+        }
+
         //Set read noise and Well depth values by obsevation type
         _readNoiseValue = gp.readMode().getReadNoise();
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
@@ -112,6 +112,10 @@ public class Niri extends Instrument implements SpectroscopyInstrument {
                         " or change the method to spectroscopy.");
         }
 
+        if (np.altair().isDefined()) {
+            if (np.altair().get().guideStarSeparation() < 0 || np.altair().get().guideStarSeparation() > 45)
+                throw new RuntimeException("Altair Guide star distance must be between 0 and 45 arcsecs for NIRI.\n");
+        }
 
         switch (np.camera()) {
             case F6:    addComponent(new F6Optics(getDirectory() + "/"));  break;


### PR DESCRIPTION
Originally, Altair.java checked that the guide star separation was <= 25" for all instruments.
However, with NIRI, the guide star separation can be <=45" when guiding off-axis.  The check in Altair.java has been removed and is now implemented separately for each of the instruments:
 -Gnirs.java and Nifs.java (limit is <= 25")
 -Niri.java (limit is <= 45")
 -Gmos.java (limit is <= 45", but has been commented out since GMOS cannot yet use Altair).
