### PR TITLE
REL-2792: skip header parsing

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
@@ -150,6 +150,26 @@ public class CgiReplyBuilder {
     }
 
     /**
+     * Builds a <code>HorizonsReply</code> of the given type, assuming the
+     * stream contains valid ephemeris data.  This method is like buildResponse
+     * but it skips the header parsing and uses the given reply type directly.
+     *
+     * @return results from the CGI query
+     */
+    public static HorizonsReply readEphemeris(InputStream stream, HorizonsReply.ReplyType replyType, String charset) throws HorizonsException {
+        final HorizonsReply reply = new HorizonsReply();
+        reply.setReplyType(replyType);
+
+        try {
+            _buildEphemeris(_readFully(new InputStreamReader(stream, charset)), reply);
+        } catch (IOException ex) {
+            throw HorizonsException.create("Exception reading data from Server", ex);
+        }
+
+        return reply;
+    }
+
+    /**
      * Process the header in the CGI reply. The header defines the content type of the
      * reply, mostly
      *

--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -1,5 +1,7 @@
 package edu.gemini.horizons.server.backend
 
+import edu.gemini.spModel.core.HorizonsDesignation.{MajorBody, AsteroidOldStyle, AsteroidNewStyle, Comet}
+
 import java.util.logging.{Level, Logger}
 
 import edu.gemini.spModel.core._
@@ -160,8 +162,15 @@ object HorizonsService2 {
         TIME_DIGITS      -> FRACTIONAL_SEC
       )
 
+    val replyType = target match {
+      case Comet(des)            => HorizonsReply.ReplyType.COMET
+      case AsteroidNewStyle(des) => HorizonsReply.ReplyType.MINOR_OBJECT
+      case AsteroidOldStyle(num) => HorizonsReply.ReplyType.MINOR_OBJECT
+      case MajorBody(num)        => HorizonsReply.ReplyType.MAJOR_PLANET
+    }
+
     def buildEphemeris(m: GetMethod): IO[Long ==>> E]  =
-      IO(CgiReplyBuilder.buildResponse(m.getResponseBodyAsStream, m.getRequestCharSet)).map(toEphemeris)
+      IO(CgiReplyBuilder.readEphemeris(m.getResponseBodyAsStream, replyType, m.getRequestCharSet)).map(toEphemeris)
 
     // And finally
     horizonsRequest(queryParams)(buildEphemeris).ensure(EphemerisEmpty)(_.size > 0)


### PR DESCRIPTION
The issue in question is that we don't know how to interpret a horizons query response header in the case of Saturn's moon Albiorix.  The header in question is

````
*******************************************************************************
 Revised: Aug 11, 2014               Albiorix / (Saturn)                    626

 For MEAN orbital elements, see  http://ssd.jpl.nasa.gov/sat_elem.html
 Recently discovered Saturnian irregular.
*******************************************************************************
````

which doesn't correspond to anything we are expecting.  This PR introduces an idea for how to handle these situations: skip the header processing when we only care about the ephemeris anyway.

I'm not sure if there are other ramifications of this change, but it does allow us to work with Albiorix and comet Schaumasse...