### PR TITLE
REL-2658: Java exception closing OT with multiple windows open

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewer.java
@@ -923,7 +923,7 @@ public final class SPViewer extends SPViewerGUI implements PropertyChangeListene
         if (!shouldClose(allPrograms())) {
             return;
         }
-        _orderedInstances.forEach(SPViewer::closeViewer);
+        instances().forEach(SPViewer::closeViewer);
 
         // TODO: Potentially there are still plugins an other parts of the application open.
         System.exit(0);


### PR DESCRIPTION
An exception can be produced when closing the OT and having multiple SPViewer instances. This PR replaces the list with `CopyOnWriteArrayList` which is safer for concurrent modification