### PR TITLE
REL-2748 reinit target table

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -415,8 +415,10 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         numberFormatter.setMaximumFractionDigits(2);
         numberFormatter.setMaximumIntegerDigits(3);
         _w.schedulingBlock.init(this, site, numberFormatter, () -> {
-            final TargetEnvironment env1 = getDataObject().getTargetEnvironment();
+            final TargetObsComp     toc  = getDataObject();
+            final TargetEnvironment env1 = toc.getTargetEnvironment();
             updateTargetDetails(env1);
+            _w.positionTable.reinit(toc, false);
         });
 
         updateTargetDetails(newTOC.getTargetEnvironment());


### PR DESCRIPTION
The target table wasn't being updated when the scheduling block changed. This PR fixes that.