### PR TITLE
REL-2797: fully initialize renumbered observations

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/init/ObservationNI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/init/ObservationNI.java
@@ -42,7 +42,7 @@ public class ObservationNI implements ISPNodeInitializer {
     /**
      * A special instance for use when importing programs from XML
      */
-    public static ObservationNI NO_CHILDREN_INSTANCE = new ObservationNI() {
+    public static final ObservationNI NO_CHILDREN_INSTANCE = new ObservationNI() {
         protected void addSubnodes(ISPFactory factory, ISPObservation obsNode) {
         }
     };

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/MergePlan.scala
@@ -6,6 +6,7 @@ import edu.gemini.shared.util._
 import edu.gemini.shared.util.IntegerIsIntegral._
 import edu.gemini.sp.vcs2.NodeDetail.Obs
 import edu.gemini.sp.vcs2.VcsFailure._
+import edu.gemini.spModel.gemini.init.ObservationNI
 import edu.gemini.spModel.rich.pot.sp._
 
 import scalaz._
@@ -105,7 +106,7 @@ case class MergePlan(update: Tree[MergeNode], delete: Set[Missing]) {
               // with the correct number.  Set the "initializer" to null though
               // since we'll be setting up the observation ourselves below.
               if (num === o.getObservationNumber) o
-              else f.createObservation(p, num, null, o.getNodeKey)
+              else f.createObservation(p, num, ObservationNI.NO_CHILDREN_INSTANCE, o.getNodeKey)
             case _                             => // not an observation
               n
           }


### PR DESCRIPTION
This is an addendum to the REL-2797 observation renumbering PR.  There is a bug in that renumbered observations are not being fully initialized with the suite of non-"data object" client data.  Instead of using a `null` node initializer in the `MergePlan` I should have used an instance that does everything except add child nodes.