### PR TITLE
REL-2805: Fixed tag menu enabling.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -582,6 +582,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 final IndexedGuideGroup igg    = result._2();
                 final SPTarget target          = new SPTarget();
                 addTargetToGroup(newEnv, igg, probe, target, obsComp, positionTable);
+                positionTable.selectTarget(target);
                 SwingUtilities.invokeLater(EdCompTargetList.this::showTargetTag);
             });
         }
@@ -657,7 +658,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 .getOrElse(() -> GuideProbeTargets.create(probe, target));
         final TargetEnvironment newEnv = env.setGuideEnvironment(env.getGuideEnvironment().putGuideProbeTargets(groupIndex, newGpt));
         obsComp.setTargetEnvironment(newEnv);
-        positionTable.selectTarget(target);
     }
 
     /**
@@ -1049,6 +1049,7 @@ class GuidePositionType implements PositionType {
             final TargetEnvironment envNew = tup._1();
             final IndexedGuideGroup igg    = tup._2();
             EdCompTargetList.addTargetToGroup(envNew, igg, guider, target.clone(), obsComp, positionTable);
+            positionTable.selectTarget(target);
         });
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -124,7 +124,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         final SPInstObsComp inst = getContextInstrumentDataObject();
         _w.newMenu.setEnabled(enabled && inst != null);
-        _w.tag.setEnabled(enabled && !selectionIsBasePosition());
+        _w.tag.setEnabled(enabled && selectedGroup().isEmpty() && !selectionIsAutoTarget() && !selectionIsBasePosition());
     }
 
     private void updateDetailEditorEnabledState(final boolean enabled) {
@@ -229,7 +229,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _w.pasteButton.setEnabled(editable && notAutoTarget);
         _w.duplicateButton.setEnabled(editable && notAutoTarget);
         updateDetailEditorEnabledState(editable && notAutoTarget);
-        _w.tag.setEnabled(notAutoTarget);
+        _w.tag.setEnabled(notAutoTarget && notBase);
     }
 
     /**


### PR DESCRIPTION
There was a problem with the enabling of the tag menu when switching observations.
Doing so could allow a BAGS target to have the tag menu enabled for it.
It was possible to also have the tag menu enabled for the base, which should not be the case.