### PR TITLE
REL-2794: Fix target morphing

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -417,8 +417,11 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         numberFormatter.setMaximumFractionDigits(2);
         numberFormatter.setMaximumIntegerDigits(3);
         _w.schedulingBlock.init(this, site, numberFormatter, () -> {
-                final TargetEnvironment env1 = getDataObject().getTargetEnvironment();
-                updateTargetDetails(env1);
+            final TargetObsComp toc      = getDataObject();
+            final TargetEnvironment env1 = toc.getTargetEnvironment();
+            updateTargetDetails(env1);
+            _w.positionTable.reinit(toc, false);
+
         });
 
         updateTargetDetails(newTOC.getTargetEnvironment());


### PR DESCRIPTION
There was an issue as described in REL-2794 where attempting to morph one target into another type in the target editor was causing issues and not behaving properly: targets were being added to the Auto group, which is incorrect.

This fixes that by moving targets correctly now: auto targets are unmorphable, and guide probe targets remain in their manual group when morphed. User targets are removed and placed in the first manual group, or if there is no first manual group, then one is created.