### PR TITLE
REL-2748 attempted fix for target detail update issue

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -407,6 +407,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.guidingControls.manualGuideStarButton().peer().setVisible(GuideStarSupport.supportsManualGuideStarSelection(getNode()));
         updateGuiding();
         _agsPub.watch(ImOption.apply(getContextObservation()));
+
+        updateTargetDetails(newTOC.getTargetEnvironment());
     }
 
     // OtItemEditor
@@ -488,12 +490,15 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.tag.setRenderer(tagRenderer);
         showTargetTag();
 
-        // Update target details
-        selectedTarget().foreach(t -> _w.detailEditor.edit(getObsContext(env), t, getNode()));
+        updateTargetDetails(env);
 
         // Set the status of the buttons and detail editors.
         updateUIForTarget();
         updateGuideStarAdders();
+    }
+
+    private void updateTargetDetails(TargetEnvironment env) {
+        selectedTarget().foreach(t -> _w.detailEditor.edit(getObsContext(env), t, getNode()));
     }
 
     private void showTargetTag() {


### PR DESCRIPTION
Before this change the target details were initialized as a side-effect of the initial selection in the target list, but this doesn't always happen for some reason. In particular if you change the scheduling block and click back to the target while the little time/date button still has focus then usually the target details would not be re-initialized. So this change adds an explicit update in the editor's `init` method to force the update.