### PR TITLE
REL-2098: Update GeMS phase-2 checks to ignore daytime calibrations

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gsaoi/GsaoiRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gsaoi/GsaoiRule.java
@@ -1,5 +1,3 @@
-//$Id: NiriRule.java 8208 2007-11-15 18:44:43Z anunez $
-
 package edu.gemini.p2checker.rules.gsaoi;
 
 import edu.gemini.p2checker.api.*;
@@ -12,13 +10,12 @@ import edu.gemini.spModel.gemini.gsaoi.Gsaoi;
 import java.util.ArrayList;
 import java.util.Collection;
 
-
 /**
  *  GSAOI Rule set
  */
 public class GsaoiRule implements IRule {
     private static final String PREFIX = "GsaoiRule_";
-    private static final Collection<IConfigRule> GSAOI_RULES = new ArrayList<IConfigRule>();
+    private static final Collection<IConfigRule> GSAOI_RULES = new ArrayList<>();
 
     private static IConfigRule SHORT_EXPOSURE_TIME_RULE = new IConfigRule() {
 
@@ -26,10 +23,6 @@ public class GsaoiRule implements IRule {
                 "Exposure time (%.1f sec) is shorter than the minimum (%.1f sec) for read mode '%s'";
 
         public Problem check(Config config, int step, ObservationElements elems, Object state) {
-            // Only apply this rule for science observations?
-//            String type = SequenceRule.getObserveType(config);
-//            if ((type != null) && !type.equals(InstConstants.SCIENCE_OBSERVE_TYPE)) return null;
-
             Double expTime = SequenceRule.getExposureTime(config);
             if (expTime == null) return null;
 
@@ -40,7 +33,7 @@ public class GsaoiRule implements IRule {
 
             if (expTime < minTime) {
                 String msg = String.format(MESSAGE, expTime, minTime, readMode.displayValue());
-                return new Problem(ERROR, PREFIX+"SHORT_EXPOSURE_TIME_RULE", msg, SequenceRule.getInstrumentOrSequenceNode(step, elems, config));
+                return new Problem(ERROR, PREFIX + "SHORT_EXPOSURE_TIME_RULE", msg, SequenceRule.getInstrumentOrSequenceNode(step, elems, config));
             }
 
             return null;
@@ -68,7 +61,7 @@ public class GsaoiRule implements IRule {
 
             if (expTime > maxTime) {
                 String msg = String.format(MESSAGE, expTime, filter.logValue(), maxTime);
-                return new Problem(WARNING, PREFIX+"LONG_EXPOSURE_TIME_RULE", msg, SequenceRule.getInstrumentOrSequenceNode(step, elems, config));
+                return new Problem(WARNING, PREFIX + "LONG_EXPOSURE_TIME_RULE", msg, SequenceRule.getInstrumentOrSequenceNode(step, elems, config));
             }
             return null;
         }
@@ -78,7 +71,7 @@ public class GsaoiRule implements IRule {
         }
     };
 
-    /**
+    /*
      * Register all the GSAOI rules to apply
      */
     static {

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/ags/AgsAnalysisRule.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/ags/AgsAnalysisRule.scala
@@ -34,7 +34,7 @@ class AgsAnalysisRule(mt: MagnitudeTable) extends IRule {
             h <- analysis
             if (h match {
               case AgsAnalysis.NoGuideStarForGroup(group, _) => !ignoredProbeGroups.contains(group)
-              case _ => true
+              case _                                         => true
             })
             s <- severity(h)
           } problems.append(new Problem(s, Prefix + "StrategyRule", h.message(withProbe = true), targetNode))

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsClassService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsClassService.java
@@ -1,7 +1,3 @@
-//
-// $Id: ObsClassService.java 46768 2012-07-16 18:58:53Z rnorris $
-//
-
 package edu.gemini.spModel.obs;
 
 import edu.gemini.pot.sp.ISPObservation;
@@ -10,8 +6,6 @@ import edu.gemini.spModel.config.map.ConfigValMapInstances;
 import edu.gemini.spModel.config2.ConfigSequence;
 import edu.gemini.spModel.config2.ItemKey;
 import edu.gemini.spModel.obsclass.ObsClass;
-
-
 
 /**
  * A service used to determine the observing class for an observation.


### PR DESCRIPTION
This PR checks the obs class to disable some of the phase2 checks for GSAOI