### PR TITLE
REL-2782 improve err reporting

### DIFF
--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B.scala
@@ -6,7 +6,7 @@ import edu.gemini.spModel.core.HorizonsDesignation.MajorBody
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.io.impl.migration.to2015B.To2015B
-import edu.gemini.spModel.pio.xml.PioXmlFactory
+import edu.gemini.spModel.pio.xml.{PioXmlUtil, PioXmlFactory}
 import edu.gemini.spModel.pio.{Document, ParamSet, Pio, Version}
 import edu.gemini.spModel.target.{SPTargetPio, SourcePio, TargetParamSetCodecs}
 import edu.gemini.spModel.target.env.GuideGroup
@@ -123,7 +123,7 @@ object To2016B extends Migration {
           case ("JPL minor body",      cs) => nonsidereal(t, cs).exec(NonSiderealTarget.empty)
           case ("MPC minor planet",    cs) => nonsidereal(t, cs).exec(NonSiderealTarget.empty)
           case ("Solar system object", cs) => (nonsidereal(t, cs) *> named(t)).exec(NonSiderealTarget.empty)
-        }.map(common(t).exec) getOrElse sys.error("Can't recognize target.")
+        }.map(common(t).exec) getOrElse sys.error("Can't recognize target:\n" + PioXmlUtil.toXmlString(t))
 
       // Drop it into the paramset.
       // TODO: remove everything else!


### PR DESCRIPTION
This doesn't fix REL-2782 (it's not really a bug) but it does improve error reporting by spitting out the XML blob in cases where old model targets aren't readable. Example:

```
[error]    java.lang.RuntimeException: Can't recognize target:
[error]    
[error]    <paramset name="base" editable="true" access="public">
[error]      <param name="name" value="WISE J064205.58+410155.5"/>
[error]      <param name="system" value="J2000"/>
[error]      <param name="epoch" value="2000.0" units="years"/>
[error]      <param name="c1" value="06:42:05.592"/>
[error]      <param name="c2" value="41:01:60.00"/>
[error]      <param name="pm1" value="0.0" units="milli-arcsecs/year"/>
[error]      <param name="pm2" value="0.0" units="milli-arcsecs/year"/>
[error]      <param name="parallax" value="0.0" units="mas"/>
[error]      <param name="z" value="0.0"/>
[error]      <paramset name="magnitudeList" editable="true" access="public">
[error]        <paramset name="magnitude" editable="true" access="public">
[error]          <param name="band" value="J"/>
[error]          <param name="val" value="16.16"/>
[error]          <param name="system" value="Vega"/>
[error]        </paramset>
[error]        <paramset name="magnitude" editable="true" access="public">
[error]          <param name="band" value="H"/>
[error]          <param name="val" value="15.09"/>
[error]          <param name="system" value="Vega"/>
[error]        </paramset>
[error]        <paramset name="magnitude" editable="true" access="public">
[error]          <param name="band" value="K"/>
[error]          <param name="val" value="14.28"/>
[error]          <param name="system" value="Vega"/>
[error]        </paramset>
[error]      </paramset>
[error]      <paramset name="PointSource" editable="true" access="public"/>
[error]    </paramset> (To2016B.scala:126)
```