### PR TITLE
REL-2793: Select base target when first viewing Target node

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -1137,16 +1137,17 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
      * Selects the relevant row in the table.
      */
     private void _setSelectedRow(final int index) {
-        if ((index < 0) || (index >= getRowCount())) return;
-        getSelectionModel().setSelectionInterval(index, index);
+        if ((index < 0) || (index >= getRowCount())) {
+            getSelectionModel().setSelectionInterval(0, 0);
+        } else {
+            getSelectionModel().setSelectionInterval(index, index);
+        }
     }
 
     void setIgnoreSelection(boolean ignore) {
         _ignoreSelection = ignore;
     }
 
-    /**
-     */
     public String toString() {
         final String head = getClass().getName() + "[\n";
         String body = "";


### PR DESCRIPTION
This PR fixes a bad UI interaction caused by ignoring the case when the index of the item selected on the target environment has no meaning for another observation. The fix will select the first item (Typically Base) instead of ignoring it