### PR TITLE
REL-2786 fix PA calculation for zero-duration obs

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -57,7 +57,11 @@ object ObsTargetCalculatorService {
       // If the duration is going to be smaller than the default step size of 30 seconds used by the
       // target calc, we will have divide by 0 issues, so take this into account.
       val stepSize = if (duration >= TimeUtils.seconds(30)) TimeUtils.seconds(30) else duration
-      TargetCalculator(s, st, Interval(b.start, end), stepSize)
+      if (end > b.start) {
+        TargetCalculator(s, st, Interval(b.start, end), stepSize)
+      } else {
+        TargetCalculator(s, st, b.start)
+      }
     }
 
     for {


### PR DESCRIPTION
The average PA calculation was blowing up for observations with no scheduling block duration or remaining plan time. This forces the duration to be 1ms for the purposes of computing the PA.