### PR TITLE
REL-2628: Update Flamingos-2 Templates for 2016B

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
@@ -41,7 +41,7 @@ case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTa
 
   val targetGroup = Seq(11,12) ++ acq ++ Seq(15,16,17,18)
   val baselineFolder = Seq.empty
-  val notes = Seq("F2 Long-Slit Notes")
+  val notes = Seq("F2 Long-Slit Notes", "Repeats contain the ABBA offsets", "Use same PA for science and Telluric")
 
   val scienceAndTellurics = Seq(12,15,16,18)
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
@@ -1,0 +1,42 @@
+package edu.gemini.phase2.skeleton.factory
+
+import edu.gemini.model.p1.immutable._
+import edu.gemini.spModel.core.MagnitudeBand
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.SpecificationLike
+
+class F2BlueprintTest extends TemplateSpec("F2_BP.xml") with SpecificationLike with ScalaCheck {
+
+  implicit val ArbitraryDisperser: Arbitrary[Flamingos2Disperser] =
+    Arbitrary(Gen.oneOf(Flamingos2Disperser.values))
+
+  implicit val ArbitraryFpu: Arbitrary[Flamingos2Fpu] =
+    Arbitrary(Gen.oneOf(Flamingos2Fpu.values))
+
+  implicit val ArbitraryFilter: Arbitrary[Flamingos2Filter] =
+    Arbitrary(Gen.oneOf(Flamingos2Filter.values))
+
+  implicit val ArbitraryFlamingos2BlueprintLongslit: Arbitrary[Flamingos2BlueprintLongslit] = Arbitrary {
+    for {
+      d  <- arbitrary[Flamingos2Disperser]
+      f  <- arbitrary[List[Flamingos2Filter]]
+      if f.nonEmpty // There must be at least one filter
+      fu <- arbitrary[Flamingos2Fpu]
+    } yield Flamingos2BlueprintLongslit(d, f, fu)
+  }
+
+  "F2 Long-Slit" should {
+    "Include notes, REL-2628" in {
+      forAll { (b: Flamingos2BlueprintLongslit) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (p, sp) =>
+          val notes = List("F2 Long-Slit Notes", "Repeats contain the ABBA offsets", "Use same PA for science and Telluric")
+          groups(sp).forall(tg => notes.forall(existsNote(tg, _)))
+        }
+      }
+    }
+  }
+
+}

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
@@ -149,7 +149,7 @@ abstract class TemplateSpec(xmlName: String) { this: SpecificationLike =>
    * Construct a phase-1 proposal with a target for each magnitude in the given band, plus a target
    * with no magnitude information, with an observation for each using the supplied blueprint.
    */
-  def proposal(bp: BlueprintBase, kmags: List[Double], band: MagnitudeBand) = {
+  def proposal(bp: BlueprintBase, kmags: List[Double], band: MagnitudeBand): Proposal = {
 
     val os: List[Observation] =
       p1Obs(bp, p1Target(Nil)) :: // one obs with no mags


### PR DESCRIPTION
This PR adds new notes to F2 Long-Slit templates. It includes a test too. The final template looks like this:

![screenshot 2016-05-27 11 51 17](https://cloud.githubusercontent.com/assets/3615303/15613416/bc968350-2409-11e6-8cd9-aca2a396fc5d.png)
