### PR TITLE
REL-2785 fix ephemeris update chaos

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -471,6 +471,7 @@ object BagsManager {
     obs.getProgram.addStructureChangeListener(StructureListener)
   }
 
+  /** Bracket an IO action with unwatch/watch for the given program. */
   def pause[A](prog: ISPProgram)(io: IO[A]): IO[A] =
     IO(unwatch(prog)) *> io ensuring IO(watch(prog))
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -470,4 +470,8 @@ object BagsManager {
     obs.getProgram.addCompositeChangeListener(ChangeListener)
     obs.getProgram.addStructureChangeListener(StructureListener)
   }
+
+  def pause[A](prog: ISPProgram)(io: IO[A]): IO[A] =
+    IO(unwatch(prog)) *> io ensuring IO(watch(prog))
+
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -471,8 +471,4 @@ object BagsManager {
     obs.getProgram.addStructureChangeListener(StructureListener)
   }
 
-  /** Bracket an IO action with unwatch/watch for the given program. */
-  def pause[A](prog: ISPProgram)(io: IO[A]): IO[A] =
-    IO(unwatch(prog)) *> io ensuring IO(watch(prog))
-
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -470,5 +470,4 @@ object BagsManager {
     obs.getProgram.addCompositeChangeListener(ChangeListener)
     obs.getProgram.addStructureChangeListener(StructureListener)
   }
-
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
@@ -107,8 +107,8 @@ object EphemerisUpdater {
     }
 
   /**
-   * Refresh the ephimerides for all nonsidereal targets in `obs`, on another thread, showing status
-   * in the root pane associated with the given `Component`.
+   * Refresh the ephemerides for all nonsidereal targets in `obs`, showing status in the root pane
+   * associated with the given `Component`, logging failures.
    */
   def refreshEphemerides(obsN: ISPObservation, c: Component): IO[Unit] = {
     val ui = UI(c)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
@@ -67,52 +67,63 @@ object EphemerisUpdater {
     } yield e1.union(e2)
   }
 
-  /** Get the target node, scheduling block start, and site; we need all of these. */
-  private def args(obsN: ISPObservation): Option[(ISPObsComponent, Long, Site)] =
+  /** Get the target node and site; we need both of these. */
+  private def args(obsN: ISPObservation): Option[(ISPObsComponent, Site)] =
     for {
       tocN  <- obsN.findObsComponentByType(TargetObsComp.SP_TYPE)
-      start <- obsN.getDataObject.asInstanceOf[SPObservation].getSchedulingBlockStart.asScalaOpt
       site  <- ObsContext.getSiteFromObservation(obsN).asScalaOpt
-    } yield (tocN, start, site)
+    } yield (tocN, site)
 
   /**
-   * Action to refresh the ephimerides for all nonsidereal targets in `obs`, showing
-   * status in the given `UI`.
+   * Action to compute a program to update the ephimerides for all nonsidereal targets in `obs`,
+   * showing status in the given `UI`. So, running this fetches all the ephemerides and constructs
+   * a program that updates the model all at once. The idea is that we can perform this final action
+   * quickly holding the program lock.
    */
-  def refreshEphemerides(obsN: ISPObservation, ui: UI): HS2[Unit] =
-    args(obsN).traverseU_ { case (tocN, start, site) =>
+  def refreshEphemerides(obsN: ISPObservation, start: Long, ui: UI): HS2[HS2[Unit]] =
+    args(obsN) match {
 
-      val toc  = tocN.getDataObject.asInstanceOf[TargetObsComp]
-      val env  = toc.getTargetEnvironment
-      val spts = env.getTargets.asScalaList
+      case Some((tocN, site)) =>
 
-      val nstArgs: List[(SPTarget, NonSiderealTarget, HorizonsDesignation)] =
-        for {
-          spt <- spts
-          nst <- spt.getNonSiderealTarget.toList
-          hd  <- nst.horizonsDesignation.toList
-        } yield (spt, nst, hd)
+        val toc  = tocN.getDataObject.asInstanceOf[TargetObsComp]
+        val env  = toc.getTargetEnvironment
+        val spts = env.getTargets.asScalaList
 
-      def update(spt: SPTarget, nst: NonSiderealTarget, hd: HorizonsDesignation, n: Int): HS2[Unit] =
-        for {
-          _ <- ui.show(s"Updating Ephemeris ${n + 1} of ${nstArgs.length} ...")
-          e <- lookup(hd, site, start)
-          _ <- HS2.delay(spt.setTarget(NonSiderealTarget.ephemeris.set(nst, e)))
-        } yield ()
+        val nstArgs: List[(SPTarget, NonSiderealTarget, HorizonsDesignation)] =
+          for {
+            spt <- spts
+            nst <- spt.getNonSiderealTarget.toList
+            hd  <- nst.horizonsDesignation.toList
+          } yield (spt, nst, hd)
 
-      nstArgs.zipWithIndex.traverseU { case ((spt, nst, hd), n) => update(spt, nst, hd, n) } *>
-      ui.onEDT(tocN.setDataObject(toc)) *>
-      ui.hide
+        def update(spt: SPTarget, nst: NonSiderealTarget, hd: HorizonsDesignation, n: Int): HS2[HS2[Unit]] =
+          for {
+            _ <- ui.show(s"Updating Ephemeris ${n + 1} of ${nstArgs.length} ...")
+            e <- lookup(hd, site, start)
+          } yield HS2.delay(spt.setTarget(NonSiderealTarget.ephemeris.set(nst, e)))
+
+        val updates: HS2[HS2[Unit]] =
+          nstArgs.zipWithIndex
+                 .traverseU { case ((spt, nst, hd), n) => update(spt, nst, hd, n) }
+                 .map(_.sequenceU.void)
+
+        updates.map(_ *> HS2.delay(tocN.setDataObject(toc)))
+
+      case None => HS2.unit.point[HS2]
 
     }
 
   /**
-   * Refresh the ephemerides for all nonsidereal targets in `obs`, showing status in the root pane
-   * associated with the given `Component`, logging failures.
+   * Fetch updated ephemerides for all nonsidereal targets in `obs`, showing status in the root pane
+   * associated with the given `Component`, returning *another* program that completes the update
+   * without any further network access (i.e., quickly) and clears out the UI.
    */
-  def refreshEphemerides(obsN: ISPObservation, c: Component): IO[Unit] = {
+  def refreshEphemerides(obsN: ISPObservation, start: Long, c: Component): IO[IO[Unit]] = {
     val ui = UI(c)
-    (refreshEphemerides(obsN, ui).withResultLogging(Log) ensuring ui.hide).run.void
+    refreshEphemerides(obsN, start, ui).withResultLogging(Log).run.map {
+      case -\/(e) => IO.ioUnit
+      case \/-(a) => (a.withResultLogging(Log) ensuring ui.hide).run.void
+    }
   }
 
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -184,13 +184,9 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       val quiet: IO[Unit] =
         IO(ispObs.setSendingEvents(false)) *> action ensuring IO(ispObs.setSendingEvents(true))
 
-      // With bagman paused
-      val bagless: IO[Unit] =
-        BagsManager.pause(ispObs.getProgram)(quiet)
-
-      // And an exception handler
+      // And with an exception handler
       val safe: IO[Unit] =
-        bagless except { case t: Throwable => edt(DialogUtil.error(peer, t)) }
+        quiet except { case t: Throwable => edt(DialogUtil.error(peer, t)) }
 
       // Run it on a short-lived worker
       new Thread(new Runnable() {


### PR DESCRIPTION
This fixes an issue where all the event listeners and automatic doodads were clobbering bits and pieces of the scheduling block + ephemeris update. Turning events off seems to fix it.