### PR TITLE
REL-2799: update hash value if altair mode differs

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
@@ -3,6 +3,7 @@ package edu.gemini.ags.api
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.shared.util.immutable.{Option => GemOption}
 import edu.gemini.spModel.ags.AgsStrategyKey
+import edu.gemini.spModel.gemini.altair.InstAltair
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gmos.{InstGmosNorth, InstGmosSouth}
 import edu.gemini.spModel.obs.context.ObsContext
@@ -128,6 +129,13 @@ object AgsHash {
         }
 
       case _                             =>
+    }
+
+    // Altair mode, which impacts not only the strategy but also the
+    // magnitude limits.
+    ctx.getAOComponent.asScalaOpt.foreach {
+      case a: InstAltair => a.getMode.## +=: buf
+      case _             =>
     }
 
     M3.orderedHash(buf)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
@@ -6,6 +6,7 @@ import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.skycalc.{Offset => SkyCalcOffset}
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.core.{Site, Declination, Angle}
+import edu.gemini.spModel.gemini.altair.{AltairParams, InstAltair}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gems.Gems
 import edu.gemini.spModel.gemini.gmos.{GmosCommonType, InstGmosSouth, GmosSouthType, GmosNorthType, InstGmosNorth}
@@ -253,6 +254,18 @@ class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.
         val ctx2 = ctx1.withInstrument(g)
 
         hashDiffers(ctx1, ctx2)
+      }
+
+    "differ if Altair mode differs" in
+      forAll { (ctx: ObsContext, gmosN: InstGmosNorth, altair1: InstAltair, mode2: AltairParams.Mode) =>
+        val ctx1    = ctx.withInstrument(gmosN).withAOComponent(altair1)
+        val mode1   = altair1.getMode
+
+        val altair2 = altair1.clone.asInstanceOf[InstAltair]
+        altair2.setMode(mode2)
+        val ctx2    = ctx1.withAOComponent(altair2)
+
+        (mode1 == mode2) == hashSame(ctx1, ctx2)
       }
   }
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/test/SpModelArbitraries.scala
@@ -7,6 +7,7 @@ import edu.gemini.skycalc.{Offset => SkyCalcOffset}
 import edu.gemini.spModel.ags.AgsStrategyKey
 import edu.gemini.spModel.core.{OffsetQ, OffsetP, Offset, Angle, Arbitraries}
 import edu.gemini.spModel.core.AngleSyntax._
+import edu.gemini.spModel.gemini.altair.{AltairParams, InstAltair}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.FPUnitMode._
 import edu.gemini.spModel.gemini.gmos.{GmosCommonType, GmosSouthType, InstGmosSouth, GmosNorthType, InstGmosNorth}
@@ -32,6 +33,17 @@ trait SpModelArbitraries extends Arbitraries with edu.gemini.spModel.target.env.
   // TODO: Eventually all instruments should be included and all instrument
   // TODO: features as well.  They should probably also be broken out into
   // TODO: individual Arbitraries.
+
+  implicit val arbAltairMode: Arbitrary[AltairParams.Mode] =
+    Arbitrary { Gen.oneOf(AltairParams.Mode.values) }
+
+  implicit val arbAltair: Arbitrary[InstAltair] =
+    Arbitrary {
+      arbitrary[AltairParams.Mode].map { mode =>
+        new InstAltair <|
+          (_.setMode(mode))
+      }
+    }
 
   implicit val arbFlamingos2Fpu: Arbitrary[Flamingos2.FPUnit] =
     Arbitrary { Gen.oneOf(Flamingos2.FPUnit.values) }


### PR DESCRIPTION
The AGS hash algorithm is missing a component for the Altair mode.  The mode impacts not only the default `AgsStrategy`, which already is taken into consideration, but also the magnitude limits for the catalog search.

The bug reported in this task happens because the initial Altair mode is NGS, which has different magnitude limits than when in LGS mode despite using the same AOWFS probe.   An initial search is performed with the NGS limits but later when the mode is switched to LGS the hash value computes the same because the AGS strategy is the same.