### PR TITLE
REL-2783 add scheduling controls to target editor

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.SPNodeKey;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.core.Magnitude;
+import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.core.Target;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeUtil;
@@ -30,6 +31,7 @@ import java.awt.*;
 import java.awt.event.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.text.NumberFormat;
 import java.util.*;
 import java.util.List;
 
@@ -407,6 +409,17 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.guidingControls.manualGuideStarButton().peer().setVisible(GuideStarSupport.supportsManualGuideStarSelection(getNode()));
         updateGuiding();
         _agsPub.watch(ImOption.apply(getContextObservation()));
+
+        final Option<Site> site = ObsContext.getSiteFromObservation(getContextObservation());
+        final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
+        numberFormatter.setMaximumFractionDigits(2);
+        numberFormatter.setMaximumIntegerDigits(3);
+        _w.schedulingBlock.init(this, site, numberFormatter, new Runnable() {
+            public void run() {
+                final TargetEnvironment env = getDataObject().getTargetEnvironment();
+                updateTargetDetails(env);
+            }
+        });
 
         updateTargetDetails(newTOC.getTargetEnvironment());
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopeForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopeForm.java
@@ -2,6 +2,7 @@ package jsky.app.ot.gemini.editor.targetComponent;
 
 import edu.gemini.shared.gui.ButtonFlattener;
 import jsky.app.ot.gemini.editor.targetComponent.details2.TargetDetailPanel;
+import jsky.app.ot.gemini.parallacticangle.ParallacticAngleControls;
 import jsky.app.ot.util.Resources;
 import jsky.util.gui.TextBoxWidget;
 
@@ -16,6 +17,7 @@ class TelescopeForm extends JPanel {
 
     final GuidingControls guidingControls = new GuidingControls();
     final TargetDetailPanel detailEditor = new TargetDetailPanel();
+    final ParallacticAngleControls schedulingBlock = new ParallacticAngleControls(false);
 
     final JMenu newMenu = new JMenu() {{
         setToolTipText("Create a new target or guide group");
@@ -152,16 +154,35 @@ class TelescopeForm extends JPanel {
             weightx = 1000;
         }});
 
-        add(detailEditor, new GridBagConstraints() {{
+        final JPanel schedulingPanel = new JPanel() {{
+            setBorder(BorderFactory.createCompoundBorder(
+                    BorderFactory.createEmptyBorder(0, 2, 0, 2),
+                    BorderFactory.createTitledBorder("Scheduling")
+            ));
+            setLayout(new BorderLayout());
+            schedulingBlock.peer().setBorder(
+                    BorderFactory.createEmptyBorder(0, 5, 0, 0)
+            );
+            add(schedulingBlock.peer(), BorderLayout.WEST);
+        }};
+
+        add(schedulingPanel, new GridBagConstraints() {{
             gridx = 0;
             gridy = 1;
             fill = HORIZONTAL;
             insets = new Insets(5, 0, 5, 0);
         }});
 
-        add(guideGroupPanel, new GridBagConstraints() {{
+        add(detailEditor, new GridBagConstraints() {{
             gridx = 0;
             gridy = 2;
+            fill = HORIZONTAL;
+            insets = new Insets(5, 0, 5, 0);
+        }});
+
+        add(guideGroupPanel, new GridBagConstraints() {{
+            gridx = 0;
+            gridy = 3;
             fill = HORIZONTAL;
             insets = new Insets(5, 0, 5, 0);
         }});

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -160,7 +160,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       val spObs = ispObs.getDataObject.asInstanceOf[SPObservation]
       spObs.setSchedulingBlock(ImOption.apply(sb))
       ispObs.setDataObject(spObs)
-      Swing.onEDT(callback.run())
+      callback.run()
       resetComponents()
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -25,9 +25,13 @@ import scala.swing.event.{ButtonClicked, Event}
  * @param isPaUi should be true for PA controls, false for Scheduling Block controls
  */
 class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publisher {
+
+  val Nop = new Runnable { def run = () }
+
   private var editor:    Option[OtItemEditor[_, _]] = None
   private var site:      Option[Site]   = None
   private var formatter: Option[Format] = None
+  private var callback:  Runnable = Nop
 
   object ui {
     object relativeTimeMenu extends Menu("Set To:") {
@@ -119,20 +123,25 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
 
   /**
    * Initialize the UI and set the instrument editor to allow for the parallactic angle updates.
+   * The `Runnable` is a callback that will be invoked on the EDT after the target is updated.
    */
-  def init(e: OtItemEditor[_, _], s: Option[Site], f: Format): Unit = {
+  def init(e: OtItemEditor[_, _], s: Option[Site], f: Format, c: Runnable): Unit = {
     editor    = Some(e)
     site      = s
     formatter = Some(f)
+    callback  = c
     ui.relativeTimeMenu.rebuild()
     resetComponents()
   }
 
   def init(e: OtItemEditor[_, _], s: Site, f: Format): Unit =
-    init(e, Some(s), f)
+    init(e, Some(s), f, Nop)
 
   def init(e: OtItemEditor[_, _], s: JOption[Site], f: Format): Unit =
-    init(e, s.asScalaOpt, f)
+    init(e, s.asScalaOpt, f, Nop)
+
+  def init(e: OtItemEditor[_, _], s: JOption[Site], f: Format, callback: Runnable): Unit =
+    init(e, s.asScalaOpt, f, callback)
 
   /** Current scheduling block, if any. */
   private def schedulingBlock: Option[SchedulingBlock] =
@@ -151,6 +160,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       val spObs = ispObs.getDataObject.asInstanceOf[SPObservation]
       spObs.setSchedulingBlock(ImOption.apply(sb))
       ispObs.setDataObject(spObs)
+      Swing.onEDT(callback.run())
       resetComponents()
     }
 


### PR DESCRIPTION
This adds the scheduling block control to the target environment editor, as requested.

![image](https://cloud.githubusercontent.com/assets/1200131/15372176/26ed3f9a-1cf4-11e6-854f-5d985a89fac7.png)