### PR TITLE
REL-2262: fix CAL/ENG ProgramId formatting

### DIFF
--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
@@ -68,7 +68,7 @@ object ProgramId {
     lazy val toSp: SPProgramID = SPProgramID.toProgramID(toString)
 
     override def toString: String =
-      s"${siteVal.abbreviation}-${ptypeVal.abbreviation}$year$month$day"
+      f"${siteVal.abbreviation}-${ptypeVal.abbreviation}$year%04d$month%02d$day%02d"
   }
 
   case class Arbitrary(site: Option[Site], semester: Option[Semester], ptype: Option[ProgramType], idString: String) extends ProgramId {


### PR DESCRIPTION
CAL and ENG program ids incorporate the date to which they correspond in format YYYYMMDD.  Unfortunately `ProgramId`, our program id parser/formatter, incorrectly formats CAL and ENG months and dates without a leading 0 in the case of single digit months and days.  Since the OT "Open" dialog works with `ProgramId` in order to accomplish its filtering, CAL and ENG programs are not handled correctly.  In particular, the "Remote" filter determines whether a program is local by asking a `ProgramId` for its corresponding `SPProgramID` and using that to lookup the program in the local ODB.  Since the `SPProgramID` is not correct, the filter fails.