### PR TITLE
REL-2701: Fix UH affiliate support

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/Affiliate.java
+++ b/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/Affiliate.java
@@ -14,7 +14,7 @@ public enum Affiliate {
     UNITED_STATES("United States", "US"),
 
     GEMINI_STAFF("Gemini Staff"),
-    UNIVERSITY_OF_HAWAII("University of Hawaii"),;
+    UNIVERSITY_OF_HAWAII("University of Hawaii", "UH"),;
 
     private static final Logger LOG = Logger.getLogger(Affiliate.class.getName());
 
@@ -26,8 +26,8 @@ public enum Affiliate {
         this(displayValue, null);
     }
 
-    Affiliate(final String displayValue, final String isoCode) {
-        this(displayValue, isoCode, true);
+    Affiliate(final String displayValue, final String code) {
+        this(displayValue, code, true);
     }
 
     Affiliate(final String displayValue, final String isoCode, final boolean isActive) {


### PR DESCRIPTION
Small fix, when importing UH proposals the partner affiliation was lost because there is no iso code for the University of Hawaii

I suppose the reason this is not present is because UH is not an iso code but I don't see downsides to this change