### PR TITLE
REL-2824: remove call to unimplemented method

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/archive/Archiver.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/archive/Archiver.scala
@@ -73,7 +73,8 @@ class Archiver(log: Logger, ks: KeyServer, vl: VcsLog, user: java.util.Set[Princ
       _ <- IO(log.info(s"exporting to $dir"))
       _ <- IO(new ExportXmlApp(SPDB.get, user).exportAll(dir))
       _ <- ks.backup(new File(dir, "keydb.zip")).run
-      _ <- IO(vl.archive(new File(dir, "vcsdb.zip")))
+// REL-2824: removing this until it can be implemented
+//      _ <- IO(vl.archive(new File(dir, "vcsdb.zip")))
     } yield ()
 
   def zip(dir: File): IO[File] =


### PR DESCRIPTION
The daily ODB backup fails when it tries to archive the fetch/store (i.e. "vcs") log. I traced this down to a call to `VcsLog.archive` which is unimplemented:

````scala
  def archive(f: File): Unit = ???
````

I'm not sure how much work is involved in implementing the method but we can get around this for the next few days and allow the backup to complete by just skipping the fetch/store log archive for now, I think.