### PR TITLE
REL-2816: log NonSiderealTargetRefFunctor exceptions and continue

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/NonSiderealTargetRefFunctor.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/NonSiderealTargetRefFunctor.scala
@@ -4,8 +4,8 @@ import edu.gemini.pot.sp.{ISPProgram, ISPNode}
 import edu.gemini.pot.spdb.{IDBDatabaseService, DBAbstractQueryFunctor}
 
 import java.security.Principal
+import java.util.logging.{Level, Logger}
 import java.util.{Set => JSet}
-
 
 import scalaz._, Scalaz._
 
@@ -13,18 +13,35 @@ import scalaz._, Scalaz._
   * observations.
   */
 object NonSiderealTargetRefFunctor {
+  private final val Log = Logger.getLogger(NonSiderealTargetRefFunctor.getClass.getName)
+
   def query(db: IDBDatabaseService, users: JSet[Principal]): List[NonSiderealTargetRef] =
     new NonSiderealTargetRefFunctor |> (f => db.getQueryRunner(users).queryPrograms(f).results)
 }
 
 private class NonSiderealTargetRefFunctor extends DBAbstractQueryFunctor{
+  import NonSiderealTargetRefFunctor.Log
   import NonSiderealTargetRef.findRelevantIn
 
   var results: List[NonSiderealTargetRef] = Nil
 
-  override def execute(db: IDBDatabaseService, node: ISPNode, principals: JSet[Principal]): Unit =
+  override def execute(db: IDBDatabaseService, node: ISPNode, principals: JSet[Principal]): Unit = {
+
+    // Get the non-sidereal target references for program p, but don't let any
+    // non-fatal exceptions kill the functor for any remaining programs.
+    def nonSidRefsFor(p: ISPProgram): List[NonSiderealTargetRef] =
+       \/.fromTryCatchNonFatal(findRelevantIn(p)) match {
+         case -\/(t)   =>
+           Log.log(Level.WARNING, s"Couldn't get non-sidereal targets in program ${Option(p.getProgramID).getOrElse(p.getProgramKey)}", t)
+           Nil
+
+         case \/-(lst) =>
+           lst
+       }
+
     node match {
-      case p: ISPProgram => results = findRelevantIn(p) ++ results
+      case p: ISPProgram => results = nonSidRefsFor(p) ++ results
       case _             => // do nothing
     }
+  }
 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/NonSiderealTargetRefTest.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/ephemeris/NonSiderealTargetRefTest.scala
@@ -1,8 +1,9 @@
 package edu.gemini.dbTools.ephemeris
 
 import edu.gemini.pot.sp.{ISPObservation, ISPProgram}
+import edu.gemini.spModel.config.IConfigBuilder
 import edu.gemini.spModel.core.{SiderealTarget, Target, NonSiderealTarget}
-import edu.gemini.spModel.obs.ObservationStatus
+import edu.gemini.spModel.obs.{ObsPhase2Status, SPObservation, ObservationStatus}
 import edu.gemini.spModel.obs.ObservationStatus.{INACTIVE, OBSERVED}
 import edu.gemini.spModel.target.env.TargetEnvironment
 import edu.gemini.spModel.target.obsComp.TargetObsComp
@@ -107,5 +108,31 @@ object NonSiderealTargetRefTest extends TestSupport {
         nsSize + inactiveCount == allSize
       }
     }
+
+    /* TODO: This works but fills the log with frightening stack traces because
+       TODO: we set it up to throw an exception.  Need a way to limit output.
+    "include observations for which we cannot compute the obs status" ! forAllPrograms { (odb, progs) =>
+      progs.forall { prog =>
+
+        // Figure out all the references w/o exceptions.
+        val refs0 = NonSiderealTargetRef.findRelevantIn(prog)
+
+        // Doctor all the observations to blow up when you compute the obs
+        // status.
+        prog.getAllObservations.asScala.foreach { obs =>
+          val sp = obs.getDataObject.asInstanceOf[SPObservation]
+          sp.setPhase2Status(ObsPhase2Status.PHASE_2_COMPLETE)
+          sp.setExecStatusOverride(edu.gemini.shared.util.immutable.ImOption.empty())
+          obs.setDataObject(sp)
+          obs.removeClientData(IConfigBuilder.USER_OBJ_KEY)
+        }
+
+        NonSiderealTargetRef.Log.setLevel(Level.WARNING)
+
+        // They should be the same
+        refs0 == refs1
+      }
+    }
+    */
   }
 }


### PR DESCRIPTION
This PR addresses a problem wherein an exception in computing the observation status of any observation in the ODB would stop the `NonSiderealTargetRefFunctor` (part of the "ephemeris robot") from finding other non-sidereal targets.  Specifically there are two changes:

- Handle exceptions in the observation status computation explicitly, since smart-gcal makes the computation error-prone.  Assume if we don't know the status because of an exception, the observation is still active.

- Handle other random exceptions that may happen while processing a particular program so that other programs without problems in the database can at least be included in the results.

(I struggled to come up with an automated test quickly so I just sanity checked it in my build.  I'll keep working on it but wanted to get this out for feedback now.)