### PR TITLE
REL-2791: ephemeris plot bugfixes

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -1,15 +1,11 @@
 package jsky.app.ot.tpe;
 
-import edu.gemini.ags.api.AgsRegistrar;
 import edu.gemini.catalog.ui.QueryResultsFrame;
 import edu.gemini.catalog.ui.tpe.CatalogImageDisplay;
-import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
 import edu.gemini.shared.util.immutable.*;
-import edu.gemini.spModel.ags.AgsStrategyKey;
 import edu.gemini.spModel.core.Coordinates;
 import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
-import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.*;
@@ -984,16 +980,17 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
             tif.reinit(this, _imgInfo);
         }
 
-        _baseOutOfView = false;
-        if (_imgInfoValid) {
-            Point2D.Double p = _imgInfo.getBaseScreenPos();
-            if ((p.x < 0) || (p.y < 0) || (p.x >= getWidth()) || (p.y >= getHeight())) {
-                _baseOutOfView = true;
-            }
-        }
+        _baseOutOfView = _imgInfoValid && !isVisible(_imgInfo.getBaseScreenPos());
         return true;
     }
 
+    /**
+     * @return <code>true</code> if the point is visible in the image widget;
+     * <code>false</code> otherwise
+     */
+    public boolean isVisible(Point2D.Double p) {
+        return (p.x >= 0) && (p.y >= 0) && (p.x < getWidth()) && (p.y < getHeight());
+    }
 
     /**
      * Return the base or center position in world coordinates.

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -36,13 +36,13 @@ class TpeEphemerisFeature extends TpeImageFeature("Ephemeris", "Show interpolate
   // represents consecutive ephemeris elements that could be successfully
   // located on the image widget.
   def toScreenEphemeris(e: Ephemeris): List[ScreenEphemeris] = {
-    val (last, others) = ((List.empty[(Long, Point)], List.empty[ScreenEphemeris])/:e.toDescList) { case ((cur, res), (t, c)) =>
-      toScreenCoordinates(c).filter(_iw.isVisible).fold {
-        cur.isEmpty ? ((cur, res)) | ((List.empty[(Long, Point)], cur :: res))
-      } { p => ((t, p) :: cur, res) }
+    val (lastSe, prevSes) = ((EmptyScreenEphemeris, List.empty[ScreenEphemeris])/:e.toDescList) { case ((se, ses), (time, coords)) =>
+      toScreenCoordinates(coords).filter(_iw.isVisible).fold {
+        se.isEmpty ? ((se, ses)) | ((EmptyScreenEphemeris, se :: ses))
+      } { p => ((time, p) :: se, ses) }
     }
 
-    last.isEmpty ? others | last :: others
+    lastSe.isEmpty ? prevSes | lastSe :: prevSes
   }
 
   def getEphemeris: Ephemeris =
@@ -158,6 +158,7 @@ class TpeEphemerisFeature extends TpeImageFeature("Ephemeris", "Show interpolate
 object TpeEphemerisFeature {
 
   type ScreenEphemeris = List[(Long, Point)]
+  val EmptyScreenEphemeris: ScreenEphemeris = List.empty
 
   val TickSize      = 3.0   // size of tick marks in pixels
   val PixelDistance = 100.0 // min distance between labeled points


### PR DESCRIPTION
A couple of tweaks to ephemeris plotting to remove erroneous points:

1) An update to ancient world coordinate to screen coordinate conversion code to remove points from the opposite side of the sky.

2) Filtering out points that don't fall on the viewport of the image widget.
