### PR TITLE
REL-2874: setting pos angle

### DIFF
--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/Helpers.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/Helpers.scala
@@ -1,0 +1,32 @@
+package edu.gemini.ags.impl
+
+import edu.gemini.ags.conf.ProbeLimitsTable
+import edu.gemini.skycalc.{DDMMSS, HHMMSS}
+import edu.gemini.spModel.core.{Declination, RightAscension, Angle, Coordinates, MagnitudeBand, Magnitude, SiderealTarget}
+import edu.gemini.spModel.target.SPTarget
+
+/**
+ *
+ */
+trait Helpers {
+  val mt       = ProbeLimitsTable.loadOrThrow()
+  val zeroBase = basePosition("00:00:00.000 00:00:00.00")
+
+    // Convert a string and magnitude to a SiderealTarget.
+  final def siderealTarget(name: String, raDecStr: String, rMag: Double): SiderealTarget =
+    SiderealTarget.empty.copy(name = name, coordinates = parseCoordinates(raDecStr), magnitudes = List(new Magnitude(rMag, MagnitudeBand.R)))
+
+  // Convert a string to a base.
+  final def basePosition(raDecStr: String): SPTarget = {
+    val c = parseCoordinates(raDecStr)
+    new SPTarget(c.ra.toAngle.toDegrees, c.dec.toDegrees)
+  }
+
+  final def parseCoordinates(raDecStr: String): Coordinates = {
+    val (raStr, decStr) = raDecStr.span(_ != ' ')
+    val ra  = Angle.fromDegrees(HHMMSS.parse(raStr).toDegrees.getMagnitude)
+    val dec = Angle.fromDegrees(DDMMSS.parse(decStr.trim).toDegrees.getMagnitude)
+    Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))
+  }
+
+}

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/PosAngleUpdateTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/PosAngleUpdateTest.scala
@@ -1,0 +1,41 @@
+package edu.gemini.ags.impl
+
+import edu.gemini.ags.api.AgsStrategy
+import edu.gemini.spModel.core.Angle
+import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe.{instance => GmosOiwfs}
+import edu.gemini.spModel.guide.GuideProbe
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.{AutomaticGroup, TargetEnv, TargetEnvironment}
+import org.junit.Test
+import org.junit.Assert
+
+import scalaz.==>>
+
+/** Test case for REL-2874. */
+class PosAngleUpdateTest extends Helpers {
+
+  @Test def testPosAngleUpdate(): Unit = {
+    // Set up a TargetEnvironment according to the description in REL-2874.
+    val base    = basePosition("02:22:32.907 42:20:53.95")
+    val gs      = siderealTarget("663-010421", "02:22:20.970 42:24:44.27", 13.805)
+    val tmap    = ==>>.singleton(GmosOiwfs: GuideProbe, new SPTarget(gs))
+    val ten     = Angle.fromDegrees(10.0)
+    val envTen  = TargetEnv.auto.set(TargetEnvironment.create(base), AutomaticGroup.Active(tmap, ten))
+
+    // Create a new selection with the same guide star mapping, but a new pos angle.
+    val ten5    = Angle.fromDegrees(10.5)
+    val sel     = AgsStrategy.Selection(ten5, List(AgsStrategy.Assignment(GmosOiwfs, gs)))
+
+    // Apply the selection to the existing target environment.
+    val envTen5 = sel.applyTo(envTen)
+
+    // Get the resulting position angle in the new environment.
+    val actual  = TargetEnv.auto.get(envTen5) match {
+      case AutomaticGroup.Active(_, pa) => Some(pa)
+      case _                            => None
+    }
+
+    // Make sure it is now 10.5
+    Assert.assertEquals(Some(ten5), actual)
+  }
+}

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -5,6 +5,7 @@ import edu.gemini.pot.ModelConverters._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.{ None => JNone }
 import edu.gemini.spModel.core._
+import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.spModel.gemini.flamingos2.{Flamingos2OiwfsGuideProbe, Flamingos2}
 import edu.gemini.spModel.gemini.gmos.{GmosOiwfsGuideProbe, InstGmosSouth}
 import edu.gemini.spModel.gemini.inst.InstRegistry

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/VignettingTest.scala
@@ -1,13 +1,10 @@
 package edu.gemini.ags.impl
 
 import edu.gemini.ags.api.AgsRegistrar
-import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.{ None => JNone }
-import edu.gemini.skycalc.{DDMMSS, HHMMSS}
 import edu.gemini.spModel.core._
-import edu.gemini.spModel.core.AngleSyntax._
 import edu.gemini.spModel.gemini.flamingos2.{Flamingos2OiwfsGuideProbe, Flamingos2}
 import edu.gemini.spModel.gemini.gmos.{GmosOiwfsGuideProbe, InstGmosSouth}
 import edu.gemini.spModel.gemini.inst.InstRegistry
@@ -30,7 +27,7 @@ import scala.util.Random
 /**
  * Right now, we only test for GMOS. In the future, this will be expanded to include other guide probes.
  */
-class VignettingTest {
+class VignettingTest extends Helpers {
   sealed trait VignettingConfiguration {
     def inst: SPInstObsComp
     def probe: ValidatableGuideProbe with VignettingGuideProbe
@@ -73,26 +70,7 @@ class VignettingTest {
   val AllNV = List(NVGS1, NVGS2, NVGS3, NVGS4, NVGS5, NVGS6, NVGS7, NVGS8)
 
   // Load the magnitude table and create base positions.
-  val mt          = ProbeLimitsTable.loadOrThrow()
-  val zeroBase    = basePosition("00:00:00.000 00:00:00.00")
   val shiftedBase = basePosition("23:59:52.747 00:01:11.40")
-
-  // Convert a string and magnitude to a SiderealTarget.
-  def siderealTarget(name: String, raDecStr: String, rMag: Double): SiderealTarget =
-    SiderealTarget.empty.copy(name = name, coordinates = parseCoordinates(raDecStr), magnitudes = List(new Magnitude(rMag, MagnitudeBand.R)))
-
-  // Convert a string to a base.
-  def basePosition(raDecStr: String): SPTarget = {
-    val c = parseCoordinates(raDecStr)
-    new SPTarget(c.ra.toAngle.toDegrees, c.dec.toDegrees)
-  }
-
-  def parseCoordinates(raDecStr: String): Coordinates = {
-    val (raStr, decStr) = raDecStr.span(_ != ' ')
-    val ra  = Angle.fromDegrees(HHMMSS.parse(raStr).toDegrees.getMagnitude)
-    val dec = Angle.fromDegrees(DDMMSS.parse(decStr.trim).toDegrees.getMagnitude)
-    Coordinates(RightAscension.fromAngle(ra), Declination.fromAngle(dec).getOrElse(Declination.zero))
-  }
 
   /**
    * Perform an AGS selection test with vignetting taken into account using the instrument and guide probe as specified


### PR DESCRIPTION
This PR fixes AGS selection application to properly record the position angle when updated, even if the selected guide star itself does not change.  In the version before this update, when AGS would run and find the same guide star that is already recorded, it would not update the target environment even if the position angle differs.