### PR TITLE
Improve build specification for itc

### DIFF
--- a/app/itc/build.sbt
+++ b/app/itc/build.sbt
@@ -18,7 +18,10 @@ ocsAppManifest := {
     configs = List(
       common(v),
         with_gogo(v),
-          itc(v)
+          itc(v),
+          with_remote_gogo(v),
+            itctest(v),
+            itcproduction(v)
     )
   )
 }
@@ -45,7 +48,7 @@ def common(version: Version) = AppConfig(
     "org.osgi.service.http.port"                 -> "8442",
     "org.osgi.service.http.secure.enabled"       -> "false" // testing only, don't turn on secure port
   ),
-  log = Some("log/spdb.%u.%g.log"),
+  log = Some("log/itc.%u.%g.log"),
   bundles = List(
     BundleSpec("com.jgoodies.looks",                     Version(2, 4, 1)),
     BundleSpec("com.mchange.c3p0",                       Version(0, 9, 5)),
@@ -78,6 +81,20 @@ def with_gogo(version: Version) = AppConfig(
   )
 ) extending List(common(version), with_gogo_credentials(version))
 
+// WITH-REMOTE-GOGO
+def with_remote_gogo(version: Version) = AppConfig(
+  id = "with-remote-gogo",
+  props = Map(
+    "gosh.args"                       -> "--nointeractive",
+    "osgi.shell.telnet.port"          -> "8224",
+    "osgi.shell.telnet.maxconn"       -> "4",
+    "osgi.shell.telnet.socketTimeout" -> "30000"
+  ),
+  bundles = List(
+    BundleSpec(10, "org.apache.felix.shell.remote", Version(1, 1, 2))
+  )
+) extending List(with_gogo(version), with_remote_gogo_credentials(version))
+
 // ITC
 def itc(version: Version) = AppConfig(
   id = "itc",
@@ -90,4 +107,32 @@ def itc(version: Version) = AppConfig(
   props = Map(
   )
 ) extending List(with_gogo(version))
+
+// ITC test
+def itctest(version: Version) = AppConfig(
+  id = "itctest",
+  distribution = List(Linux32),
+  vmargs = List(
+    "-Xmx1024M",
+    "-XX:MaxPermSize=196M"
+  ),
+  props = Map(
+    "org.osgi.service.http.port" -> "9080",
+    "osgi.shell.telnet.ip"       -> "172.16.55.80"
+  )
+) extending List(with_remote_gogo(version))
+
+// ITC production
+def itcproduction(version: Version) = AppConfig(
+  id = "itcproduction",
+  distribution = List(Linux32),
+  vmargs = List(
+    "-Xmx1024M",
+    "-XX:MaxPermSize=196M"
+  ),
+  props = Map(
+    "org.osgi.service.http.port" -> "9080",
+    "osgi.shell.telnet.ip"       -> "172.16.5.80"
+  )
+) extending List(with_remote_gogo(version))
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -18,7 +18,7 @@ footer {font-size: 75%;}
 <body>
 <h1>Integration Time Calculator Test Page</h1>
 
-This page provides a simple way to test the ITC servlets by using the ITC forms for 
+This page provides a simple way to test the ITC servlets by using the ITC forms for
 Gemini North and South instruments.
 <br>
 <br>
@@ -26,7 +26,7 @@ Note that these forms are not the same ones as in the production server.
 <br>
 <br>
 <br>
- 
+
 <table id="maintable">
 <tr><th>Gemini North</th><th>Gemini South</th></tr>
 <tr><td>
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated January 5, 2015</footer>
+<footer>Last updated June 13, 2016</footer>
 </body>
 </html>


### PR DESCRIPTION
This PR contains changes to the standalone itc build to let it be deployed properly

Note that the current itc hosts are Linux32 unlike most of the other servers