### PR TITLE
REL-2762 fix magical disappearing ephemeris

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
@@ -32,7 +32,6 @@ class EphemerisEditor extends TelescopePosEditor with ReentrancyHack {
 
   val start, end, size, now, sched, schedCoords  = new JLabel <| { l =>
     l.setForeground(Color.DARK_GRAY)
-    l.setMinimumSize(l.getMinimumSize <| (_.width = 200))
     l.setHorizontalTextPosition(SwingConstants.LEFT)
   }
 


### PR DESCRIPTION
After literally hours of doing things at random it turns out that setting a minimum size for the labels was causing them to disappear when the window was sized down.