### PR TITLE
REL-2740 p2 check for obs site and ephemeris site consistency

### DIFF
--- a/bundle/edu.gemini.ags.servlet/src/main/scala/edu/gemini/ags/servlet/ToContextHelper.scala
+++ b/bundle/edu.gemini.ags.servlet/src/main/scala/edu/gemini/ags/servlet/ToContextHelper.scala
@@ -1,13 +1,11 @@
 package edu.gemini.ags.servlet
 
-import edu.gemini.spModel.core.{Ephemeris, Coordinates, NonSiderealTarget}
-
-import scalaz.IMap
+import edu.gemini.spModel.core.{Ephemeris, Site, Coordinates, NonSiderealTarget}
 
 class ToContextHelper {
 
   def nonSiderealWithSingleEphemerisElement(ra: Double, dec: Double, when: Long): NonSiderealTarget = {
-    val e: Ephemeris = Coordinates.fromDegrees(ra, dec).fold[Ephemeris](IMap.empty)(IMap.singleton(when, _))
+    val e: Ephemeris = Coordinates.fromDegrees(ra, dec).fold[Ephemeris](Ephemeris.empty)(Ephemeris.singleton(Site.GN, when, _)) // N.B. site is irrelevant here
     NonSiderealTarget.empty.copy(ephemeris = e)
   }
 

--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -111,7 +111,7 @@ object HorizonsService2 {
    * short timespans (no more than one entry will be returned per minute).
    */
   def lookupEphemeris(target: HorizonsDesignation, site: Site, start: Date, stop: Date, elems: Int): HS2[Ephemeris] =
-    lookupEphemerisE(target, site, start, stop, elems) { _.coords }
+    lookupEphemerisE(target, site, start, stop, elems)(_.coords).map(Ephemeris(site, _))
 
   /** Date formatter used for formatting the Horizons start/stop time parameters. */
   val DateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss", US).withZone(UTC)

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -92,8 +92,8 @@ final class NonSiderealTargetRules extends IRule {
         nst <- tar.getNonSiderealTarget.toList
         sit <- ObsContext.getSiteFromObservation(es.getObservationNode).asScalaOpt.toList
         eph  = nst.ephemeris
-        if eph.nonEmpty && eph.site != sit
-      } p2p.addError(ERR_EPHEMERIS_TOO_SPARSE,
+        if eph.size > 1 && eph.site != sit
+      } p2p.addError(ERR_EPHEMERIS_WRONG_SITE,
         s"The ephemeris for ${nst.name} was computed for ${eph.site} but the observation is " +
         s"associated with ${sit}. Refresh the ephemeris to correct this.",
         ocn)

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/target/NonSiderealTargetRules.scala
@@ -3,6 +3,7 @@ package edu.gemini.p2checker.target
 import edu.gemini.p2checker.api.{P2Problems, IP2Problems, ObservationElements, IRule}
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core._
+import edu.gemini.spModel.obs.context.ObsContext
 import scalaz._, Scalaz._
 
 final class NonSiderealTargetRules extends IRule {
@@ -20,6 +21,7 @@ final class NonSiderealTargetRules extends IRule {
     p2p.append(checkNoSchedulingBlock(es))
     p2p.append(checkNoEphemerisForSchedulingBlock(es))
     p2p.append(checkEphemerisTooSparse(es))
+    p2p.append(checkEphemerisWrongSite(es))
     p2p
   }
 
@@ -81,6 +83,22 @@ final class NonSiderealTargetRules extends IRule {
         ocn)
     }
 
+  def checkEphemerisWrongSite(es: ObservationElements): IP2Problems =
+    new P2Problems <| { p2p =>
+      for {
+        ocn <- es.getTargetObsComponentNode.asScalaOpt.toList
+        toc <- es.getTargetObsComp.asScalaOpt.toList
+        tar <- toc.getTargetEnvironment.getTargets.asScalaList
+        nst <- tar.getNonSiderealTarget.toList
+        sit <- ObsContext.getSiteFromObservation(es.getObservationNode).asScalaOpt.toList
+        eph  = nst.ephemeris
+        if eph.nonEmpty && eph.site != sit
+      } p2p.addError(ERR_EPHEMERIS_TOO_SPARSE,
+        s"The ephemeris for ${nst.name} was computed for ${eph.site} but the observation is " +
+        s"associated with ${sit}. Refresh the ephemeris to correct this.",
+        ocn)
+    }
+
 }
 
 object NonSiderealTargetRules {
@@ -89,5 +107,6 @@ object NonSiderealTargetRules {
   val ERR_NO_EPHEMERIS_FOR_BLOCK  = "NoEphemerisForSchedulingBlock"
   val ERR_EPHEMERIS_TOO_SPARSE    = "EphemerisTooSparse"
   val ERR_NO_HORIZONS_DESIGNATION = "NoHorizonsDesignation"
+  val ERR_EPHEMERIS_WRONG_SITE    = "EphemerisWrongSite"
 
 }

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/NonSiderealTargetRulesSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import edu.gemini.p2checker.target.NonSiderealTargetRules
 import edu.gemini.pot.sp.{ISPObservation, SPComponentType}
 import edu.gemini.pot.util.POTUtil
-import edu.gemini.spModel.core.{Coordinates, Site, Semester, SiderealTarget, HorizonsDesignation, NonSiderealTarget, Target, SPProgramID}
+import edu.gemini.spModel.core._
 import edu.gemini.spModel.obs.{SPObservation, SchedulingBlock}
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.target.SPTarget
@@ -47,7 +47,7 @@ class NonSiderealTargetRulesSpec extends RuleSpec {
 
     "on error if ephemeris for scheduling block" in
       expectNoneOf(ERR_NO_EPHEMERIS_FOR_BLOCK) {
-        obs(NonSiderealTarget.empty.copy(ephemeris = ==>>.singleton(0L, Coordinates.zero)), Some(SchedulingBlock(0L)))
+        obs(NonSiderealTarget.empty.copy(ephemeris = Ephemeris(Site.GS, ==>>.singleton(0L, Coordinates.zero))), Some(SchedulingBlock(0L)))
       }
 
   }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonServlet.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonServlet.scala
@@ -190,7 +190,8 @@ final class SkeletonServlet(odb: IDBDatabaseService, templateFactory: TemplateFa
 
   private def makeSkeleton(id: StandardProgramId, p: Proposal): Either[Failure, SkeletonShell] =
     (for {
-      f <- Phase1FolderFactory.create(p).right
+      s <- id.site.toRight("Program ID has no Site: " + id).right
+      f <- Phase1FolderFactory.create(s, p).right
     } yield new SkeletonShell(id.toSp, SpProgramFactory.create(p), f)).left map { Failure.badRequest }
 
   private def expandTemplates(folder: Phase1Folder): Either[Failure, TemplateFolderExpansion] =

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
@@ -51,7 +51,7 @@ abstract class TemplateSpec(xmlName: String) { this: SpecificationLike =>
     val db = DBLocalDatabase.createTransient()
     try {
       val pid = SPProgramID.toProgramID("GS-2015A-Q-1")
-      val f   = Phase1FolderFactory.create(p).unsafeGet
+      val f   = Phase1FolderFactory.create(pid.site, p).unsafeGet
       val ss  = new SkeletonShell(pid, SpProgramFactory.create(p), f)
       val tf  = TemplateFactoryImpl(templateDb)
       val tfe = TemplateFolderExpansionFactory.expand(ss.folder, tf, preserveLibraryIds = true).unsafeGet

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamCodecs.scala
@@ -12,6 +12,9 @@ import scalaz._, Scalaz._
 
 object TargetParamCodecs {
 
+  implicit val SiteParamCodec: ParamCodec[Site] =
+    ParamCodec[String].xmap(Site.parse, _.abbreviation)
+
   implicit val RedshiftParamCodec: ParamCodec[Redshift] =
     ParamCodec[Double].xmap(Redshift(_), _.z)
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
@@ -89,7 +89,7 @@ object TargetParamSetCodecs {
       def encode(key: String, a: HorizonsDesignation): ParamSet = {
         val (tag, ps) = a match {
           case d: HorizonsDesignation.Comet            => ("comet", CometParamSetCodec.encode(key, d))
-          case d: HorizonsDesignation.AsteroidNewStyle         => ("asteroid", AsteroidParamSetCodec.encode(key, d))
+          case d: HorizonsDesignation.AsteroidNewStyle => ("asteroid", AsteroidParamSetCodec.encode(key, d))
           case d: HorizonsDesignation.AsteroidOldStyle => ("asteroid-old-style", AsteroidOldStyleParamSetCodec.encode(key, d))
           case d: HorizonsDesignation.MajorBody        => ("major-body", MajorBodyParamSetCodec.encode(key, d))
         }
@@ -107,11 +107,16 @@ object TargetParamSetCodecs {
       }
     }
 
+  implicit val EphemerisParamSetCodec: ParamSetCodec[Ephemeris] =
+    ParamSetCodec.initial(Ephemeris.empty)
+      .withParam("site", Ephemeris.site)
+      .withManyParamSet("ephemeris-element", Ephemeris.ephemerisElements)
+
   implicit val NonSiderealTargetParamSetCodec: ParamSetCodec[NonSiderealTarget] =
     ParamSetCodec.initial(NonSiderealTarget.empty)
       .withParam("name",                             NonSiderealTarget.name)
       .withOptionalParamSet("horizons-designation",  NonSiderealTarget.horizonsDesignation)
-      .withManyParamSet("ephemeris-element",         NonSiderealTarget.ephemerisElements)
+      .withParamSet("ephemeris",                     NonSiderealTarget.ephemeris)
       .withManyParamSet("magnitude",                 NonSiderealTarget.magnitudes)
       .withOptionalParamSet("spectral-distribution", NonSiderealTarget.spectralDistribution)
       .withOptionalParamSet("spatial-profile",       NonSiderealTarget.spatialProfile)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
@@ -109,7 +109,7 @@ object TargetParamSetCodecs {
 
   implicit val EphemerisParamSetCodec: ParamSetCodec[Ephemeris] =
     ParamSetCodec.initial(Ephemeris.empty)
-      .withParam("site", Ephemeris.site)
+      .withParam("site",                     Ephemeris.site)
       .withManyParamSet("ephemeris-element", Ephemeris.ephemerisElements)
 
   implicit val NonSiderealTargetParamSetCodec: ParamSetCodec[NonSiderealTarget] =

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamCodecSpec.scala
@@ -44,6 +44,7 @@ object TargetParamCodecsSpec extends Specification with ScalaCheck with Arbitrar
     close[Dec]
     close[RightAscensionAngularVelocity]
     close[DeclinationAngularVelocity]
+    exact[Site]
   }
 
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamSetCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamSetCodecSpec.scala
@@ -44,6 +44,7 @@ object TargetParamSetCodecsSpec extends Specification with ScalaCheck with Arbit
     exact[TooTarget]
     close[NonSiderealTarget]
     close[Target]
+    close[Ephemeris]
   }
 
 }

--- a/bundle/edu.gemini.sp.vcs.log/src/test/scala/edu/gemini/sp/vcs/log/impl/PersistentVcsLog2Spec.scala
+++ b/bundle/edu.gemini.sp.vcs.log/src/test/scala/edu/gemini/sp/vcs/log/impl/PersistentVcsLog2Spec.scala
@@ -46,28 +46,28 @@ object PersistentVcsLog2Spec extends Specification {
       _   <- checkSchema("«in memory»")
     } yield ()
 
-  "compatibility" should {
-
-    "query old database with identical result" in go {
-
-      // result as constructed by the old implementation
-      val expected = {
-        val pid = SPProgramID.toProgramID("GN-2015B-Q-10")
-        (List(
-          VcsEventSet(2061 to 2061, Map(OpFetch -> 1), (1449531008701L,1449531008701L), pid, Set(ProgramPrincipal(pid))), 
-          VcsEventSet(1982 to 1988, Map(OpFetch -> 2, OpStore -> 1), (1449523267535L,1449523650543L), pid, Set(StaffPrincipal.Gemini)),
-          VcsEventSet(1960 to 1965, Map(OpFetch -> 2, OpStore -> 2), (1449516911922L,1449517556842L), pid, Set(ProgramPrincipal(pid))) //,
-        ), true)
-      }
-
-      for {
-        _ <- initTestData
-        x <- doSelectByProgram(SPProgramID.toProgramID("GN-2015B-Q-10"), 1, 3)
-      } yield x must_== expected
-
-    }.pendingUntilFixed("See REL-2682")
-
-  }
+//  "compatibility" should {
+//
+//    "query old database with identical result" in go {
+//
+//      // result as constructed by the old implementation
+//      val expected = {
+//        val pid = SPProgramID.toProgramID("GN-2015B-Q-10")
+//        (List(
+//          VcsEventSet(2061 to 2061, Map(OpFetch -> 1), (1449531008701L,1449531008701L), pid, Set(ProgramPrincipal(pid))),
+//          VcsEventSet(1982 to 1988, Map(OpFetch -> 2, OpStore -> 1), (1449523267535L,1449523650543L), pid, Set(StaffPrincipal.Gemini)),
+//          VcsEventSet(1960 to 1965, Map(OpFetch -> 2, OpStore -> 2), (1449516911922L,1449517556842L), pid, Set(ProgramPrincipal(pid))) //,
+//        ), true)
+//      }
+//
+//      for {
+//        _ <- initTestData
+//        x <- doSelectByProgram(SPProgramID.toProgramID("GN-2015B-Q-10"), 1, 3)
+//      } yield x must_== expected
+//
+//    }
+//
+//  }
 
   "checkSchema" should {
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
@@ -52,10 +52,6 @@ object Ephemeris extends EphemerisInstances with EphemerisLenses {
   def singleton(site: Site, time: Long, coordinates: Coordinates): Ephemeris =
     apply(site, ==>>.singleton(time, coordinates))
 
-  /** An empty ephemeris with the given site affinity. */
-  def apply(site: Site): Ephemeris =
-    apply(site, ==>>.empty)
-
 }
 
 trait EphemerisInstances {

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
@@ -24,9 +24,13 @@ final case class Ephemeris(site: Site, data: Long ==>> Coordinates) {
   def toList: List[(Long, Coordinates)] =
     data.toList
 
-  /** Is the ephemeris empty? */
+  /** Are there no elements? */
   def isEmpty: Boolean =
     data.isEmpty
+
+  /** Is there at least one element? */
+  def nonEmpty: Boolean =
+    !isEmpty
 
   /** Find the closest matching element, if any. */
   def lookupClosestAssoc(k: Long): Option[(Long, Coordinates)] =

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
@@ -1,0 +1,79 @@
+package edu.gemini.spModel.core
+
+import scalaz._, Scalaz._
+
+final case class Ephemeris(site: Site, data: Long ==>> Coordinates) {
+
+  /** Perform an exact or interpolated lookup. */
+  def iLookup(k: Long): Option[Coordinates] =
+    data.iLookup(k)
+
+  /** Construct an exact or interpolated slice. */
+  def iSlice(lo: Long, hi: Long): Option[Ephemeris] =
+    data.iSlice(lo, hi).map(Ephemeris(site, _))
+
+  /** Construct a table of (Long, Coordinates) values on the given interval. */
+  def iTable(lo: Long, hi: Long, step: Long): Option[List[(Long, Coordinates)]] =
+    data.iTable(lo, hi, step)
+
+  /** Number of elements in the ephemeris. */
+  def size: Int =
+    data.size
+
+  /** Ephemeris elements as an association list. */
+  def toList: List[(Long, Coordinates)] =
+    data.toList
+
+  /** Is the ephemeris empty? */
+  def isEmpty: Boolean =
+    data.isEmpty
+
+  /** Find the closest matching element, if any. */
+  def lookupClosestAssoc(k: Long): Option[(Long, Coordinates)] =
+    data.lookupClosestAssoc(k)
+
+  /** Find the closest matching Coordinates, if any. */
+  def lookupClosest(k: Long): Option[Coordinates] =
+    data.lookupClosest(k)
+
+  /** Find the closest matching time, if any. */
+  def lookupClosestKey(k: Long): Option[Long] =
+    data.lookupClosestKey(k)
+
+}
+
+object Ephemeris extends EphemerisInstances with EphemerisLenses {
+
+  /** The empty ephemeris, with site arbitrarily chosen to be GN. */
+  val empty: Ephemeris =
+    apply(Site.GN, ==>>.empty)
+
+  /** A single-point ephemeris. */
+  def singleton(site: Site, time: Long, coordinates: Coordinates): Ephemeris =
+    apply(site, ==>>.singleton(time, coordinates))
+
+  /** An empty ephemeris with the given site affinity. */
+  def apply(site: Site): Ephemeris =
+    apply(site, ==>>.empty)
+
+}
+
+trait EphemerisInstances {
+
+  implicit val EqualEphemeris: Equal[Ephemeris] =
+    Equal.equalBy(e => (e.site, e.data))
+
+}
+
+trait EphemerisLenses {
+
+  val site: Ephemeris @> Site =
+    Lens.lensu((a, b) => a.copy(site = b), _.site)
+
+  val data: Ephemeris @> (Long ==>> Coordinates) =
+    Lens.lensu((a, b) => a.copy(data = b), _.data)
+
+  val ephemerisElements: Ephemeris @> List[(Long, Coordinates)] =
+    data.xmapB(_.toList)(==>>.fromList(_))
+
+}

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
@@ -241,7 +241,7 @@ case class NonSiderealTarget(
 }
 
 object NonSiderealTarget extends NonSiderealTargetLenses {
-  val empty = NonSiderealTarget("Untitled", ==>>.empty, None, Nil, None, None)
+  val empty = NonSiderealTarget("Untitled", Ephemeris.empty, None, Nil, None, None)
 }
 
 trait NonSiderealTargetLenses {
@@ -257,9 +257,6 @@ trait NonSiderealTargetLenses {
 
   val magnitudes: NonSiderealTarget @> List[Magnitude] =
     Lens.lensu((a, b) => a.copy(magnitudes = b), _.magnitudes)
-
-  val ephemerisElements: NonSiderealTarget @> List[(Long, Coordinates)] =
-    ephemeris.xmapB(_.toList)(==>>.fromList(_))
 
   val spectralDistribution: NonSiderealTarget @> Option[SpectralDistribution] =
     Lens.lensu((a, b) => a.copy(spectralDistribution = b), _.spectralDistribution)

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
@@ -24,11 +24,6 @@ package object core {
   type Dec = Declination
   val  Dec = Declination
 
-  type Ephemeris = Long ==>> Coordinates
-  object Ephemeris {
-    val empty: Ephemeris = ==>>.empty
-  }
-
   implicit def SPProgramIdToRichProgramId(id: SPProgramID): RichSpProgramId =
     new RichSpProgramId(id)
 

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -125,11 +125,18 @@ object AlmostEqual {
         (a.spatialProfile       ~= b.spatialProfile)
     }
 
+  implicit val EphemerisAlmostEqual =
+    new AlmostEqual[Ephemeris] {
+      def almostEqual(a: Ephemeris, b: Ephemeris) =
+        (a.site   == b.site)   &&
+        (a.toList ~= b.toList)
+    }
+
   implicit val NonSiderealTargetAlmostEqual =
     new AlmostEqual[NonSiderealTarget] {
       def almostEqual(a: NonSiderealTarget, b: NonSiderealTarget) =
         (a.name                 == b.name)                 &&
-        (a.ephemeris.toList     ~= b.ephemeris.toList)     &&
+        (a.ephemeris            ~= b.ephemeris)            &&
         (a.horizonsDesignation  == b.horizonsDesignation)  &&
         (a.magnitudes           ~= b.magnitudes)           &&
         (a.spectralDistribution ~= b.spectralDistribution) &&

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
@@ -141,16 +141,24 @@ trait Arbitraries {
       } yield SiderealTarget(name, coordinates, properMotion, redshift, parallax, magnitudes, spectralDistr, spatialProfile)
     }
 
+  implicit val arbEphemeris: Arbitrary[Ephemeris] =
+    Arbitrary {
+      for {
+        site <- arbitrary[Site]
+        data <- arbitrary[List[(Long, Coordinates)]]
+      } yield Ephemeris(site, ==>>.fromList(data))
+    }
+
   implicit val arbNonSiderealTarget: Arbitrary[NonSiderealTarget] =
     Arbitrary {
       for {
          name           <- arbitrary[String]
-         ephemeris      <- arbitrary[List[(Long, Coordinates)]]
+         ephemeris      <- arbitrary[Ephemeris]
          horizonsDes    <- arbitrary[Option[HorizonsDesignation]]
          magnitudes     <- arbitrary[List[Magnitude]]
          spectralDistr  <- arbitrary[Option[SpectralDistribution]]
          spatialProfile <- arbitrary[Option[SpatialProfile]]
-      } yield NonSiderealTarget(name, ==>>.fromList(ephemeris), horizonsDes, magnitudes, spectralDistr, spatialProfile)
+      } yield NonSiderealTarget(name, ephemeris, horizonsDes, magnitudes, spectralDistr, spatialProfile)
     }
 
   implicit val arbTarget: Arbitrary[Target] =

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
@@ -1,6 +1,7 @@
 package edu.gemini.spModel.io.impl.migration
 
 import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.core.{ProgramId, StandardProgramId, Site}
 import edu.gemini.spModel.io.impl.SpIOTags
 import edu.gemini.spModel.pio.xml.PioXmlUtil
 import edu.gemini.spModel.pio.{Container, ParamSet, Document, Version}
@@ -66,4 +67,13 @@ trait Migration {
     PioXmlUtil.write(d, writer)
     writer.toString
   }
+
+  /** Gets the site from the Program ID, if any. */
+  protected def programSite(d: Document): Option[Site] =
+    for {
+      cont <- d.containers.find(_.getKind == SpIOTags.PROGRAM)
+      pid  <- ProgramId.parseStandardId(cont.getName)
+      site <- pid.site
+    } yield site
+
 }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -79,7 +79,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
       p.findBaseByObsTitle("named") must_== Some(
         NonSiderealTarget(
           "Mars",
-          IMap(1457994429000L -> Coordinates.fromDegrees(240.99149999999997, 340.4314722222223).get),
+          Ephemeris(Site.GS, IMap(1457994429000L -> Coordinates.fromDegrees(240.99149999999997, 340.4314722222223).get)),
           Some(MajorBody(499)),
           List(),
           None,
@@ -91,7 +91,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
       p.findBaseByObsTitle("jpl-minor-body") must_== Some(
         NonSiderealTarget(
           "halley",
-          IMap(1457994460000L -> Coordinates.fromDegrees(125.49337500000001, 1.8927499999999782).get),
+          Ephemeris(Site.GS, IMap(1457994460000L -> Coordinates.fromDegrees(125.49337500000001, 1.8927499999999782).get)),
           None,
           List(),
           None,
@@ -102,7 +102,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
     "Migrate MPC Minor Planets" in withTestProgram2("targetMigration.xml") { p =>
       p.findBaseByObsTitle("mpc-minor-planet") must_== Some(NonSiderealTarget(
         "beer",
-        IMap(1457994485000L -> Coordinates.fromDegrees(88.769, 21.08299999999997).get),
+        Ephemeris(Site.GS, IMap(1457994485000L -> Coordinates.fromDegrees(88.769, 21.08299999999997).get)),
         None,
         List(),
         None,

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/TargetMigrationTest.scala
@@ -79,7 +79,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
       p.findBaseByObsTitle("named") must_== Some(
         NonSiderealTarget(
           "Mars",
-          Ephemeris(Site.GS, IMap(1457994429000L -> Coordinates.fromDegrees(240.99149999999997, 340.4314722222223).get)),
+          Ephemeris(Site.GN, IMap(1457994429000L -> Coordinates.fromDegrees(240.99149999999997, 340.4314722222223).get)),
           Some(MajorBody(499)),
           List(),
           None,
@@ -91,7 +91,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
       p.findBaseByObsTitle("jpl-minor-body") must_== Some(
         NonSiderealTarget(
           "halley",
-          Ephemeris(Site.GS, IMap(1457994460000L -> Coordinates.fromDegrees(125.49337500000001, 1.8927499999999782).get)),
+          Ephemeris(Site.GN, IMap(1457994460000L -> Coordinates.fromDegrees(125.49337500000001, 1.8927499999999782).get)),
           None,
           List(),
           None,
@@ -102,7 +102,7 @@ class TargetMigrationTest extends Specification with MigrationTest {
     "Migrate MPC Minor Planets" in withTestProgram2("targetMigration.xml") { p =>
       p.findBaseByObsTitle("mpc-minor-planet") must_== Some(NonSiderealTarget(
         "beer",
-        Ephemeris(Site.GS, IMap(1457994485000L -> Coordinates.fromDegrees(88.769, 21.08299999999997).get)),
+        Ephemeris(Site.GN, IMap(1457994485000L -> Coordinates.fromDegrees(88.769, 21.08299999999997).get)),
         None,
         List(),
         None,

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/TestSupport.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/TestSupport.scala
@@ -2,7 +2,7 @@ package edu.gemini.dbTools.ephemeris
 
 import edu.gemini.pot.sp.{ISPObsComponent, ISPObservation, ProgramTestSupport, SPComponentType, ISPFactory, ISPProgram, ProgramGen}
 import edu.gemini.shared.util.immutable.ScalaConverters._
-import edu.gemini.spModel.core.{SiderealTarget, NonSiderealTarget, HorizonsDesignation}
+import edu.gemini.spModel.core.{Ephemeris, SiderealTarget, NonSiderealTarget, HorizonsDesignation}
 import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.obs.{ObservationStatus, ObsPhase2Status, SPObservation}
 import edu.gemini.spModel.obsrecord.ObsExecStatus
@@ -17,7 +17,6 @@ import java.security.Principal
 
 import scala.collection.JavaConverters._
 import scala.util.Random
-import scalaz.==>>
 
 trait TestSupport extends ProgramTestSupport {
   val User = java.util.Collections.singleton[Principal](StaffPrincipal.Gemini)
@@ -33,7 +32,7 @@ trait TestSupport extends ProgramTestSupport {
 
   val genNonSiderealTarget: Gen[NonSiderealTarget] =
     Gen.oneOf(nonSids).map { case (hid, name) =>
-      NonSiderealTarget(name, ==>>.empty, Some(hid), List.empty, None, None)
+      NonSiderealTarget(name, Ephemeris.empty, Some(hid), List.empty, None, None)
     }
 
   def findOrCreateTargetComp(f: ISPFactory, o: ISPObservation): ISPObsComponent =

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/tcc/TcsConfigTest.scala
@@ -1,6 +1,6 @@
 package edu.gemini.wdba.tcc
 
-import edu.gemini.spModel.core.{Declination, Angle, RightAscension, Coordinates, SiderealTarget, NonSiderealTarget, Target}
+import edu.gemini.spModel.core._
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import edu.gemini.spModel.util.SPTreeUtil
 import org.junit.Assert._
@@ -22,7 +22,7 @@ final class TcsConfigTest extends TestBase {
 
   @Test
   def testNonSiderealWithoutHorizonsDesignation(): Unit = {
-    setBase(NonSiderealTarget("Titan", ==>>.empty, None, List.empty, None, None))
+    setBase(NonSiderealTarget("Titan", Ephemeris.empty, None, List.empty, None, None))
     val m = getTcsConfigurationMap(getSouthResults)
     assertNull(m.get(TccNames.EPHEMERIS))
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
@@ -62,7 +62,7 @@ object EphemerisUpdater {
     for {
       e1 <- lookupEphemerisWithPadding(d, site, 1000, s)
       e2 <- lookupEphemeris(d, site, new Date(n.getStartTime), new Date(n.getEndTime), 300)
-    } yield e1.union(e2)
+    } yield Ephemeris(site, e1.data.union(e2.data))
   }
 
   /** Get the target node, scheduling block start, and site; we need all of these. */

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/EphemerisEditor.scala
@@ -56,8 +56,8 @@ class EphemerisEditor extends TelescopePosEditor with ReentrancyHack {
       // Ephemeris bounds and resolution
       for {
         e <- Target.ephemeris.get(spt.getTarget).filterNot(_.isEmpty)
-        a <- e.findMin.map(_._1)
-        b <- e.findMax.map(_._1)
+        a <- e.data.findMin.map(_._1)
+        b <- e.data.findMax.map(_._1)
       } {
         start.setText(formatDate(a))
         end  .setText(formatDate(b))

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -36,7 +36,7 @@ class TpeEphemerisFeature extends TpeImageFeature("Ephemeris", "Show interpolate
   // represents consecutive ephemeris elements that could be successfully
   // located on the image widget.
   def toScreenEphemeris(e: Ephemeris): List[ScreenEphemeris] = {
-    val (lastSe, prevSes) = ((EmptyScreenEphemeris, List.empty[ScreenEphemeris])/:e.toDescList) { case ((se, ses), (time, coords)) =>
+    val (lastSe, prevSes) = ((EmptyScreenEphemeris, List.empty[ScreenEphemeris])/:e.data.toDescList) { case ((se, ses), (time, coords)) =>
       toScreenCoordinates(coords).filter(_iw.isVisible).fold {
         se.isEmpty ? ((se, ses)) | ((EmptyScreenEphemeris, se :: ses))
       } { p => ((time, p) :: se, ses) }


### PR DESCRIPTION
Science wanted a P2 check for the case where you fetch an ephemeris for one site, then the instrument changes or the target is copy/pasted such that the ephemeris is no longer consistent with the site where the observation will take place. This ended up being quite a lot of work.

- `Ephemeris` is now a data type with a `site` field and a `data` field (which contains the time/coord map). For an empty ephemeris the site is irrelevant and is arbitrarily set to `GN`. This was a simpler change than introducing an `Option` or `Either` and is really ok.
- This changes both binary and PIO serialization.
- A P2 error is raised if the observation's site is know and inconsistent with the ephemeris.

👎  for now but you can go ahead and review; I need to add a unit test.