### PR TITLE
REL-2788: simplify default strategy calculation

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsRegistrar.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsRegistrar.scala
@@ -20,32 +20,8 @@ object AgsRegistrar {
   /**
    * Determines the default or best strategy for the given observation.
    */
-  def defaultStrategy(ctx: ObsContext): Option[AgsStrategy] = {
-    // Figure out which guide probes we're using, preferring those we mark as
-    // selected (i.e., with a primary target)
-    val guideEnv   = ctx.getTargets.getGuideEnvironment
-    val ref0       = guideEnv.getPrimaryReferencedGuiders
-    val referenced = (if (ref0.isEmpty) guideEnv.getReferencedGuiders else ref0).asScala
-
-    // Determine how many referenced guiders in the context are assigned by the
-    // given strategy.
-    def incidence(s: AgsStrategy): Int = (referenced & s.guideProbes.toSet).size
-
-    // Get the first strategy with the highest overlap between referenced
-    // guiders and guiders assigned by the strategy.  It's important to preserve
-    // order in this search because the valid strategies are returned in ranked
-    // order of preference.
-    AgsRegistrar.validStrategies(ctx) match {
-      case Nil    =>
-        None
-      case h :: t =>
-        val (highestIncidence, _) = ((h, incidence(h))/:t) { case ((s0, i0), s1) =>
-          val i1 = incidence(s1)
-          if (i0 >= i1) (s0, i0) else (s1, i1)
-        }
-        Some(highestIncidence)
-    }
-  }
+  def defaultStrategy(ctx: ObsContext): Option[AgsStrategy] =
+    validStrategies(ctx).headOption
 
   /**
    * Obtains the user's preference, if any, to override the default strategy

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/AgsStrategyCombo.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/AgsStrategyCombo.java
@@ -61,7 +61,7 @@ public final class AgsStrategyCombo extends AgsSelectorControl implements Action
         final ImList<ComboEntry> validEntries = opts.validStrategies.map(agsStrategy -> new ComboEntry(agsStrategy.key().displayName(), new Some<>(agsStrategy)));
 
         final Option<ComboEntry> defaultEntry = opts.defaultStrategy.map(agsStrategy -> {
-            final String name = String.format("Auto (%s)", agsStrategy.key().displayName());
+            final String name = String.format("Default (%s)", agsStrategy.key().displayName());
             return new ComboEntry(name, None.instance());
         });
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/GuidingControls.scala
@@ -10,7 +10,7 @@ class GuidingControls extends GridBagPanel {
   opaque = false
 
   private object guiderLabel extends Label {
-    text                = "Guide with:"
+    text                = "Auto Guide Search:"
     horizontalAlignment = Alignment.Right
     opaque              = false
   }


### PR DESCRIPTION
The AGS registrar provides a method to obtain the valid strategies for a given observation, ranked in order of preference.  It also provides a method to obtain the "default" strategy for the observation.  Rather than simply picking the first (if any) ranked valid strategy, the code was performing a convoluted calculation involving the number of guide probes already selected in the observation.  Unfortunately I can't remember why this was done but it is, naturally, picking the wrong default strategy for simple cases. I believe that the separation of Auto/Manual groups makes the previous method obsolete.

In addition to simplifying the default strategy calculation, I updated a couple of labels as requested/approved by Bryan. 

