### PR TITLE
OCSADV-383: fix ephemeris file header for TCS parsing

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFileFormat.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisFileFormat.scala
@@ -18,7 +18,7 @@ object EphemerisFileFormat {
   /** Header required by the TCS. */
   val Header =
     """***************************************************************************************
-      |Date_(UT)HR:MN Date_______JDUT R.A._(ICRF/J2000.0)__DEC dRA*cosD d(DEC)/dt
+      | Date__(UT)__HR:MN Date_________JDUT     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
       |***************************************************************************************""".stripMargin
 
   /** Marker for the start of ephemeris elements in the file. */


### PR DESCRIPTION
The ephemeris file header comment must align with the columns expected by the TCS.  The header I added in the previous PR was not properly aligned and so the TCS couldn't parse the reference frame.  This fixes that issue.

The only remaining inconsistency with horizons output is the RA/Dec tracking rate where the robot is using a fixed precision and horizons changes the precision in order to make the values always occupy the same number of characters in the text file.  According to @jluhrs, the TCS is able to handle this particular inconsistency so I'll leave it as is.