### PR TITLE
REL-2814: add execution context parameter

### DIFF
--- a/bundle/edu.gemini.ags.client.api/src/main/scala/edu/gemini/ags/client/api/AgsClient.scala
+++ b/bundle/edu.gemini.ags.client.api/src/main/scala/edu/gemini/ags/client/api/AgsClient.scala
@@ -3,8 +3,7 @@ package edu.gemini.ags.client.api
 import edu.gemini.model.p1.immutable.Observation
 import java.net.URL
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * Base trait for AGS client implementations.
@@ -22,7 +21,7 @@ trait AgsClient {
    * Performs an asynchronous estimation request, providing the result to the
    * given callback function when available.
    */
-  def estimate(obs: Observation, time: Long)(callback: Callback) {
+  def estimate(obs: Observation, time: Long)(callback: Callback)(implicit ec: ExecutionContext) {
     Future.apply { callback(estimateNow(obs, time)) }
   }
 

--- a/bundle/edu.gemini.ags.servlet/src/main/scala/edu/gemini/ags/servlet/AgsServlet.scala
+++ b/bundle/edu.gemini.ags.servlet/src/main/scala/edu/gemini/ags/servlet/AgsServlet.scala
@@ -12,6 +12,7 @@ import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import javax.servlet.http.HttpServletResponse.{SC_BAD_GATEWAY, SC_BAD_REQUEST, SC_INTERNAL_SERVER_ERROR, SC_OK}
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
 object AgsServlet {

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -13,7 +13,7 @@ import edu.gemini.shared.util.immutable.{Option => JOption, Some => JSome}
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scalaz._
 import Scalaz._
 
@@ -32,16 +32,16 @@ trait AgsStrategy {
     else analyze(ctx, mt, guideProbe, guideStar).asGeminiOpt
   }
 
-  def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]]
+  def candidates(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]]
 
   /**
    * Returns a list of catalog queries that would be used to search for guide stars with the given context
    */
   def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery]
 
-  def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate]
+  def estimate(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[AgsStrategy.Estimate]
 
-  def select(ctx: ObsContext, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]]
+  def select(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[Option[AgsStrategy.Selection]]
 
   def guideProbes: List[GuideProbe]
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsUtil.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsUtil.scala
@@ -4,7 +4,7 @@ import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
 import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 object AgsUtil {
   private def lookupAndThen[A](obs: ISPObservation, default: => A)(op: (AgsStrategy, ObsContext) => Future[A]): Future[A] =
@@ -13,10 +13,10 @@ object AgsUtil {
       strategy <- AgsRegistrar.currentStrategy(ctx)
     } yield op(strategy, ctx)).getOrElse(Future.successful(default))
 
-  def lookupAndEstimate(obs: ISPObservation, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
+  def lookupAndEstimate(obs: ISPObservation, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[AgsStrategy.Estimate] =
     lookupAndThen(obs, AgsStrategy.Estimate.CompleteFailure)((s,c) => s.estimate(c, mt))
 
-  def lookupAndSelect(obs: ISPObservation, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]] =
+  def lookupAndSelect(obs: ISPObservation, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] =
     lookupAndThen(obs, Option.empty[AgsStrategy.Selection])((s,c) => s.select(c, mt))
 
   def currentStrategy(obs: ISPObservation): Option[AgsStrategy] =

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -9,12 +9,12 @@ import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.guide.{ValidatableGuideProbe, GuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGuideProbe, override val probeBands: BandsList) extends AgsStrategy {
 
   // Since the science target is the used as the guide star, success is always guaranteed.
-  override def estimate(ctx: ObsContext, mt: MagnitudeTable): Future[AgsStrategy.Estimate] =
+  override def estimate(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[AgsStrategy.Estimate] =
     Future.successful(AgsStrategy.Estimate.GuaranteedSuccess)
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
@@ -23,12 +23,12 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, probeBands).toList
 
-  override def candidates(ctx: ObsContext, mt: MagnitudeTable): Future[List[(GuideProbe, List[SiderealTarget])]] = {
+  override def candidates(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = {
     val so = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
     Future.successful(List((guideProbe, List(so))))
   }
 
-  override def select(ctx: ObsContext, mt: MagnitudeTable): Future[Option[AgsStrategy.Selection]] = {
+  override def select(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] = {
     // The science target is the guide star, but must be converted from SPTarget to SkyObject.
     val siderealTarget = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
     val posAngle       = ctx.getPositionAngle.toNewModel

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -32,6 +32,7 @@ import scala.concurrent.duration._
 import org.specs2.mutable.SpecificationLike
 import AlmostEqual.AlmostEqualOps
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scalaz._
 import Scalaz._

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
@@ -23,6 +23,7 @@ import scalaz._
 import Scalaz._
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
 
 class GemsVoTableCatalogSpec extends Specification {

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -25,6 +25,7 @@ import org.specs2.mutable.Specification
 import AlmostEqual.AlmostEqualOps
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 import scalaz._

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -31,6 +31,7 @@ import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -25,6 +25,7 @@ import org.specs2.mutable.Specification
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 import scalaz._

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
@@ -3,15 +3,14 @@ package edu.gemini.catalog.votable
 import java.net.URL
 
 import edu.gemini.catalog.api.{UCAC4, CatalogQuery}
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
 import scalaz.NonEmptyList
 
 // Backend for tests, reads votable xml files from the classpath
 case class TestVoTableBackend(file: String) extends VoTableBackend {
   override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
 
-  override def doQuery(query: CatalogQuery, url: URL) = Future {
+  override def doQuery(query: CatalogQuery, url: URL)(implicit ec: ExecutionContext) = Future {
     VoTableParser.parse(UCAC4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
   }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -1021,7 +1021,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
 
     private void showGemsGuideStarSearchDialog() {
         if (_gemsGuideStarSearchDialog == null) {
-            _gemsGuideStarSearchDialog = new GemsGuideStarSearchDialog(this);
+            _gemsGuideStarSearchDialog = new GemsGuideStarSearchDialog(this, scala.concurrent.ExecutionContext$.MODULE$.global());
         } else {
             _gemsGuideStarSearchDialog.reset();
             _gemsGuideStarSearchDialog.setVisible(true);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
@@ -48,7 +48,7 @@ class GemsGuideStarSearchController {
     /**
      * Searches for guide star candidates and saves the results in the model
      */
-    public void query() throws Exception {
+    public void query(scala.concurrent.ExecutionContext ec) throws Exception {
         WorldCoords basePos = _tpe.getBasePos();
         ObsContext obsContext = _worker.getObsContext(basePos.getRaDeg(), basePos.getDecDeg());
         Set<edu.gemini.spModel.core.Angle> posAngles = getPosAngles(obsContext);
@@ -59,7 +59,7 @@ class GemsGuideStarSearchController {
         List<GemsCatalogSearchResults> results;
         try {
             results = _worker.search(_model.getCatalog(), tipTiltMode, obsContext, posAngles,
-                    new scala.Some<>(nirBand));
+                    new scala.Some<>(nirBand), ec);
         } catch(Exception e) {
             DialogUtil.error(_dialog, e);
             results = new ArrayList<>();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -164,14 +164,17 @@ public class GemsGuideStarSearchDialog extends JFrame {
     private boolean _ignoreSelection;
     private TargetEnvironment _savedTargetEnv;
 
+    private final scala.concurrent.ExecutionContext ec;
+
     private TargetEnvironment getEnvironment(TpeImageWidget tpe) {
         return tpe.getContext().targets().envOrDefault();
     }
 
-    public GemsGuideStarSearchDialog(TpeImageWidget tpe) {
+    public GemsGuideStarSearchDialog(TpeImageWidget tpe, scala.concurrent.ExecutionContext ec) {
         super("GeMS Guide Star Search");
         _tpe = tpe;
         _plotter = tpe.plotter();
+        this.ec = ec;
 
         _candidateGuideStarsTable = new CandidateGuideStarsTable(_plotter);
 
@@ -183,7 +186,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         getContentPane().add(makeBottomPanel(), BorderLayout.SOUTH);
 
         _model = new GemsGuideStarSearchModel();
-        _worker = new GemsGuideStarWorker(_statusPanel);
+        _worker = new GemsGuideStarWorker(_statusPanel, ec);
         _statusPanel.setText("");
 
         _controller = new GemsGuideStarSearchController(_model, _worker, this, _tpe);
@@ -489,7 +492,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
             @Override
             public Object construct() {
                 try {
-                    _controller.query();
+                    _controller.query(ec);
                     return null;
                 } catch (Exception e) {
                     return e;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -243,7 +243,7 @@ object BagsManager {
   private val worker = new ScheduledThreadPoolExecutor(NumWorkers, new ThreadFactory() {
     override def newThread(r: Runnable): Thread = {
       val t = new Thread(r, "BagsManager - Worker")
-      t.setPriority(Thread.NORM_PRIORITY - 1)
+      t.setPriority(Thread.NORM_PRIORITY - 2)
       t.setDaemon(true)
       t
     }


### PR DESCRIPTION
This PR adds an implicit `ExecutionContext` parameter to all the AGS methods (and also to the `VoTableClient` catalog search).  This makes it possible to run the BAGS searches in the BAGS execution context instead of the default global execution context where everything else runs.  The BAGS execution context runs with lower-priority threads so manual catalog searches and target name resolution can continue to be responsive while BAGS is running.  The execution context parameter bubbled up through the AGS APIs so a number of files had to be modified.

I also lowered the priority of BAGS searches a bit so as to not compete with the worker that updates serialized program files in the database. 