### PR TITLE
use special executor for blocking catalog queries

### DIFF
--- a/bundle/edu.gemini.ags.client.api/src/main/scala/edu/gemini/ags/client/api/AgsClient.scala
+++ b/bundle/edu.gemini.ags.client.api/src/main/scala/edu/gemini/ags/client/api/AgsClient.scala
@@ -21,8 +21,8 @@ trait AgsClient {
    * Performs an asynchronous estimation request, providing the result to the
    * given callback function when available.
    */
-  def estimate(obs: Observation, time: Long)(callback: Callback)(implicit ec: ExecutionContext) {
-    Future.apply { callback(estimateNow(obs, time)) }
+  def estimate(obs: Observation, time: Long)(callback: Callback)(ec: ExecutionContext) {
+    Future.apply { callback(estimateNow(obs, time)) }(ec)
   }
 
   /**

--- a/bundle/edu.gemini.ags.servlet/src/main/scala/edu/gemini/ags/servlet/AgsServlet.scala
+++ b/bundle/edu.gemini.ags.servlet/src/main/scala/edu/gemini/ags/servlet/AgsServlet.scala
@@ -69,7 +69,7 @@ class AgsServlet(magTable: MagnitudeTable) extends HttpServlet {
     def estimate(ctx: ObsContext, s: AgsStrategy): Either[Response, AgsStrategy.Estimate] = {
       import scala.concurrent.duration._
       Try {
-        Await.result(s.estimate(ctx, magTable), 1.minute)
+        Await.result(s.estimate(ctx, magTable)(implicitly), 1.minute)
       } match {
         case Success(e)               => Right(e)
         case Failure(io: IOException) => Left(failure(SC_BAD_GATEWAY, io))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -32,16 +32,16 @@ trait AgsStrategy {
     else analyze(ctx, mt, guideProbe, guideStar).asGeminiOpt
   }
 
-  def candidates(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]]
+  def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]]
 
   /**
    * Returns a list of catalog queries that would be used to search for guide stars with the given context
    */
   def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery]
 
-  def estimate(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[AgsStrategy.Estimate]
+  def estimate(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[AgsStrategy.Estimate]
 
-  def select(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[Option[AgsStrategy.Selection]]
+  def select(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[Option[AgsStrategy.Selection]]
 
   def guideProbes: List[GuideProbe]
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsUtil.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsUtil.scala
@@ -13,11 +13,11 @@ object AgsUtil {
       strategy <- AgsRegistrar.currentStrategy(ctx)
     } yield op(strategy, ctx)).getOrElse(Future.successful(default))
 
-  def lookupAndEstimate(obs: ISPObservation, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[AgsStrategy.Estimate] =
-    lookupAndThen(obs, AgsStrategy.Estimate.CompleteFailure)((s,c) => s.estimate(c, mt))
+  def lookupAndEstimate(obs: ISPObservation, mt: MagnitudeTable)(ec: ExecutionContext): Future[AgsStrategy.Estimate] =
+    lookupAndThen(obs, AgsStrategy.Estimate.CompleteFailure)((s,c) => s.estimate(c, mt)(ec))
 
-  def lookupAndSelect(obs: ISPObservation, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] =
-    lookupAndThen(obs, Option.empty[AgsStrategy.Selection])((s,c) => s.select(c, mt))
+  def lookupAndSelect(obs: ISPObservation, mt: MagnitudeTable)(ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] =
+    lookupAndThen(obs, Option.empty[AgsStrategy.Selection])((s,c) => s.select(c, mt)(ec))
 
   def currentStrategy(obs: ISPObservation): Option[AgsStrategy] =
     ObsContext.create(obs).asScalaOpt.flatMap(AgsRegistrar.currentStrategy)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGuideProbe, override val probeBands: BandsList) extends AgsStrategy {
 
   // Since the science target is the used as the guide star, success is always guaranteed.
-  override def estimate(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[AgsStrategy.Estimate] =
+  override def estimate(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[AgsStrategy.Estimate] =
     Future.successful(AgsStrategy.Estimate.GuaranteedSuccess)
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
@@ -23,12 +23,12 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, probeBands).toList
 
-  override def candidates(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = {
+  override def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = {
     val so = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
     Future.successful(List((guideProbe, List(so))))
   }
 
-  override def select(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] = {
+  override def select(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] = {
     // The science target is the guide star, but must be converted from SPTarget to SkyObject.
     val siderealTarget = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
     val posAngle       = ctx.getPositionAngle.toNewModel

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -16,6 +16,7 @@ import edu.gemini.shared.util.immutable.ScalaConverters._
 
 import scala.collection.JavaConverters._
 import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scalaz._
 import Scalaz._
@@ -40,27 +41,27 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
   override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] =
     params.catalogQueries(withCorrectedSite(ctx), mt).toList
 
-  override def candidates(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = {
+  override def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = {
     val empty = Future.successful(List((params.guideProbe: GuideProbe, List.empty[SiderealTarget])))
 
     // We cannot let VoTableClient to filter targets as usual, instead we provide an empty magnitude constraint and filter locally
-    catalogQueries(withCorrectedSite(ctx), mt).strengthR(backend).headOption.map(Function.tupled(VoTableClient.catalog)).map(_.flatMap {
+    catalogQueries(withCorrectedSite(ctx), mt).strengthR(backend).headOption.map { case (a, b) => VoTableClient.catalog(a, b)(ec) }.map(_.flatMap {
         case r if r.result.containsError => Future.failed(CatalogException(r.result.problems))
         case r                           => Future.successful(List((params.guideProbe, r.result.targets.rows)))
     }).getOrElse(empty)
   }
 
-  private def catalogResult(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[List[SiderealTarget]] =
+  private def catalogResult(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[SiderealTarget]] =
     // call candidates and extract the one and only tuple for this strategy,
     // throw away the guide probe (which we know anyway), and obtain just the
     // list of guide stars
-    candidates(ctx, mt).map { lst =>
+    candidates(ctx, mt)(ec).map { lst =>
       lst.headOption.foldMap(_._2)
     }
 
-  override def estimate(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[AgsStrategy.Estimate] = {
+  override def estimate(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[AgsStrategy.Estimate] = {
     val ct = withCorrectedSite(ctx)
-    catalogResult(ct, mt).map(estimate(ct, mt, _))
+    catalogResult(ct, mt)(ec).map(estimate(ct, mt, _))
   }
 
   private def estimate(ctx: ObsContext, mt: MagnitudeTable, candidates: List[SiderealTarget]): AgsStrategy.Estimate = {
@@ -73,9 +74,9 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
     AgsStrategy.Estimate.toEstimate(successProbability)
   }
 
-  override def select(ctx: ObsContext, mt: MagnitudeTable)(implicit ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] = {
+  override def select(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] = {
     val ct = withCorrectedSite(ctx)
-    catalogResult(ct, mt).map(select(ct, mt, _))
+    catalogResult(ct, mt)(ec).map(select(ct, mt, _))
   }
 
   private def withCorrectedSite(ctx: ObsContext): ObsContext =

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -352,7 +352,7 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
 
     val options = new GemsGuideStarSearchOptions(instrument, tipTiltMode, posAngles)
 
-    val results = Await.result(catalog.search(obsContext, base.toNewModel, options, scala.None), 5.seconds)
+    val results = Await.result(catalog.search(obsContext, base.toNewModel, options, scala.None)(implicitly), 5.seconds)
     val gemsResults = GemsResultsAnalyzer.analyze(obsContext, posAngles, results.asJava, scala.None)
     (results, gemsResults.asScala.toList)
   }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
@@ -45,7 +45,7 @@ class GemsVoTableCatalogSpec extends Specification {
       val posAngles = new java.util.HashSet[Angle]()
       val options = new GemsGuideStarSearchOptions(instrument, tipTiltMode, posAngles)
 
-      val results = Await.result(GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml")).search(ctx, base, options, scala.None), 30.seconds)
+      val results = Await.result(GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml")).search(ctx, base, options, scala.None)(implicitly), 30.seconds)
       results should be size 2
 
       results.head.criterion should beEqualTo(GemsCatalogSearchCriterion(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, GsaoiOdgw.Group.instance), CatalogSearchCriterion("On-detector Guide Window tiptilt", RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01666666666665151)), MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(14.5), Some(SaturationConstraint(7.3))), Some(Offset(0.0014984027777700248.degrees[OffsetP], 0.0014984027777700248.degrees[OffsetQ])), scala.None)))

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
@@ -244,7 +244,7 @@ class MascotGuideStarSpec extends Specification {
       val coordinates = Coordinates(RightAscension.fromAngle(Angle.fromHMS(3, 19, 48.2341).getOrElse(Angle.zero)), Declination.fromAngle(Angle.fromDMS(41, 30, 42.078).getOrElse(Angle.zero)).getOrElse(Declination.zero))
 
       val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromArcmin(MascotCat.defaultMinRadius), Angle.fromArcmin(MascotCat.defaultMaxRadius)), PPMXL)
-      val r = VoTableClient.catalog(query, TestVoTableBackend("/mascotquery.xml")).map { t =>
+      val r = VoTableClient.catalog(query, TestVoTableBackend("/mascotquery.xml"))(implicitly).map { t =>
         val base = new SPTarget(coordinates.ra.toAngle.toDegrees, coordinates.dec.toDegrees)
         val env = TargetEnvironment.create(base)
         val inst = new Gsaoi()

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -50,7 +50,7 @@ class GemsStrategySpec extends Specification {
 
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), SPSiteQuality.Conditions.BEST, null, new Gems, JNone.instance())
 
-      val estimate = TestGemsStrategy("/gemsstrategyquery.xml").estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = TestGemsStrategy("/gemsstrategyquery.xml").estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
     "support search" in {
@@ -65,7 +65,7 @@ class GemsStrategySpec extends Specification {
 
       val posAngles = Set.empty[Angle]
 
-      val results = Await.result(TestGemsStrategy("/gemsstrategyquery.xml").search(tipTiltMode, ctx, posAngles, scala.None), 20.seconds)
+      val results = Await.result(TestGemsStrategy("/gemsstrategyquery.xml").search(tipTiltMode, ctx, posAngles, scala.None)(implicitly), 20.seconds)
       results should be size 2
 
       results.head.criterion should beEqualTo(GemsCatalogSearchCriterion(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, GsaoiOdgw.Group.instance), CatalogSearchCriterion("On-detector Guide Window tiptilt", RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01666666666665151)), MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(14.5), scala.Option(SaturationConstraint(7.3))), scala.Option(Offset(0.0014984027777700248.degrees[OffsetP], 0.0014984027777700248.degrees[OffsetQ])), scala.None)))
@@ -88,7 +88,7 @@ class GemsStrategySpec extends Specification {
       testSearchOnNominal("/gems_pal1.xml", ctx, tipTiltMode, posAngles, 2, 2)
 
       val gemsStrategy = TestGemsStrategy("/gems_pal1.xml")
-      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
+      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow())(implicitly), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.zero)
       val assignments = ~selection.map(_.assignments)
       assignments should be size 3
@@ -138,7 +138,7 @@ class GemsStrategySpec extends Specification {
       } should beSome(true)
 
       // Test estimate
-      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
     "support search/select and analyze on SN-1987A" in {
@@ -156,7 +156,7 @@ class GemsStrategySpec extends Specification {
       testSearchOnStandardConditions("/gems_sn1987A.xml", ctx, tipTiltMode, posAngles, 9, 9)
 
       val gemsStrategy = TestGemsStrategy("/gems_sn1987A.xml")
-      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
+      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow())(implicitly), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.zero)
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
@@ -216,7 +216,7 @@ class GemsStrategySpec extends Specification {
       } should beSome(true)
 
       // Test estimate
-      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
     "support search/select and analyze on SN-1987A part 2" in {
@@ -234,7 +234,7 @@ class GemsStrategySpec extends Specification {
       testSearchOnBestConditions("/gems_sn1987A.xml", ctx, tipTiltMode, posAngles, 12, 9)
 
       val gemsStrategy = TestGemsStrategy("/gems_sn1987A.xml")
-      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
+      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow())(implicitly), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.zero)
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
@@ -281,7 +281,7 @@ class GemsStrategySpec extends Specification {
       } should beSome(true)
 
       // Test estimate
-      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
     "support search/select and analyze on TYC 8345-1155-1" in {
@@ -299,7 +299,7 @@ class GemsStrategySpec extends Specification {
       testSearchOnStandardConditions("/gems_TYC_8345_1155_1.xml", ctx, tipTiltMode, posAngles, 25, 28)
 
       val gemsStrategy = TestGemsStrategy("/gems_TYC_8345_1155_1.xml")
-      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
+      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow())(implicitly), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.zero)
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
@@ -356,7 +356,7 @@ class GemsStrategySpec extends Specification {
       } should beSome(true)
 
       // Test estimate
-      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
     "support search/select and analyze on M6" in {
@@ -374,7 +374,7 @@ class GemsStrategySpec extends Specification {
       testSearchOnStandardConditions("/gems_m6.xml", ctx, tipTiltMode, posAngles, 5, 7)
 
       val gemsStrategy = TestGemsStrategy("/gems_m6.xml")
-      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
+      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow())(implicitly), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.fromDegrees(90))
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
@@ -433,7 +433,7 @@ class GemsStrategySpec extends Specification {
       } should beSome(true)
 
       // Test estimate
-      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
     "support search/select and analyze on BPM 37093" in {
@@ -451,7 +451,7 @@ class GemsStrategySpec extends Specification {
       testSearchOnStandardConditions("/gems_bpm_37093.xml", ctx, tipTiltMode, posAngles, 4, 5)
 
       val gemsStrategy = TestGemsStrategy("/gems_bpm_37093.xml")
-      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
+      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow())(implicitly), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.zero)
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
@@ -497,7 +497,7 @@ class GemsStrategySpec extends Specification {
       } should beSome(true)
 
       // Test estimate
-      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
     "support search/select and analyze on BPM 37093 part 2" in {
@@ -515,7 +515,7 @@ class GemsStrategySpec extends Specification {
       testSearchOnBestConditions("/gems_bpm_37093.xml", ctx, tipTiltMode, posAngles, 5, 5)
 
       val gemsStrategy = TestGemsStrategy("/gems_bpm_37093.xml")
-      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow()), 2.minutes)
+      val selection = Await.result(gemsStrategy.select(ctx, ProbeLimitsTable.loadOrThrow())(implicitly), 2.minutes)
       selection.map(_.posAngle) should beSome(Angle.zero)
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
@@ -561,13 +561,13 @@ class GemsStrategySpec extends Specification {
       } should beSome(true)
 
       // Test estimate
-      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())
+      val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
       Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
     }
   }
 
   def testSearchOnStandardConditions(file: String, ctx: ObsContext, tipTiltMode: GemsTipTiltMode, posAngles: Set[Angle], expectedTipTiltResultsCount: Int, expectedFlexureResultsCount: Int): Unit = {
-    val results = Await.result(TestGemsStrategy(file).search(tipTiltMode, ctx, posAngles, scala.None), 20.seconds)
+    val results = Await.result(TestGemsStrategy(file).search(tipTiltMode, ctx, posAngles, scala.None)(implicitly), 20.seconds)
     results should be size 2
 
     results.head.criterion.key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, Wfs.Group.instance))
@@ -579,7 +579,7 @@ class GemsStrategySpec extends Specification {
   }
 
   def testSearchOnNominal(file: String, ctx: ObsContext, tipTiltMode: GemsTipTiltMode, posAngles: Set[Angle], expectedTipTiltResultsCount: Int, expectedFlexureResultsCount: Int): Unit = {
-    val results = Await.result(TestGemsStrategy(file).search(tipTiltMode, ctx, posAngles, scala.None), 20.seconds)
+    val results = Await.result(TestGemsStrategy(file).search(tipTiltMode, ctx, posAngles, scala.None)(implicitly), 20.seconds)
     results should be size 2
 
     results.head.criterion.key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, Wfs.Group.instance))
@@ -591,7 +591,7 @@ class GemsStrategySpec extends Specification {
   }
 
   def testSearchOnBestConditions(file: String, ctx: ObsContext, tipTiltMode: GemsTipTiltMode, posAngles: Set[Angle], expectedTipTiltResultsCount: Int, expectedFlexureResultsCount: Int): Unit = {
-    val results = Await.result(TestGemsStrategy(file).search(tipTiltMode, ctx, posAngles, scala.None), 20.seconds)
+    val results = Await.result(TestGemsStrategy(file).search(tipTiltMode, ctx, posAngles, scala.None)(implicitly), 20.seconds)
     results should be size 2
 
     results.head.criterion.key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, Wfs.Group.instance))

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeStrategySpec.scala
@@ -74,7 +74,7 @@ class SingleProbeStrategySpec extends Specification {
       val aoComp = new InstAltair <| {_.setMode(AltairParams.Mode.NGS)}
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.BEST, null, aoComp, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "553-036128", AltairAowfsGuider.instance)
     }
@@ -90,7 +90,7 @@ class SingleProbeStrategySpec extends Specification {
       val aoComp = new InstAltair <| {_.setMode(AltairParams.Mode.LGS)}
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), null, aoComp, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "344-198748", AltairAowfsGuider.instance)
     }
@@ -108,7 +108,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "340-000202", PwfsGuideProbe.pwfs1)
     }
@@ -126,7 +126,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).cc(SPSiteQuality.CloudCover.PERCENT_80).iq(SPSiteQuality.ImageQuality.PERCENT_85)
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "458-000297", PwfsGuideProbe.pwfs2)
     }
@@ -144,7 +144,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "288-000438", GmosOiwfsGuideProbe.instance)
     }
@@ -173,7 +173,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
       val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
-      val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection  = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff", GmosOiwfsGuideProbe.instance, PossibleIqDegradation)
     }
     "when there is equal vignetting at a given pos angle, pick the brightest option" in {
@@ -201,7 +201,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
       val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
-      val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection  = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff Bright", GmosOiwfsGuideProbe.instance)
     }
     "when there is equal vignetting at a multiple pos angles, pick the brightest option" in {
@@ -233,7 +233,7 @@ class SingleProbeStrategySpec extends Specification {
       val strategy   = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), voTable)
       val conditions = SPSiteQuality.Conditions.NOMINAL
       val ctx        = ObsContext.create(env, inst, new Some(Site.GN), conditions, os.asJava, null, JNone.instance())
-      val selection  = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection  = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
       verifyGuideStarSelection(strategy, ctx, selection, "Biff Flip Bright", GmosOiwfsGuideProbe.instance)
     }
     "find a guide star for GMOS-N+PWFS2, OCSADV-255" in {
@@ -250,7 +250,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.WORST
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "560-017530", PwfsGuideProbe.pwfs2)
     }
@@ -268,7 +268,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.WORST
       val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "105-014127", Flamingos2OiwfsGuideProbe.instance)
     }
@@ -286,7 +286,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70)
       val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "105-014476", PwfsGuideProbe.pwfs2)
     }
@@ -304,7 +304,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
       val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       // 138-005574 is slightly brighter but vignettes a bit more
       verifyGuideStarSelection(strategy, ctx, selection, "138-005571", GmosOiwfsGuideProbe.instance)
@@ -323,7 +323,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
       val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "302-000084", PwfsGuideProbe.pwfs2)
     }
@@ -341,7 +341,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.NOMINAL.cc(SPSiteQuality.CloudCover.PERCENT_70).sb(SPSiteQuality.SkyBackground.ANY)
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "571-008701", PwfsGuideProbe.pwfs2)
     }
@@ -359,7 +359,7 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.NOMINAL.cc(SPSiteQuality.CloudCover.PERCENT_70).sb(SPSiteQuality.SkyBackground.ANY)
       val ctx = ObsContext.create(env, inst, new Some(Site.GN), conditions, null, null, JNone.instance())
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "424-010170", PwfsGuideProbe.pwfs2)
     }
@@ -377,11 +377,11 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.WORST
       val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
-      val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
+      val estimate = Await.result(strategy.estimate(ctx, magTable)(implicitly), 10.seconds)
 
       estimate should beEqualTo(Estimate.CompleteFailure)
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
       selection should beNone
     }
     "find a guide star for Phoenix with slightly better conditions, REL-2436" in {
@@ -398,11 +398,11 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70).iq(SPSiteQuality.ImageQuality.PERCENT_85)
       val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
-      val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
+      val estimate = Await.result(strategy.estimate(ctx, magTable)(implicitly), 10.seconds)
 
       estimate should beEqualTo(Estimate.GuaranteedSuccess)
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx, selection, "195-006563", PwfsGuideProbe.pwfs2)
     }
@@ -420,11 +420,11 @@ class SingleProbeStrategySpec extends Specification {
       val conditions = SPSiteQuality.Conditions.WORST.cc(SPSiteQuality.CloudCover.PERCENT_70).iq(SPSiteQuality.ImageQuality.PERCENT_85)
       val ctx = ObsContext.create(env, inst, new Some(Site.GS), conditions, null, null, JNone.instance())
 
-      val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
+      val estimate = Await.result(strategy.estimate(ctx, magTable)(implicitly), 10.seconds)
 
       estimate should beEqualTo(Estimate.CompleteFailure)
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
       selection should beNone
     }
     "find a guide star for Visitor even if the site is not defined, REL-2476" in {
@@ -441,11 +441,11 @@ class SingleProbeStrategySpec extends Specification {
       // Note, no site defined
       val ctx = ObsContext.create(env, inst, JNone.instance(), conditions, null, null, JNone.instance())
 
-      val estimate = Await.result(strategy.estimate(ctx, magTable), 10.seconds)
+      val estimate = Await.result(strategy.estimate(ctx, magTable)(implicitly), 10.seconds)
 
       estimate should beEqualTo(Estimate.GuaranteedSuccess)
 
-      val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+      val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
       verifyGuideStarSelection(strategy, ctx.withSite(new Some(Site.GS)), selection, "195-006563", PwfsGuideProbe.pwfs2)
     }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -109,7 +109,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
         val (ctx, candidates) = env
 
         val strategy  = SingleProbeStrategy(GmosNorthOiwfsKey, SingleProbeStrategyParams.GmosOiwfsParams(Site.GN), CannedBackend(candidates))
-        val selection = Await.result(strategy.select(ctx, magTable), 10.seconds)
+        val selection = Await.result(strategy.select(ctx, magTable)(implicitly), 10.seconds)
 
         val analyzedCandidates = for {
           gs <- candidates

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
@@ -4,13 +4,14 @@ import java.net.URL
 
 import edu.gemini.catalog.api.{UCAC4, CatalogQuery}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 import scalaz.NonEmptyList
 
 // Backend for tests, reads votable xml files from the classpath
 case class TestVoTableBackend(file: String) extends VoTableBackend {
   override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
 
-  override def doQuery(query: CatalogQuery, url: URL)(implicit ec: ExecutionContext) = Future {
+  override def doQuery(query: CatalogQuery, url: URL)(ec: ExecutionContext) = Future {
     VoTableParser.parse(UCAC4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -790,7 +790,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
     import scala.concurrent.ExecutionContext.Implicits.global
 
     GlassLabel.show(peer.getRootPane, message)
-    VoTableClient.catalog(query, backend).onComplete {
+    VoTableClient.catalog(query, backend)(global).onComplete {
       case scala.util.Failure(f)                           =>
         GlassLabel.hide(peer.getRootPane)
         errorLabel.show(s"Exception: ${f.getMessage}")

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/SiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/SiderealNameEditor.scala
@@ -26,7 +26,7 @@ final class SiderealNameEditor(mags: MagnitudeEditor2) extends TelescopePosEdito
   private def forkSearch(): Unit = {
     val searchItem = name.getValue
     GlassLabel.show(SwingUtilities.getRootPane(name), "Searching...") // We are on the EDT
-    VoTableClient.catalog(CatalogQuery(searchItem), SimbadNameBackend).onComplete { case t =>
+    VoTableClient.catalog(CatalogQuery(searchItem), SimbadNameBackend)(implicitly).onComplete { case t =>
       Swing.onEDT {
         GlassLabel.hide(SwingUtilities.getRootPane(name))
         t.map(r => (r.result.problems, r.result.targets.rows.headOption)) match {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/obscat/OTBrowserPresetsPersistence.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/obscat/OTBrowserPresetsPersistence.scala
@@ -6,6 +6,7 @@ import java.io._
 import java.util.logging.{Level, Logger}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 import scalaz._
 import Scalaz._
 
@@ -46,7 +47,7 @@ object OTBrowserPresetsPersistence {
     dir.ifNone(Log.warning("Must initialize the OTBrowser history"))
   }
 
-  def saveAsync(conf: OTBrowserConf)(implicit ctx: ExecutionContext): Future[Unit] = Future.apply(save(conf))
+  def saveAsync(conf: OTBrowserConf)(ctx: ExecutionContext): Future[Unit] = Future.apply(save(conf))
 
   private def save(conf: OTBrowserConf): Unit = catchingAll {
     dir.foreach { d =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/obscat/ObsCatalogQueryTool.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/obscat/ObsCatalogQueryTool.scala
@@ -167,7 +167,7 @@ final class ObsCatalogQueryTool(catalog: Catalog) {
               model.setSelectedItem(preset)
               this.peer.setModel(model)
               // Optimistically assume the save works ok
-              OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))
+              OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))(implicitly)
             }
             existingNames.find(_ == name).foreach { n =>
               DialogUtil.error(s"Name '$n' already in used")
@@ -181,7 +181,7 @@ final class ObsCatalogQueryTool(catalog: Catalog) {
             val model = new DefaultComboBoxModel[ObsQueryPreset]((existingElements.toList ::: (SaveNewPreset :: ~head)).toArray)
             existingElements.headOption.foreach(model.setSelectedItem)
             // Optimistically assume the save works ok
-            OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))
+            OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))(implicitly)
             this.peer.setModel(model)
           case SaveExistingPreset(preset) =>
             val updatedPreset = SavedPreset(queryPanel.selectionPreset(preset.name, remote.selected))
@@ -194,13 +194,13 @@ final class ObsCatalogQueryTool(catalog: Catalog) {
             this.peer.setModel(model)
             this.selection.item = updatedPreset
             // Save the updated preset
-            OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))
+            OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))(implicitly)
           case s @ SavedPreset(preset) =>
             // Update the model
             val previousModel = this.peer.getModel
             val existingElements = (0 until previousModel.getSize).map(previousModel.getElementAt).filter(_.hasSettings)
             val model = new DefaultComboBoxModel[ObsQueryPreset]((existingElements.toList ::: List(SaveNewPreset, SaveExistingPreset(s), DeletePreset(s))).toArray)
-            OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))
+            OTBrowserPresetsPersistence.saveAsync(presetsToSave(model))(implicitly)
             this.peer.setModel(model)
             this.selection.item = s
             remote.selected = preset.includeRemote


### PR DESCRIPTION
Ok so this modifies @swalker2m's work on #998 by making all the `implicit ec: ExecutionContext` parameters **ex**plicit, and only using the passed `ec` at the very bottom, when doing the blocking call to look up targets. Everything else runs on the global executor, except the BAGS worker itself, which is on its own pool still but may not need to be. I didn't mess with it.

In any case the end result is that BAGS results trickle in rather than batching up, and don't interfere with high-priority manual searches (and sidereal name lookups).

Reviewers need to pull this branch and test locally; the code itself isn't going to tell you much.