### PR TITLE
REL-2783 scheduling block editor enablement

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
@@ -9,13 +9,11 @@ import edu.gemini.shared.util.TimeValue;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
-import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.dataset.DataflowStatus;
 import edu.gemini.spModel.dataset.DatasetQaState;
 import edu.gemini.spModel.dataset.DatasetQaStateSums;
 import edu.gemini.spModel.obs.*;
 import edu.gemini.spModel.obs.ObservationStatus;
-import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummary;
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummaryService;
 import edu.gemini.spModel.obsclass.ObsClass;
@@ -326,12 +324,6 @@ public final class EdObservation2 extends OtItemEditor<ISPObservation, SPObserva
 
         _updateObsTimeCorrectionTable();
         _updateTotalUsedTime(false);
-
-        final Option<Site> site = ObsContext.getSiteFromObservation(getNode());
-        final NumberFormat numberFormatter = NumberFormat.getInstance(Locale.US);
-        numberFormatter.setMaximumFractionDigits(2);
-        numberFormatter.setMaximumIntegerDigits(3);
-        _editorPanel.schedulingBlock.init(this, site, numberFormatter);
 
         // GUI editable state depends on the observation status
         OT.updateEditableState(getNode());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ObsForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ObsForm.java
@@ -52,9 +52,6 @@ public class ObsForm extends JPanel {
         phase2StatusBox = new SingleSelectComboBox<>();
         execStatusPanel = new JPanel();
 
-        final JLabel schedulingBlockLabel = new JLabel();
-        schedulingBlock = new ParallacticAngleControls(false);
-
         JLabel label3 = new JLabel();
         qaStateBox = new DropDownListBoxWidget<>();
         override = new JCheckBox();
@@ -237,12 +234,6 @@ public class ObsForm extends JPanel {
             panel1.add(tooCardPanel, cc.xywh(7, 1, 5, 1, CellConstraints.FILL, CellConstraints.FILL));
         }
         add(panel1, cc.xywh(3, row, 9, 1));
-
-        row += 2;
-
-        schedulingBlockLabel.setText("Scheduling ");
-        add(schedulingBlockLabel, cc.xy(1, row));
-        add(schedulingBlock.peer(), cc.xywh(3, row, 9, 1));
 
         row += 2;
 
@@ -540,7 +531,4 @@ public class ObsForm extends JPanel {
     JPanel tooLabelOnlyPanel;
     JLabel tooSinglePriorityLabel;
     // JFormDesigner - End of variables declaration  //GEN-END:variables
-
-    ParallacticAngleControls schedulingBlock;
-
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -91,7 +91,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       anchor = Anchor.West
     }
 
-    private object dateTimeButton extends Button {
+    object dateTimeButton extends Button {
       icon    = Resources.getIcon("dates.gif")
       tooltip = "Select the time and duration for the average parallactic angle calculation."
     }
@@ -261,6 +261,13 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
         case _                          => None
       }
     } yield a
+
+  override def enabled_=(b: Boolean): Unit = {
+    super.enabled_=(b)
+    ui.relativeTimeMenu.enabled = b
+    ui.dateTimeButton.enabled = b
+  }
+
 }
 
 object ParallacticAngleControls {


### PR DESCRIPTION
This PR makes two changes, as requested:

- It removes the scheduling block editor from `EdObservation2`.
- It updates the enablement logic for the scheduling block editor in `EdCompTargetList` such that it is enabled if and only if there is at least one nonsidereal target in the target environment.

Tested with switching program state and keys and the global magical enablement stuff seems to work correctly.