### PR TITLE
REL-2797: duplicate observation numbers

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPObservation.java
@@ -29,12 +29,6 @@ public interface ISPObservation extends ISPObsComponentContainer, ISPContainerNo
     int getObservationNumber();
 
     /**
-     * Sets the observation number.  It is the caller's responsibility to
-     * ensure that observation numbers are not duplicated.
-     */
-    void setObservationNumber(int num);
-
-    /**
      * Gets the observation id, which is the reference number of the program
      * and a sequential index.  This id is known to, displayed to, and used
      * by humans.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPProgram.java
@@ -48,17 +48,5 @@ public interface ISPProgram extends ISPGroupContainer, ISPObservationContainer,
 
     VersionVector<LifespanId, Integer> getVersions(SPNodeKey key);
     void setVersions(SPNodeKey key, VersionVector<LifespanId, Integer> vv);
-
-    /**
-     * Renumbers the observations in this program to match those in
-     * <code>that</code> program where a matching observation is determined by
-     * observation key.  This is used when merging two versions of the same
-     * program together.
-     * <p>
-     * This is really a horrible method, an embarrassment, and a reflection of
-     * how bad this model really is.  Please don't call this method.
-     * </p>
-     */
-    void renumberObservationsToMatch(ISPProgram that);
 }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemFactory.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemFactory.java
@@ -8,7 +8,6 @@
 package edu.gemini.pot.sp.memImpl;
 
 import edu.gemini.pot.sp.*;
-import edu.gemini.pot.sp.version.LifespanId;
 import edu.gemini.spModel.core.SPProgramID;
 
 
@@ -146,7 +145,7 @@ public class MemFactory extends SPAbstractFactory {
         if (index < 0) {
             index = pd.nextObsNumber();
         } else {
-            pd.updateNextObsNumber(index);
+            pd.updateMaxObsNumber(index);
         }
         return new MemObservation(mp, index, key);
     }
@@ -165,7 +164,7 @@ public class MemFactory extends SPAbstractFactory {
             // Updated to avoid renumbering observations on fetch/store.
             //
             index = observation.getObservationNumber();
-            progData.updateNextObsNumber(index);
+            progData.updateMaxObsNumber(index);
         } else {
             index = progData.nextObsNumber();
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemFactory.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemFactory.java
@@ -143,9 +143,9 @@ public class MemFactory extends SPAbstractFactory {
         final MemProgram  mp = (MemProgram) prog;
         final ProgramData pd = (ProgramData) mp.getDocumentData();
         if (index < 0) {
-            index = pd.nextObsNumber();
+            index = pd.incrAndGetMaxObsNumber();
         } else {
-            pd.updateMaxObsNumber(index);
+            pd.ensureMaxEqualToOrGreaterThan(index);
         }
         return new MemObservation(mp, index, key);
     }
@@ -164,9 +164,9 @@ public class MemFactory extends SPAbstractFactory {
             // Updated to avoid renumbering observations on fetch/store.
             //
             index = observation.getObservationNumber();
-            progData.updateMaxObsNumber(index);
+            progData.ensureMaxEqualToOrGreaterThan(index);
         } else {
-            index = progData.nextObsNumber();
+            index = progData.incrAndGetMaxObsNumber();
         }
         MemObservation obs = new MemObservation(mprog, index, this, observation,
                                                 preserveKeys);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObservation.java
@@ -23,7 +23,7 @@ public final class MemObservation extends MemAbstractContainer implements ISPObs
     public static final String OBS_EXEC_LOG_PROP = "ObsExecLog";
 
     private final MemProgram _program;
-    private int _obsNumber;
+    private final int _obsNumber;
 
     // The list of observation components
     private final List<ISPObsComponent> _compList = new ArrayList<>();
@@ -106,16 +106,6 @@ public final class MemObservation extends MemAbstractContainer implements ISPObs
 
     public int getObservationNumber() {
         return _obsNumber;
-    }
-
-    public void setObservationNumber(int number) {
-        getProgramWriteLock();
-        try {
-            _obsNumber = number;
-            ((ProgramData) getProgram().getDocumentData()).ensureMaxEqualToOrGreaterThan(number);
-        } finally {
-            returnProgramWriteLock();
-        }
     }
 
     public SPObservationID getObservationID() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObservation.java
@@ -109,7 +109,13 @@ public final class MemObservation extends MemAbstractContainer implements ISPObs
     }
 
     public void setObservationNumber(int number) {
-        _obsNumber = number;
+        getProgramWriteLock();
+        try {
+            _obsNumber = number;
+            ((ProgramData) getProgram().getDocumentData()).ensureMaxEqualToOrGreaterThan(number);
+        } finally {
+            returnProgramWriteLock();
+        }
     }
 
     public SPObservationID getObservationID() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
@@ -292,7 +292,7 @@ public final class MemProgram extends MemAbstractContainer implements ISPProgram
     private void checkForDuplicate(MemObservation localObs) throws SPTreeStateException {
         // Check for duplicate observation id.
         int newObsNum = localObs.getObservationNumber();
-        for (ISPObservation ispObservation : getObservations()) {
+        for (ISPObservation ispObservation : getAllObservations()) {
             MemObservation obs = (MemObservation) ispObservation;
             int obsNum = obs.getObservationNumber();
             if (newObsNum == obsNum) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
@@ -157,7 +157,16 @@ public final class MemProgram extends MemAbstractContainer implements ISPProgram
 
         getProgramWriteLock();
         try {
-            SPAssert.setsNoDuplicateObs(this, Collections.singletonList(templateFolder));
+            // Create the new child list to use for the duplicate check, then
+            // ensure there are no duplicate observations.
+            if (templateFolder != null) {
+                final List<ISPNode> newChildren = new ArrayList<>();
+                newChildren.add(templateFolder);
+                newChildren.addAll(_obsList);
+                newChildren.addAll(_groupList);
+                SPAssert.setsNoDuplicateObs(this, newChildren);
+            }
+
             MemTemplateFolder oldValue = this.templateFolder;
             this.templateFolder = node;
             updateParentLinks(oldValue, node);
@@ -270,7 +279,15 @@ public final class MemProgram extends MemAbstractContainer implements ISPProgram
         final List<ISPObservation> newCopy = new ArrayList<>(newObsList);
         getProgramWriteLock();
         try {
-            SPAssert.setsNoDuplicateObs(this, newCopy);
+            // Create the new child list to use for the duplicate check, then
+            // ensure there are no duplicate observations.
+            if (!newObsList.isEmpty()) {
+                final List<ISPNode> newChildren = new ArrayList<>(newObsList);
+                if (templateFolder != null) newChildren.add(templateFolder);
+                newChildren.addAll(_groupList);
+                SPAssert.setsNoDuplicateObs(this, newChildren);
+            }
+
             final List<ISPObservation> oldCopy = new ArrayList<>(_obsList);
             updateChildren(_obsList, newCopy);
             firePropertyChange(OBSERVATIONS_PROP, oldCopy, newCopy);
@@ -351,7 +368,15 @@ public final class MemProgram extends MemAbstractContainer implements ISPProgram
         List<ISPGroup> newCopy = new ArrayList<>(newGroupList);
         getProgramWriteLock();
         try {
-            SPAssert.setsNoDuplicateObs(this, newCopy);
+            // Create the new child list to use for the duplicate check, then
+            // ensure there are no duplicate observations.
+            if (!newGroupList.isEmpty()) {
+                final List<ISPNode> newChildren = new ArrayList<>(newGroupList);
+                if (templateFolder != null) newChildren.add(templateFolder);
+                newChildren.addAll(_obsList);
+                SPAssert.setsNoDuplicateObs(this, newChildren);
+            }
+
             List<ISPGroup> oldCopy = new ArrayList<>(_groupList);
             updateChildren(_groupList, newCopy);
             firePropertyChange(OBS_GROUP_PROP, oldCopy, newCopy);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
@@ -523,7 +523,7 @@ public final class MemProgram extends MemAbstractContainer implements ISPProgram
 
         // Remember where to start counting again if we make any new
         // observations.
-        ((ProgramData) getDocumentData()).updateNextObsNumber(max);
+        ((ProgramData) getDocumentData()).updateMaxObsNumber(max);
     }
 }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemTemplateFolder.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemTemplateFolder.java
@@ -86,6 +86,7 @@ public final class MemTemplateFolder extends MemAbstractContainer implements ISP
         List<ISPTemplateGroup> newCopy = new ArrayList<>(newGroupList);
         getProgramWriteLock();
         try {
+            SPAssert.setsNoDuplicateObs(this, newCopy);
             List<ISPTemplateGroup> oldCopy = new ArrayList<>(templates);
             updateChildren(templates, newCopy);
             firePropertyChange(TEMPLATE_GROUP_PROP, oldCopy, newCopy);
@@ -105,6 +106,7 @@ public final class MemTemplateFolder extends MemAbstractContainer implements ISP
         MemTemplateGroup node = (MemTemplateGroup) group;
         getProgramWriteLock();
         try {
+            SPAssert.addsNoDuplicateObs(this, group);
             List<ISPTemplateGroup> oldCopy = new ArrayList<>(templates);
             node.attachTo(this);
             if (index >= 0) templates.add(index, node); else templates.add(node);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemTemplateGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemTemplateGroup.java
@@ -128,10 +128,11 @@ public final class MemTemplateGroup extends MemAbstractContainer implements ISPT
     }
 
     public void setObservations(List<? extends ISPObservation> newObsList) throws SPNodeNotLocalException, SPTreeStateException {
-        List<ISPObservation> newCopy = new ArrayList<>(newObsList);
+        final List<ISPObservation> newCopy = new ArrayList<>(newObsList);
         getProgramWriteLock();
         try {
-            List<ISPObservation> oldCopy = new ArrayList<>(obsList);
+            SPAssert.setsNoDuplicateObs(this, newCopy);
+            final List<ISPObservation> oldCopy = new ArrayList<>(obsList);
             updateChildren(obsList, newCopy);
             firePropertyChange(TEMPLATE_OBSERVATIONS_PROP, oldCopy, newCopy);
             fireStructureChange(TEMPLATE_OBSERVATIONS_PROP, this, oldCopy, newCopy);
@@ -147,9 +148,10 @@ public final class MemTemplateGroup extends MemAbstractContainer implements ISPT
     public void addObservation(int index, ISPObservation obs) throws IndexOutOfBoundsException, SPNodeNotLocalException, SPTreeStateException {
         // Get the local component (throwing an SPNodeNotLocalException if not
         // local).
-        MemObservation node = (MemObservation) obs;
+        final MemObservation node = (MemObservation) obs;
         getProgramWriteLock();
         try {
+            SPAssert.addsNoDuplicateObs(this, obs);
             List<ISPObservation> oldCopy = new ArrayList<>(obsList);
             node.attachTo(this);
             if (index >= 0) obsList.add(index, node); else obsList.add(node);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/ProgramData.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/ProgramData.java
@@ -36,7 +36,7 @@ class ProgramData extends DocumentData {
     }
 
     // make sure _maxObsNumber >= n
-    void updateNextObsNumber(int n) {
+    void updateMaxObsNumber(int n) {
         getProgramWriteLock();
         try {
             _maxObsNumber = Math.max(n, _maxObsNumber);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/ProgramData.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/ProgramData.java
@@ -17,7 +17,7 @@ import java.util.UUID;
  * This implementation class holds data that should be associated with
  * every node in a program.
  */
-class ProgramData extends DocumentData {
+final class ProgramData extends DocumentData {
 
     // The highest index of the any observation ever created in this program.
     private int _maxObsNumber;
@@ -26,7 +26,13 @@ class ProgramData extends DocumentData {
         super(progKey, progId, uuid, lifespanId);
     }
 
-    int nextObsNumber() {
+    /**
+     * Increments the maximum observation number in the program and returns it.
+     * This method is intended to be used for setting the observation number
+     * for a newly created observation such that it adds no duplicate
+     * observation number to the program.
+     */
+    int incrAndGetMaxObsNumber() {
         getProgramWriteLock();
         try {
             return ++_maxObsNumber;
@@ -35,8 +41,12 @@ class ProgramData extends DocumentData {
         }
     }
 
-    // make sure _maxObsNumber >= n
-    void updateMaxObsNumber(int n) {
+    /**
+     * Potentially updates the maximum observation number in the program to the
+     * given value, assuming it is larger than the previously known maximum
+     * observation number.
+     */
+    void ensureMaxEqualToOrGreaterThan(int n) {
         getProgramWriteLock();
         try {
             _maxObsNumber = Math.max(n, _maxObsNumber);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/ProgramData.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/ProgramData.java
@@ -19,8 +19,8 @@ import java.util.UUID;
  */
 class ProgramData extends DocumentData {
 
-    // The index of the next observation created in this program.
-    private int _nextObsNumber;
+    // The highest index of the any observation ever created in this program.
+    private int _maxObsNumber;
 
     ProgramData(SPNodeKey progKey, SPProgramID progId, UUID uuid, LifespanId lifespanId) {
         super(progKey, progId, uuid, lifespanId);
@@ -29,21 +29,19 @@ class ProgramData extends DocumentData {
     int nextObsNumber() {
         getProgramWriteLock();
         try {
-            return ++_nextObsNumber;
+            return ++_maxObsNumber;
         } finally {
             returnProgramWriteLock();
         }
     }
 
-    // make sure _nextObsNumber >= n
+    // make sure _maxObsNumber >= n
     void updateNextObsNumber(int n) {
-        if (n > _nextObsNumber) {
-            getProgramWriteLock();
-            try {
-                _nextObsNumber = n;
-            } finally {
-                returnProgramWriteLock();
-            }
+        getProgramWriteLock();
+        try {
+            _maxObsNumber = Math.max(n, _maxObsNumber);
+        } finally {
+            returnProgramWriteLock();
         }
     }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/SPAssert.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/SPAssert.scala
@@ -1,0 +1,53 @@
+package edu.gemini.pot.sp
+
+import edu.gemini.spModel.rich.pot.sp.remoteNodeWrapper
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+object SPAssert {
+  /** Asserts that adding `newChild` to `parent` will not duplicate observation
+    * numbers in the program tree.
+    *
+    * @throws SPTreeStateException if the assertion doesn't hold
+    */
+  def addsNoDuplicateObs(parent: ISPContainerNode, newChild: ISPNode): Unit =
+    setsNoDuplicateObs(parent, newChild :: parent.children)
+
+  /** Asserts that setting the children of `parent` to `children` will not
+    * duplicate observation numbers in the program tree.
+    *
+    * @throws SPTreeStateException if the assertion doesn't hold
+    */
+  def setsNoDuplicateObs[T <: ISPNode](parent: ISPContainerNode, children: java.util.List[T]): Unit =
+    setsNoDuplicateObs(parent, children.asScala.toList)
+
+  // Scala implementation used by assertion methods designed for use in Java code.
+  private def setsNoDuplicateObs[T <: ISPNode](parent: ISPContainerNode, children: List[T]): Unit = {
+    @tailrec
+    def go(rem: List[ISPNode], all: Set[Int], dups: Set[Int]): Set[Int] =
+      rem match {
+        case Nil    => dups
+        case h :: t => h match {
+          case o: ISPObservation   =>
+            val n = o.getObservationNumber
+            go(t, all + n, if (all(n)) dups + n else dups)
+
+          case c: ISPContainerNode =>
+            val cs = if (c == parent) children else c.children
+            go(cs ++ t, all, dups)
+
+          case _                   =>
+            go(t, all, dups)
+        }
+      }
+
+    val dups = go(List(parent.getProgram), Set.empty, Set.empty)
+
+    val msg = dups.size match {
+      case 0 => None
+      case 1 => Some("There is an existing observation " + dups.mkString(", "))
+      case _ => Some("There are existing observations " + dups.mkString(", "))
+    }
+    msg.foreach { s => throw new SPTreeStateException(s) }
+  }
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/SPAssert.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/pot/sp/SPAssert.scala
@@ -18,11 +18,11 @@ object SPAssert {
     *
     * @throws SPTreeStateException if the assertion doesn't hold
     */
-  def setsNoDuplicateObs[T <: ISPNode](parent: ISPContainerNode, children: java.util.List[T]): Unit =
-    setsNoDuplicateObs(parent, children.asScala.toList)
+  def setsNoDuplicateObs[T <: ISPNode](parent: ISPContainerNode, newChildren: java.util.List[T]): Unit =
+    setsNoDuplicateObs(parent, newChildren.asScala.toList)
 
   // Scala implementation used by assertion methods designed for use in Java code.
-  private def setsNoDuplicateObs[T <: ISPNode](parent: ISPContainerNode, children: List[T]): Unit = {
+  private def setsNoDuplicateObs[T <: ISPNode](parent: ISPContainerNode, newChildren: List[T]): Unit = {
     @tailrec
     def go(rem: List[ISPNode], all: Set[Int], dups: Set[Int]): Set[Int] =
       rem match {
@@ -33,7 +33,7 @@ object SPAssert {
             go(t, all + n, if (all(n)) dups + n else dups)
 
           case c: ISPContainerNode =>
-            val cs = if (c == parent) children else c.children
+            val cs = if (c == parent) newChildren else c.children
             go(cs ++ t, all, dups)
 
           case _                   =>
@@ -46,7 +46,7 @@ object SPAssert {
     val msg = dups.size match {
       case 0 => None
       case 1 => Some("There is an existing observation " + dups.mkString(", "))
-      case _ => Some("There are existing observations " + dups.mkString(", "))
+      case _ => Some("There are existing observations: " + dups.mkString(", "))
     }
     msg.foreach { s => throw new SPTreeStateException(s) }
   }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/DuplicateSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/DuplicateSpec.scala
@@ -1,0 +1,161 @@
+package edu.gemini.pot.sp
+
+import edu.gemini.spModel.rich.pot.sp._
+import org.scalacheck.Gen
+
+import scala.collection.JavaConverters._
+import scala.util.Random
+
+object DuplicateSpec extends ProgramTestSupport {
+
+  val genTestProg: Gen[ISPFactory => ISPProgram] =
+    ProgramGen.genProg
+
+  def randomInstance[A](as: Vector[A]): Option[A] = {
+    val s = as.size
+    if (s == 0) None else Some(as(Random.nextInt(s)))
+  }
+
+  def randomObs(p: ISPProgram): Option[ISPObservation] =
+    randomInstance(ObservationIterator.apply(p).asScala.toVector)
+
+  def randomObsNumber(p: ISPProgram): Option[Int] =
+    randomObs(p).map(_.getObservationNumber)
+
+  def randomContainer(p: ISPProgram): Option[ISPObservationContainer] =
+    randomInstance(p.toStream.collect {
+      case oc: ISPObservationContainer => oc
+    }.toVector)
+
+  def expectTreeStateException(block: => Unit): Boolean =
+    try {
+      block
+      false
+    } catch {
+      case _: SPTreeStateException => true
+    }
+
+
+  "the obs number duplication assertion" should {
+    "prevent a duplicate when directly adding an observation" ! forAllPrograms { (odb, progs) =>
+      progs.forall { p =>
+        val setup =
+          for {
+            oc <- randomContainer(p)
+            on <- randomObsNumber(p)
+          } yield (oc, on)
+
+        setup.forall { case (obsContainer, obsNum) =>
+          val obs = odb.getFactory.createObservation(p, obsNum, null)
+          expectTreeStateException { obsContainer.addObservation(obs) }
+        }
+      }
+    }
+
+    "prevent a duplicate when adding a group" ! forAllPrograms { (odb, progs) =>
+      progs.forall { p =>
+        randomObsNumber(p).forall { obsNum =>
+          val f = odb.getFactory
+          val g = f.createGroup(p, null)
+          val o = f.createObservation(p, obsNum, null)
+          g.addObservation(o)
+          expectTreeStateException { p.addGroup(g) }
+        }
+      }
+    }
+
+    "prevent a duplicate when adding a template group" ! forAllPrograms { (odb, progs) =>
+      progs.forall { p =>
+        randomObsNumber(p).forall { obsNum =>
+          Option(p.getTemplateFolder).forall { tf =>
+            val f = odb.getFactory
+            val g = f.createTemplateGroup(p, null)
+            val o = f.createObservation(p, obsNum, null)
+            g.addObservation(o)
+            expectTreeStateException { tf.addTemplateGroup(g) }
+          }
+        }
+      }
+    }
+
+    "prevent a duplicate when setting obs children" ! forAllPrograms { (odb, progs) =>
+      progs.forall { p =>
+        val setup =
+          for {
+            oc <- randomContainer(p)
+            on <- randomObsNumber(p)
+          } yield (oc, on)
+
+        setup.forall { case (obsContainer, obsNum) =>
+          val obs = odb.getFactory.createObservation(p, obsNum, null)
+          expectTreeStateException {
+            obsContainer.children = obs :: obsContainer.children
+          }
+        }
+      }
+    }
+
+    "prevent a duplicate when setting group children" ! forAllPrograms { (odb, progs) =>
+      progs.forall { p =>
+        randomObsNumber(p).forall { obsNum =>
+          val f = odb.getFactory
+          val g = f.createGroup(p, null)
+          val o = f.createObservation(p, obsNum, null)
+          g.addObservation(o)
+
+          val gs = p.getGroups
+          gs.add(g)
+
+          expectTreeStateException { p.setGroups(gs) }
+        }
+      }
+    }
+
+    "prevent a duplicate when setting template group children" ! forAllPrograms { (odb, progs) =>
+      progs.forall { p =>
+        val setup =
+          for {
+            tf <- Option(p.getTemplateFolder)
+            on <- randomObsNumber(p)
+          } yield (tf, on)
+
+        setup.forall { case (templateFolder, obsNum) =>
+          val f = odb.getFactory
+          val g = f.createTemplateGroup(p, null)
+          val o = f.createObservation(p, obsNum, null)
+          g.addObservation(o)
+
+          val gs = templateFolder.getTemplateGroups
+          gs.add(g)
+
+          expectTreeStateException { templateFolder.setTemplateGroups(gs) }
+        }
+      }
+    }
+
+    "prevent a duplicate when setting template folder" ! forAllPrograms { (odb, progs) =>
+      progs.forall { p =>
+        randomObsNumber(p).forall { obsNum =>
+          val f   = odb.getFactory
+          val tf  = f.createTemplateFolder(p, null)
+          val tgs = Option(p.getTemplateFolder).map(_.getTemplateGroups).getOrElse(new java.util.ArrayList[ISPTemplateGroup]())
+
+          val tg  = f.createTemplateGroup(p, null)
+          val o   = f.createObservation(p, obsNum, null)
+          tg.addObservation(o)
+          tgs.add(tg)
+
+          expectTreeStateException {
+            // One of the two calls should fail, depending upon which random
+            // observation number we picked up.
+            tf.setTemplateGroups(tgs)
+            p.setTemplateFolder(tf)
+          }
+        }
+      }
+    }
+
+  }
+
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ObservationIteratorSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/pot/sp/ObservationIteratorSpec.scala
@@ -1,0 +1,26 @@
+package edu.gemini.pot.sp
+
+import edu.gemini.pot.sp.ProgramGen.genProg
+import org.scalacheck.Gen
+
+import scala.collection.JavaConverters._
+
+object ObservationIteratorSpec extends ProgramTestSupport {
+
+  val genTestProg: Gen[ISPFactory => ISPProgram] = genProg
+
+  "ObservationIterator" should {
+    "include all of a program's observations" ! forAllPrograms { (odb, progs) =>
+      val obsIds0 = progs.map { p =>
+        p.getAllObservations.asScala.map(_.getNodeKey).toSet
+      }
+
+      val obsIds1 = progs.map { p =>
+        ObservationIterator.apply(p).asScala.map(_.getNodeKey).toSet
+      }
+
+      obsIds0 == obsIds1
+    }
+  }
+
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/DuplicateObsNumberTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/DuplicateObsNumberTest.scala
@@ -1,0 +1,71 @@
+package edu.gemini.sp.vcs2
+
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.pot.spdb.DBLocalDatabase
+import edu.gemini.sp.vcs2.VcsAction._
+import edu.gemini.spModel.core.SPProgramID
+import org.junit.Test
+import org.junit.Assert
+
+import scala.collection.JavaConverters._
+
+/**
+ * A test case that reveals the bug in REL-2797:
+ *
+ * "edu.gemini.pot.sp.SPTreeStateException: There is an existing observation with number:"
+ *
+ * when adding an observation.
+ */
+class DuplicateObsNumberTest {
+
+  val key = new SPNodeKey()
+  val pid = SPProgramID.toProgramID("GS-2016B-Q-1")
+
+  @Test def testDuplicateObsNumber(): Unit = {
+    val odb  = DBLocalDatabase.createTransient()
+    val fact = odb.getFactory
+
+    try {
+      val progA = fact.createProgram(key, pid)
+      val progB = fact.createProgram(key, pid)
+
+      Assert.assertNotSame("have different lifespan ids", progA.getLifespanId, progB.getLifespanId)
+
+      // Create a new observation for progA but don't add it.
+      val obsA1 = fact.createObservation(progA, null)
+
+      // Create a second observation for progA and add it.
+      val obsA2 = fact.createObservation(progA, null)
+      progA.addObservation(obsA2)
+
+      // Create a new observation for progB and add it.
+      val obsB1 = fact.createObservation(progB, null)
+      progB.addObservation(obsB1)
+
+      // Pull changes from progA into progB, which should renumber B1
+      val diffs = ProgramDiff.compare(progA, progB.getVersions, Set.empty)
+      val mc    = MergeContext(progB, diffs)
+      val act   =
+        for {
+          prelim <- PreliminaryMerge.merge(mc).liftVcs
+          plan   <- MergeCorrection(mc)(prelim, _ => VcsAction(true))
+          _      <- plan.merge(fact, progB)
+        } yield ()
+
+      act.unsafeRun
+
+      // Now progB should have obsB1 (renumbered to 3) and obsA2
+      val obsKeys = progB.getObservations.asScala.map(_.getNodeKey).toSet
+      Assert.assertEquals(Set(obsB1.getNodeKey, obsA2.getNodeKey), obsKeys)
+
+      // Create a new observation for progB.  It should get number 4.
+      val obsB4 = fact.createObservation(progB, null)
+      progB.addObservation(obsB4)
+
+      Assert.assertEquals(4, obsB4.getObservationNumber)
+
+    } finally {
+      odb.getDBAdmin.shutdown()
+    }
+  }
+}

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/MergeTest.scala
@@ -1,5 +1,6 @@
 package edu.gemini.sp.vcs2
 
+import edu.gemini.pot.sp.memImpl.MemProgram
 import edu.gemini.spModel.conflict.ConflictFolder
 import edu.gemini.spModel.obs.ObservationStatus
 
@@ -748,6 +749,18 @@ class MergeTest extends JUnitSuite {
         }
 
         expected.toSet == actual.toSet
+      }
+    ),
+
+    ("Updated local program has no observations with numbers greater than the program data max obs counter",
+      (start, local, remote, pc) => {
+        pc.updatedLocalProgram.exists { ulp =>
+          val allObsNumbers = ulp.getAllObservations.asScala.map(_.getObservationNumber)
+          val max = if (allObsNumbers.isEmpty) 0 else allObsNumbers.max
+
+          val newObs = pc.fact.createObservation(ulp, null)
+          newObs.getObservationNumber > max
+        }.unsafePerformSync
       }
     )
   )

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/AddObservationAction.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/AddObservationAction.java
@@ -2,11 +2,6 @@ package jsky.app.ot.viewer.action;
 
 import edu.gemini.pot.sp.*;
 import edu.gemini.shared.util.immutable.ImOption;
-import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.core.ProgramId;
-import edu.gemini.spModel.core.ProgramId$;
-import edu.gemini.spModel.core.SPProgramID;
-import edu.gemini.spModel.core.Semester;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.util.DefaultSchedulingBlock;
@@ -35,7 +30,7 @@ public final class AddObservationAction extends AbstractViewerAction implements 
         if (requires == null) {
             this.requires = Collections.emptySet();
         } else {
-            this.requires = Collections.unmodifiableSet(new HashSet<SPComponentType>(requires));
+            this.requires = Collections.unmodifiableSet(new HashSet<>(requires));
         }
     }
 
@@ -81,6 +76,7 @@ public final class AddObservationAction extends AbstractViewerAction implements 
         return componentType;
     }
 
+    @SuppressWarnings("NullableProblems")
     public int compareTo(AddObservationAction action) {
         return componentType.readableStr.compareToIgnoreCase(action.componentType.readableStr);
     }


### PR DESCRIPTION
This PR addresses an issue in which it was possible to create two observations with the same observation number.  A little background is required to understand the issue.  Each program maintains a `ProgramData` object which tracks the maximum observation number ever created in the program.  When a new observation is created by the factory, this number is incremented and used for the observation.  Since programs can be edited independently, it is possible for observations with the same numbers to be created in distinct databases.  The sync process takes care of renumbering duplicate observation numbers though so that all observations in the merged update have a unique observation number once again.  It was not, however, updating the max observation number counter but instead leaving it set incorrectly for subsequent new observations.

In addition, the check we performed to detect duplicate observation numbers was not complete.  It would correctly avoid adding an observation with a duplicate number to the same list of observations in a program, group, or template group, but would not check all observations anywhere in the program.

This PR:

* fixes the max observation number increment issue
* checks the entire program when observations are added to make sure there are no duplicates
* removes an older, now unused observation renumbering method in `MemProgram`
* adds a number of test cases

It is possible that existing observations in the ODB have duplicate numbers.  Those will now be rejected on import and we'll have to fix them manually.

@jluhrs @sraaphorst @cquiroz @tpolecat @arturog8m  All test cases run but since this is a fairly sensitive and fairly late change I'd like to ask everyone to carefully review it and comment.