### PR TITLE
REL-2724:  BagsManager Refactor

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
@@ -667,7 +667,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
 
             // If there was an old root, clean up
             if (getRoot() != null) {
-                BagsManager.instance().unwatch(getRoot());
+                BagsManager.unwatch(getRoot());
                 getDatabase().checkpoint();
                 getRoot().removePropertyChangeListener(ISPProgram.DATA_OBJECT_KEY, authListener);
                 updateEngToolWindow(null);
@@ -711,7 +711,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
                 if (getRoot() != null && OTOptions.isCheckingEngineEnabled()) {
                     _checker.check(getRoot(), getTree(), OT.getMagnitudeTable());
                 }
-                BagsManager.instance().watch(getRoot());
+                BagsManager.watch(getRoot());
             }
 
             // Finally, update title and actions
@@ -876,7 +876,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
             return;
         }
         if (p != null) {
-            BagsManager.instance().unwatch(p);
+            BagsManager.unwatch(p);
             treeSnapshots.remove(p.getNodeKey());
         }
         tryNavigate(_history.delete());
@@ -884,7 +884,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
 
     public void closeProgram(ISPProgram node) {
         if (node != null) {
-            BagsManager.instance().unwatch(node);
+            BagsManager.unwatch(node);
             treeSnapshots.remove(node.getNodeKey());
         }
         tryNavigate(_history.delete(node));
@@ -893,7 +893,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
     /** Close the current viewer window, but don't exit the application, even if it is the last window. */
     private void closeViewer() {
         if (getRoot() != null) {
-            BagsManager.instance().unwatch(getRoot());
+            BagsManager.unwatch(getRoot());
         }
 
         tryNavigate(_history.empty());


### PR DESCRIPTION
There were a few issues with the `BagsManager` that I found hard to solve by tweaking the existing version.  In particular:

1. When the `BagsManager` determines that an observation is not eligible for BAGS, it clears the `Auto` guide group.  It does not however remove the `AgsHash` value which is used to determine whether anything going into the AGS computation has changed.  If the observation should later become eligible again (say due to an observation class change) a new lookup is not performed. 

2. The above also applies when an AGS lookup fails, say due to a network issue.  The hash value is updated before we know whether the lookup will ultimately be successful.  By the time we try again we've stored the hash value and draw the conclusion that there is nothing to do.

3. The cache of AGS hashes is being manipulated in multiple threads without synchronization.

My naive attempt to fix these issues lead to deadlock on testing.  I don't think I'm capable of fixing it within the existing design so this PR introduces a rather radical reworking of the `BagsManger` for discussion.  It solves these issues by transforming `BagsManager` into an explicit state machine.  All state transitions run in the Swing event thread.  Only a timer wake up and the actual AGS search are performed in separate threads.  It's still a bit more complex than I'd like but to my mind at least it is an improvement.  On the other hand it is late in the dev cycle for such a big change.  Discuss.
