### PR TITLE
REL-2518: new pointing origin and instrument types for GMOS-N + Altair

### DIFF
--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/None.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/None.java
@@ -115,6 +115,9 @@ public final class None<T> implements Option<T>, Serializable {
     }
 
     @Override
+    public boolean contains(final T that) { return false; }
+
+    @Override
     public boolean exists(final Function1<? super T, Boolean> op) { return false; }
 
     @Override

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Option.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Option.java
@@ -89,6 +89,12 @@ public interface Option<T> extends Iterable<T>, Serializable {
     void foreach(ApplyOp<? super T> op);
 
     /**
+     * Returns <code>true</code> if Some and the contained value is equal to the
+     * given value.
+     */
+    boolean contains(T that);
+
+    /**
      * Returns <code>true</code> if Some and the contained value matches the
      * predicate.
      */

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Some.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Some.java
@@ -71,6 +71,11 @@ public final class Some<T> implements Option<T> {
     }
 
     @Override
+    public boolean contains(final T that) {
+        return val.equals(that);
+    }
+
+    @Override
     public boolean exists(final Function1<? super T, Boolean> op) {
         return op.apply(val);
     }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GMOSSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GMOSSupport.java
@@ -6,7 +6,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.telescope.IssPort;
 
-public class GMOSSupport implements ITccInstrumentSupport {
+public final class GMOSSupport implements ITccInstrumentSupport {
 
     private String _wavelength;
     private ObservationEnvironment _oe;
@@ -56,11 +56,17 @@ public class GMOSSupport implements ITccInstrumentSupport {
     }
 
     public String getTccConfigInstrument() {
-        String side = _oe.isNorth() ? "5" : "3";
-        String port = (((InstGmosCommon) _oe.getInstrument()).getIssPort() == IssPort.UP_LOOKING) ? "" : side;
-        String ao   = (_oe.isNorth() && _oe.isAltair()) ? "AO2" : "";
-        String p2   = (_oe.containsTargets(PwfsGuideProbe.pwfs2)) ? "_P2" : "";
-        return ao + "GMOS" + port + p2;
+        final String side = _oe.isNorth() ? "5" : "3";
+        final String port = (((InstGmosCommon) _oe.getInstrument()).getIssPort() == IssPort.UP_LOOKING) ? "" : side;
+
+        if (_oe.isNorth() && _oe.isAltair()) {
+            final String oi = _oe.containsTargets(GmosOiwfsGuideProbe.instance) ? "_OI" : "";
+            final String p1 = _oe.containsTargets(PwfsGuideProbe.pwfs1) ? "_P1" : "";
+            return "AO2GMOS" + port + p1 + oi;
+        } else {
+            final String p2 = (_oe.containsTargets(PwfsGuideProbe.pwfs2)) ? "_P2" : "";
+            return "GMOS" + port + p2;
+        }
     }
 
     /**
@@ -78,7 +84,7 @@ public class GMOSSupport implements ITccInstrumentSupport {
      * @return String that is the name of a TCC config file.  See WDBA-5.
      */
     public String getTccConfigInstrumentOrigin() {
-        InstGmosCommon<?, ?, ?, ?> inst = (InstGmosCommon) _oe.getInstrument();
+        final InstGmosCommon<?, ?, ?, ?> inst = (InstGmosCommon) _oe.getInstrument();
         return (inst instanceof InstGmosNorth) ? northOrigin(inst) : southOrigin(inst);
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GMOSSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GMOSSupport.java
@@ -2,6 +2,7 @@ package edu.gemini.wdba.tcc;
 
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon;
 import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
+import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.telescope.IssPort;
 
@@ -78,11 +79,38 @@ public class GMOSSupport implements ITccInstrumentSupport {
      */
     public String getTccConfigInstrumentOrigin() {
         InstGmosCommon<?, ?, ?, ?> inst = (InstGmosCommon) _oe.getInstrument();
+        return (inst instanceof InstGmosNorth) ? northOrigin(inst) : southOrigin(inst);
+    }
+
+    private static final String NGS   = "ngs2gmos";
+    private static final String LGS   = "lgs2gmos";
+    private static final String NO_AO = "gmos";
+
+    private String oi() {
+        return _oe.containsTargets(GmosOiwfsGuideProbe.instance) ? "_oi" : "";
+    }
+
+    private String p1() {
+        return _oe.containsTargets(PwfsGuideProbe.pwfs1) ? "_p1" : "";
+    }
+
+    private static String ifu(InstGmosCommon<?, ?, ?, ?> inst) {
+        return inst.getFPUnit().isIFU() ? "_ifu" : "";
+    }
+
+    private String northOrigin(InstGmosCommon<?, ?, ?, ?> gmos) {
         switch (_oe.getAoAspect()) {
-            case ngs : return "ngs2gmos";
-            case lgs : return _oe.adjustInstrumentOriginForLGS_P1("lgs2gmos");
-            default:
-                return inst.getFPUnit().isIFU() ? "gmos_ifu" : "gmos";
+            case ngs: return NGS   + oi();
+            case lgs: return LGS   + p1() + oi();
+            default:  return NO_AO + ifu(gmos);
+        }
+    }
+
+    private String southOrigin(InstGmosCommon<?, ?, ?, ?> gmos) {
+        switch (_oe.getAoAspect()) {
+            case ngs : return NGS;
+            case lgs : return LGS   + p1();
+            default:   return NO_AO + ifu(gmos);
         }
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GuideConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GuideConfig.java
@@ -22,7 +22,7 @@ import java.util.Set;
 /**
  *  Class to evaluate the {@link ObservationEnvironment} and produce a guide config and guide config  name.
  */
-public final class GuideConfigSouth extends ParamSet {
+public final class GuideConfig extends ParamSet {
     private static final Set<GuideProbe> ODGW_PROBES = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(GsaoiOdgw.values()))
     );
@@ -33,7 +33,7 @@ public final class GuideConfigSouth extends ParamSet {
 
     private final ObservationEnvironment _oe;
 
-    public GuideConfigSouth(ObservationEnvironment oe) {
+    public GuideConfig(ObservationEnvironment oe) {
         super(TccNames.GUIDE_CONFIG);
         if (oe == null) throw new NullPointerException("Config requires a non-null observation environment");
         _oe = oe;

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GuideConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GuideConfig.java
@@ -117,10 +117,10 @@ public final class GuideConfig extends ParamSet {
     }
 
     public String guideName() {
-        String guideName;
+        final String guideName;
 
         // Indicate which one is selected
-        if (_oe.containsTargets(AltairAowfsGuider.instance)) {
+        if (contains(AltairAowfsGuider.instance)) {
             guideName = _getAOGuideConfig();
         } else if (isAltairP1()) {
             // REL-542.
@@ -142,7 +142,7 @@ public final class GuideConfig extends ParamSet {
      * an XML document.
      */
     public boolean build() throws WdbaGlueException {
-        String guideWith = guideName();
+        final String guideWith = guideName();
         putParameter(TccNames.GUIDE_WITH, guideWith);
 
         // Hack in special configuration for GeMS.  Ideally this would be
@@ -155,7 +155,7 @@ public final class GuideConfig extends ParamSet {
 
     private Option<ParamSet> createGemsConfig(String guideWith) throws WdbaGlueException {
         // Only relevant if using GSAOI
-        SPInstObsComp inst = _oe.getInstrument();
+        final SPInstObsComp inst = _oe.getInstrument();
         if (inst == null) return None.instance();
         if (!Gsaoi.SP_TYPE.equals(inst.getType())) return None.instance();
 
@@ -163,9 +163,9 @@ public final class GuideConfig extends ParamSet {
         if (!guideWith.contains(TccNames.GeMS)) return None.instance();
         if (!containsGsaoi()) return None.instance();
 
-        Gsaoi.OdgwSize size = ((Gsaoi) inst).getOdgwSize();
-        ParamSet gems = new ParamSet(TccNames.GeMS);
-        ParamSet odgw = new ParamSet("odgw");
+        final Gsaoi.OdgwSize size = ((Gsaoi) inst).getOdgwSize();
+        final ParamSet gems = new ParamSet(TccNames.GeMS);
+        final ParamSet odgw = new ParamSet("odgw");
         gems.putParamSet(odgw);
         odgw.putParameter("size", size.displayValue());
         return new Some<>(gems);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -152,16 +152,16 @@ public final class ObservationEnvironment {
         return _targetEnv;
     }
 
-    private SortedSet<GuideProbe> guiders() {
+    public SortedSet<GuideProbe> usedGuiders() {
         return _targetEnv.getGuideEnvironment().getPrimaryReferencedGuiders();
     }
 
     public boolean containsTargets(GuideProbe probe) {
-        return guiders().contains(probe);
+        return usedGuiders().contains(probe);
     }
 
     public boolean containsTargets(GuideProbe.Type type) {
-        return guiders().stream().anyMatch(gp -> gp.getType() == type);
+        return usedGuiders().stream().anyMatch(gp -> gp.getType() == type);
     }
 
     public enum AoAspect {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -14,18 +14,13 @@ import edu.gemini.spModel.gemini.seqcomp.SeqRepeatOffsetBase;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeUtil;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
-import edu.gemini.spModel.target.env.GuideGroup;
-import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.wdba.glue.api.WdbaGlueException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Logger;
 
 /**
@@ -157,15 +152,16 @@ public final class ObservationEnvironment {
         return _targetEnv;
     }
 
+    private SortedSet<GuideProbe> guiders() {
+        return _targetEnv.getGuideEnvironment().getPrimaryReferencedGuiders();
+    }
+
     public boolean containsTargets(GuideProbe probe) {
-        final Option<GuideProbeTargets> gtOpt = _targetEnv.getPrimaryGuideProbeTargets(probe);
-        return gtOpt.exists(GuideProbeTargets::containsTargets);
+        return guiders().contains(probe);
     }
 
     public boolean containsTargets(GuideProbe.Type type) {
-        final GuideGroup grp = _targetEnv.getPrimaryGuideGroup();
-        final ImList<GuideProbeTargets> gtList = grp.getAllMatching(type);
-        return gtList.exists(GuideProbeTargets::containsTargets);
+        return guiders().stream().anyMatch(gp -> gp.getType() == type);
     }
 
     public enum AoAspect {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -67,7 +67,7 @@ public class TccFieldConfig extends ParamSet {
             }
         }
 
-        GuideConfigSouth gc = new GuideConfigSouth(_oe);
+        GuideConfig gc = new GuideConfig(_oe);
         if (gc.build()) putParamSet(gc);
 
         addTargets(obsComp.getTargetEnvironment());

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/AoConfigTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/AoConfigTest.java
@@ -17,20 +17,22 @@ import edu.gemini.spModel.gemini.niri.InstNIRI;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 import java.util.List;
 
 /**
  * Test cases for RotatorConfig.  The logic is about as convoluted as the
  * class itself ...
  */
-public class AoConfigTest extends TestBase {
+public final class AoConfigTest extends TestBase {
 
-    private ISPObsComponent instObsComp;
     private ISPObsComponent gemsObsComp;
     private ISPObsComponent altairObsComp;
 
     private ISPObsComponent addInstrument(SPComponentType type) throws Exception {
-        instObsComp = odb.getFactory().createObsComponent(prog, type, null);
+        final ISPObsComponent instObsComp = odb.getFactory().createObsComponent(prog, type, null);
         obs.addObsComponent(instObsComp);
         return instObsComp;
     }
@@ -90,7 +92,7 @@ public class AoConfigTest extends TestBase {
             String type = site == Site.north ? TccNames.GAOS : "gems";
             Element e = getSubconfig(doc, type);
             if (e == null) return None.instance();
-            return new Some<Element>(e);
+            return new Some<>(e);
         }
 
 
@@ -157,11 +159,11 @@ public class AoConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testAltairDefault()  throws Exception {
+    @Test public void testAltairDefault()  throws Exception {
         testAltair( new InstAltair() );
     }
 
-    public void testAltairNdFilter() throws Exception {
+    @Test public void testAltairNdFilter() throws Exception {
         InstAltair altair = new InstAltair();
         for(AltairParams.NdFilter ndFilter: AltairParams.NdFilter.values()) {
             altair.setNdFilter(ndFilter);
@@ -169,7 +171,7 @@ public class AoConfigTest extends TestBase {
         }
     }
 
-    public void testAltairWavelength() throws Exception {
+    @Test public void testAltairWavelength() throws Exception {
         InstAltair altair = new InstAltair();
         for(AltairParams.Wavelength wavelength: AltairParams.Wavelength.values()) {
             altair.setWavelength(wavelength);
@@ -189,11 +191,11 @@ public class AoConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testGemsDefault() throws Exception {
+    @Test public void testGemsDefault() throws Exception {
         testGems(new Gems());
     }
 
-    public void testGemsAdc() throws Exception {
+    @Test public void testGemsAdc() throws Exception {
         Gems gems = new Gems();
         for (Gems.Adc adc : Gems.Adc.values()) {
             gems.setAdc(adc);
@@ -201,7 +203,7 @@ public class AoConfigTest extends TestBase {
         }
     }
 
-    public void testGemsDichroic() throws Exception {
+    @Test public void testGemsDichroic() throws Exception {
         Gems gems = new Gems();
         for (Gems.DichroicBeamsplitter bs : Gems.DichroicBeamsplitter.values()) {
             gems.setDichroicBeamsplitter(bs);
@@ -209,7 +211,7 @@ public class AoConfigTest extends TestBase {
         }
     }
 
-    public void testGemsAstrometric() throws Exception {
+    @Test public void testGemsAstrometric() throws Exception {
         Gems gems = new Gems();
         for (Gems.AstrometricMode am : Gems.AstrometricMode.values()) {
             gems.setAstrometricMode(am);
@@ -217,7 +219,7 @@ public class AoConfigTest extends TestBase {
         }
     }
 
-    public void testSouthNoGems() throws Exception {
+    @Test public void testSouthNoGems() throws Exception {
         addGsaoi();
 
         AoConfigValidator val = new GemsAoConfigValidator();

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/Flamingos2SupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/Flamingos2SupportTest.java
@@ -15,6 +15,7 @@ import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.telescope.IssPort;
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +69,7 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
         targetNode.getRemoteNode().setDataObject(obsComp);
     }
 
-    public void testF2_SIDE() throws Exception {
+    @Test public void testF2_SIDE() throws Exception {
         final Flamingos2 flam2 = getInstrument();
         flam2.setIssPort(IssPort.SIDE_LOOKING);
         assertEquals(flam2.getDisperser(), Flamingos2.Disperser.NONE);
@@ -77,7 +78,7 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
         verifyInstrumentConfig(getSouthResults(), "F25");
     }
 
-    public void testF2_UP() throws Exception {
+    @Test public void testF2_UP() throws Exception {
         final Flamingos2 flam2 = getInstrument();
         flam2.setIssPort(IssPort.UP_LOOKING);
         assertEquals(flam2.getDisperser(), Flamingos2.Disperser.NONE);
@@ -96,7 +97,7 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
         verifyInstrumentConfig(getSouthResults(), "F25_P2");
     }
 
-    public void testF2_P2_UP() throws Exception {
+    @Test public void testF2_P2_UP() throws Exception {
         final Flamingos2 flam2 = getInstrument();
         flam2.setIssPort(IssPort.UP_LOOKING);
         assertEquals(flam2.getDisperser(), Flamingos2.Disperser.NONE);
@@ -106,7 +107,7 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
         verifyInstrumentConfig(getSouthResults(), "F2_P2");
     }
 
-    public void testF2_SIDE_SPEC() throws Exception {
+    @Test public void testF2_SIDE_SPEC() throws Exception {
         final Flamingos2 flam2 = getInstrument();
         flam2.setIssPort(IssPort.SIDE_LOOKING);
         flam2.setDisperser(Flamingos2.Disperser.R3000);
@@ -115,7 +116,7 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
         verifyInstrumentConfig(getSouthResults(), "F25");
     }
 
-    public void testF2_UP_SPEC() throws Exception {
+    @Test public void testF2_UP_SPEC() throws Exception {
         final Flamingos2 flam2 = getInstrument();
         flam2.setIssPort(IssPort.UP_LOOKING);
         flam2.setDisperser(Flamingos2.Disperser.R3000);
@@ -125,7 +126,7 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
     }
 
     @SuppressWarnings({"ResultOfMethodCallIgnored","unchecked","rawtypes"})
-    public void testWavelength() throws Exception {
+    @Test public void testWavelength() throws Exception {
         final Flamingos2 flam2 = getInstrument();
         flam2.setFilter(Filter.OPEN);
         flam2.setDisperser(Disperser.NONE);
@@ -189,11 +190,11 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
         }
     }
 
-    public void testNoAoPointOrig() throws Exception {
+    @Test public void testNoAoPointOrig() throws Exception {
         verifyPointOrig(getSouthResults(), "f2");
     }
 
-    public void testLgsPointOrig() throws Exception {
+    @Test public void testLgsPointOrig() throws Exception {
         addGems();
         verifyPointOrig(getSouthResults(), "lgs2f2");
     }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
@@ -17,7 +17,7 @@ import static edu.gemini.spModel.gemini.altair.AltairParams.GuideStarType.NGS;
 /**
  * Test cases for GMOS instrument support.
  */
-public class GmosNorthSupportTest extends InstrumentSupportTestBase<InstGmosNorth>{
+public final class GmosNorthSupportTest extends InstrumentSupportTestBase<InstGmosNorth>{
 
     public GmosNorthSupportTest() {
         super(InstGmosNorth.SP_TYPE);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
@@ -7,6 +7,7 @@ package edu.gemini.wdba.tcc;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
+import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.telescope.IssPort;
 import org.junit.Test;
 
@@ -40,6 +41,7 @@ public class GmosNorthSupportTest extends InstrumentSupportTestBase<InstGmosNort
 
     @Test public void testLgsP1PointOrig() throws Exception {
         addAltair(AltairParams.Mode.LGS_P1);
+        addGuideStar(PwfsGuideProbe.pwfs1);
         verifyPointOrig(getSouthResults(), "lgs2gmos_p1");
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
@@ -85,10 +85,44 @@ public final class GmosNorthSupportTest extends InstrumentSupportTestBase<InstGm
         verifyInstrumentConfig(getNorthResults(), "AO2GMOS5");
     }
 
+    @Test public void testAoP1SideLooking() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addAltair();
+        addGuideStar(PwfsGuideProbe.pwfs1);
+        verifyInstrumentConfig(getNorthResults(), "AO2GMOS5_P1");
+    }
+
+    @Test public void testAoOiSideLooking() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addAltair();
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyInstrumentConfig(getNorthResults(), "AO2GMOS5_OI");
+    }
+
+    @Test public void testAoP1OiSideLooking() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addAltair();
+        addGuideStar(PwfsGuideProbe.pwfs1);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyInstrumentConfig(getNorthResults(), "AO2GMOS5_P1_OI");
+    }
+
     @Test public void testAoUpLooking() throws Exception {
         setPort(IssPort.UP_LOOKING);
         addAltair();
         verifyInstrumentConfig(getNorthResults(), "AO2GMOS");
+    }
+
+    @Test public void testSideLookingP2() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs2);
+        verifyInstrumentConfig(getNorthResults(), "GMOS5_P2");
+    }
+
+    @Test public void testUpLookingP2() throws Exception {
+        setPort(IssPort.UP_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs2);
+        verifyInstrumentConfig(getNorthResults(), "GMOS_P2");
     }
 
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
@@ -6,6 +6,7 @@ package edu.gemini.wdba.tcc;
 
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType;
+import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.telescope.IssPort;
@@ -45,8 +46,27 @@ public final class GmosNorthSupportTest extends InstrumentSupportTestBase<InstGm
         verifyPointOrig(getSouthResults(), "lgs2gmos_p1");
     }
 
+    @Test public void testLgsOiPointOrig() throws Exception {
+        addAltair(AltairParams.Mode.LGS_OI);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyPointOrig(getSouthResults(), "lgs2gmos_oi");
+    }
+
+    @Test public void testLgsP1OiPointOrig() throws Exception {
+        addAltair(AltairParams.Mode.LGS_P1);
+        addGuideStar(PwfsGuideProbe.pwfs1);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyPointOrig(getSouthResults(), "lgs2gmos_p1_oi");
+    }
+
     @Test public void testNgsPointOrig() throws Exception {
         addAltair(NGS); verifyPointOrig(getSouthResults(), "ngs2gmos");
+    }
+
+    @Test public void testNgsOiPointOrig() throws Exception {
+        addAltair(NGS);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyPointOrig(getSouthResults(), "ngs2gmos_oi");
     }
 
     @Test public void testNoAoSideLooking() throws Exception {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 /**
  * Test cases for GMOS instrument support.
  */
-public class GmosSouthSupportTest extends InstrumentSupportTestBase<InstGmosSouth>{
+public final class GmosSouthSupportTest extends InstrumentSupportTestBase<InstGmosSouth>{
 
     public GmosSouthSupportTest() {
         super(InstGmosSouth.SP_TYPE);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
@@ -48,8 +48,20 @@ public final class GmosSouthSupportTest extends InstrumentSupportTestBase<InstGm
         verifyInstrumentConfig(getSouthResults(), "GMOS3");
     }
 
+    @Test public void testSideLookingP2() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs2);
+        verifyInstrumentConfig(getSouthResults(), "GMOS3_P2");
+    }
+
     @Test public void testUpLooking() throws Exception {
         setPort(IssPort.UP_LOOKING);
         verifyInstrumentConfig(getSouthResults(), "GMOS");
+    }
+
+    @Test public void testUpLookingP2() throws Exception {
+        setPort(IssPort.UP_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs2);
+        verifyInstrumentConfig(getSouthResults(), "GMOS_P2");
     }
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
@@ -7,6 +7,7 @@ package edu.gemini.wdba.tcc;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.gmos.GmosSouthType;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
+import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.telescope.IssPort;
 import org.junit.Test;
 
@@ -38,6 +39,7 @@ public class GmosSouthSupportTest extends InstrumentSupportTestBase<InstGmosSout
 
     @Test public void testLgsP1PointOrig() throws Exception {
         addAltair(AltairParams.Mode.LGS_P1);
+        addGuideStar(PwfsGuideProbe.pwfs1);
         verifyPointOrig(getSouthResults(), "lgs2gmos_p1");
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GnirsSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GnirsSupportTest.java
@@ -9,6 +9,7 @@ import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS;
 import edu.gemini.spModel.telescope.IssPort;
+import org.junit.Test;
 
 import static edu.gemini.spModel.gemini.altair.AltairParams.GuideStarType.LGS;
 import static edu.gemini.spModel.gemini.altair.AltairParams.GuideStarType.NGS;
@@ -22,16 +23,16 @@ public final class GnirsSupportTest extends InstrumentSupportTestBase<InstGNIRS>
         super(InstGNIRS.SP_TYPE);
     }
 
-    public void testGNIRS_DefaultPort() throws Exception {
+    @Test public void testGNIRS_DefaultPort() throws Exception {
         verifyInstrumentConfig(getNorthResults(), "GNIRS" + GNIRSSupport.GNIRS_SIDE_PORT);
     }
 
-    public void testGNIRS_SideLooking() throws Exception {
+    @Test public void testGNIRS_SideLooking() throws Exception {
         setPort(IssPort.SIDE_LOOKING);
         verifyInstrumentConfig(getNorthResults(), "GNIRS" + GNIRSSupport.GNIRS_SIDE_PORT);
     }
 
-    public void testGNIRS_UpLooking() throws Exception {
+    @Test public void testGNIRS_UpLooking() throws Exception {
         setPort(IssPort.UP_LOOKING);
         verifyInstrumentConfig(getNorthResults(), "GNIRS");
     }
@@ -51,46 +52,46 @@ public final class GnirsSupportTest extends InstrumentSupportTestBase<InstGNIRS>
         obs.addObsComponent(altair);
     }
 
-    public void testNGS2GNIRS() throws Exception {
+    @Test public void testNGS2GNIRS() throws Exception {
         // Add Altair to the observation.
         setup(AltairParams.GuideStarType.NGS);
         verifyInstrumentConfig(getNorthResults(), "AO2GNIRS" + GNIRSSupport.GNIRS_SIDE_PORT);
     }
 
-    public void testNGS2GNIRS_UpLooking() throws Exception {
+    @Test public void testNGS2GNIRS_UpLooking() throws Exception {
         setPort(IssPort.UP_LOOKING);
         // Add Altair to the observation.
         setup(AltairParams.GuideStarType.NGS);
         verifyInstrumentConfig(getNorthResults(), "AO2GNIRS");
     }
 
-    public void testLGS2GNIRS() throws Exception {
+    @Test public void testLGS2GNIRS() throws Exception {
         // Add Altair to the observation.
         setup(AltairParams.GuideStarType.LGS);
         verifyInstrumentConfig(getNorthResults(), "AO2GNIRS" + GNIRSSupport.GNIRS_SIDE_PORT);
     }
 
-    public void testLGS2GNIRS_UpLooking() throws Exception {
+    @Test public void testLGS2GNIRS_UpLooking() throws Exception {
         setPort(IssPort.UP_LOOKING);
         // Add Altair to the observation.
         setup(AltairParams.GuideStarType.LGS);
         verifyInstrumentConfig(getNorthResults(), "AO2GNIRS");
     }
 
-    public void testNoAoPointOrig() throws Exception {
+    @Test public void testNoAoPointOrig() throws Exception {
         verifyPointOrig(getSouthResults(), "gnirs");
     }
 
-    public void testLgsPointOrig() throws Exception {
+    @Test public void testLgsPointOrig() throws Exception {
         addAltair(LGS); verifyPointOrig(getSouthResults(), "lgs2gnirs");
     }
 
-    public void testLgsP1PointOrig() throws Exception {
+    @Test public void testLgsP1PointOrig() throws Exception {
         addAltair(AltairParams.Mode.LGS_P1);
         verifyPointOrig(getSouthResults(), "lgs2gnirs_p1");
     }
 
-    public void testNgsPointOrig() throws Exception {
+    @Test public void testNgsPointOrig() throws Exception {
         addAltair(NGS); verifyPointOrig(getSouthResults(), "ngs2gnirs");
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GpiSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GpiSupportTest.java
@@ -6,6 +6,9 @@ package edu.gemini.wdba.tcc;
 
 import edu.gemini.spModel.gemini.gpi.Gpi;
 
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
 /**
  * Test cases for {@link GpiSupport}.
  */
@@ -15,21 +18,21 @@ public final class GpiSupportTest extends InstrumentSupportTestBase<Gpi> {
         super(Gpi.SP_TYPE);
     }
 
-    public void testName() throws Exception {
+    @Test public void testName() throws Exception {
         Gpi gpi = getInstrument();
         setInstrument(gpi);
 
         verifyInstrumentConfig(getSouthResults(), "GPI");
     }
 
-    public void testChopState() throws Exception {
+    @Test public void testChopState() throws Exception {
         Gpi gpi = getInstrument();
         setInstrument(gpi);
 
         verifyInstrumentChopConfig(getSouthResults(), "NoChop");
     }
 
-    public void testPointOrigin() throws Exception {
+    @Test public void testPointOrigin() throws Exception {
         Gpi gpi = getInstrument();
         gpi.setAdc(Gpi.Adc.IN);
         setInstrument(gpi);
@@ -42,7 +45,7 @@ public final class GpiSupportTest extends InstrumentSupportTestBase<Gpi> {
         verifyPointOrig(getSouthResults(), "gpi");
     }
 
-    public void testWavelength() throws Exception {
+    @Test public void testWavelength() throws Exception {
         Gpi gpi = getInstrument();
         setInstrument(gpi);
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
@@ -16,6 +16,9 @@ import edu.gemini.spModel.telescope.IssPort;
 import org.dom4j.Document;
 import org.dom4j.Element;
 import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -102,34 +105,34 @@ public final class GsaoiSupportTest extends InstrumentSupportTestBase<Gsaoi> {
         verify(new Some<>(size));
     }
 
-    public void testDefaultGuideConfig() throws Exception {
+    @Test public void testDefaultGuideConfig() throws Exception {
         setTargetEnv(Canopus.Wfs.cwfs1, GsaoiOdgw.odgw1);
         verify(Gsaoi.OdgwSize.DEFAULT);
     }
 
-    public void testExplicitGuideConfig() throws Exception {
+    @Test public void testExplicitGuideConfig() throws Exception {
         setTargetEnv(Canopus.Wfs.cwfs1, GsaoiOdgw.odgw1);
         setOdgw(Gsaoi.OdgwSize.SIZE_8);
         verify(Gsaoi.OdgwSize.SIZE_8);
     }
 
-    public void testNoGsaoi() throws Exception {
+    @Test public void testNoGsaoi() throws Exception {
         setTargetEnv(Canopus.Wfs.cwfs1);
         final Option<Gsaoi.OdgwSize> none = None.instance();
         verify(none);
     }
 
-    public void testNotGems() throws Exception {
+    @Test public void testNotGems() throws Exception {
         setTargetEnv(PwfsGuideProbe.pwfs1);
         final Option<Gsaoi.OdgwSize> none = None.instance();
         verify(none);
     }
 
-    public void testPointOrig() throws Exception {
+    @Test public void testPointOrig() throws Exception {
         verifyPointOrig(getSouthResults(), "lgs2gsaoi");
     }
 
-    public void testConfig() throws Exception {
+    @Test public void testConfig() throws Exception {
         final Gsaoi gsaoi = getInstrument();
 
         gsaoi.setIssPort(IssPort.SIDE_LOOKING);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
@@ -23,6 +23,9 @@ import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import org.dom4j.Document;
 import org.dom4j.Element;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,11 +33,11 @@ import java.util.List;
 /**
  *
  */
-public class GuideConfigTest extends TestBase {
+public final class GuideConfigTest extends TestBase {
 
     private SPTarget base;
 
-    protected void setUp() throws Exception {
+    @Before public void setUp() throws Exception {
         super.setUp();
 
         base = new SPTarget();
@@ -60,61 +63,61 @@ public class GuideConfigTest extends TestBase {
         return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
     }
 
-    public void testNoGuide() throws Exception {
+    @Test public void testNoGuide() throws Exception {
         testTargetEnvironment(TccNames.NO_GUIDING, create());
     }
 
-    public void testP1() throws Exception {
+    @Test public void testP1() throws Exception {
         testTargetEnvironment(TccNames.P1, create(PwfsGuideProbe.pwfs1));
     }
 
-    public void testP2() throws Exception {
+    @Test public void testP2() throws Exception {
         testTargetEnvironment(TccNames.P2, create(PwfsGuideProbe.pwfs2));
     }
 
-    public void testP1P2() throws Exception {
+    @Test public void testP1P2() throws Exception {
         testTargetEnvironment(TccNames.P1P2, create(PwfsGuideProbe.values()));
     }
 
-    public void testOI() throws Exception {
+    @Test public void testOI() throws Exception {
         testTargetEnvironment(TccNames.OI, create(NiciOiwfsGuideProbe.instance));
     }
 
-    public void testP1OI() throws Exception {
+    @Test public void testP1OI() throws Exception {
         testTargetEnvironment(TccNames.P1OI, create(PwfsGuideProbe.pwfs1, NiciOiwfsGuideProbe.instance));
     }
 
-    public void testP2OI() throws Exception {
+    @Test public void testP2OI() throws Exception {
         testTargetEnvironment(TccNames.P2OI, create(PwfsGuideProbe.pwfs2, NiciOiwfsGuideProbe.instance));
     }
 
-    public void testGeMS() throws Exception {
+    @Test public void testGeMS() throws Exception {
         testTargetEnvironment(TccNames.GeMS, create(Canopus.Wfs.values()));
         testTargetEnvironment(TccNames.GeMS, create(Canopus.Wfs.cwfs1, Canopus.Wfs.cwfs2, GsaoiOdgw.odgw1));
     }
 
-    public void testGeMSOI() throws Exception {
+    @Test public void testGeMSOI() throws Exception {
         testTargetEnvironment(TccNames.GeMSOI, create(Canopus.Wfs.cwfs1, Flamingos2OiwfsGuideProbe.instance));
         testTargetEnvironment(TccNames.GeMSOI, create(Canopus.Wfs.cwfs1, GsaoiOdgw.odgw1, Flamingos2OiwfsGuideProbe.instance));
     }
 
-    public void testGeMSP1() throws Exception {
+    @Test public void testGeMSP1() throws Exception {
         testTargetEnvironment(TccNames.GeMSP1, create(PwfsGuideProbe.pwfs1, Canopus.Wfs.cwfs1));
     }
 
-    public void testGeMSP1OI() throws Exception {
+    @Test public void testGeMSP1OI() throws Exception {
         testTargetEnvironment(TccNames.GeMSP1OI, create(PwfsGuideProbe.pwfs1, Canopus.Wfs.cwfs1, Flamingos2OiwfsGuideProbe.instance));
     }
 
-    public void testAO() throws Exception {
+    @Test public void testAO() throws Exception {
         testTargetEnvironment(TccNames.AO, create(AltairAowfsGuider.instance));
     }
 
-    public void testAOOI() throws Exception {
+    @Test public void testAOOI() throws Exception {
         testTargetEnvironment(TccNames.AOOI, create(AltairAowfsGuider.instance, NiriOiwfsGuideProbe.instance));
     }
 
-    public void testAOP1() throws Exception {
+    @Test public void testAOP1() throws Exception {
         testTargetEnvironment(TccNames.AOP1, create(AltairAowfsGuider.instance, PwfsGuideProbe.pwfs1));
     }
 
@@ -126,22 +129,22 @@ public class GuideConfigTest extends TestBase {
         obs.addObsComponent(altairComp);
     }
 
-    public void testLGSP1() throws Exception {
+    @Test public void testLGSP1() throws Exception {
         addAltair(AltairParams.Mode.LGS_P1);
         testTargetEnvironment(TccNames.AOP1, create(PwfsGuideProbe.pwfs1));
     }
 
-    public void testLGSOI() throws Exception {
+    @Test public void testLGSOI() throws Exception {
         addAltair(AltairParams.Mode.LGS_OI);
         testTargetEnvironment(TccNames.AOOI, create(GmosOiwfsGuideProbe.instance));
     }
 
-    public void testNGSAO() throws Exception {
+    @Test public void testNGSAO() throws Exception {
         addAltair(AltairParams.Mode.NGS); // altair but no AO guide star
         testTargetEnvironment(TccNames.P1, create(PwfsGuideProbe.pwfs1));
     }
 
-    public void testAOP2() throws Exception {
+    @Test public void testAOP2() throws Exception {
         testTargetEnvironment(TccNames.AOP2, create(AltairAowfsGuider.instance, PwfsGuideProbe.pwfs2));
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
@@ -19,13 +19,17 @@ import edu.gemini.spModel.target.env.OptionsListImpl;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public final class GuideGroupTest extends TestBase {
     private SPTarget base;
 
-    protected void setUp() throws Exception {
+    @Before public void setUp() throws Exception {
         super.setUp();
 
         base = new SPTarget();
@@ -51,7 +55,7 @@ public final class GuideGroupTest extends TestBase {
         return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
     }
 
-    public void testLoneGroup() throws Exception {
+    @Test public void testLoneGroup() throws Exception {
         // Create a target environment that uses Gems canopus wfs.
         final TargetEnvironment env = TargetEnvironment.create(base);
         final ImList<GuideProbeTargets> gtCollection = createGuideTargetsList(Canopus.Wfs.cwfs1, Canopus.Wfs.cwfs2, Canopus.Wfs.cwfs3);
@@ -66,7 +70,7 @@ public final class GuideGroupTest extends TestBase {
         testTargetEnvironment("LoneGroup", env2);
     }
 
-    public void testNamedGroup() throws Exception {
+    @Test public void testNamedGroup() throws Exception {
         // Create a target environment that uses Gems canopus wfs.
         final TargetEnvironment env = TargetEnvironment.create(base);
         final ImList<GuideProbeTargets> gtCollection = createGuideTargetsList(Canopus.Wfs.cwfs1, Canopus.Wfs.cwfs2, Canopus.Wfs.cwfs3);
@@ -86,10 +90,10 @@ public final class GuideGroupTest extends TestBase {
 
     private String getGuideGroup(final Document doc) throws Exception {
         final Element tccFieldConfig = getTccFieldConfig(doc);
-        if (tccFieldConfig == null) fail("no tcc_tcs_config_file element");
+        if (tccFieldConfig == null) Assert.fail("no tcc_tcs_config_file element");
 
         final Element param = (Element) tccFieldConfig.selectSingleNode("//param[@name='guideGroup']");
-        if (param == null) fail("missing 'guideGroup' param");
+        if (param == null) Assert.fail("missing 'guideGroup' param");
         return param.attributeValue("value");
     }
 
@@ -105,7 +109,7 @@ public final class GuideGroupTest extends TestBase {
         // Get the results.
         final Document doc = getSouthResults();
 
-        assertEquals(guideGroupName, getGuideGroup(doc));
+        Assert.assertEquals(guideGroupName, getGuideGroup(doc));
     }
 
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
@@ -12,7 +12,6 @@ import edu.gemini.spModel.gemini.altair.InstAltair;
 import edu.gemini.spModel.gemini.gems.Gems;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.target.SPTarget;
-import edu.gemini.spModel.target.env.GuideEnvironment;
 import edu.gemini.spModel.target.env.GuideGroup;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
@@ -22,6 +21,8 @@ import edu.gemini.spModel.telescope.IssPortProvider;
 import edu.gemini.spModel.util.SPTreeUtil;
 import org.dom4j.Document;
 import org.dom4j.Element;
+import org.junit.Assert;
+import org.junit.Before;
 
 /**
  * Test cases for {@link edu.gemini.wdba.tcc.Flamingos2Support}.
@@ -35,7 +36,7 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
         this.instrumentType = instrumentType;
     }
 
-    protected void setUp() throws Exception {
+    @Before public void setUp() throws Exception {
         super.setUp();
 
         // Add an instrument component to the observation.
@@ -128,17 +129,17 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
 
     protected void verifyPointOrig(Document doc, String expected) throws Exception {
         String actual = getPointOrig(doc);
-        assertEquals(expected, actual);
+        Assert.assertEquals(expected, actual);
     }
 
     protected void verifyInstrumentConfig(Document doc, String expected) throws Exception {
         String actual = getInstrumentConfig(doc);
-        assertEquals("Instrument config mismatch", expected, actual);
+        Assert.assertEquals("Instrument config mismatch", expected, actual);
     }
 
     protected void verifyInstrumentChopConfig(Document doc, String expected) throws Exception {
         String actual = getInstrumentChop(doc);
-        assertEquals("Instrument chop config mismatch", expected, actual);
+        Assert.assertEquals("Instrument chop config mismatch", expected, actual);
     }
 
     protected String getWavelength(Document doc) throws Exception {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
@@ -81,7 +81,7 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
         TargetEnvironment env = getTargetEnvironment();
         GuideGroup        grp = env.getPrimaryGuideGroup();
         if (grp.isAutomatic()) {
-            grp = GuideGroup.create("Manual Group");
+            grp = GuideGroup.create(GuideGroup.ManualGroupDefaultName());
             env = env.setGuideEnvironment(env.getGuideEnvironment().setOptions(env.getGroups().append(grp))).setPrimaryGuideGroup(grp);
         }
         setTargetEnvironment(env.putPrimaryGuideProbeTargets(GuideProbeTargets.create(probe, new SPTarget())));

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/InstrumentSupportTestBase.java
@@ -10,8 +10,16 @@ import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
 import edu.gemini.spModel.gemini.gems.Gems;
+import edu.gemini.spModel.guide.GuideProbe;
+import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.GuideEnvironment;
+import edu.gemini.spModel.target.env.GuideGroup;
+import edu.gemini.spModel.target.env.GuideProbeTargets;
+import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.telescope.IssPort;
 import edu.gemini.spModel.telescope.IssPortProvider;
+import edu.gemini.spModel.util.SPTreeUtil;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
@@ -51,6 +59,31 @@ public abstract class InstrumentSupportTestBase<T extends ISPDataObject> extends
         public void store() throws Exception {
             obsComp.setDataObject(dataObject);
         }
+    }
+
+    protected TargetEnvironment getTargetEnvironment() {
+        final ISPObsComponent oc = SPTreeUtil.findTargetEnvNode(obs);
+        @SuppressWarnings("ConstantConditions")
+        final TargetObsComp toc  = (TargetObsComp) oc.getDataObject();
+        return toc.getTargetEnvironment();
+    }
+
+    protected void setTargetEnvironment(TargetEnvironment env) {
+        final ISPObsComponent oc = SPTreeUtil.findTargetEnvNode(obs);
+        @SuppressWarnings("ConstantConditions")
+        final TargetObsComp toc  = (TargetObsComp) oc.getDataObject();
+        toc.setTargetEnvironment(env);
+        oc.setDataObject(toc);
+    }
+
+    protected void addGuideStar(GuideProbe probe) {
+        TargetEnvironment env = getTargetEnvironment();
+        GuideGroup        grp = env.getPrimaryGuideGroup();
+        if (grp.isAutomatic()) {
+            grp = GuideGroup.create("Manual Group");
+            env = env.setGuideEnvironment(env.getGuideEnvironment().setOptions(env.getGroups().append(grp))).setPrimaryGuideGroup(grp);
+        }
+        setTargetEnvironment(env.putPrimaryGuideProbeTargets(GuideProbeTargets.create(probe, new SPTarget())));
     }
 
     protected ObsComponentPair<InstAltair> addAltair() throws Exception {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/NiciSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/NiciSupportTest.java
@@ -7,6 +7,8 @@ package edu.gemini.wdba.tcc;
 import edu.gemini.spModel.gemini.nici.InstNICI;
 import edu.gemini.spModel.telescope.IssPort;
 
+import org.junit.Test;
+
 /**
  * Test cases for {@link edu.gemini.wdba.tcc.Flamingos2Support}.
  */
@@ -16,7 +18,7 @@ public final class NiciSupportTest extends InstrumentSupportTestBase<InstNICI> {
         super(InstNICI.SP_TYPE);
     }
 
-    public void testNICI5() throws Exception {
+    @Test public void testNICI5() throws Exception {
         InstNICI nici = getInstrument();
         nici.setIssPort(IssPort.SIDE_LOOKING);
         setInstrument(nici);
@@ -24,7 +26,7 @@ public final class NiciSupportTest extends InstrumentSupportTestBase<InstNICI> {
         verifyInstrumentConfig(getSouthResults(), "NICI5");
     }
 
-    public void testNICI1() throws Exception {
+    @Test public void testNICI1() throws Exception {
         InstNICI nici = getInstrument();
         nici.setIssPort(IssPort.UP_LOOKING);
         setInstrument(nici);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/NifsSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/NifsSupportTest.java
@@ -6,6 +6,7 @@ import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.nifs.InstNIFS;
 import edu.gemini.spModel.gemini.nifs.NIFSParams;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test cases for NIFS instrument support.

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/RotatorConfigTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/RotatorConfigTest.java
@@ -16,6 +16,9 @@ import edu.gemini.spModel.gemini.niri.InstNIRI;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
+import static org.junit.Assert.*;
+import org.junit.Test;
+
 import java.util.List;
 
 /**
@@ -149,7 +152,7 @@ public class RotatorConfigTest extends TestBase {
 
     }
 
-    public void testPosAngle() throws Exception {
+    @Test public void testPosAngle() throws Exception {
         InstGmosSouth gmos = addGmos();
         gmos.setPosAngle(10.5);
         instObsComp.setDataObject(gmos);
@@ -163,7 +166,7 @@ public class RotatorConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testAltairPosAngle() throws Exception {
+    @Test public void testAltairPosAngle() throws Exception {
         InstNIRI niri = addNiri();
         niri.setPosAngle(10.5);
         instObsComp.setDataObject(niri);
@@ -180,7 +183,7 @@ public class RotatorConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testAltairFixed() throws Exception {
+    @Test public void testAltairFixed() throws Exception {
         InstNIRI niri = addNiri();
         niri.setPosAngle(10.5);
         instObsComp.setDataObject(niri);
@@ -195,7 +198,7 @@ public class RotatorConfigTest extends TestBase {
         assertEquals(0, getTccFieldContainedParamSet(res, "rotator").size());
     }
 
-    public void testNiciFixed() throws Exception {
+    @Test public void testNiciFixed() throws Exception {
         InstNICI nici = addNici();
         nici.setPosAngle(10.5);
         nici.setCassRotator(NICIParams.CassRotator.FIXED);
@@ -210,7 +213,7 @@ public class RotatorConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testNiciPosAngle() throws Exception {
+    @Test public void testNiciPosAngle() throws Exception {
         InstNICI nici = addNici();
         nici.setCassRotator(NICIParams.CassRotator.FOLLOW);
         nici.setPosAngle(10.5);
@@ -225,7 +228,7 @@ public class RotatorConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testGpiFixed() throws Exception {
+    @Test public void testGpiFixed() throws Exception {
         Gpi gpi = addGpi();
         instObsComp.setDataObject(gpi);
 
@@ -238,7 +241,7 @@ public class RotatorConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testGpiPosAngle0() throws Exception {
+    @Test public void testGpiPosAngle0() throws Exception {
         Gpi gpi = addGpi();
         gpi.setPosAngle(0);
         instObsComp.setDataObject(gpi);
@@ -252,7 +255,7 @@ public class RotatorConfigTest extends TestBase {
         val.validate();
     }
 
-    public void testGpiPosAngle180() throws Exception {
+    @Test public void testGpiPosAngle180() throws Exception {
         Gpi gpi = addGpi();
         gpi.setPosAngle(180);
         instObsComp.setDataObject(gpi);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -20,6 +20,10 @@ import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 import java.util.*;
 
 /**
@@ -38,7 +42,7 @@ public final class TargetGroupTest extends TestBase {
     private NameMap nameMap;
     private SPTarget base, pwfs1_1, pwfs1_2, pwfs2_1, pwfs2_2;
 
-    protected void setUp() throws Exception {
+    @Before public void setUp() throws Exception {
         super.setUp();
         nameMap = new NameMap();
 
@@ -59,7 +63,7 @@ public final class TargetGroupTest extends TestBase {
     /**
      * Single unamed base position.
      */
-    public void testUnamedBase() throws Exception {
+    @Test public void testUnamedBase() throws Exception {
         final SPTarget base = new SPTarget();
         base.setName("");
         nameMap.putTargetName(base, TccNames.BASE);
@@ -69,14 +73,14 @@ public final class TargetGroupTest extends TestBase {
     /**
      * Single unamed base position.
      */
-    public void testNamedBase() throws Exception {
+    @Test public void testNamedBase() throws Exception {
         testTargetEnvironment(TargetEnvironment.create(base));
     }
 
     /**
      * An unamed base and user target.
      */
-    public void testUnamedBaseAndUser() throws Exception {
+    @Test public void testUnamedBaseAndUser() throws Exception {
         final SPTarget base = new SPTarget(); base.setName("");
         final SPTarget user = new SPTarget(); user.setName("");
         final ImList<SPTarget> userTargets = ImCollections.singletonList(user);
@@ -100,35 +104,35 @@ public final class TargetGroupTest extends TestBase {
     /**
      * A base position and single guide target for single guider.
      */
-    public void testSingleGuideTargetSingleGuider() throws Exception {
+    @Test public void testSingleGuideTargetSingleGuider() throws Exception {
         testSingleGuider(pwfs2_1);
     }
 
     /**
      * A base position and multiple guide targets for a single guider.
      */
-    public void testMultipleGuideTargetsSingleGuider() throws Exception {
+    @Test public void testMultipleGuideTargetsSingleGuider() throws Exception {
         testSingleGuider(pwfs2_1, pwfs2_2);
     }
 
     /**
      * Using the second guide star as the primary wfs star.
      */
-    public void testNonDefaultPrimary() throws Exception {
+    @Test public void testNonDefaultPrimary() throws Exception {
         testSingleGuider(pwfs2_1, pwfs2_2);
     }
 
     /**
      * Having no primary guide star.
      */
-    public void testNoExplicitPrimary() throws Exception {
+    @Test public void testNoExplicitPrimary() throws Exception {
         testSingleGuider(pwfs2_1, pwfs2_2);
     }
 
     /**
      * Disabled guide targets.
      */
-    public void testDisabledGuideTargets() throws Exception {
+    @Test public void testDisabledGuideTargets() throws Exception {
 
         // Add a GMOS-S component so that the guider is available.
         final ISPObsComponent gmosComp = odb.getFactory().createObsComponent(prog, InstGmosSouth.SP_TYPE, null);
@@ -150,7 +154,7 @@ public final class TargetGroupTest extends TestBase {
         testTargetEnvironment(env);
     }
 
-    public void testMultipleGuiders() throws Exception {
+    @Test public void testMultipleGuiders() throws Exception {
         // Create the target environment with multiple guiders.
         final ImList<SPTarget> targetList1 = DefaultImList.create(pwfs1_1, pwfs1_2);
         final GuideProbeTargets pwfs1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, targetList1);
@@ -162,7 +166,7 @@ public final class TargetGroupTest extends TestBase {
         testTargetEnvironment(env);
     }
 
-    public void testNoPrimary() throws Exception {
+    @Test public void testNoPrimary() throws Exception {
         // Create the target environment with multiple guiders.
         final ImList<SPTarget> targetList1 = DefaultImList.create(pwfs1_1, pwfs1_2);
         final GuideProbeTargets pwfs1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, targetList1);
@@ -174,7 +178,7 @@ public final class TargetGroupTest extends TestBase {
         testTargetEnvironment(env);
     }
 
-    public void testOiwfsMapping() throws Exception {
+    @Test public void testOiwfsMapping() throws Exception {
         // Create a target environment that uses an instrument OIWFS.
         final SPTarget oiwfsTarget = new SPTarget(); oiwfsTarget.setName("");
 
@@ -195,7 +199,7 @@ public final class TargetGroupTest extends TestBase {
         testTargetEnvironment(env);
     }
 
-    public void testGsaoiOdgwMapping() throws Exception {
+    @Test public void testGsaoiOdgwMapping() throws Exception {
         // Create a target environment that uses an instrument OIWFS.
         final SPTarget odgwTarget = new SPTarget(); odgwTarget.setName("");
 
@@ -216,7 +220,7 @@ public final class TargetGroupTest extends TestBase {
         testTargetEnvironment(env);
     }
 
-    public void testAowfsMapping() throws Exception {
+    @Test public void testAowfsMapping() throws Exception {
         // Create a target environment that uses the altair AOWFS.
         final SPTarget aowfsTarget = new SPTarget(); aowfsTarget.setName("");
 
@@ -237,7 +241,7 @@ public final class TargetGroupTest extends TestBase {
         testTargetEnvironment(env);
     }
 
-    public void testGemsMapping() throws Exception {
+    @Test public void testGemsMapping() throws Exception {
         // Create a target environment that uses Gems canopus wfs.
         final SPTarget cwfsTarget = new SPTarget(); cwfsTarget.setName("");
 
@@ -259,7 +263,7 @@ public final class TargetGroupTest extends TestBase {
     }
 
 
-    public void testDefaultGroupName() throws Exception {
+    @Test public void testDefaultGroupName() throws Exception {
         final ImList<SPTarget> targetList1 = ImCollections.singletonList(pwfs1_1);
         final GuideProbeTargets gpt_pwfs1_1 = GuideProbeTargets.create(PwfsGuideProbe.pwfs1, targetList1);
         final ImList<GuideProbeTargets> gpt1 = ImCollections.singletonList(gpt_pwfs1_1);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetMagnitudeTest.java
@@ -14,6 +14,10 @@ import org.dom4j.Document;
 import org.dom4j.Element;
 import scala.collection.JavaConversions$;
 
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 import java.util.*;
 
 /**
@@ -26,7 +30,7 @@ public final class TargetMagnitudeTest extends TestBase {
     private SPTarget pwfs1_1;
     private TargetEnvironment env;
 
-    protected void setUp() throws Exception {
+    @Before public void setUp() throws Exception {
         super.setUp();
 
         final SPTarget base = new SPTarget();
@@ -40,23 +44,23 @@ public final class TargetMagnitudeTest extends TestBase {
         env = TargetEnvironment.create(base).setPrimaryGuideGroup(grp);
     }
 
-    public void testNoMagnitudeInfo() throws Exception {
+    @Test public void testNoMagnitudeInfo() throws Exception {
         testTargetEnvironment(env);
     }
 
-    public void testOneMagnitude() throws Exception {
+    @Test public void testOneMagnitude() throws Exception {
         pwfs1_1.putMagnitude(new Magnitude(10, MagnitudeBand.J$.MODULE$));
         testTargetEnvironment(env);
     }
 
-    public void testNonSiderealMagnitude() throws Exception {
+    @Test public void testNonSiderealMagnitude() throws Exception {
         pwfs1_1.putMagnitude(new Magnitude(10, MagnitudeBand.J$.MODULE$));
         pwfs1_1.setNonSidereal();
         pwfs1_1.setName("PWFS1-1");
         testTargetEnvironment(env);
     }
 
-    public void testTwoMagnitudes() throws Exception {
+    @Test public void testTwoMagnitudes() throws Exception {
         pwfs1_1.putMagnitude(new Magnitude(10, MagnitudeBand.J$.MODULE$));
         pwfs1_1.putMagnitude(new Magnitude(10, MagnitudeBand.K$.MODULE$));
         testTargetEnvironment(env);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TestBase.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TestBase.java
@@ -16,10 +16,11 @@ import edu.gemini.wdba.glue.WdbaGlueService;
 import edu.gemini.wdba.glue.api.WdbaContext;
 import edu.gemini.wdba.glue.api.WdbaDatabaseAccessService;
 import edu.gemini.wdba.xmlrpc.ITccXmlRpc;
-import junit.framework.TestCase;
 import org.dom4j.Document;
 import org.dom4j.Element;
 import org.dom4j.io.SAXReader;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -36,7 +37,7 @@ import java.util.*;
  * <b>The property <code>HLPG_PROJECT_BASE</code> must be set to OCS
  * installation dir.</b>
  */
-public abstract class TestBase extends TestCase {
+public abstract class TestBase /*extends TestCase*/ {
 
     protected IDBDatabaseService odb;
 
@@ -52,7 +53,7 @@ public abstract class TestBase extends TestCase {
     final Set<Principal> user = Collections.<Principal>singleton(StaffPrincipal.Gemini());
 
     @SuppressWarnings({"ResultOfMethodCallIgnored"})
-    protected void setUp() throws Exception {
+    @Before public void setUp() throws Exception {
         odb = DBLocalDatabase.createTransient();
 
         progId  = SPProgramID.toProgramID("GS-2009B-Q-1");
@@ -67,7 +68,7 @@ public abstract class TestBase extends TestCase {
         databaseAccessService = new WdbaGlueService(odb, user);
     }
 
-    protected void tearDown() throws Exception {
+    @After public void tearDown() throws Exception {
         odb.getDBAdmin().shutdown();
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/VisitorInstrumentSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/VisitorInstrumentSupportTest.java
@@ -6,6 +6,9 @@ package edu.gemini.wdba.tcc;
 
 import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
 
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
 /**
  * Test cases for {@link edu.gemini.wdba.tcc.VisitorInstrumentSupport}.
  */
@@ -15,28 +18,28 @@ public final class VisitorInstrumentSupportTest extends InstrumentSupportTestBas
         super(VisitorInstrument.SP_TYPE);
     }
 
-    public void testName() throws Exception {
+    @Test public void testName() throws Exception {
         VisitorInstrument visitor = getInstrument();
         setInstrument(visitor);
 
         verifyInstrumentConfig(getSouthResults(), "VISITOR");
     }
 
-    public void testChopState() throws Exception {
+    @Test public void testChopState() throws Exception {
         VisitorInstrument visitor = getInstrument();
         setInstrument(visitor);
 
         verifyInstrumentChopConfig(getSouthResults(), "NoChop");
     }
 
-    public void testPointOrigin() throws Exception {
+    @Test public void testPointOrigin() throws Exception {
         VisitorInstrument visitor = getInstrument();
         setInstrument(visitor);
 
         verifyPointOrig(getSouthResults(), "visitor");
     }
 
-    public void testWavelength() throws Exception {
+    @Test public void testWavelength() throws Exception {
         VisitorInstrument visitor = getInstrument();
         setInstrument(visitor);
 


### PR DESCRIPTION
This PR updates WDBA GMOS support to add new pointing origin and instrument types for GMOS-N + Altair.  The changes are relatively simple despite the size of the diff.  The meat of the change is in `GMOSSupport` in the `getTccConfigInstrument` and `getTccConfigInstrumentOrigin` methods.  For the most part the rest is code cleanup and updating test cases.  It also renames `GuideConfigSouth` to just `GuideConfig` since in reality it is used for both sites.

The WDBA is arguably the worst remaining code in the OCS, though the sequence model vies for that title.  This PR doesn't do much to improve the situation unfortunately. It does however introduce an important change to the way that we determine whether a given guide probe is "used" in a target environment.  Instead of just having associated targets for a guide probe, there now must be an _active_ target for the probe.  In addition to being necessary to implement REL-2518 correctly, this fixes REL-2789 in passing.