### PR TITLE
REL-2768: Require a time when converting from arbitrary SPTarget to SiderealTarget

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -141,7 +141,7 @@ object AgsAnalysis {
       } yield gStar
 
     selection(ctx, guideProbe).fold(Some(NoGuideStarForProbe(guideProbe, bands)): Option[AgsAnalysis]) { guideStar =>
-      AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar.toNewModel, bands)
+      AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar.toSiderealTarget(ctx.getSchedulingBlockStart), bands)
     }
   }
 
@@ -151,6 +151,7 @@ object AgsAnalysis {
    */
   protected [ags] def analysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget, bands: BandsList): Option[AgsAnalysis] = {
     val spTarget = new SPTarget(SiderealTarget.empty.copy(coordinates = Coordinates(guideStar.coordinates.ra, guideStar.coordinates.dec)))
+
     if (guideProbe.validate(spTarget, ctx) != GuideStarValidation.VALID) Some(NotReachable(guideProbe, guideStar, bands))
     else magnitudeAnalysis(ctx, mt, guideProbe, guideStar, bands)
   }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsGuideStars.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsGuideStars.scala
@@ -7,7 +7,7 @@ import edu.gemini.spModel.gems.GemsGuideProbeGroup
 import edu.gemini.spModel.target.env.GuideGroup
 import edu.gemini.spModel.target.env.GuideProbeTargets
 import edu.gemini.shared.util.immutable.ScalaConverters._
-import edu.gemini.shared.util.immutable.{ None => JNone }
+import edu.gemini.shared.util.immutable.{None => JNone}
 import edu.gemini.pot.ModelConverters._
 
 import scala.annotation.tailrec
@@ -121,7 +121,7 @@ case class GemsGuideStars(pa: Angle, tiptiltGroup: GemsGuideProbeGroup, strehl: 
     val r = for {
       g <- gp
       p <- g.getPrimary.asScalaOpt
-      m <- RBandsList.extract(p.toNewModel)
+      m <- RBandsList.extract(p.toSiderealTarget(None))
     } yield m.value
     r.getOrElse(99.0)
   }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -196,7 +196,7 @@ trait GemsStrategy extends AgsStrategy {
       gemsGuideStars.map { x =>
         val assignments = x.guideGroup.getAll.asScalaList.flatMap(targets => {
           val guider = targets.getGuider
-          targets.getTargets.asScalaList.map(target => Assignment(guider, target.toNewModel))
+          targets.getTargets.asScalaList.map(target => Assignment(guider, target.toSiderealTarget(ctx.getSchedulingBlockStart)))
         })
         Selection(x.pa, assignments)
       }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -24,13 +24,13 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
     AgsAnalysis.analysis(ctx, mt, guideProbe, probeBands).toList
 
   override def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]] = {
-    val so = ctx.getTargets.getBase.toNewModel
+    val so = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
     Future.successful(List((guideProbe, List(so))))
   }
 
   override def select(ctx: ObsContext, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]] = {
     // The science target is the guide star, but must be converted from SPTarget to SkyObject.
-    val siderealTarget = ctx.getTargets.getBase.toNewModel
+    val siderealTarget = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
     val posAngle       = ctx.getPositionAngle.toNewModel
     val assignment     = AgsStrategy.Assignment(guideProbe, siderealTarget)
     val selection      = AgsStrategy.Selection(posAngle, List(assignment))

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -88,10 +88,17 @@ object ModelConverters {
       sp.getTarget.fold(
         too => SiderealTarget.empty.copy(name = too.name),
         sid => sid,
-        ns  => {
-          val coords = when.flatMap(ns.coords).getOrElse(Coordinates.zero)
-          SiderealTarget.empty.copy(name = ns.name, coordinates = coords, magnitudes = ns.magnitudes, spectralDistribution = ns.spectralDistribution, spatialProfile = ns.spatialProfile)
-        }
+        ns  =>
+          SiderealTarget(
+            name                 = ns.name,
+            coordinates          = when.flatMap(ns.coords).getOrElse(Coordinates.zero),
+            properMotion         = None,
+            redshift             = None,
+            parallax             = None,
+            magnitudes           = ns.magnitudes,
+            spectralDistribution = ns.spectralDistribution,
+            spatialProfile       = ns.spatialProfile
+          )
       )
 
   }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/ModelConverters.scala
@@ -7,6 +7,9 @@ import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.offset.OffsetPosBase
 
+import edu.gemini.shared.util.immutable.{Option => GOption}
+import edu.gemini.shared.util.immutable.ScalaConverters.ImOptionOps
+
 import scalaz._
 import Scalaz._
 
@@ -20,7 +23,7 @@ object ModelConverters {
 
   def toCoordinates(coords: skycalc.Coordinates): Coordinates = coords.toNewModel
 
-  def toSideralTarget(spTarget: SPTarget):SiderealTarget = spTarget.toNewModel
+  def toSideralTarget(spTarget: SPTarget, when: GOption[java.lang.Long]):SiderealTarget = spTarget.toSiderealTarget(when)
 
   def toOffset(pos: OffsetPosBase): Offset = pos.toNewModel
 
@@ -78,12 +81,17 @@ object ModelConverters {
 
   implicit class SPTarget2SiderealTarget(val sp:SPTarget) extends AnyVal {
 
-    // RCN: this is suuper sketchy but it's what the old code was doing, so ... ?
-    def toNewModel:SiderealTarget =
+    def toSiderealTarget(when: GOption[java.lang.Long]): SiderealTarget =
+       toSiderealTarget(when.asScalaOpt.map(_.longValue))
+
+    def toSiderealTarget(when: Option[Long]): SiderealTarget =
       sp.getTarget.fold(
         too => SiderealTarget.empty.copy(name = too.name),
         sid => sid,
-        ns  => SiderealTarget.empty.copy(name = ns.name, magnitudes = ns.magnitudes, spectralDistribution = ns.spectralDistribution, spatialProfile = ns.spatialProfile)
+        ns  => {
+          val coords = when.flatMap(ns.coords).getOrElse(Coordinates.zero)
+          SiderealTarget.empty.copy(name = ns.name, coordinates = coords, magnitudes = ns.magnitudes, spectralDistribution = ns.spectralDistribution, spatialProfile = ns.spatialProfile)
+        }
       )
 
   }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/OtItemEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/OtItemEditor.java
@@ -2,9 +2,12 @@ package jsky.app.ot.editor;
 
 import edu.gemini.pot.sp.*;
 import edu.gemini.shared.gui.calendar.JCalendarPopup;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
+import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
@@ -236,6 +239,10 @@ public abstract class OtItemEditor<N extends ISPNode, T extends ISPDataObject> {
     public ISPObservation getContextObservation() {
         final ISPNode n = getNode();
         return (n != null) ? n.getContextObservation() : null;
+    }
+
+    public Option<Long> getSchedulingBlockStart() {
+        return ImOption.apply(getContextObservation()).flatMap(o -> ((SPObservation) o.getDataObject()).getSchedulingBlockStart());
     }
 
     private Optional<ISPObsComponent> findObsComponent(final Predicate<ISPObsComponent> p) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -471,7 +471,7 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
                     final ValidatableGuideProbe vgp = (ValidatableGuideProbe) guideProbe;
                     return AgsRegistrar.instance().currentStrategyForJava(ctx).map(strategy -> {
                         final Option<AgsAnalysis> agsAnalysis = strategy.analyzeForJava(ctx, magTable, vgp,
-                                ModelConverters.toSideralTarget(guideStar));
+                                ModelConverters.toSideralTarget(guideStar, ctx.getSchedulingBlockStart()));
                         return agsAnalysis.map(AgsAnalysis::quality);
                     }).getOrElse(None.instance());
                 } else {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
@@ -10,6 +10,8 @@ import edu.gemini.spModel.obscomp.SPInstObsComp
 import edu.gemini.spModel.target.env.TargetEnvironment
 import edu.gemini.spModel.telescope.IssPort
 
+import edu.gemini.shared.util.immutable.{Option => GOption}
+
 import scalaz._
 import Scalaz._
 
@@ -19,6 +21,7 @@ import Scalaz._
 trait ItcParametersProvider {
   def sequence: ConfigSequence
   def instrument: Option[SPInstObsComp]
+  def schedulingBlockStart: GOption[java.lang.Long]
   def observation: Option[ISPObservation]
   def analysisMethod: String \/ AnalysisMethod
   def conditions: String \/ ObservingConditions
@@ -36,6 +39,9 @@ object ItcParametersProvider {
 
     def instrument: Option[SPInstObsComp] =
       Option(owner.getContextInstrumentDataObject)
+
+    def schedulingBlockStart: GOption[java.lang.Long] =
+      owner.getSchedulingBlockStart
 
     def observation: Option[ISPObservation] =
       Option(owner.getContextObservation)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingFeedback.scala
@@ -173,7 +173,7 @@ object GuidingFeedback {
 
   // GuidingFeedback.Row related to the given guide star itself.
   def guideStarAnalysis(ctx: ObsContext, mt: MagnitudeTable, gp: ValidatableGuideProbe, target: SPTarget): Option[Row] =
-    AgsRegistrar.currentStrategy(ctx).flatMap(_.analyze(ctx, mt, gp, target.toNewModel).map { a =>
+    AgsRegistrar.currentStrategy(ctx).flatMap(_.analyze(ctx, mt, gp, target.toSiderealTarget(ctx.getSchedulingBlockStart)).map { a =>
       val plo = mt(ctx, gp).flatMap(ProbeLimits(a.probeBands, ctx, _))
       Row(a, plo, includeProbeName = false)
     })

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/OiwfsPlotFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/inst/OiwfsPlotFeature.scala
@@ -97,7 +97,7 @@ sealed class OiwfsPlotFeature(probe: OffsetValidatingGuideProbe, probeArm: Probe
           for {
             gpt   <- tpeCtx.targets.envOrDefault.getPrimaryGuideProbeTargets(probe).asScalaOpt
             gsOld <- gpt.getPrimary.asScalaOpt
-            gs     = gsOld.toNewModel.coordinates // TODO: when?
+            gs     = gsOld.toSiderealTarget(obsCtx.getSchedulingBlockStart).coordinates
             shape <- probeArm.geometry(obsCtx, gs, offset)
           } yield new Figure(shape, ProbeArmColor, Blocked, ProbeArmStroke)
         else None


### PR DESCRIPTION
This PR addresses a bug with using non-sidereal targets as guide stars.  In particular the AGS analysis of a guide star works only with `SiderealTarget` so we convert arbitrary guide star targets to `SiderealTarget` if necessary before performing the analysis.  Unfortunately the conversion process would lose the coordinates of non-sidereal targets at the scheduling block start and always use (0,0) coordinates.  The analysis then reported that the guide star is out of reach.

To fix the conversion we need to know the coordinates at the scheduling block start time, which requires adding that time as a parameter.  This parameter then bubbles up a bit through a few APIs and in particular in the ITC, which accounts for most of the changes.

I also renamed the `SPTarget => SiderealTarget` conversion method from `toNewModel` to `toSiderealTarget` to better reflect what it does.