### PR TITLE
REL-2821 Revert "Remove warnings on obslog bundle"

### DIFF
--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/TextExport/support/AbstractTextSegmentExporter.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/TextExport/support/AbstractTextSegmentExporter.java
@@ -7,19 +7,27 @@ import edu.gemini.obslog.obslog.IObservingLogSegment;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
+
+//
+// Gemini Observatory/AURA
+// $Id: AbstractTextSegmentExporter.java,v 1.3 2006/12/05 15:14:02 gillies Exp $
+//
 
 /**
  * This class takes a segment and produces a table in the traditional obslog ascii text format.
  */
-abstract class AbstractTextSegmentExporter extends TextExportBase {
+public abstract class AbstractTextSegmentExporter extends TextExportBase {
     private static final Logger LOG = Logger.getLogger(AbstractTextSegmentExporter.class.getName());
+
+    protected static final Pattern ENDLINE_PATTERN = Pattern.compile("$", Pattern.MULTILINE);
 
     private IObservingLogSegment _segment;
     private List<ConfigMap> _rows;
     private Map<String, ColumnInfo> _columnInfo;
     private int _totalWidth;
 
-    class ColumnInfo {
+    protected class ColumnInfo {
         OlLogItem _logItem;
         int _headingWidth;
         int _maxColumnWidth;
@@ -44,6 +52,10 @@ abstract class AbstractTextSegmentExporter extends TextExportBase {
             return _headingWidth;
         }
 
+        void setHeadingWidth(int headingWidth) {
+            _headingWidth = headingWidth;
+        }
+
         int getMaxColumnWidth() {
             return _maxColumnWidth;
         }
@@ -53,32 +65,32 @@ abstract class AbstractTextSegmentExporter extends TextExportBase {
         }
     }
 
-    AbstractTextSegmentExporter(IObservingLogSegment segment) {
+    public AbstractTextSegmentExporter(IObservingLogSegment segment) {
         if (segment == null) throw new NullPointerException("Segment argument is null for export");
         _segment = segment;
         _build();
     }
 
-    Map<String,ColumnInfo> _getColumnInfoMap() {
+    protected Map<String,ColumnInfo> _getColumnInfoMap() {
         if (_columnInfo == null) {
-            _columnInfo = new LinkedHashMap<>();
+            _columnInfo = new LinkedHashMap<String,ColumnInfo>();
         }
         return _columnInfo;
     }
 
-    int _getTotalWidth() {
+    protected int _getTotalWidth() {
         return _totalWidth;
     }
 
-    List<ConfigMap> _getRows() {
+    protected List<ConfigMap> _getRows() {
         return _rows;
     }
 
-    IObservingLogSegment _getSegment() {
+    protected IObservingLogSegment _getSegment() {
         return _segment;
     }
 
-    // Private method to build all the structures needed for the text segment export
+    // Private method to build all the strucutures needed for the text segment export
     private void _build() {
         // Get the rows -- done once since this requires some work
         _rows = _segment.getRows();
@@ -90,7 +102,9 @@ abstract class AbstractTextSegmentExporter extends TextExportBase {
         int width = cinfo.getHeadingWidth();
         String property = cinfo.getProperty();
 
-        for (Map<String, Object> rowMap : rowMaps) {
+        for (int i = 0, size = rowMaps.size(); i < size; i++) {
+            Map rowMap = rowMaps.get(i);
+
             String value = (String) rowMap.get(property);
             if (value == null) {
                 if (LOG.isLoggable(Level.FINE)) LOG.fine("Property: " + property + " missing in map for obslog");
@@ -117,7 +131,7 @@ abstract class AbstractTextSegmentExporter extends TextExportBase {
         if (LOG.isLoggable(Level.FINE)) LOG.fine("Total width: " + totalWidth);
     }
 
-    OlLogItem _lookupColumnInfo(String propertyName) {
+    protected OlLogItem _lookupColumnInfo(String propertyName) {
         for (OlLogItem logItem : _segment.getTableInfo()) {
             if (logItem.getProperty().equals(propertyName)) {
                 return logItem;
@@ -148,7 +162,7 @@ abstract class AbstractTextSegmentExporter extends TextExportBase {
         _setTotalWidth();
     }
 
-    void _printJustifiedMultilineComment(StringBuilder sb, int maxColWidth, String prefix, String comment) {
+    protected void _printJustifiedMultilineComment(StringBuilder sb, int maxColWidth, String prefix, String comment) {
         //String[] lines = _splitComment(comment);
         //LOG.info("Length is: " + lines.length);
         StringTokenizer st = new StringTokenizer(comment, "\n\r");
@@ -160,7 +174,7 @@ abstract class AbstractTextSegmentExporter extends TextExportBase {
         }
     }
 
-    void _printOneRow(StringBuilder sb, ConfigMap row) {
+    protected void _printOneRow(StringBuilder sb, ConfigMap row) {
         Map<String,ColumnInfo> columns = _getColumnInfoMap();
 
         for (ColumnInfo cinfo : columns.values()) {
@@ -173,16 +187,16 @@ abstract class AbstractTextSegmentExporter extends TextExportBase {
         }
     }
 
-   void _printHeading(StringBuilder sb, List<ColumnInfo> columns) {
+   protected void _printHeading(StringBuilder sb,  List<ColumnInfo> columns) {
         for (ColumnInfo cinfo : columns) {
             _printJustifiedText(sb, cinfo.getMaxColumnWidth(), cinfo.getColumnHeading());
         }
         sb.append(AbstractTextSegmentExporter.NEWLINE);
     }
 
-    void _printHeading(StringBuilder sb) {
+    protected void _printHeading(StringBuilder sb) {
         Map<String,ColumnInfo> columns = _getColumnInfoMap();
-        _printHeading(sb, new ArrayList<>(columns.values()));
+        _printHeading(sb, new ArrayList<ColumnInfo>(columns.values()));
     }
 
     /**

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/actions/CommentTableDecorator.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/actions/CommentTableDecorator.java
@@ -1,0 +1,28 @@
+package edu.gemini.obslog.actions;
+
+import edu.gemini.obslog.obslog.ConfigMapUtil;
+import org.displaytag.decorator.TableDecorator;
+
+import java.util.Map;
+
+//
+// Gemini Observatory/AURA
+// $Id: CommentTableDecorator.java,v 1.3 2005/12/11 15:54:15 gillies Exp $
+//
+
+public class CommentTableDecorator extends TableDecorator {
+
+    public String getComment() {
+        Map m = (Map) getCurrentRowObject();
+
+        String svalue = (String) m.get(ConfigMapUtil.OBSLOG_COMMENT_ITEM_NAME);
+
+        String obsID = (String) m.get("observationID");
+        String configID = (String) m.get(ConfigMapUtil.OBSLOG_UNIQUECONFIG_ID);
+
+        String name = obsID + '-' + configID;
+
+        return "<div style='carea'><textarea id=\"" + name + "\" rows=2 cols=25>" + svalue + "</textarea></div>";
+    }
+
+}

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/actions/ListPlanAction.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/actions/ListPlanAction.java
@@ -7,15 +7,32 @@ import edu.gemini.obslog.obslog.functor.OlListPlanFunctor;
 import java.util.List;
 import java.util.logging.Logger;
 
+//
+// Gemini Observatory/AURA
+// $Id: ListPlanAction.java,v 1.1 2005/12/11 15:54:15 gillies Exp $
+//
+
 public class ListPlanAction extends OlBaseAction {
+    private static final Logger LOG = Logger.getLogger(ListPlanAction.class.getName());
+
+    private List _plans;
+
+    public List getPlans() {
+        return _plans;
+    }
 
     public String execute() {
+
         try {
-            OlListPlanFunctor.create(getPersistenceManager().getDatabase(), _user);
+            _plans = OlListPlanFunctor.create(getPersistenceManager().getDatabase(), _user);
         } catch (OlLogException ex) {
             addActionError("Plan request caused a log exception: " + ex);
             return ERROR;
-        }
+//        } catch (RemoteException ex) {
+//            ex.printStackTrace();
+//            addActionError("Plan request caused a remote exception: " + ex.toString());
+//            return ERROR;
+        } 
         return SUCCESS;
     }
 

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/model/OlBasicConfiguration.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/model/OlBasicConfiguration.java
@@ -6,6 +6,11 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.logging.Logger;
 
+//
+// Gemini Observatory/AURA
+// $Id: OlBasicConfiguration.java,v 1.5 2005/12/11 15:54:15 gillies Exp $
+//
+
 /**
  * OlBasicConfiguration is the top level model of configuration information.
  */
@@ -24,7 +29,7 @@ public class OlBasicConfiguration implements OlConfiguration, Serializable {
 
     // Internal class to model the keyed set of entries
     private class LogItems implements Serializable {
-        private Map<String, OlLogItem> items = new HashMap<>();
+        private Map<String, OlLogItem> items = new HashMap<String, OlLogItem>();
 
         void addLogItem(OlLogItem logItem) {
             if (logItem == null) throw new NullPointerException();
@@ -57,7 +62,7 @@ public class OlBasicConfiguration implements OlConfiguration, Serializable {
             return items.size();
         }
 
-        Iterator<String> iterator() {
+        Iterator iterator() {
             return items.keySet().iterator();
         }
     }
@@ -66,7 +71,7 @@ public class OlBasicConfiguration implements OlConfiguration, Serializable {
      * This class is a <tt>Hashmap</tt> of instrument names to OlBasicLogEntries which are a list of entries.
      */
     private class ObsLogs implements Serializable {
-        private Map<String, OlObsLogData> obsLogs = new HashMap<>();
+        private Map<String, OlObsLogData> obsLogs = new HashMap<String, OlObsLogData>();
 
         void addLogData(OlObsLogData obsLogData) {
             obsLogs.put(obsLogData.getKey(), obsLogData);
@@ -120,7 +125,7 @@ public class OlBasicConfiguration implements OlConfiguration, Serializable {
     // Key is the name of an instrument or obslog containing a list of logItems
     private class OlBasicLogData implements OlObsLogData, Serializable {
         private String _key;
-        private List<OlLogItem> _items = new ArrayList<>();
+        private List<OlLogItem> _items = new ArrayList<OlLogItem>();
         private OlSegmentType _type;
 
         OlBasicLogData(String key) {
@@ -150,11 +155,27 @@ public class OlBasicConfiguration implements OlConfiguration, Serializable {
             return logItem;
         }
 
+        public OlLogItem getLogItem(String itemKey) {
+            for (int i = 0, size = _items.size(); i < size; i++) {
+                OlLogItem item = _items.get(i);
+                if (item.getKey().equals(itemKey)) return item;
+            }
+            return null;
+        }
+
+        public OlLogItem getBySequenceName(String sequenceName) {
+            for (int i = 0, size = _items.size(); i < size; i++) {
+                OlLogItem item = _items.get(i);
+                if (sequenceName.equals(item.getSequenceName())) return item;
+            }
+            return null;
+        }
+
         public List<OlLogItem> getLogTableData() {
             return _items;
         }
 
-        public Iterator<OlLogItem> iterator() {
+        public Iterator iterator() {
             return _items.iterator();
         }
 
@@ -168,7 +189,6 @@ public class OlBasicConfiguration implements OlConfiguration, Serializable {
         }
     }
 
-    @Override
     public String getVersion() {
         return _VERSION;
     }
@@ -187,22 +207,67 @@ public class OlBasicConfiguration implements OlConfiguration, Serializable {
         return _allLogItems;
     }
 
-    @Override
+    /**
+     * public void addObsLogLogEntry(String logKey, String entryKey) throws OlModelException {
+     * OlObsLogData logEntry = _logEntries.getLogEntry(logKey);
+     * logEntry.addEntryKey(entryKey);
+     * <p/>
+     * <p/>
+     * <p/>
+     * <p/>
+     * public int getNumberLogEntries() {
+     * return _getLogEntries().getSize();
+     * }
+     * public void addLogItem(String entryKey) {
+     * if (entryKey == null) throw new IllegalArgumentException();
+     * OlBasicLogItem entry = new OlBasicLogItem(entryKey);
+     * _getEntries().addEntry(entry);
+     * }
+     */
+
+    public OlLogItem getItemInObsLog(String logKey, String itemKey) {
+        if (logKey == null || itemKey == null) throw new NullPointerException();
+
+        OlObsLogData obsLogData = _getObsLogs().getLogData(logKey);
+        if (obsLogData == null) return null;
+        return obsLogData.getLogItem(itemKey);
+    }
+
     public OlLogItem addItemToObsLog(String logKey, String itemKey) throws OlModelException {
         return _getObsLogs().addItemToObsLog(logKey, itemKey);
+    }
+
+    public OlLogItem getLogItem(String itemKey) {
+        return _getLogItems().getLogItem(itemKey);
     }
 
     public OlLogItem addLogItem(String itemKey) {
         return _getLogItems().addLogItem(itemKey);
     }
 
-    @Override
+    public OlObsLogData getDataForLog(String logKey) {
+        return _getObsLogs().getLogData(logKey);
+    }
+
     public OlObsLogData getDataForLogByType(String logKey) {
         return _getObsLogs().getDataForLogByType(logKey);
     }
 
-    @Override
-    public Iterator<String> getItems() {
+    public int getNumberObsLogs() {
+        return _getObsLogs().getSize();
+    }
+
+    public int getNumberLogItems() {
+        return _getLogItems().getSize();
+    }
+
+    public Iterator getObsLogItems(String logKey) {
+        OlObsLogData obsLogData = _getObsLogs().getLogData(logKey);
+        if (obsLogData == null) return new ArrayList().iterator();
+        return obsLogData.iterator();
+    }
+
+    public Iterator getItems() {
         return _getLogItems().iterator();
     }
 }

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/model/OlConfiguration.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/model/OlConfiguration.java
@@ -2,15 +2,32 @@ package edu.gemini.obslog.config.model;
 
 import java.util.Iterator;
 
+//
+// Gemini Observatory/AURA
+// $Id: OlConfiguration.java,v 1.2 2004/12/01 15:03:00 gillies Exp $
+//
+
 public interface OlConfiguration {
     String getVersion();
 
     OlLogItem addLogItem(String itemKey);
 
+    OlLogItem getLogItem(String itemKey);
+
+    OlLogItem getItemInObsLog(String logKey, String itemKey);
+
     OlLogItem addItemToObsLog(String logKey, String itemKey) throws OlModelException;
+
+    OlObsLogData getDataForLog(String logKey);
 
     OlObsLogData getDataForLogByType(String narrowType);
 
-    Iterator<String> getItems();
+    int getNumberObsLogs();
+
+    int getNumberLogItems();
+
+    Iterator getObsLogItems(String logKey);
+
+    Iterator getItems();
 }
 

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/model/OlObsLogData.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/model/OlObsLogData.java
@@ -5,18 +5,27 @@ import edu.gemini.obslog.core.OlSegmentType;
 import java.util.Iterator;
 import java.util.List;
 
+//
+// Gemini Observatory/AURA
+// $Id: OlObsLogData.java,v 1.2 2005/12/11 15:54:15 gillies Exp $
+//
+
 public interface OlObsLogData {
 
-    String getKey();
+    public String getKey();
 
-    OlSegmentType getType();
+    public OlSegmentType getType();
 
-    OlLogItem addLogItem(String key) throws OlModelException;
+    public OlLogItem addLogItem(String key) throws OlModelException;
 
-    Iterator<OlLogItem> iterator();
+    public OlLogItem getLogItem(String key);
 
-    List<OlLogItem> getLogTableData();
+    public Iterator iterator();
 
-    int getSize();
+    public OlLogItem getBySequenceName(String sequenceKey);
+
+    public List<OlLogItem> getLogTableData();
+
+    public int getSize();
 }
 

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/xml/OlXmlConfiguration.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/config/xml/OlXmlConfiguration.java
@@ -12,13 +12,19 @@ import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
 
 import java.net.URL;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Logger;
+
+//
+// Gemini Observatory/AURA
+// $Id: OlXmlConfiguration.java,v 1.3 2005/03/17 06:04:33 gillies Exp $
+//
 
 public final class OlXmlConfiguration {
     public static final Logger LOG = Logger.getLogger(OlXmlConfiguration.class.getName());
 
-    private static String _CONFIG_FILE;
+    static public String _CONFIG_FILE;
 
     public OlXmlConfiguration(String configFile) throws NullPointerException {
         if (configFile == null) throw new NullPointerException();
@@ -44,8 +50,9 @@ public final class OlXmlConfiguration {
 
     /**
      * Build a configuration from the XML file.
+     *
+     * @param d
      */
-    @SuppressWarnings("unchecked")
     private OlConfiguration _buildModel(Document d) throws OlModelException {
         Node versionNode = d.selectSingleNode("//obslog/@version");
         if (versionNode == null) throw new NullPointerException("No obslog version attribute.");
@@ -55,10 +62,12 @@ public final class OlXmlConfiguration {
         OlConfiguration config = new OlBasicConfiguration(version);
 
         // Get the entryGroups and foreach add the entries
-        List<Element> list = d.selectNodes("/configuration/entry");
+        List list = d.selectNodes("/configuration/entry");
         if (list == null) throw new NullPointerException();
 
-        for (Element node : list) {
+        for (Iterator iter = list.iterator(); iter.hasNext();) {
+
+            Element node = (Element) iter.next();
             String entryKey = node.attribute("key").getStringValue();
             LOG.fine("EntryKey: " + entryKey);
             String isVisible = node.attributeValue("visible");
@@ -71,18 +80,22 @@ public final class OlXmlConfiguration {
             String sequenceName = node.elementText("sequenceName");
             logItem.setSequenceName(sequenceName);
             // Set to true unless present and false
-            logItem.setVisible(isVisible == null || Boolean.getBoolean(isVisible));
+            logItem.setVisible(isVisible != null ? Boolean.getBoolean(isVisible) : true);
         }
 
         // Now add the instruments
-        List<Element> logEntries = d.selectNodes("//logEntry");
-        for (Element node : logEntries) {
+        List logEntries = d.selectNodes("//logEntry");
+        for (Iterator iter = logEntries.iterator(); iter.hasNext();) {
+            Element node = (Element) iter.next();
+
             String logKey = node.attribute("key").getStringValue();
             LOG.fine("logEntry key: " + logKey);
 
 
-            List<Element> glist = node.selectNodes("entry");
-            for (Element gnode: glist) {
+            List glist = node.selectNodes("entry");
+            for (Iterator giter = glist.iterator(); giter.hasNext();) {
+                Element gnode = (Element) giter.next();
+
                 String entryKey = gnode.attribute("key").getStringValue();
                 LOG.fine("Entry name: " + entryKey);
 

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/instruments/GsaoiLogSegment.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/instruments/GsaoiLogSegment.java
@@ -39,8 +39,9 @@ public class GsaoiLogSegment extends InstrumentLogSegment {
     */
 
     // must match ObsLogConfig.xml
-    private static final String FILTER_KEY    = "filter";
-    private static final String READ_MODE_KEY = "readMode";
+    public static final String FILTER_KEY    = "filter";
+    public static final String READ_MODE_KEY = "readMode";
+    public static final String COADDS_KEY    = "coadds";
 
     public GsaoiLogSegment(List<OlLogItem> logItems, OlLogOptions obsLogOptions) {
         super(SEG_TYPE, logItems, obsLogOptions);
@@ -58,7 +59,7 @@ public class GsaoiLogSegment extends InstrumentLogSegment {
         decorateVal(map, READ_MODE_KEY, Gsaoi.ReadMode.class);
     }
 
-    private void decorateVal(ConfigMap map, String key, Class<?> c) {
+    private void decorateVal(ConfigMap map, String key, Class c) {
         if (map == null) return;
 
         String strValue = map.sget(key);

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/OlDefaultObservingLog.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/OlDefaultObservingLog.java
@@ -7,6 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+//
+// Gemini Observatory/AURA
+// $Id: OlDefaultObservingLog.java,v 1.4 2005/12/11 15:54:15 gillies Exp $
+//
+
 public class OlDefaultObservingLog implements IObservingLog, Serializable {
 
     private List<IObservingLogSegment> _logSegments;
@@ -15,7 +20,7 @@ public class OlDefaultObservingLog implements IObservingLog, Serializable {
 
     private synchronized List<IObservingLogSegment> _getLogSegments() {
         if (_logSegments == null) {
-            _logSegments = new ArrayList<>();
+            _logSegments = new ArrayList<IObservingLogSegment>();
         }
         return _logSegments;
     }
@@ -26,12 +31,24 @@ public class OlDefaultObservingLog implements IObservingLog, Serializable {
     }
 
     public List<IObservingLogSegment> getLogSegments() {
-        return Collections.unmodifiableList(new ArrayList<>(_getLogSegments()));
+        return Collections.unmodifiableList(new ArrayList<IObservingLogSegment>(_getLogSegments()));
+    }
+
+    public void setLogSegments(List<IObservingLogSegment> segments) {
+        if (segments == null) segments = new ArrayList<IObservingLogSegment>();
+        _logSegments = segments;
     }
 
     public void addLogSegment(IObservingLogSegment segment) {
         List<IObservingLogSegment> logSegments = _getLogSegments();
         logSegments.add(segment);
+    }
+
+    public IObservingLogSegment getLogSegment(int segmentIndex) {
+        if (segmentIndex < getLogSegmentCount()) {
+            return getLogSegments().get(segmentIndex);
+        }
+        return null;
     }
 
     /**
@@ -61,9 +78,9 @@ public class OlDefaultObservingLog implements IObservingLog, Serializable {
     }
 
     public void dump() {
-        List<IObservingLogSegment> segs = getLogSegments();
+        List segs = getLogSegments();
         for (int i = 0; i < getLogSegmentCount(); i++) {
-            segs.get(i).dump();
+            ((IObservingLogSegment) segs.get(i)).dump();
         }
     }
 }

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/functor/OlObsVisitFunctor.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/functor/OlObsVisitFunctor.java
@@ -14,6 +14,11 @@ import edu.gemini.shared.util.GeminiRuntimeException;
 import java.security.Principal;
 import java.util.*;
 
+//
+// Gemini Observatory/AURA
+// $Id: OlObsVisitFunctor.java,v 1.3 2006/12/05 14:56:16 gillies Exp $
+//
+
 public final class OlObsVisitFunctor extends OlTransferDataFunctor {
 
     public OlObsVisitFunctor(OlLogOptions obsLogOptions, List<SPObservationID> observationIDs) {
@@ -26,13 +31,13 @@ public final class OlObsVisitFunctor extends OlTransferDataFunctor {
      *
      * @param observations the list of observations that should be fetched from the database
      * @return a new <tt>List</tt> of <tt>ObservationData</tt> objects.
+     * @throws java.rmi.RemoteException
      */
-    @Override
     protected List<EObslogVisit> fetchObservationData(List<ISPObservation> observations)  {
-        List<EObslogVisit> obsData = new ArrayList<>();
+        List<EObslogVisit> obsData = new ArrayList<EObslogVisit>();
 
-        for (ISPObservation observation : observations) {
-            List<EObslogVisit> od = ObservationObsVisitsFactory.build(observation, _getObsLogOptions());
+        for (int i = 0, size = observations.size(); i < size; i++) {
+            List<EObslogVisit> od = ObservationObsVisitsFactory.build(observations.get(i), _getObsLogOptions());
             obsData.addAll(od);
         }
 
@@ -41,7 +46,7 @@ public final class OlObsVisitFunctor extends OlTransferDataFunctor {
         return obsData;
     }
 
-    public static List<EObslogVisit> create(IDBDatabaseService db, OlLogOptions obsLogOptions, List<SPObservationID> observationIDs, Set<Principal> user)  {
+    public static List create(IDBDatabaseService db, OlLogOptions obsLogOptions, List<SPObservationID> observationIDs, Set<Principal> user)  {
 
         OlObsVisitFunctor lf = new OlObsVisitFunctor(obsLogOptions, observationIDs);
         try {
@@ -53,9 +58,8 @@ public final class OlObsVisitFunctor extends OlTransferDataFunctor {
         return lf.getResult();
     }
 
-    @Override
     public void mergeResults(Collection<IDBFunctor> functorCollection) {
-        List<EObslogVisit> res = new ArrayList<>();
+        List<EObslogVisit> res = new ArrayList<EObslogVisit>();
         for (IDBFunctor f : functorCollection) {
             res.addAll(((OlObsVisitFunctor) f).getResult());
         }

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/functor/OlObsVisitTimeFunctor.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/functor/OlObsVisitTimeFunctor.java
@@ -16,6 +16,11 @@ import edu.gemini.shared.util.GeminiRuntimeException;
 import java.security.Principal;
 import java.util.*;
 
+//
+// Gemini Observatory/AURA
+// $Id: OlObsVisitTimeFunctor.java,v 1.2 2006/10/17 21:37:11 shane Exp $
+//
+
 public final class OlObsVisitTimeFunctor extends BaseTransferDataFunctor {
     private List<EChargeObslogVisit> _result;
 
@@ -27,13 +32,15 @@ public final class OlObsVisitTimeFunctor extends BaseTransferDataFunctor {
      * This private method takes a list of {@link edu.gemini.pot.sp.ISPObservation} instances and constructs
      * their ObservationData objects.
      *
+     * @param observations
      * @return a new <tt>List</tt> of <tt>ObservationData</tt> objects.
+     * @throws java.rmi.RemoteException
      */
-    private List<EChargeObslogVisit> fetchObservationData(List<ISPObservation> observations)  {
-        List<EChargeObslogVisit> obsData = new ArrayList<>();
+    protected List<EChargeObslogVisit> fetchObservationData(List<ISPObservation> observations)  {
+        List<EChargeObslogVisit> obsData = new ArrayList<EChargeObslogVisit>();
 
-        for (ISPObservation observation : observations) {
-            List<EChargeObslogVisit> od = ObservationObsVisitTimeFactory.build(observation, _getObsLogOptions());
+        for (int i = 0, size = observations.size(); i < size; i++) {
+            List<EChargeObslogVisit> od = ObservationObsVisitTimeFactory.build(observations.get(i), _getObsLogOptions());
             obsData.addAll(od);
         }
 
@@ -42,10 +49,15 @@ public final class OlObsVisitTimeFunctor extends BaseTransferDataFunctor {
         return obsData;
     }
 
-    @Override
     public void execute(IDBDatabaseService db, ISPNode node, Set<Principal> principals) {
-        List<ISPObservation> observations = _fetchObservations(db);
-        _result = fetchObservationData(observations);
+//        try {
+            List<ISPObservation> observations = _fetchObservations(db);
+            _result = fetchObservationData(observations);
+
+//        } catch (RemoteException ex) {
+            //LOG.error("Remote exception in local code!", ex);
+//            throw GeminiRuntimeException.newException(ex);
+//        }
     }
 
     /**
@@ -58,7 +70,7 @@ public final class OlObsVisitTimeFunctor extends BaseTransferDataFunctor {
     }
 
 
-    public static List<EChargeObslogVisit> create(IDBDatabaseService db, OlLogOptions obsLogOptions, List<SPObservationID> observationIDs, Set<Principal> user)  {
+    public static List create(IDBDatabaseService db, OlLogOptions obsLogOptions, List<SPObservationID> observationIDs, Set<Principal> user)  {
 
         OlObsVisitTimeFunctor lf = new OlObsVisitTimeFunctor(obsLogOptions, observationIDs);
         try {
@@ -70,9 +82,8 @@ public final class OlObsVisitTimeFunctor extends BaseTransferDataFunctor {
         return lf.getResult();
     }
 
-    @Override
     public void mergeResults(Collection<IDBFunctor> functorCollection) {
-        List<EChargeObslogVisit> res = new ArrayList<>();
+        List<EChargeObslogVisit> res = new ArrayList<EChargeObslogVisit>();
         for (IDBFunctor f : functorCollection) {
             res.addAll(((OlObsVisitTimeFunctor) f).getResult());
         }

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/osgi/DatabaseTracker.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/osgi/DatabaseTracker.java
@@ -8,29 +8,30 @@ import org.osgi.util.tracker.ServiceTracker;
 
 import java.util.logging.Logger;
 
-class DatabaseTracker extends ServiceTracker<IDBDatabaseService, IDBDatabaseService> {
+public class DatabaseTracker extends ServiceTracker {
 
-    private static final Logger LOGGER = Logger.getLogger(DatabaseTracker.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(DatabaseTracker.class.getName());
 
-    DatabaseTracker(BundleContext context) {
-        super(context, IDBDatabaseService.class.getName(), null);
-    }
+	public DatabaseTracker(BundleContext context) {
+		super(context, IDBDatabaseService.class.getName(), null);
+	}
 
-    @Override
-    public IDBDatabaseService addingService(ServiceReference<IDBDatabaseService> ref) {
-        IDBDatabaseService db = context.getService(ref);
-        SPDB.init(db);
-        LOGGER.info("Adding " + db.getUuid());
-        return db;
+	@Override
+	public Object addingService(ServiceReference ref) {
+		IDBDatabaseService db = (IDBDatabaseService) context.getService(ref);
+		SPDB.init(db);
+		LOGGER.info("Adding " + db.getUuid());
+		return db;
 
-    }
+	}
 
-    @Override
-    public void removedService(ServiceReference<IDBDatabaseService> ref, IDBDatabaseService db) {
+	@Override
+	public void removedService(ServiceReference ref, Object service) {
+		IDBDatabaseService db = (IDBDatabaseService) service;
         LOGGER.info("Removing " + db.getUuid());
         SPDB.clear();
-        context.ungetService(ref);
-    }
+		context.ungetService(ref);
+	}
 
 }
 


### PR DESCRIPTION
This reverts commit 411661636a53c9f07103616a6a44e1f9a16b4c9a.

The issue with listing observing plans was traced to this commit, which did a bit of premature cleanup.  It removed "unused" code that turned out to have been accessed via reflection/JSPs.  Reverting the update fixes the issue.  There may be unrelated obslog cleanup that is being reverted as well, but it was easiest to just revert the commit altogether.