### PR TITLE
REL-2831: compress ephemerides

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/TargetParamSetCodecs.scala
@@ -29,11 +29,6 @@ object TargetParamSetCodecs {
       .withParam("system",        Magnitude.system)
       .withOptionalParam("error", Magnitude.error)
 
-  implicit val EphemerisElementParamSetCodec: ParamSetCodec[(Long, Coordinates)] =
-    ParamSetCodec.initial((0L, Coordinates.zero))
-      .withParam("time",           Lens.firstLens[Long, Coordinates])
-      .withParamSet("coordinates", Lens.secondLens[Long, Coordinates])
-
   implicit val SpectralDistributionParamSetCodec: ParamSetCodec[SpectralDistribution] =
     new ParamSetCodec[SpectralDistribution] {
       val pf = new PioXmlFactory
@@ -109,8 +104,8 @@ object TargetParamSetCodecs {
 
   implicit val EphemerisParamSetCodec: ParamSetCodec[Ephemeris] =
     ParamSetCodec.initial(Ephemeris.empty)
-      .withParam("site",                     Ephemeris.site)
-      .withManyParamSet("ephemeris-element", Ephemeris.ephemerisElements)
+      .withParam("site", Ephemeris.site)
+      .withParam("data", Ephemeris.compressedData)
 
   implicit val NonSiderealTargetParamSetCodec: ParamSetCodec[NonSiderealTarget] =
     ParamSetCodec.initial(NonSiderealTarget.empty)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamSetCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/TargetParamSetCodecSpec.scala
@@ -37,7 +37,6 @@ object TargetParamSetCodecsSpec extends Specification with ScalaCheck with Arbit
     close[Coordinates]
     close[ProperMotion]
     close[Magnitude]
-    close[(Long, Coordinates)]
     close[SpectralDistribution]
     close[SpatialProfile]
     close[SiderealTarget]

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Deflated.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Deflated.scala
@@ -4,25 +4,35 @@ import java.io._
 import java.util.Arrays
 import java.util.zip.{ Deflater, Inflater }
 
-/**
- * A compressed value.
- * @param data the underlying byte array
- */
-final class Deflated[A] private (val data: Array[Byte]) extends Serializable {
+import scalaz.Functor
+
+/** A value that has been serialized and compressed. */
+final class Deflated[A] private (
+  private val blob: Array[Byte], 
+  private val k: Object => A
+) extends Serializable {
+
+  /** Return a *reference* to the deflated blob. */
+  def unsafeToByteArray: Array[Byte] =
+    blob
+
+  /** Return a *copy* of the deflated blob. */
+  def toByteArray: Array[Byte] =
+    blob.clone
 
   /** Size of the compressed blob in bytes. */
   def size: Int =
-    data.length
+    blob.length
 
   /** 
    * Inflate and return the value. Note that this operation is not memoized; each call will
-   * require re-inflating the compressed blob.
+   * re-inflate the compressed blob.
    */
   def inflate: A = {
 
     // First inflate
     val inflater = new Inflater();
-    inflater.setInput(data);
+    inflater.setInput(blob);
     val baos = new ByteArrayOutputStream();
     val buf = new Array[Byte](Deflated.BUF_SIZE);
     while (!inflater.needsInput) {
@@ -36,23 +46,27 @@ final class Deflated[A] private (val data: Array[Byte]) extends Serializable {
     val ois  = new ObjectInputStream(bais)
 
     // Done
-    ois.readObject.asInstanceOf[A]
+    k(ois.readObject)
 
   }
 
+  /** Return a new `Deflated` that applies `f` to its inflated value. */
+  def map[B](f: A => B): Deflated[B] =
+    new Deflated(blob, k andThen f)
+
   override def equals(a: Any): Boolean =
     a match {
-      case d: Deflated[_] => Arrays.equals(data, d.data)
+      case d: Deflated[_] => Arrays.equals(blob, d.blob)
       case _              => false
     }
 
   override def hashCode: Int =
-    Arrays.hashCode(data)
+    Arrays.hashCode(blob)
 
 }
 
 object Deflated {
-  val BUF_SIZE = 1024 * 16
+  private val BUF_SIZE = 1024 * 16
 
   /** 
    * Construct a deflated object by serializing and compressing the passed value. This method will
@@ -80,19 +94,29 @@ object Deflated {
       val len = deflater.deflate(buf)
       baos.write(buf, 0, len)
     }
-    deflater.end()           // (1) these two lines are important; see note in CompressedString.java
-    System.runFinalization() // (2)
+    // If you don't call end() the deflater leaks system heap on Linux. This is documented in 
+    // 6293787. It still leaks slowly but running finalizers seems to fix it.
+    deflater.end()
+    System.runFinalization()
     
     // Done
-    new Deflated(baos.toByteArray)
+    unsafeFromByteArray(baos.toByteArray)
   
   }
 
-  /**
-   * Construct a deflated object from the given byte array, which is *not* copied, under the
-   * assertion that its can be decompressed into a value of type A.
-   */
-  def unsafeFromBytes[A](data: Array[Byte]): Deflated[A] =
-    new Deflated[A](data)
+  /** Construct a deflated object using a *reference* to the passed byte array. */
+  def unsafeFromByteArray[A](blob: Array[Byte]): Deflated[A] =
+    new Deflated(blob, _.asInstanceOf[A])
+
+  /** Construct a deflated object using a *copy* of the passed byte array. */
+  def fromByteArray[A](blob: Array[Byte]): Deflated[A] =
+    unsafeFromByteArray(blob.clone)
+
+  /** Deflated is a covariant functor. */
+  implicit val DeflatedFunctor: Functor[Deflated] =
+    new Functor[Deflated] {
+      def map[A, B](fa: Deflated[A])(f: A => B): Deflated[B] =
+        fa.map(f)
+    }
 
 }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Deflated.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Deflated.scala
@@ -1,0 +1,98 @@
+package edu.gemini.spModel.core
+
+import java.io._
+import java.util.Arrays
+import java.util.zip.{ Deflater, Inflater }
+
+/**
+ * A compressed value.
+ * @param data the underlying byte array
+ */
+final class Deflated[A] private (val data: Array[Byte]) extends Serializable {
+
+  /** Size of the compressed blob in bytes. */
+  def size: Int =
+    data.length
+
+  /** 
+   * Inflate and return the value. Note that this operation is not memoized; each call will
+   * require re-inflating the compressed blob.
+   */
+  def inflate: A = {
+
+    // First inflate
+    val inflater = new Inflater();
+    inflater.setInput(data);
+    val baos = new ByteArrayOutputStream();
+    val buf = new Array[Byte](Deflated.BUF_SIZE);
+    while (!inflater.needsInput) {
+      val len = inflater.inflate(buf);
+      baos.write(buf, 0, len);
+    }
+    val bs = baos.toByteArray
+
+    // Now deserialize
+    val bais = new ByteArrayInputStream(bs)
+    val ois  = new ObjectInputStream(bais)
+
+    // Done
+    ois.readObject.asInstanceOf[A]
+
+  }
+
+  override def equals(a: Any): Boolean =
+    a match {
+      case d: Deflated[_] => Arrays.equals(data, d.data)
+      case _              => false
+    }
+
+  override def hashCode: Int =
+    Arrays.hashCode(data)
+
+}
+
+object Deflated {
+  val BUF_SIZE = 1024 * 16
+
+  /** 
+   * Construct a deflated object by serializing and compressing the passed value. This method will
+   * throw if the value is not serializable.
+   */
+  def apply[A](a: A): Deflated[A] = {
+
+    // First serialize
+    val bs: Array[Byte] = {
+      val baos = new ByteArrayOutputStream
+      val oos  = new ObjectOutputStream(baos)
+      oos.writeObject(a)
+      oos.close
+      baos.close
+      baos.toByteArray
+    }
+
+    // Now deflate
+    val deflater = new Deflater(Deflater.BEST_COMPRESSION)
+    deflater.setInput(bs)
+    deflater.finish()
+    val baos = new ByteArrayOutputStream()
+    val buf = new Array[Byte](BUF_SIZE)
+    while (!deflater.finished) {
+      val len = deflater.deflate(buf)
+      baos.write(buf, 0, len)
+    }
+    deflater.end()           // (1) these two lines are important; see note in CompressedString.java
+    System.runFinalization() // (2)
+    
+    // Done
+    new Deflated(baos.toByteArray)
+  
+  }
+
+  /**
+   * Construct a deflated object from the given byte array, which is *not* copied, under the
+   * assertion that its can be decompressed into a value of type A.
+   */
+  def unsafeFromBytes[A](data: Array[Byte]): Deflated[A] =
+    new Deflated[A](data)
+
+}

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Deflated.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Deflated.scala
@@ -8,8 +8,7 @@ import scalaz.Functor
 
 /** A value that has been serialized and compressed. */
 final class Deflated[A] private (
-  private val blob: Array[Byte], 
-  private val k: Object => A
+  private val blob: Array[Byte]
 ) extends Serializable {
 
   /** Return a *reference* to the deflated blob. */
@@ -46,13 +45,9 @@ final class Deflated[A] private (
     val ois  = new ObjectInputStream(bais)
 
     // Done
-    k(ois.readObject)
+    ois.readObject.asInstanceOf[A]
 
   }
-
-  /** Return a new `Deflated` that applies `f` to its inflated value. */
-  def map[B](f: A => B): Deflated[B] =
-    new Deflated(blob, k andThen f)
 
   override def equals(a: Any): Boolean =
     a match {
@@ -106,17 +101,10 @@ object Deflated {
 
   /** Construct a deflated object using a *reference* to the passed byte array. */
   def unsafeFromByteArray[A](blob: Array[Byte]): Deflated[A] =
-    new Deflated(blob, _.asInstanceOf[A])
+    new Deflated(blob)
 
   /** Construct a deflated object using a *copy* of the passed byte array. */
   def fromByteArray[A](blob: Array[Byte]): Deflated[A] =
     unsafeFromByteArray(blob.clone)
-
-  /** Deflated is a covariant functor. */
-  implicit val DeflatedFunctor: Functor[Deflated] =
-    new Functor[Deflated] {
-      def map[A, B](fa: Deflated[A])(f: A => B): Deflated[B] =
-        fa.map(f)
-    }
 
 }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
@@ -4,18 +4,15 @@ import scalaz._, Scalaz._
 
 final class Ephemeris(val site: Site, val compressedData: Deflated[List[(Long, Float, Float)]]) extends Serializable {
 
+  /**
+   * A map from time to coordinates. This value is stored in compressed form and is deflated (and
+   * memoized) on demand. The deflated value is transient, and is thus not serialized.
+   */
   @transient lazy val data: Long ==>> Coordinates =
     ==>>.fromList(compressedData.inflate.map { case (t, r, d) =>
       t -> Coordinates.fromDegrees(r, d).getOrElse(sys.error(s"corrupted ephemeris data: $t $r $d"))
     })
-
-  /** True if the ephemeris data is compressed (will be uncompressed by need). */
-  def isCompressed: Boolean = {
-    val f = getClass.getDeclaredField("data")
-    f.setAccessible(true)
-    f.get(this) == null
-  }
-
+    
   /** Perform an exact or interpolated lookup. */
   def iLookup(k: Long): Option[Coordinates] =
     data.iLookup(k)

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/EphemerisSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/EphemerisSpec.scala
@@ -12,9 +12,10 @@ object EphemerisSpec extends Specification with ScalaCheck with Arbitraries with
 
   implicit class EphemerisTrickery(e: Ephemeris) {
 
-    // Peek at the transient lazy field to see if it has been assigned
+    // Peek at the transient lazy field to see if it has been assigned.
+    // Look how nutty the mangled field name is!
     def isCompressed: Boolean = {
-      val f = e.getClass.getDeclaredField("data")
+      val f = e.getClass.getDeclaredField("edu$gemini$spModel$core$Ephemeris$$_data")
       f.setAccessible(true)
       f.get(e) == null
     }
@@ -32,7 +33,7 @@ object EphemerisSpec extends Specification with ScalaCheck with Arbitraries with
     }
 
 
-    "be decompressed on access to 'data' field" ! forAll { (e: Ephemeris) =>
+    "be decompressed on access to '_data' field" ! forAll { (e: Ephemeris) =>
       e.data
       e.isCompressed == false
     }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/EphemerisSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/EphemerisSpec.scala
@@ -1,0 +1,38 @@
+package edu.gemini.spModel.core
+
+import org.specs2.mutable.Specification
+
+import scalaz._
+import Scalaz._
+import org.scalacheck.Prop._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object EphemerisSpec extends Specification with ScalaCheck with Arbitraries with Helpers {
+
+  "Ephemeris Data" should {
+
+    "be serializable" ! forAll { (e: Ephemeris) =>
+      canSerialize(e)
+    }
+
+    "be compressed on construction" ! forAll { (e: Ephemeris) =>
+      e.isCompressed
+    }
+
+
+    "be decompressed on access to 'data' field" ! forAll { (e: Ephemeris) =>
+      e.data
+      e.isCompressed == false
+    }
+
+    "be compressed after serialization roundtrip" ! forAll { (e: Ephemeris) =>
+      e.data
+      canSerializeP(e) { (e, e2) =>
+        e2.isCompressed && !e.isCompressed
+      }
+    }
+
+  }
+
+}

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/EphemerisSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/EphemerisSpec.scala
@@ -10,6 +10,17 @@ import org.specs2.mutable.Specification
 
 object EphemerisSpec extends Specification with ScalaCheck with Arbitraries with Helpers {
 
+  implicit class EphemerisTrickery(e: Ephemeris) {
+
+    // Peek at the transient lazy field to see if it has been assigned
+    def isCompressed: Boolean = {
+      val f = e.getClass.getDeclaredField("data")
+      f.setAccessible(true)
+      f.get(e) == null
+    }
+
+  }
+
   "Ephemeris Data" should {
 
     "be serializable" ! forAll { (e: Ephemeris) =>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
@@ -29,7 +29,7 @@ class PlutoDemotionTest extends MigrationTest {
               case List((t, c)) =>
 
                   Assert.assertEquals("ValidAt", "10/28/15 7:39:58 PM UTC", SPTargetPio.formatter.format(t))
-                  Assert.assertEquals("RA",      "15:41:38.380", c.ra.toAngle.formatHMS)
+                  Assert.assertEquals("RA",      "15:41:38.379", c.ra.toAngle.formatHMS)
                   Assert.assertEquals("Dec",     "-15:52:28.70", c.dec.formatDMS)
 
               case e => Assert.fail("Expected 1-element ephemeris, found " + e)

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamCodec.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamCodec.scala
@@ -1,7 +1,7 @@
 package edu.gemini.spModel.pio.codec
 
 import edu.gemini.spModel.core.Deflated
-import sun.misc.{BASE64Decoder, BASE64Encoder}
+import java.util.Base64
 
 import scalaz._, Scalaz._
 
@@ -32,13 +32,13 @@ object ParamCodec {
 
   implicit val ByteArrayParamCodec: ParamCodec[Array[Byte]] =
     StringParamCodec.xmap[Array[Byte]](
-      new BASE64Decoder().decodeBuffer,
-      new BASE64Encoder().encode
+      Base64.getMimeDecoder.decode,
+      Base64.getMimeEncoder.encodeToString
     )
 
   implicit def deflatedParamCodec[A]: ParamCodec[Deflated[A]] =
     ByteArrayParamCodec.xmap[Deflated[A]](
-      Deflated.unsafeFromBytes[A], _.data
+      Deflated.unsafeFromByteArray[A], _.unsafeToByteArray
     )
 
   implicit val DoubleParamCodec: ParamCodec[Double] =

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamCodec.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamCodec.scala
@@ -1,5 +1,8 @@
 package edu.gemini.spModel.pio.codec
 
+import edu.gemini.spModel.core.Deflated
+import sun.misc.{BASE64Decoder, BASE64Encoder}
+
 import scalaz._, Scalaz._
 
 import edu.gemini.spModel.pio._
@@ -26,6 +29,17 @@ object ParamCodec {
       def encode(key: String, a: String): Param = pf.createParam(key) <| (_.setValue(a))
       def decode(p: Param): PioError \/ String = Option(p.getValue) \/> NullValue(p.getName)
     }
+
+  implicit val ByteArrayParamCodec: ParamCodec[Array[Byte]] =
+    StringParamCodec.xmap[Array[Byte]](
+      new BASE64Decoder().decodeBuffer,
+      new BASE64Encoder().encode
+    )
+
+  implicit def deflatedParamCodec[A]: ParamCodec[Deflated[A]] =
+    ByteArrayParamCodec.xmap[Deflated[A]](
+      Deflated.unsafeFromBytes[A], _.data
+    )
 
   implicit val DoubleParamCodec: ParamCodec[Double] =
     new ParamCodec[Double] {


### PR DESCRIPTION
This is an experimental PR to see if we can make it less impossible to work with gigantic programs with many ephemerides. This stores data as a compressed blob, expanded lazily into a transient. The blob is written as Base64 in the XML.

If this seems ok we will need to write an updater to read earlier 16A files which have big ephemerides in their XML.

A test program with 1000 copies of IO's ephemeris results in ~24m of XML, which is much better than before. Currently this would be ~500m of XML.