### PR TITLE
REL-2771 include higher-res data around scheduling block start

### DIFF
--- a/bundle/edu.gemini.horizons.api/build.sbt
+++ b/bundle/edu.gemini.horizons.api/build.sbt
@@ -28,3 +28,9 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.horizons.api",
   "edu.gemini.horizons.server.backend"
 )
+
+initialCommands :=
+  """
+    |import edu.gemini.spModel.core._
+    |import edu.gemini.horizons.server.backend.HorizonsService2._
+  """.stripMargin

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -91,7 +91,7 @@ final class NonSiderealTargetRules extends IRule {
       } p2p.addWarning(ERR_EPHEMERIS_TOO_SPARSE,
         f"""
            |Reference point for ${nst.name}%s at scheduling block start is ${d.toInt}' away.
-           |Refresh to re-center the high-resolution portion of the ephemeris."
+           |Refresh to re-center the high-resolution portion of the ephemeris.
          """.stripMargin,
         ocn)
     }

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -88,9 +88,9 @@ final class NonSiderealTargetRules extends IRule {
         cs  <- nst.coords(sb.start)
         d   <- nst.ephemeris.lookupClosest(sb.start).map(cs.angularDistance(_).toArcmins)
         if d > 10 // arcmins
-      } p2p.addWarning(ERR_EPHEMERIS_TOO_SPARSE,
+      } p2p.addError(ERR_EPHEMERIS_TOO_SPARSE,
         f"""
-           |Reference point for ${nst.name}%s at scheduling block start is ${d.toInt}' away.
+           |Nearest ephemeris data point for ${nst.name}%s is ${d.toInt}' away.
            |Refresh to re-center the high-resolution portion of the ephemeris.
          """.stripMargin,
         ocn)

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
@@ -9,7 +9,7 @@ import squants.motion.VelocityConversions._
 import squants.radio.IrradianceConversions._
 import squants.radio.SpectralIrradianceConversions._
 
-import scalaz.==>>
+import scalaz.{ ==>>, Order }
 import scalaz.std.anyVal._
 
 trait Arbitraries {
@@ -161,5 +161,8 @@ trait Arbitraries {
 
   implicit val arbWavelength: Arbitrary[Wavelength] =
     Arbitrary(arbitrary[Short].map(n => Math.abs(n).nm))
+
+  implicit def arbMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[K ==>> V] =
+    Arbitrary(arbitrary[List[(K, V)]].map(==>>.fromList(_)))
 
 }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/NumericKeyedMapOpsSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/NumericKeyedMapOpsSpec.scala
@@ -1,0 +1,21 @@
+package edu.gemini.spModel.core
+
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import scalaz.{ ==>>, IList }
+import scalaz.std.anyVal._
+import scalaz.syntax.foldable._
+
+class NumericKeyedMapOpsSpec extends Specification with ScalaCheck with Arbitraries {
+  val N = implicitly[Numeric[Byte]]
+
+  "lookupClosest" should {
+    "find the closest key" ! forAll { ((m: Byte ==>> Angle), k: Byte) =>
+      val closest = IList.fromList(m.keys).reverse.minimumBy(k0 => N.abs(N.minus(k, k0)))
+      closest.flatMap(m.lookupAssoc(_)) must_== m.lookupClosestAssoc(k)
+    }
+  }
+
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
@@ -62,10 +62,7 @@ class EphemerisEditor extends TelescopePosEditor with ReentrancyHack {
       } {
         start.setText(formatDate(a))
         end  .setText(formatDate(b))
-        val hrs: Double = (b - a) / (e.size.toDouble * 1000 * 60 * 60)
-        e.findMin.map(_._1).map(formatDate).foreach(start.setText)
-        e.findMax.map(_._1).map(formatDate).foreach(end.setText)
-        size.setText(f"${e.size} elems @ ~$hrs%3.1f hrs")
+        size.setText(e.size.toString)
       }
 
       // Scheduled time and coordinates
@@ -87,7 +84,7 @@ class EphemerisEditor extends TelescopePosEditor with ReentrancyHack {
     p.setBorder(BorderFactory.createCompoundBorder(titleBorder("Ephemeris"),
       BorderFactory.createEmptyBorder(1, 2, 1, 2)))
 
-    p.add(new JLabel("Resolution"), new GridBagConstraints <| { c =>
+    p.add(new JLabel("Elements"), new GridBagConstraints <| { c =>
       c.anchor = GridBagConstraints.WEST
       c.gridx  = 0
       c.gridy  = 0


### PR DESCRIPTION
This PR updates the ephemeris fetching logic to fetch fewer data points across the whole semester, and then add extra points for the observing night in which the schedule time falls, in order to allow accurate guidestar selection for rapidly moving/accelerating targets. A somewhat contrived example here, for Enceladus.

![image](https://cloud.githubusercontent.com/assets/1200131/15264628/2bd0f75e-192a-11e6-8e83-2e90657fcfdb.png)

This also adds a P2 error if the base position is more than 10 arcminutes from the nearest ephemeris point, and removes the "resolution" value from the ephemeris editor since it's non-uniform now.

