### PR TITLE
REL-2831: purge ephemeris action

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichObservation.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichObservation.scala
@@ -2,10 +2,11 @@ package edu.gemini.spModel.rich.pot.sp
 
 import edu.gemini.pot.sp._
 import edu.gemini.spModel.core.Site
-import edu.gemini.spModel.obs.SPObservation
+import edu.gemini.spModel.obs.{ObservationStatus, SPObservation}
 import edu.gemini.spModel.obscomp.SPInstObsComp
 
 import scala.collection.JavaConverters._
+import scalaz.\/
 
 /**
  * Adds convenience to ISPObservation instances.
@@ -53,4 +54,7 @@ class RichObservation(obs: ISPObservation) {
     findObsComponent { _.getType.broadType == SPComponentBroadType.INSTRUMENT }.map { oc =>
       oc.getDataObject.asInstanceOf[SPInstObsComp].getSite.asScala.toSet
     }.fold(Set.empty[Site])(identity)
+
+  def isObserved: Boolean =
+    \/.fromTryCatchNonFatal(ObservationStatus.computeFor(obs)).exists(_ == ObservationStatus.OBSERVED)
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/EphemerisPurge.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/EphemerisPurge.scala
@@ -1,0 +1,70 @@
+package edu.gemini.spModel.target
+
+import edu.gemini.pot.sp.{ISPObsComponent, ISPObservation}
+import edu.gemini.shared.util.immutable.ScalaConverters.ImOptionOps
+import edu.gemini.spModel.core.{Ephemeris, Coordinates}
+import edu.gemini.spModel.obs.SPObservation
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.util.SPTreeUtil
+
+import scala.collection.JavaConverters._
+
+import scalaz._, Scalaz._
+import scalaz.effect.IO
+
+/** A utility for purging ephemeris data from an observation.  "Purge" means
+  * truncate the ephemeris down to a single element valid at the scheduling
+  * block start time.
+  */
+object EphemerisPurge {
+
+  /** Returns an `Option[ IO[Unit] ]` with any actions required to purge the
+    * observation of ephemeris data.  The `Option` is defined if the observation
+    * will be modified when executed.
+    */
+  def purge(o: ISPObservation): Option[IO[Unit]] = {
+    def go(oc: ISPObsComponent, toc: TargetObsComp): Option[IO[Unit]] = {
+
+      // Get the scheduling block start time, if defined.
+      val when = o.getDataObject match {
+        case spObs: SPObservation => spObs.getSchedulingBlockStart.asScalaOpt.map(_.toLong)
+        case _                    => None
+      }
+
+      // Get a list[(SPTarget, NonSiderealTarget)] for all non-sidereal targets
+      // in the environment (if any).
+      val nsts = toc.getTargetEnvironment.getTargets.asScala.flatMap { sp =>
+        sp.getNonSiderealTarget.strengthL(sp)
+      }
+
+      // Map each (SPTarget, NonSiderealTarget) pair to (SPTarget, Option[NonSiderealTarget])
+      // where the option is defined only if an update is needed and if so,
+      // the NonSiderealTarget is the updated target.  Then collect only those
+      // with updates.
+      val updates = nsts.map { _.map { nst =>
+        val site  = nst.ephemeris.site
+        val tc    = when.flatMap { t => nst.ephemeris.iLookup(t).strengthL(t) }
+        val table = tc.fold[Long ==>> Coordinates](==>>.empty) { case (t,c) => ==>>.singleton(t, c) }
+        val eph   = Ephemeris(site, table)
+        (eph =/= nst.ephemeris) ? some(nst.copy(ephemeris = eph)) | none
+      }}.collect { case (sp, Some(updatedNst)) => (sp, updatedNst) }
+
+      // Only apply new data object if there are actual updates.  Note,
+      // the target environment is immutable but holds references to
+      // mutable SPTargets.  We will have updated those SPTargets.  We
+      // have to store that back to the ISPObsComponent because we are
+      // working with a clone of its data object.
+      updates.nonEmpty option IO {
+        updates.foreach { case (sp, nst) => sp.setTarget(nst) }
+        oc.setDataObject(toc)
+      }
+    }
+
+    Option(SPTreeUtil.findTargetEnvNode(o)).flatMap { oc =>
+      oc.getDataObject match {
+        case toc: TargetObsComp => go(oc, toc)
+        case _                  => none
+      }
+    }
+  }
+}

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImEither.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImEither.java
@@ -17,6 +17,17 @@ public final class ImEither<L,R> implements Serializable {
         return new ImEither<>(None.instance(), new Some<>(right));
     }
 
+    /**
+     * Returns the left value or the right value depending upon which one is
+     * defined.
+     */
+    public static <T> T merge(ImEither<T, T> e) {
+        return e.getLeft().orElse(e.getRight()).getValue();
+    }
+
+    // TODO: an ImEither(None, None) wouldn't make any sense.  Reimplement
+    // TODO: with an ImEither interface and Left and Right implementations.
+
     private ImEither(final Option<L> left, final Option<R> right) {
         this.left  = left;
         this.right = right;
@@ -74,6 +85,10 @@ public final class ImEither<L,R> implements Serializable {
 
     public <T> ImEither<L,T> map(final Function1<? super R, ? extends T> rightFunc) {
         return new ImEither<>(left, right.map(rightFunc));
+    }
+
+    public <T> ImEither<L,T> flatMap(final Function1<? super R, ImEither<L, T>> rightFunc) {
+        return left.isDefined() ? ImEither.<L,T>left(left.getValue()) : rightFunc.apply(right.getValue());
     }
 
     /**

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisPurgeCron.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisPurgeCron.scala
@@ -1,0 +1,25 @@
+package edu.gemini.dbTools.ephemeris
+
+import edu.gemini.pot.spdb.IDBDatabaseService
+import org.osgi.framework.BundleContext
+
+import java.io.File
+import java.security.Principal
+import java.util.logging.{Level, Logger}
+
+/** A cron job that will purge ephemeris data in executed observations. */
+object EphemerisPurgeCron {
+  val Log = Logger.getLogger(EphemerisPurgeCron.getClass.getName)
+
+
+  /** Cron job entry point.  See edu.gemini.spdb.cron.osgi.Activator. */
+  def run(ctx: BundleContext)(tmpDir: File, logger: Logger, env: java.util.Map[String, String], user: java.util.Set[Principal]): Unit = {
+    val odbRef = ctx.getServiceReference(classOf[IDBDatabaseService])
+    val odb    = ctx.getService(odbRef)
+
+    Log.log(Level.INFO, "Start EphemerisPurgeCron")
+    EphemerisPurgeFunctor.query(odb, user)
+    Log.log(Level.INFO, "End EphemerisPurgeCron")
+  }
+
+}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisPurgeFunctor.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/ephemeris/EphemerisPurgeFunctor.scala
@@ -1,0 +1,35 @@
+package edu.gemini.dbTools.ephemeris
+
+import edu.gemini.pot.sp.{ISPObservation, ISPNode}
+import edu.gemini.pot.spdb.{IDBDatabaseService, DBAbstractQueryFunctor}
+import edu.gemini.spModel.rich.pot.sp.obsWrapper
+import edu.gemini.spModel.target.EphemerisPurge
+
+import java.security.Principal
+import java.util.logging.{Level, Logger}
+import java.util.{Set => JSet}
+
+/** An ODB observation query functor that finds all executed non-sidereal
+  * observations and purges ephemeris data.
+  */
+object EphemerisPurgeFunctor {
+  private final val Log = Logger.getLogger(EphemerisPurgeFunctor.getClass.getName)
+
+  def query(db: IDBDatabaseService, users: JSet[Principal]): Unit =
+    db.getQueryRunner(users).queryObservations(new EphemerisPurgeFunctor)
+}
+
+private class EphemerisPurgeFunctor extends DBAbstractQueryFunctor {
+  import EphemerisPurgeFunctor.Log
+
+  override def execute(db: IDBDatabaseService, node: ISPNode, principals: JSet[Principal]): Unit =
+    node match {
+      case o: ISPObservation =>
+        EphemerisPurge.purge(o).filter(_ => o.isObserved).foreach { action =>
+          Log.log(Level.INFO, s"Purge ephemeris data in: ${Option(o.getObservationID).getOrElse(o.getNodeKey)}.")
+          action.unsafePerformIO()
+        }
+
+      case _                 => // do nothing
+    }
+}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/spdb/cron/osgi/Activator.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/spdb/cron/osgi/Activator.scala
@@ -1,6 +1,6 @@
 package edu.gemini.spdb.cron.osgi
 
-import edu.gemini.dbTools.ephemeris.TcsEphemerisCron
+import edu.gemini.dbTools.ephemeris.{EphemerisPurgeCron, TcsEphemerisCron}
 import org.osgi.framework.{BundleContext, BundleActivator}
 import org.osgi.util.tracker.ServiceTracker
 import edu.gemini.util.osgi.Tracker._
@@ -39,7 +39,8 @@ class Activator extends BundleActivator {
          "odbMail"        -> OdbMailAgent.run,
          "weather"        -> new WeatherUpdater(c).run,
          "archive"        -> Archiver.run(c),
-         "ephemeris"      -> TcsEphemerisCron.run(c))
+         "ephemeris"      -> TcsEphemerisCron.run(c),
+         "ephemerisPurge" -> EphemerisPurgeCron.run(c))
 
   var tracker: ServiceTracker[HttpService, HttpService] = null
 

--- a/bundle/edu.gemini.spdb.shell/src/main/java/edu/gemini/spdb/shell/osgi/Activator.java
+++ b/bundle/edu.gemini.spdb.shell/src/main/java/edu/gemini/spdb/shell/osgi/Activator.java
@@ -21,11 +21,11 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<IDBD
 
     public void start(final BundleContext context) throws Exception {
         this.context = context;
-        this.tracker = new ServiceTracker<IDBDatabaseService, IDBDatabaseService>(context, IDBDatabaseService.class, this);
+        this.tracker = new ServiceTracker<>(context, IDBDatabaseService.class, this);
 
         tracker.open();
 
-        final Dictionary<String, Object> dict = new Hashtable<String, Object>();
+        final Dictionary<String, Object> dict = new Hashtable<>();
         dict.put(COMMAND_SCOPE, "spdb");
         dict.put(COMMAND_FUNCTION, new String[]{
                 "lsprogs",
@@ -35,9 +35,10 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<IDBD
                 "exportXml",
                 "du",
                 "purge",
-                "migrateAltair"
+                "migrateAltair",
+                "purgeEphemeris"
         });
-        final Set<Principal> user = Collections.<Principal>singleton(StaffPrincipal.Gemini());
+        final Set<Principal> user = Collections.singleton(StaffPrincipal.Gemini());
         context.registerService(Commands.class.getName(), new Commands(tracker, user), dict);
         System.out.println("edu.gemini.spdb.shell started.");
     }
@@ -45,7 +46,6 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<IDBD
     public void stop(BundleContext context) throws Exception {
         tracker.close();
         tracker = null;
-        context = null;
         System.out.println("edu.gemini.spdb.shell stopped.");
     }
 

--- a/bundle/edu.gemini.spdb.shell/src/main/scala/edu/gemini/spdb/shell/misc/EphemerisPurgeCommand.scala
+++ b/bundle/edu.gemini.spdb.shell/src/main/scala/edu/gemini/spdb/shell/misc/EphemerisPurgeCommand.scala
@@ -1,0 +1,52 @@
+package edu.gemini.spdb.shell.misc
+
+import edu.gemini.pot.sp.{ISPObservation, ISPProgram}
+import edu.gemini.spModel.rich.pot.sp.obsWrapper
+import edu.gemini.spModel.target.EphemerisPurge
+
+import scala.collection.JavaConverters._
+import scalaz._, Scalaz._
+
+/** Shell command for purging ephemeris data. */
+object EphemerisPurgeCommand {
+  sealed trait PurgeOption {
+    def include(o: ISPObservation): Boolean = this match {
+      case All          => true
+      case ObservedOnly => o.isObserved
+    }
+
+    def displayValue: String = this match {
+      case All          => "all"
+      case ObservedOnly => "observed"
+    }
+  }
+
+  object PurgeOption {
+    val AllValues = List(All, ObservedOnly)
+
+    def fromDisplayValue(s: String): Option[PurgeOption] =
+      AllValues.find(_.displayValue === s)
+
+    def usageString: String =
+      AllValues.map(_.displayValue).mkString("[", " | ", "]")
+  }
+
+  /** Option to purge ephemeris data from all observations in the program. */
+  case object All extends PurgeOption
+
+  /** Option to purge ephemeris data from just the observed observations in the program. */
+  case object ObservedOnly extends PurgeOption
+
+
+  /** Purges ephemeris data from observations in the provided program. */
+  def apply(p: ISPProgram, purgeOption: PurgeOption): String = {
+    val updates = for {
+      o  <- p.getAllObservations.asScala.filter(purgeOption.include)
+      io <- EphemerisPurge.purge(o)
+    } yield io
+
+    updates.foreach(_.unsafePerformIO())
+
+    s"Purged ephemeris data from ${updates.size} ${(purgeOption == ObservedOnly) ? "OBSERVED " | ""}observation(s)."
+  }
+}

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
@@ -59,6 +59,7 @@ public final class SPViewerActions {
     public final AbstractViewerAction addInfoNoteAction;
     public final AbstractViewerAction addInfoSchedulingNoteAction;
     public final AbstractViewerAction addInfoProgramNoteAction;
+    public final AbstractViewerAction purgeEphemerisAction;
 
     // Groups of actions. In some cases these appear in the list above, in other cases not.
     final List<AbstractViewerAction> templateActions = new ArrayList<AbstractViewerAction>();
@@ -144,6 +145,7 @@ public final class SPViewerActions {
 
         // Program-level Actions
         programAdminAction = new ProgramAdminAction(viewer);
+        purgeEphemerisAction = new EphemerisPurgeAction(viewer);
 
         // Group actions
         addSchedulingGroupAction = new AddGroupAction(viewer, SPGroup.GroupType.TYPE_SCHEDULING);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
@@ -452,6 +452,7 @@ final class SPViewerMenuBar extends JMenuBar {
         menu.add(_viewer._actions.programAdminAction);
         menu.add(_viewer._actions.setPhase2StatusAction);
         menu.add(_viewer._actions.setExecStatusAction);
+        menu.add(_viewer._actions.purgeEphemerisAction);
 
         menu.add(_viewer._actions.showKeyManagerAction);
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/EphemerisPurgeAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/EphemerisPurgeAction.scala
@@ -1,0 +1,99 @@
+package jsky.app.ot.viewer.action
+
+import edu.gemini.pot.sp.{ISPProgram, ISPObservation}
+import edu.gemini.spModel.rich.pot.sp.obsWrapper
+import edu.gemini.spModel.target.EphemerisPurge
+import jsky.app.ot.OTOptions
+import jsky.app.ot.viewer.SPViewer
+import jsky.app.ot.viewer.action.EphemerisPurgeAction._
+
+import java.awt.event.ActionEvent
+import javax.swing.{JOptionPane, Action}
+import javax.swing.JOptionPane.{INFORMATION_MESSAGE, QUESTION_MESSAGE, YES_NO_CANCEL_OPTION}
+
+import scala.collection.JavaConverters._
+import scalaz._, Scalaz._
+
+
+/** Purge ephemeris data throughout the program. */
+class EphemerisPurgeAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Purge Ephemeris Data ...") {
+  val Title               = "Purge Ephemeris Data?"
+  val ConfirmationMessage =
+  """ Delete extra ephemeris data for all non-sidereal targets in this program that you
+    | have permission to edit?  This will decrease the amount of memory required to edit
+    | the program by keeping only target coordinates at the scheduling block time.
+    |
+    | Ephemeris data can always be re-fetched later for each observation in its Target
+    | Environment component.
+  """.stripMargin
+
+  putValue(AbstractViewerAction.SHORT_NAME, "Purge Ephemeris")
+  putValue(Action.SHORT_DESCRIPTION, "Purge ephemeris data in all non-sidereal observations.")
+  setEnabled(true)
+
+  override def computeEnabledState: Boolean = true
+
+  override def actionPerformed(e: ActionEvent): Unit = {
+
+    // Ask the user what to purge: only observed, all, or nothing.
+    val userChoice: PurgeOption = {
+      val staff = OTOptions.isStaffGlobally || Option(getProgram).exists(OTOptions.isStaff)
+      val base  = List(All, Cancel)
+      val opts  = staff ? (ObservedOnly :: base) | base
+      val res   = JOptionPane.showOptionDialog(viewer, ConfirmationMessage, Title, YES_NO_CANCEL_OPTION, QUESTION_MESSAGE, null, opts.toArray, Cancel)
+      if ((res < 0) || (res >= opts.length)) Cancel else opts(res)
+    }
+
+    if (userChoice != Cancel) {
+      val updates = for {
+        p  <- Option(getProgram).toList
+        f   = userChoice.filter(p)
+        o  <- p.getAllObservations.asScala.filter(f).toList
+        io <- EphemerisPurge.purge(o)
+      } yield io
+
+      val msg = updates.size match {
+        case 0 => "No observations were updated."
+        case 1 => "One observation was updated."
+        case n => s"$n observations updated."
+      }
+
+      updates.foreach(_.unsafePerformIO())
+
+      JOptionPane.showMessageDialog(viewer, msg, "Purge Results", INFORMATION_MESSAGE)
+    }
+  }
+}
+
+object EphemerisPurgeAction {
+  sealed trait PurgeOption {
+    /** Computes the observation filter that corresponds to this purge option. */
+    def filter(p: ISPProgram): ISPObservation => Boolean = {
+      val staff = OTOptions.isStaffGlobally || OTOptions.isStaff(p)
+
+      // We can only truncate ephemeris elements in observations that we can
+      // legally edit. Otherwise, the merge will just reject the change on sync.
+      // Staff, however, can edit anything without it being rejected on sync
+      // because they are allowed to toggle the observation status to any value
+      // anyway.
+      def isEditable(o: ISPObservation): Boolean =
+        staff || OTOptions.isObservationEditable(o)
+
+      this match {
+        case All          => isEditable
+        case ObservedOnly => (o: ISPObservation) => isEditable(o) && o.isObserved
+        case Cancel       => Function.const(false)
+      }
+    }
+
+    override def toString: String = this match {
+      case ObservedOnly => "Purge Observed Observations"
+      case All          => "Purge All Observations"
+      case Cancel       => "Cancel"
+    }
+  }
+
+  case object All extends PurgeOption
+  case object ObservedOnly extends PurgeOption
+  case object Cancel extends PurgeOption
+}


### PR DESCRIPTION
This PR introduces a new "Edit" menu item that, when selected, purges ephemeris data in all non-sidereal observations that the user has permission to edit.  In particular, it replaces the full ephemeris table with a single-element entry at the scheduling block start.  This can reduce the amount of memory occupied by the program in an observing database, including the OT's local database.  This is, hopefully, a stop-gap option for 16B.  The idea is that this action will only be needed in very special cases where the program has many non-sidereal target instances.

~~The usefulness of this item is somewhat questionable though because it can only update observations that the user can edit.  Otherwise, the updated observations will only be rejected by the merge algorithm upon sync.  Unfortunately that means observed observations cannot be purged even by staff members despite the fact that observed observations are precisely those for which full ephemeris data is least useful.  Sad!~~

__UPDATE:__ The sync allows staff members to "edit" observed observations because the OT allows them to toggle observation status, make a change, and toggle back to observed.  We can allow the ephemeris purge to reset observed observation ephemeris after all.  Sorry for the confusion.