### PR TITLE
OCSADV-383-K

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Declination.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Declination.scala
@@ -128,7 +128,7 @@ object Declination {
    */
   def formatSexigesimal(dec: Declination, sep: String = ":", fractionalDigits: Int = 2): String = {
     val a0       = dec.toDegrees
-    val (a, sgn) = if (a0 < 0) (a0.abs, "-") else (a0, "+")
+    val (a, sgn) = if (a0 < 0) (a0.abs, "-") else (a0, "")
     s"$sgn${Angle.formatSexigesimal(Angle.fromDegrees(a), sep, fractionalDigits)}"
   }
 

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFileFormat.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFileFormat.scala
@@ -54,7 +54,8 @@ object EphemerisFileFormat {
     def formatCoords(coords: Coordinates): String = {
       val ra  = Angle.formatHMS(coords.ra.toAngle, " ", 4)
       val dec = Declination.formatDMS(coords.dec, " ", 3)
-      s"$ra $dec"
+      // Add spacing as required for TCS.
+      f"$ra%14s $dec%13s"
     }
 
     val lines = ephemeris.toList.map { case (time, (coords, raTrack, decTrack)) =>
@@ -146,7 +147,11 @@ object EphemerisFileFormat {
     private val timestampList: Parser[ISet[Instant]] =
       rep(timestamp).map(lst => ISet.fromList(lst))
 
-    val timestamps: Parser[ISet[Instant]] = soeLine~>timestampList<~eoeLine
+    val timestampsSection: Parser[ISet[Instant]] =
+      soeLine~>timestampList<~eoeLine
+
+    val timestamps: Parser[ISet[Instant]] =
+      headerSection~>timestampsSection
 
     def toDisjunction[A](p: Parser[A], input: String): String \/ A =
       parse(p, input) match {

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/EphemerisFileFormatTest.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/EphemerisFileFormatTest.scala
@@ -18,6 +18,7 @@ object EphemerisFileFormatTest extends Specification with ScalaCheck with Arbitr
       }
     }
 
+    /*
     "permit parsing timestamps" in {
       Prop.forAll { (em0: EphemerisMap) =>
         val s  = EphemerisFileFormat.format(em0)
@@ -25,5 +26,6 @@ object EphemerisFileFormatTest extends Specification with ScalaCheck with Arbitr
         em0.keySet == ts
       }
     }
+    */
   }
 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/EphemerisFileFormatTest.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/EphemerisFileFormatTest.scala
@@ -18,7 +18,6 @@ object EphemerisFileFormatTest extends Specification with ScalaCheck with Arbitr
       }
     }
 
-    /*
     "permit parsing timestamps" in {
       Prop.forAll { (em0: EphemerisMap) =>
         val s  = EphemerisFileFormat.format(em0)
@@ -26,6 +25,5 @@ object EphemerisFileFormatTest extends Specification with ScalaCheck with Arbitr
         em0.keySet == ts
       }
     }
-    */
   }
 }


### PR DESCRIPTION
A small update to ephemeris formatting to meet TCS expectations.

* Adds a small header which is expected and parsed by the TCS to obtain the coordinate reference frame.

* Adds a space to positive RAs and replaces the declination `+` with a space so that they line up in the expected columns.

