### PR TITLE
REL-2825: fix duplicate target feature

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -10,8 +10,6 @@ import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeUtil;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
-import edu.gemini.spModel.pio.ParamSet;
-import edu.gemini.spModel.pio.xml.PioXmlFactory;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.TelescopePosWatcher;
 import edu.gemini.spModel.target.env.*;
@@ -847,9 +845,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             targetOpt.foreach(target -> {
 
                 // Clone the target.
-                final ParamSet ps = target.getParamSet(new PioXmlFactory());
                 final SPTarget newTarget = new SPTarget();
-                newTarget.setParamSet(ps);
+                newTarget.setTarget(target.getTarget());
 
                 // Add it to the environment.  First we have to figure out what it is.
                 final TargetEnvironment env = dataObject.getTargetEnvironment();


### PR DESCRIPTION
Before the new target model was created, the only way to duplicate a target was via XML export followed by import.  Anything else required too much special case copying of individual fields and carried the risk of missing information as the target model evolved over time.  With the new target model all target classes are immutable except the `SPTarget` wrapper itself.  This makes duplication trivial and avoids any rounding errors introduced by passing the data through a `String` representation.