### PR TITLE
REL-2604: Expand comment field

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/EdCompObslog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/EdCompObslog.java
@@ -13,7 +13,6 @@ import java.beans.PropertyChangeListener;
 import java.util.*;
 import java.util.logging.Logger;
 
-
 /**
  * An ObsLog editor component.
  * @author rnorris (then hacked by swalker)
@@ -21,33 +20,29 @@ import java.util.logging.Logger;
 public class EdCompObslog extends OtItemEditor<ISPObsQaLog, ObsQaLog> {
     private static final Logger LOG = Logger.getLogger(EdCompObslog.class.getName());
 
-	private final ObslogGUI gui = new ObslogGUI();
-	private ObsQaLog currentLog;
-	private Map<DatasetLabel,String> originalComments; // original comments, so we can tell what is dirty
+    private final ObslogGUI gui = new ObslogGUI();
+    private ObsQaLog currentLog;
+    private Map<DatasetLabel,String> originalComments; // original comments, so we can tell what is dirty
     private ISPNode prev;
 
     // Watches for changes to the ObsExecLog so that it can update the GUI,
     // showing the latest datasets that have arrived, etc.
-    private final PropertyChangeListener execLogListener = new PropertyChangeListener() {
-        @Override public void propertyChange(final PropertyChangeEvent evt) {
-            if (SPUtil.getDataObjectPropertyName().equals(evt.getPropertyName())) {
-                SwingUtilities.invokeLater(new Runnable() {
-                    @Override public void run() {
-                        final ISPObsExecLog execLogShell = (ISPObsExecLog) evt.getSource();
-                        gui.setup(new ObsLog(getNode(), getDataObject(), execLogShell, (ObsExecLog) evt.getNewValue()));
-                    }
-                });
-            }
+    private final PropertyChangeListener execLogListener = evt -> {
+        if (SPUtil.getDataObjectPropertyName().equals(evt.getPropertyName())) {
+            SwingUtilities.invokeLater(() -> {
+                final ISPObsExecLog execLogShell = (ISPObsExecLog) evt.getSource();
+                gui.setup(new ObsLog(getNode(), getDataObject(), execLogShell, (ObsExecLog) evt.getNewValue()));
+            });
         }
     };
 
-	protected void updateEnabledState(boolean enabled) {
-		// Do nothing. I will control my own enabled state, thank you.
-	}
+    protected void updateEnabledState(boolean enabled) {
+        // Do nothing. I will control my own enabled state, thank you.
+    }
 
-	public JPanel getWindow() {
-		return gui;
-	}
+    public JPanel getWindow() {
+        return gui;
+    }
 
     // Forwards events as property change events so that updates are stored
     // in the ISPObsQaLog shell.
@@ -100,8 +95,8 @@ public class EdCompObslog extends OtItemEditor<ISPObsQaLog, ObsQaLog> {
                 for (DatasetLabel lab : labels) {
                     final String currentComment  = currentLog.getComment(lab);
                     final String incomingComment = incomingLog.getComment(lab);
-			        final String resolved        = resolveComment(originalComments.get(lab), currentComment, incomingComment);
-			        incomingLog.setComment(lab, resolved);
+                    final String resolved        = resolveComment(originalComments.get(lab), currentComment, incomingComment);
+                    incomingLog.setComment(lab, resolved);
                 }
             }
 
@@ -122,20 +117,20 @@ public class EdCompObslog extends OtItemEditor<ISPObsQaLog, ObsQaLog> {
         }
     }
 
-    private static final Map<DatasetLabel, String> comments(ObsQaLog qa, Collection<DatasetLabel> labels) {
-        final Map<DatasetLabel,String> res = new HashMap<DatasetLabel, String>(Math.round(labels.size() / 0.75f));
+    private static Map<DatasetLabel, String> comments(ObsQaLog qa, Collection<DatasetLabel> labels) {
+        final Map<DatasetLabel,String> res = new HashMap<>(Math.round(labels.size() / 0.75f));
         for (DatasetLabel lab : labels) res.put(lab, qa.getComment(lab));
         return res;
     }
 
-	private String resolveComment(String original, String current, String incoming) {
-		// Originally this was kind of a complex set of rules, but it turns out
-		// that a simple rule works fine. Just use whichever one is newer. That
-		// is, if we have unsaved edits, keep them. Otherwise use the incoming value.
-		return equiv(original, current) ? incoming : current;
-	}
+    private String resolveComment(String original, String current, String incoming) {
+        // Originally this was kind of a complex set of rules, but it turns out
+        // that a simple rule works fine. Just use whichever one is newer. That
+        // is, if we have unsaved edits, keep them. Otherwise use the incoming value.
+        return equiv(original, current) ? incoming : current;
+    }
 
-	private boolean equiv(Object a, Object b) {
-		return (a == null && b == null) || (a != null && a.equals(b));
-	}
+    private boolean equiv(Object a, Object b) {
+        return (a == null && b == null) || (a != null && a.equals(b));
+    }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
@@ -512,7 +512,7 @@ class ObslogGUI extends JPanel {
      */
     private final class CommentsComponent extends JPanel implements ObslogTableModels, ListSelectionListener {
 
-        private final JTable table;
+        private final CommentsTable table;
         private final JTextArea area = new JTextArea();
 
         private final DocumentListener docListener = new DocumentListener() {
@@ -530,8 +530,11 @@ class ObslogGUI extends JPanel {
 
             private void updateText() {
                 final int row = table.getSelectedRow();
-                if (row > -1)
+                if (row > -1) {
                     table.getModel().setValueAt(area.getText(), row, CommentTableModel.COL_COMMENT);
+                    // The comment width may have changed, let's expand it
+                    table.expandCommentColumn();
+                }
             }
         };
 
@@ -623,6 +626,27 @@ class ObslogGUI extends JPanel {
                     attachCommentRenderer(CommentTableModel.COL_COMMENT);
                     sizeColumnsToFitData();
                 }
+            }
+
+            // Recalculates the width of the columns comment
+            void expandCommentColumn() {
+                TableColumn column = getColumnModel().getColumn(CommentTableModel.COL_COMMENT);
+                int preferredWidth = 0;
+                for (int i = 0; i < getModel().getRowCount(); i++) {
+                    final TableCellRenderer cellRenderer = this.getCellRenderer(i, CommentTableModel.COL_COMMENT);
+                    final Component c = table.prepareRenderer(cellRenderer, i, CommentTableModel.COL_COMMENT);
+                    final int width = c.getPreferredSize().width + table.getIntercellSpacing().width;
+                    preferredWidth = Math.max(preferredWidth, width);
+                }
+
+                int gutter = 10;
+                preferredWidth += gutter;
+
+                // NB The order of these calls is critical to get the width correct
+                // DON'T reorder
+                column.setMinWidth(preferredWidth);
+                column.setMaxWidth(preferredWidth);
+                column.setPreferredWidth(preferredWidth);
             }
 
             private void attachCommentRenderer(int i) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
@@ -33,7 +33,7 @@ import java.util.List;
  * GUI component for the ObsLog editor component.
  * @author rnorris
  */
-public class ObslogGUI extends JPanel {
+class ObslogGUI extends JPanel {
     private final DataAnalysisComponent tabDataAnalysis = new DataAnalysisComponent("Data Analysis");
     private final VisitsComponent tabVisits = new VisitsComponent("Visits");
     private final CommentsComponent tabComments = new CommentsComponent("Comments");
@@ -83,7 +83,7 @@ public class ObslogGUI extends JPanel {
     };
 
 
-    public ObslogGUI() {
+    ObslogGUI() {
         setLayout(new BorderLayout());
         add(new JTabbedPane() {{
             add(tabComments);
@@ -105,11 +105,11 @@ public class ObslogGUI extends JPanel {
 
     class AbstractDatasetRecordTable extends JTable implements ObslogTableModels {
 
-        protected AbstractDatasetRecordTable() {
+        AbstractDatasetRecordTable() {
             setAutoResizeMode(AUTO_RESIZE_OFF);
         }
 
-        protected AbstractDatasetRecordTable(TableModel model) {
+        AbstractDatasetRecordTable(TableModel model) {
             super(model);
             setAutoResizeMode(AUTO_RESIZE_OFF);
         }
@@ -180,12 +180,12 @@ public class ObslogGUI extends JPanel {
      * Information extracted from an ActiveRequest object for formatting and
      * display.
      */
-    static final class RequestDetail {
+    private static final class RequestDetail {
         final QaRequestStatus status;
         final Instant when;
         final int retry;
 
-        public RequestDetail(QaRequestStatus status, Instant when, int retry) {
+        RequestDetail(QaRequestStatus status, Instant when, int retry) {
             this.status = status;
             this.when   = when;
             this.retry  = retry;
@@ -206,7 +206,7 @@ public class ObslogGUI extends JPanel {
             return Objects.hash(status, when, retry);
         }
 
-        public String formatWhen() {
+        String formatWhen() {
             final ZoneId z = ZoneId.systemDefault();
             final OffsetDateTime    whenOff = OffsetDateTime.ofInstant(when, z);
             final OffsetDateTime    nowOff  = OffsetDateTime.ofInstant(Instant.now(), z);
@@ -220,17 +220,17 @@ public class ObslogGUI extends JPanel {
                     dateFmt.format(whenDate) + " " + timeString;
         }
 
-        public static RequestDetail fromActiveRequest(SummitState.ActiveRequest ar) {
+        static RequestDetail fromActiveRequest(SummitState.ActiveRequest ar) {
             return new RequestDetail(ar.status(), ar.when(), ar.retryCount());
         }
 
-        public static Optional<RequestDetail> fromSummitState(SummitState ss) {
+        static Optional<RequestDetail> fromSummitState(SummitState ss) {
             return (ss instanceof SummitState.ActiveRequest) ?
                 Optional.of(fromActiveRequest((SummitState.ActiveRequest) ss)) :
                 Optional.empty();
         }
 
-        public static Optional<RequestDetail> fromDatasetRecord(DatasetRecord dr) {
+        static Optional<RequestDetail> fromDatasetRecord(DatasetRecord dr) {
             return fromSummitState(dr.exec().summit());
         }
     }
@@ -241,13 +241,13 @@ public class ObslogGUI extends JPanel {
      *
      * @author rnorris
      */
-    class DataAnalysisComponent extends JPanel implements ObslogTableModels {
+    private class DataAnalysisComponent extends JPanel implements ObslogTableModels {
 
         private final DataAnalysisTable table = new DataAnalysisTable();
         private final JPanel editArea = new Editor();
         private Optional<Boolean> isStaffMode = Optional.empty();
 
-        public DataAnalysisComponent(String name) {
+        DataAnalysisComponent(String name) {
             super(new BorderLayout());
             setName(name);
         }
@@ -424,7 +424,7 @@ public class ObslogGUI extends JPanel {
             JPanel editArea;
             boolean adjusting = false;
 
-            public DataAnalysisTable() {
+            DataAnalysisTable() {
                 setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
             }
 
@@ -510,7 +510,7 @@ public class ObslogGUI extends JPanel {
      *
      * @author rnorris
      */
-    final class CommentsComponent extends JPanel implements ObslogTableModels, ListSelectionListener {
+    private final class CommentsComponent extends JPanel implements ObslogTableModels, ListSelectionListener {
 
         private final JTable table;
         private final JTextArea area = new JTextArea();
@@ -535,7 +535,7 @@ public class ObslogGUI extends JPanel {
             }
         };
 
-        public CommentsComponent(String name) {
+        CommentsComponent(String name) {
             super(new BorderLayout());
             setName(name);
 
@@ -594,7 +594,7 @@ public class ObslogGUI extends JPanel {
 
         private class CommentsTable extends AbstractDatasetRecordTable {
 
-            public CommentsTable() {
+            CommentsTable() {
                 super();
                 setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
                 getSelectionModel().addListSelectionListener(this);
@@ -667,12 +667,12 @@ public class ObslogGUI extends JPanel {
      *
      * @author rnorris
      */
-    final class VisitsComponent extends JScrollPane implements ObslogTableModels {
+    private final class VisitsComponent extends JScrollPane implements ObslogTableModels {
 
         private final DateFormat OBSLOG_DATE_FORMAT = ObslogGUI.OBSLOG_DATE_FORMAT;
         private final Box clientArea;
 
-        public VisitsComponent(String name) {
+        VisitsComponent(String name) {
             super(new Box(BoxLayout.Y_AXIS));
             clientArea = (Box) getViewport().getView();
             clientArea.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 10));
@@ -767,7 +767,7 @@ public class ObslogGUI extends JPanel {
 
         private class DatasetRecordTable extends AbstractDatasetRecordTable {
 
-            public DatasetRecordTable(TableModel model) {
+            DatasetRecordTable(TableModel model) {
                 super(model);
                 setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
@@ -631,7 +631,9 @@ class ObslogGUI extends JPanel {
             // Recalculates the width of the columns comment
             void expandCommentColumn() {
                 TableColumn column = getColumnModel().getColumn(CommentTableModel.COL_COMMENT);
-                int preferredWidth = 0;
+                Component headerRenderer = getTableHeader().getDefaultRenderer()    .getTableCellRendererComponent(this, column.getHeaderValue(), false, false, -1, CommentTableModel.COL_COMMENT);
+
+                int preferredWidth = headerRenderer.getPreferredSize().width;
                 for (int i = 0; i < getModel().getRowCount(); i++) {
                     final TableCellRenderer cellRenderer = this.getCellRenderer(i, CommentTableModel.COL_COMMENT);
                     final Component c = table.prepareRenderer(cellRenderer, i, CommentTableModel.COL_COMMENT);
@@ -639,7 +641,8 @@ class ObslogGUI extends JPanel {
                     preferredWidth = Math.max(preferredWidth, width);
                 }
 
-                int gutter = 10;
+                // Give it a bit of space to breathe
+                int gutter = table.getFontMetrics(table.getFont()).charWidth('A');
                 preferredWidth += gutter;
 
                 // NB The order of these calls is critical to get the width correct

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogTableModels.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogTableModels.java
@@ -36,18 +36,18 @@ public interface ObslogTableModels {
         /**
          * The {@link edu.gemini.spModel.dataset.DatasetExecRecord} instances known to this model.
          */
-        protected final ObsLog obsLog;
-        protected final List<DatasetRecord> records;
+        final ObsLog obsLog;
+        final List<DatasetRecord> records;
 
         /**
          * Constructs a table model that keeps an array of {@link edu.gemini.spModel.dataset.DatasetExecRecord} instances in
          * protected member {@link #records} and registers for change events on each.
          */
-        protected AbstractDatasetRecordTableModel(ObsLog obsLog) {
+        AbstractDatasetRecordTableModel(ObsLog obsLog) {
             this(obsLog, obsLog.getAllDatasetRecords());
         }
 
-        protected AbstractDatasetRecordTableModel(ObsLog obsLog, List<DatasetRecord> records) {
+        AbstractDatasetRecordTableModel(ObsLog obsLog, List<DatasetRecord> records) {
             this.obsLog  = obsLog;
             this.records = new ArrayList<>(records);
 
@@ -70,7 +70,7 @@ public interface ObslogTableModels {
             });
         }
 
-        public boolean isUnavailable(int row) {
+        boolean isUnavailable(int row) {
             final DatasetRecord rec = records.get(row);
             return !obsLog.getExecRecord().inSummitStorage(rec.label());
         }
@@ -103,20 +103,20 @@ public interface ObslogTableModels {
      */
     class DatasetAnalysisTableModel extends AbstractDatasetRecordTableModel {
 
-        public static final int COL_LABEL    = 0;
-        public static final int COL_FILENAME = 1;
-        public static final int COL_QA_STATE = 2;
-        public static final int COL_STATUS   = 3;
+        static final int COL_LABEL    = 0;
+        static final int COL_FILENAME = 1;
+        static final int COL_QA_STATE = 2;
+        static final int COL_STATUS   = 3;
 
         private static final String[] COL_NAMES = new String[]{
                 "Label", "Filename", "QA State", "Dataset Status"
         };
 
-        public DatasetAnalysisTableModel(ObsLog log) {
+        DatasetAnalysisTableModel(ObsLog log) {
             super(log);
         }
 
-        public DatasetAnalysisTableModel(ObsLog log, List<DatasetRecord> records) {
+        DatasetAnalysisTableModel(ObsLog log, List<DatasetRecord> records) {
             super(log, records);
         }
 
@@ -128,7 +128,7 @@ public interface ObslogTableModels {
             return COL_NAMES[i];
         }
 
-        public DatasetRecord getRecordAt(int row) {
+        DatasetRecord getRecordAt(int row) {
             return records.get(row);
         }
 
@@ -186,18 +186,17 @@ public interface ObslogTableModels {
      */
     class CommentTableModel extends AbstractDatasetRecordTableModel {
 
-        public static final int COL_LABEL = 0;
-        public static final int COL_FILENAME = 1;
-        public static final int COL_COMMENT = 2;
+        static final int COL_LABEL = 0;
+        static final int COL_FILENAME = 1;
+        static final int COL_COMMENT = 2;
 
         private static final String[] COL_NAMES = new String[]{
                 "Label", "Filename", "Comment",
         };
 
-        public CommentTableModel(ObsLog log) {
+        CommentTableModel(ObsLog log) {
             super(log);
         }
-
 
         public int getColumnCount() {
             return COL_NAMES.length;
@@ -253,8 +252,8 @@ public interface ObslogTableModels {
      */
     class ConfigTableModel extends AbstractTableModel {
 
-        public static final int COL_PARAMETER = 0;
-        public static final int COL_VALUE = 1;
+        static final int COL_PARAMETER = 0;
+        static final int COL_VALUE = 1;
 
         private static final String[] COL_NAMES = new String[]{
                 "Parameter", "Value",
@@ -262,7 +261,7 @@ public interface ObslogTableModels {
 
         private final Config config;
 
-        public ConfigTableModel(Config config) {
+        ConfigTableModel(Config config) {
             this.config = config;
         }
 
@@ -309,9 +308,9 @@ public interface ObslogTableModels {
      */
     class EventTableModel extends AbstractTableModel {
 
-        public static final int COL_TIME = 0;
-        public static final int COL_EVENT = 1;
-        public static final int COL_DATASET = 2;
+        static final int COL_TIME = 0;
+        static final int COL_EVENT = 1;
+        static final int COL_DATASET = 2;
 
         private static final String[] COL_NAMES = new String[]{
                 "Time", "Event", "Dataset",
@@ -319,7 +318,7 @@ public interface ObslogTableModels {
 
         private final ObsExecEvent[] events;
 
-        public EventTableModel(ObsExecEvent[] events) {
+        EventTableModel(ObsExecEvent[] events) {
             this.events = events;
         }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/test/TestEventGenerator.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/test/TestEventGenerator.java
@@ -22,62 +22,59 @@ public final class TestEventGenerator implements Runnable {
         this.obsId = obsId;
     }
 
-	private void addEvent(final ObsExecEvent event) {
-		try {
+    private void addEvent(final ObsExecEvent event) {
+        try {
             System.out.println("Adding event: "+ event);
 
-			// Get a copy of the data object.
-            ObsLog.update(odb, obsId, new ObsLog.UpdateOp() {
-                @Override public void apply(ISPObservation obs, ObsLog log) {
-                    // Now add the event and update the UI.
-                    log.getExecRecord().addEvent(event, new DefaultConfig());
-                }
+            // Get a copy of the data object.
+            ObsLog.update(odb, obsId, (obs, log) -> {
+                // Now add the event and update the UI.
+                log.getExecRecord().addEvent(event, new DefaultConfig());
             });
 
-			// Sleep a while so it's not totally nuts
-			Thread.sleep(2000);
+            // Sleep a while so it's not totally nuts
+            Thread.sleep(2000);
 
-		} catch (Exception e) {
-			e.printStackTrace();
-			System.exit(-1);
-		}
-	}
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(-1);
+        }
+    }
 
     public void run() {
-		int index = 0;
+        int index = 0;
 
-		// Now add some visits, sequences, and data sets.
-		addEvent(new StartVisitEvent(System.currentTimeMillis(), obsId));
-		addEvent(new StartSequenceEvent(System.currentTimeMillis(), obsId));
+        // Now add some visits, sequences, and data sets.
+        addEvent(new StartVisitEvent(System.currentTimeMillis(), obsId));
+        addEvent(new StartSequenceEvent(System.currentTimeMillis(), obsId));
 
-		// Add a good one.
-		{
-			final Dataset dataset = new Dataset(new DatasetLabel(obsId, ++index), "GOOD-" + index, System.currentTimeMillis());
-			addEvent(new StartDatasetEvent(System.currentTimeMillis(), dataset));
-			addEvent(new EndDatasetEvent(System.currentTimeMillis(), dataset.getLabel()));
-		}
+        // Add a good one.
+        {
+            final Dataset dataset = new Dataset(new DatasetLabel(obsId, ++index), "GOOD-" + index, System.currentTimeMillis());
+            addEvent(new StartDatasetEvent(System.currentTimeMillis(), dataset));
+            addEvent(new EndDatasetEvent(System.currentTimeMillis(), dataset.getLabel()));
+        }
 
-		// Add a bad one.
-		{
-			final Dataset dataset = new Dataset(new DatasetLabel(obsId, ++index), "BAD-" + index, System.currentTimeMillis());
-			addEvent(new StartDatasetEvent(System.currentTimeMillis(), dataset));
-//			addEvent(new EndDatasetEvent(System.currentTimeMillis(), dataset.getLabel()));
-		}
+        // Add a bad one.
+        {
+            final Dataset dataset = new Dataset(new DatasetLabel(obsId, ++index), "BAD-" + index, System.currentTimeMillis());
+            addEvent(new StartDatasetEvent(System.currentTimeMillis(), dataset));
+        }
 
-		for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
 
-		// And another good one
-		{
-			final Dataset dataset = new Dataset(new DatasetLabel(obsId, ++index), "GOOD-" + index, System.currentTimeMillis());
-			addEvent(new StartDatasetEvent(System.currentTimeMillis(), dataset));
-			addEvent(new EndDatasetEvent(System.currentTimeMillis(), dataset.getLabel()));
-		}
+        // And another good one
+        {
+            final Dataset dataset = new Dataset(new DatasetLabel(obsId, ++index), "GOOD-" + index, System.currentTimeMillis());
+            addEvent(new StartDatasetEvent(System.currentTimeMillis(), dataset));
+            addEvent(new EndDatasetEvent(System.currentTimeMillis(), dataset.getLabel()));
+        }
 
-		}
+        }
 
-		addEvent(new EndSequenceEvent(System.currentTimeMillis(), obsId));
-		addEvent(new EndVisitEvent(System.currentTimeMillis(), obsId));
-	}
+        addEvent(new EndSequenceEvent(System.currentTimeMillis(), obsId));
+        addEvent(new EndVisitEvent(System.currentTimeMillis(), obsId));
+    }
 
     public static void test(IDBDatabaseService odb, SPObservationID obsId) {
         final TestEventGenerator teg = new TestEventGenerator(odb, obsId);


### PR DESCRIPTION
This PR changes the old obslog comments table to dynamically adjust the width for the widest comment available. This is done at runtime as the user types the changes

There is quite some cleanup code, the commit f585d11 is the most relevante

Here's a screenshot

![screenshot 2016-05-18 16 09 07](https://cloud.githubusercontent.com/assets/3615303/15373280/47cb91f4-1d1b-11e6-9d2c-5eb4c66fa898.png)
