### PR TITLE
REL-2781: Allow selecting any target in executed observations

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -710,6 +710,11 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
         dragSource = new TelescopePosTableDragSource(this);
     }
 
+    @Override public void setEnabled(boolean enabled) {
+        // Don't disable, the rest of the controls get disabled
+        // but this table should always be enabled to let the user select targets
+    }
+
     @Override public void telescopePosUpdate(final WatchablePos tp) {
         final int index = getSelectedRow();
         _resetTable(_env);


### PR DESCRIPTION
Once an obs is 'Observed' you cannot change it so everything is disabled. As a side effect you cannot select items on the targets' table

This PR disables the enabling of the table