### PR TITLE
REL-2785 - WIP on auto ephemeris update

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -323,10 +323,7 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
      * Get the scheduling block's starting time.
      */
     public Option<Long> getSchedulingBlockStart() {
-        return _schedulingBlock.flatMap(b -> {
-            final scala.Option<Object> osb = b.duration(); // boxing
-            return (osb.isDefined()) ? new Some((Long) osb.get()) : None.instance();
-        });
+        return _schedulingBlock.map(SchedulingBlock::start);
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
@@ -1,5 +1,8 @@
 package edu.gemini.spModel.obs
 
+import edu.gemini.skycalc.ObservingNight
+import edu.gemini.spModel.core.Site
+
 /** A reference time for planning observations. */
 sealed abstract class SchedulingBlock {
 
@@ -11,6 +14,14 @@ sealed abstract class SchedulingBlock {
 
   /** Duration, if any, otherwise zero. */
   def durationOrZero = duration.getOrElse(0L)
+
+  /** Observing night of the scheduling block start, at the given site. */
+  def observingNight(site: Site): ObservingNight =
+    new ObservingNight(site, start)
+
+  /** True if these blocks fall on the same observing night. */
+  def sameObservingNightAs(other: SchedulingBlock): Boolean =
+    observingNight(Site.GN) == other.observingNight(Site.GN) // site is arbitrary
 
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
@@ -1,0 +1,134 @@
+package jsky.app.ot.gemini.editor
+
+import java.awt.Component
+import java.util.logging.Logger
+
+import edu.gemini.pot.sp.{ISPObsComponent, ISPObservation}
+import edu.gemini.skycalc.ObservingNight
+
+import java.util.Date
+import javax.swing.{JRootPane, SwingUtilities}
+
+import edu.gemini.horizons.server.backend.HorizonsService2._
+import edu.gemini.shared.gui.GlassLabel
+import edu.gemini.spModel.core._
+import edu.gemini.spModel.obs.SPObservation
+import edu.gemini.spModel.obs.context.ObsContext
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.target.env.TargetEnvironment
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import jsky.util.gui.DialogUtil
+
+import scala.swing.Swing
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+
+object EphemerisUpdater {
+  val Log = Logger.getLogger(getClass.getName)
+
+  /**
+   * Module of actions in `HS2` for displaying status messages and doing things on the EDT.
+ *
+   * @param c any component; `UI` will use its parent `RootPane`
+   */
+  class UI private (c: () => Component) {
+
+    private def rootPane: Option[JRootPane] =
+      Option(SwingUtilities.getRootPane(c()))
+
+    def onEDT(f: => Unit): HS2[Unit] =
+      HS2.delay(Swing.onEDT(f))
+
+    def show(msg: String): HS2[Unit] =
+      onEDT {
+        println("show: " + msg + " ... " + rootPane)
+        rootPane.foreach(GlassLabel.show(_, msg))
+      }
+
+    val hide: HS2[Unit] =
+      onEDT(rootPane.foreach(GlassLabel.hide))
+
+  }
+  object UI {
+    def apply(c: => Component): UI = new UI(c _)
+  }
+
+  /**
+   * Action to look up an ephemeris given a designation, site, and point in time. The ephemeris
+   * will contain 1000 points over the entire semester plus a month's padding on each side; and
+   * an additional 300 points for the `ObservingNight` in which `when` falls.
+   */
+  def lookup(d: HorizonsDesignation, site: Site, when: Long): HS2[Ephemeris] = {
+    val s = new Semester(site, when)
+    val n = new ObservingNight(site, when)
+    for {
+      e1 <- lookupEphemerisWithPadding(d, site, 1000, s)
+      e2 <- lookupEphemeris(d, site, new Date(n.getStartTime), new Date(n.getEndTime), 300)
+    } yield e1.union(e2)
+  }
+
+  /** Get the target node, scheduling block start, and site; we need all of these. */
+  private def args(obsN: ISPObservation): Option[(ISPObsComponent, Long, Site)] =
+    for {
+      tocN  <- obsN.findObsComponentByType(TargetObsComp.SP_TYPE)
+      _ = println(tocN)
+      _ = println(obsN.getDataObject.asInstanceOf[SPObservation].getSchedulingBlock)
+      _ = println(obsN.getDataObject.asInstanceOf[SPObservation].getSchedulingBlockStart)
+      start <- obsN.getDataObject.asInstanceOf[SPObservation].getSchedulingBlockStart.asScalaOpt
+      _ = println(start)
+      site  <- ObsContext.getSiteFromObservation(obsN).asScalaOpt
+      _ = println(site)
+    } yield (tocN, start, site)
+
+  /**
+   * Action to refresh the ephimerides for all nonsidereal targets in `obs`, showing
+   * status in the given `UI`.
+   */
+  def refreshEphemerides(obsN: ISPObservation, ui: UI): HS2[Unit] = {
+    val x = args(obsN)
+    println(getClass.getName + " ... " + x)
+    x.traverseU_ { case (tocN, start, site) =>
+
+      println("UPDATING ...")
+
+      val toc  = tocN.getDataObject.asInstanceOf[TargetObsComp]
+      val env  = toc.getTargetEnvironment
+      val spts = env.getTargets.asScalaList
+
+      val nstArgs: List[(SPTarget, NonSiderealTarget, HorizonsDesignation)] =
+        for {
+          spt <- spts
+          nst <- spt.getNonSiderealTarget.toList
+          hd  <- nst.horizonsDesignation.toList
+        } yield (spt, nst, hd)
+
+      def update(spt: SPTarget, nst: NonSiderealTarget, hd: HorizonsDesignation, n: Int): HS2[Unit] =
+        for {
+          _ <- ui.show(s"Updating Ephemeris ${n + 1} of ${nstArgs.length} ...")
+          e <- lookup(hd, site, start)
+          _ <- HS2.delay(spt.setTarget(NonSiderealTarget.ephemeris.set(nst, e)))
+        } yield ()
+
+      nstArgs.zipWithIndex.traverseU { case ((spt, nst, hd), n) => update(spt, nst, hd, n) } *>
+      ui.onEDT(tocN.setDataObject(toc)) *>
+      ui.hide
+
+    }
+  }
+
+  /**
+   * Refresh the ephimerides for all nonsidereal targets in `obs`, on another thread, showing status
+   * in the root pane associated with the given `Component`.
+   */
+  def unsafeRefreshEphemerides(obsN: ISPObservation, c: Component): Unit = {
+    val ui = UI(c)
+    val action = (refreshEphemerides(obsN, ui) ensuring ui.hide).withResultLogging(Log)
+    Task(action.run.unsafePerformIO).unsafePerformAsync {
+      case -\/(t) => Swing.onEDT(DialogUtil.error(c, t))
+      case \/-(_) => () // done!
+    }
+  }
+
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameEditor.scala
@@ -1,19 +1,18 @@
 package jsky.app.ot.gemini.editor.targetComponent.details2
 
 import java.awt.Color
-import java.util.Date
-import javax.swing.{SwingUtilities, JOptionPane, JLabel}
+import java.util.logging.Logger
+import javax.swing.{ JOptionPane, JLabel}
 
 import edu.gemini.horizons.server.backend.HorizonsService2
-import edu.gemini.horizons.server.backend.HorizonsService2.HS2
+import edu.gemini.horizons.server.backend.HorizonsService2.{ HS2, HS2Ops }
 import edu.gemini.pot.sp.ISPNode
-import edu.gemini.shared.gui.GlassLabel
 import edu.gemini.shared.util.immutable.{Option => GOption}
 import edu.gemini.shared.util.immutable.ScalaConverters._
-import edu.gemini.skycalc.ObservingNight
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
+import jsky.app.ot.gemini.editor.EphemerisUpdater
 
 import jsky.app.ot.gemini.editor.targetComponent.TelescopePosEditor
 import jsky.util.gui.{DialogUtil, TextBoxWidget, TextBoxWidgetWatcher}
@@ -28,7 +27,8 @@ final class NonSiderealNameEditor extends TelescopePosEditor with ReentrancyHack
   private[this] var start = Option.empty[Long]
   private[this] var spt   = new SPTarget // never null
 
-  /// Some IO actions for looking up targets and epherimides
+  // A module of actions for displaying status in the GlassPane
+  val ui = EphemerisUpdater.UI(name)
 
   val askSearch: HS2[Option[Search[_ <: HorizonsDesignation]]] =
     HS2.delay {
@@ -47,28 +47,10 @@ final class NonSiderealNameEditor extends TelescopePosEditor with ReentrancyHack
       } .map(_.asInstanceOf[Wrapper].unwrap)
     }
 
-  def show(msg: String): HS2[Unit] =
-    HS2.delay(Swing.onEDT(GlassLabel.show(SwingUtilities.getRootPane(name), msg)))
-
-  def hide: HS2[Unit] =
-    HS2.delay(Swing.onEDT(GlassLabel.hide(SwingUtilities.getRootPane(name))))
-
-  // semester for scheduling block if any, or current time
-  def semester(site: Site): Semester =
-    new Semester(site, start.getOrElse(System.currentTimeMillis))
-
-  def lookup(d: HorizonsDesignation, site: Site): HS2[Ephemeris] = {
-    val s = semester(site)
-    val n = start.map(new ObservingNight(site, _))
-    for {
-      _  <- show(s"Fetching Ephemeris for $s ...")
-      e1 <- HorizonsService2.lookupEphemerisWithPadding(d, site, 1000, s)
-      e2 <- n.fold(Ephemeris.empty.point[HS2]) { n =>
-              show(s"Fetching Ephemeris for ${n.getNightString} ...") *>
-              HorizonsService2.lookupEphemeris(d, site, new Date(n.getStartTime), new Date(n.getEndTime), 300)
-            }
-    } yield e1.union(e2)
-  }
+  def lookup(d: HorizonsDesignation, site: Site): HS2[Ephemeris] =
+    start.fold(Ephemeris.empty.point[HS2]) { when =>
+      ui.show(s"Fetching Ephemeris ...") *> EphemerisUpdater.lookup(d, site, when)
+    }
 
   // Given designation and name from horizons, along with the current target name, provide a new
   // target name. We try to find a match, and if there is none we just return the old name.
@@ -76,19 +58,13 @@ final class NonSiderealNameEditor extends TelescopePosEditor with ReentrancyHack
     List(hn, hd.des).find(s => s.toLowerCase.indexOf(n.toLowerCase) >= 0).getOrElse(n)
 
   def updateDesignation(hd: HorizonsDesignation, name: String, rename: Boolean): HS2[Unit] =
-    HS2.delay {
-      Swing.onEDT {
-        val t0 = if (rename) Target.name.mod(modifyName(hd, name), spt.getTarget) else spt.getTarget
-        Target.horizonsDesignation.set(t0, Some(hd)).foreach(spt.setTarget)
-      }
+    ui.onEDT {
+      val t0 = if (rename) Target.name.mod(modifyName(hd, name), spt.getTarget) else spt.getTarget
+      Target.horizonsDesignation.set(t0, Some(hd)).foreach(spt.setTarget)
     }
 
   def updateEphem(e: Ephemeris): HS2[Unit] =
-    HS2.delay {
-      Swing.onEDT {
-        Target.ephemeris.set(spt.getTarget, e).foreach(spt.setTarget)
-      }
-    }
+    ui.onEDT(Target.ephemeris.set(spt.getTarget, e).foreach(spt.setTarget))
 
   def manyResults(rs: List[Row[_ <: HorizonsDesignation]]): HS2[Unit] =
     HS2.delay {
@@ -112,37 +88,42 @@ final class NonSiderealNameEditor extends TelescopePosEditor with ReentrancyHack
 
   def oneResult(r: Row[_ <: HorizonsDesignation], rename: Boolean): HS2[Unit] =
     updateDesignation(r.a, r.name, rename).as(site) >>= {
-      case Some(site) => lookup(r.a, site) <* hide >>= updateEphem
+      case Some(site) => lookup(r.a, site) <* ui.hide >>= updateEphem
       case None       => HS2.delay(Swing.onEDT(DialogUtil.error(name, "Cannot determine site for this observation; this is needed for ephemeris lookup.")))
     }
 
   val noResults: HS2[Unit] =
     HS2.delay(DialogUtil.message(name, "No results found."))
 
-  val search = show("Searching...") *> askSearch >>= {
-    case None => ().point[HS2] // user hit cancel
-    case Some(s) =>
-      (HorizonsService2.search(s) <* hide) >>= {
-        case Nil     => noResults
-        case List(r) => oneResult(r, true)
-        case rs      => manyResults(rs)
-      }
-  }
+  val search: HS2[Unit] =
+    ui.show("Searching...") *>
+    askSearch >>= {
+      case None => ().point[HS2] // user hit cancel
+      case Some(s) =>
+        (HorizonsService2.search(s) <* ui.hide) >>= {
+          case Nil     => noResults
+          case List(r) => oneResult(r, true)
+          case rs      => manyResults(rs)
+        }
+    }
 
-  def unsafeRun[A](io: IO[A]): Unit =
-    Task(io.unsafePerformIO).unsafePerformAsync {
+  // run this action on another thread, ensuring that the glasspane is always hidden, and log any failures
+  def unsafeRun[A](hs2: HS2[A]): Unit = {
+    val action = hs2.withResultLogging(NonSiderealNameEditor.Log) ensuring ui.hide
+    Task(action.run.unsafePerformIO).unsafePerformAsync {
       case -\/(t) => Swing.onEDT(DialogUtil.error(name, t))
       case \/-(_) => () // done!
     }
+  }
 
   def lookup(site: Option[Site]): Unit =
-    unsafeRun(search.run.ensuring(hide.run))
+    unsafeRun(search)
 
   def horizonsDesignation: Option[HorizonsDesignation] =
     spt.getNonSiderealTarget.flatMap(Target.horizonsDesignation.get).flatten
 
   def refreshEphemeris(): Unit =
-    horizonsDesignation.map(hd => oneResult(Row(hd, spt.getName), false).run).foreach(unsafeRun)
+    horizonsDesignation.map(hd => oneResult(Row(hd, spt.getName), false)).foreach(unsafeRun)
 
   val name = new TextBoxWidget <| { w =>
     w.setMinimumSize(w.getPreferredSize)
@@ -183,4 +164,8 @@ final class NonSiderealNameEditor extends TelescopePosEditor with ReentrancyHack
   }
 
 
+}
+
+object NonSiderealNameEditor {
+  val Log = Logger.getLogger(classOf[NonSiderealNameEditor].getName)
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -13,6 +13,7 @@ import edu.gemini.spModel.obs.{ObsTargetCalculatorService, SPObservation, Schedu
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.shared.util.immutable.{Option => JOption, ImOption}
 import jsky.app.ot.editor.OtItemEditor
+import jsky.app.ot.gemini.editor.EphemerisUpdater
 import jsky.app.ot.util.TimeZonePreference
 
 import scala.swing.GridBagPanel.{Anchor, Fill}
@@ -22,6 +23,7 @@ import scala.swing.event.{ButtonClicked, Event}
 /**
  * This class encompasses all of the logic required to manage the average parallactic angle information associated
  * with an instrument configuration.
+ *
  * @param isPaUi should be true for PA controls, false for Scheduling Block controls
  */
 class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publisher {
@@ -160,6 +162,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       val spObs = ispObs.getDataObject.asInstanceOf[SPObservation]
       spObs.setSchedulingBlock(ImOption.apply(sb))
       ispObs.setDataObject(spObs)
+      EphemerisUpdater.unsafeRefreshEphemerides(ispObs, e.getWindow)
       callback.run()
       resetComponents()
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -160,9 +160,12 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       ispObs <- Option(e.getContextObservation)
     } {
       val spObs = ispObs.getDataObject.asInstanceOf[SPObservation]
+      val sameNight = spObs.getSchedulingBlock.asScalaOpt.exists(_.sameObservingNightAs(sb))
       spObs.setSchedulingBlock(ImOption.apply(sb))
       ispObs.setDataObject(spObs)
-      EphemerisUpdater.unsafeRefreshEphemerides(ispObs, e.getWindow)
+      if (!sameNight) {
+        EphemerisUpdater.unsafeRefreshEphemerides(ispObs, e.getWindow)
+      }
       callback.run()
       resetComponents()
     }


### PR DESCRIPTION
This PR updates the OT as follows:
- When the user moves the scheduling block into another observing night all ephemerides in the observation are updated.
- Refactored the existing ephemeris lookup a bit.
- Added logging for Horizons errors.
- Fixed a dumb bug in `SPTarget` that was returning the scheduling block duration rather than its start.