### PR TITLE
REL-2873: Keep TPE guide star add buttons active

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -273,7 +273,7 @@ public final class TelescopePosEditor extends JSkyCat implements TpeMouseObserve
             }
         }
     };
-    
+
     private final PropertyChangeListener selListener = evt -> {
         reset((ISPNode) evt.getSource());
     };

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeCreatableItem.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeCreatableItem.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package jsky.app.ot.tpe;
 
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeEditorTools.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeEditorTools.java
@@ -122,22 +122,11 @@ final class TpeEditorTools {
         return ctx.progShell().isDefined() && ctx.obsShell().isDefined() && OTOptions.isProgramEditable(ctx.progShell().get()) && OTOptions.isObservationEditable(ctx.obsShell().get());
     }
 
-    private boolean isManual() {
-        return ImOption.fromScalaOpt(_tpe.getImageWidget().getContext().targets().env())
-                .exists(te -> te.getGuideEnvironment().getPrimary().isManual());
-    }
-
-    // Returns true if the only group is an auto group.
-    private boolean onlyAutomatic() {
-        return ImOption.fromScalaOpt(_tpe.getImageWidget().getContext().targets().env())
-                .exists(te -> te.getGuideEnvironment().manualGroups().isEmpty());
-    }
-
     /**
      * Update the enable states of the buttons based on the OT editable state and whether or not the group is
      * the automatic guide group.
      */
-    public void updateEnabledStates() {
+    void updateEnabledStates() {
         final boolean enabled = isEnabled();
         _dragButton.setEnabled(enabled);
         _eraseButton.setEnabled(enabled);
@@ -205,12 +194,6 @@ final class TpeEditorTools {
 
         // If not enabled, then we're done.
         if (enabled) {
-            // Determine if we are in a manual group.
-            final boolean manual = isManual();
-
-            // Determine if the only group is the auto group.
-            final boolean onlyAuto = onlyAutomatic();
-
             // Add create buttons according to the enabled state of each item.
             for (final TpeImageFeature feature : feats) {
                 if (!(feature instanceof TpeCreatableFeature)) continue;
@@ -218,12 +201,8 @@ final class TpeEditorTools {
                 final TpeCreatableFeature cFeature = (TpeCreatableFeature) feature;
                 for (final TpeCreatableItem item : cFeature.getCreatableItems()) {
                     if (item.isEnabled(_tpe.getImageWidget().getContext())) {
-                        final boolean isWFSTarget = item.getType() == TpeCreatableItem.Type.wfsTarget;
                         final JToggleButton btn = _createButtonMap.get(item.getLabel());
                         btn.setVisible(true);
-
-                        // If we are on the auto group, only allow non WFS targets to be created.
-                        btn.setEnabled(manual || onlyAuto || !isWFSTarget);
                     }
                 }
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeEditorTools.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeEditorTools.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 final class TpeEditorTools {
 
-    static class ButtonState {
+    private static class ButtonState {
         private static final String KEY = ButtonState.class.getName();
         final TpeMode mode;
         final TpeImageFeature feature;
@@ -55,7 +55,7 @@ final class TpeEditorTools {
     private final JToggleButton _dragButton;
     private final JToggleButton _eraseButton;
 
-    private Map<String, JToggleButton> _createButtonMap = new HashMap<>();
+    private final Map<String, JToggleButton> _createButtonMap = new HashMap<>();
 
     /** Create with the Presentation that contains the tool buttons. */
     TpeEditorTools(final TelescopePosEditor tpe) {
@@ -143,7 +143,6 @@ final class TpeEditorTools {
         _eraseButton.setEnabled(enabled);
     }
 
-
     //
     // Add a create tool.
     //
@@ -175,11 +174,10 @@ final class TpeEditorTools {
         _createButtonMap.put(label, btn);
     }
 
-
     /**
      * Add the create tools for the given feature.
      */
-    public void addFeature(final TpeImageFeature tif) {
+    void addFeature(final TpeImageFeature tif) {
         if (!(tif instanceof TpeCreatableFeature)) return;  // nothing to add
         final TpeCreatableItem[] items = ((TpeCreatableFeature) tif).getCreatableItems();
         for (TpeCreatableItem item : items) _addCreateTool(item, tif);
@@ -189,7 +187,7 @@ final class TpeEditorTools {
      * Disable or enable the set of creation tools associated with the
      * given image features.
      */
-    public void updateAvailableOptions(final Collection<TpeImageFeature> feats) {
+    void updateAvailableOptions(final Collection<TpeImageFeature> feats) {
         boolean enabled = true;
         if (!isEnabled()) {
             _browseButton.setSelected(true); // make sure we are only in browse mode
@@ -206,33 +204,33 @@ final class TpeEditorTools {
         }
 
         // If not enabled, then we're done.
-        if (!enabled) return;
+        if (enabled) {
+            // Determine if we are in a manual group.
+            final boolean manual = isManual();
 
-        // Determine if we are in a manual group.
-        final boolean manual = isManual();
+            // Determine if the only group is the auto group.
+            final boolean onlyAuto = onlyAutomatic();
 
-        // Determine if the only group is the auto group.
-        final boolean onlyAuto = onlyAutomatic();
+            // Add create buttons according to the enabled state of each item.
+            for (final TpeImageFeature feature : feats) {
+                if (!(feature instanceof TpeCreatableFeature)) continue;
 
-        // Add create buttons according to the enabled state of each item.
-        for (final TpeImageFeature feature : feats) {
-            if (!(feature instanceof TpeCreatableFeature)) continue;
+                final TpeCreatableFeature cFeature = (TpeCreatableFeature) feature;
+                for (final TpeCreatableItem item : cFeature.getCreatableItems()) {
+                    if (item.isEnabled(_tpe.getImageWidget().getContext())) {
+                        final boolean isWFSTarget = item.getType() == TpeCreatableItem.Type.wfsTarget;
+                        final JToggleButton btn = _createButtonMap.get(item.getLabel());
+                        btn.setVisible(true);
 
-            final TpeCreatableFeature cFeature = (TpeCreatableFeature) feature;
-            for (final TpeCreatableItem item : cFeature.getCreatableItems()) {
-                if (item.isEnabled(_tpe.getImageWidget().getContext())) {
-                    final boolean isWFSTarget = item.getType() == TpeCreatableItem.Type.wfsTarget;
-                    final JToggleButton btn   = _createButtonMap.get(item.getLabel());
-                    btn.setVisible(true);
-
-                    // If we are on the auto group, only allow non WFS targets to be created.
-                    btn.setEnabled(manual || onlyAuto || !isWFSTarget);
+                        // If we are on the auto group, only allow non WFS targets to be created.
+                        btn.setEnabled(manual || onlyAuto || !isWFSTarget);
+                    }
                 }
             }
-        }
 
-        if ((selected != null) && !(selected.isVisible() && selected.isEnabled())) {
-            _browseButton.doClick();
+            if ((selected != null) && !(selected.isVisible() && selected.isEnabled())) {
+                _browseButton.doClick();
+            }
         }
     }
 
@@ -258,7 +256,7 @@ final class TpeEditorTools {
     /**
      * Get the creatable item currently selected.
      */
-    public TpeCreatableItem getCurrentCreatableItem() {
+    TpeCreatableItem getCurrentCreatableItem() {
         if (_current == null) return null;
         return ButtonState.get(_current).item;
     }
@@ -266,7 +264,7 @@ final class TpeEditorTools {
     /**
      * Go to browse mode.
      */
-    public void gotoBrowseMode() {
+    void gotoBrowseMode() {
         _browseButton.setSelected(true);
     }
 
@@ -275,5 +273,3 @@ final class TpeEditorTools {
         return getClass().getName() + "[tool=" + getCurrentCreatableItem() + "]";
     }
 }
-
-

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMode.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMode.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package jsky.app.ot.tpe;
 
 /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeToolBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeToolBar.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: TpeToolBar.java 45662 2012-05-31 02:54:05Z fnussber $
- */
-
 package jsky.app.ot.tpe;
 
 import jsky.app.ot.ags.AgsSelectorControl;
@@ -22,7 +15,7 @@ import java.awt.event.ComponentListener;
  *
  * @version $Revision: 45662 $
  * @author Allan Brighton */
-public final class TpeToolBar extends JPanel {
+final class TpeToolBar extends JPanel {
 
     private static GridBagConstraints gbc(final int y) {
         return new GridBagConstraints() {{
@@ -49,21 +42,21 @@ public final class TpeToolBar extends JPanel {
     /**
      * The left side toolbar for the position editor.
      */
-    public TpeToolBar() {
+    TpeToolBar() {
         super(new GridBagLayout());
 
         setBorder(BorderFactory.createEmptyBorder(10, 5, 10, 5));
 
         _modePanel = new JPanel(new GridBagLayout());
         add(_modePanel, new GridBagConstraints() {{
-            gridx=0; gridy=0; anchor=NORTH; fill=HORIZONTAL; weightx=1;
-            insets=new Insets(0, 5, 0, 0);
+            gridx = 0; gridy = 0; anchor = NORTH; fill = HORIZONTAL; weightx = 1;
+            insets = new Insets(0, 5, 0, 0);
         }});
 
         _createPanel = new JPanel(new GridBagLayout());
         add(_createPanel, new GridBagConstraints() {{
-            gridx=0; gridy=1; anchor=NORTH; fill=HORIZONTAL; weightx=1;
-            insets=new Insets(5, 5, 0, 0);
+            gridx = 0; gridy = 1; anchor = NORTH; fill = HORIZONTAL; weightx = 1;
+            insets = new Insets(5, 5, 0, 0);
         }});
 
         int i=0;
@@ -71,8 +64,8 @@ public final class TpeToolBar extends JPanel {
             _viewPanel[i] = new JPanel(new GridBagLayout());
 
             GridBagConstraints gbc = new GridBagConstraints() {{
-                gridx=0; anchor=NORTH; fill=HORIZONTAL;
-                insets=new Insets(10, 0, 0, 0);
+                gridx = 0; anchor = NORTH; fill = HORIZONTAL;
+                insets = new Insets(10, 0, 0, 0);
             }};
             gbc.gridy = 2+i;
 
@@ -81,15 +74,15 @@ public final class TpeToolBar extends JPanel {
         }
 
         final int yPos = 2+i;
-        JPanel wrappedGuiderSelector = wrapPanel("", _guiderSelector.getUi());
+        final JPanel wrappedGuiderSelector = wrapPanel("", _guiderSelector.getUi());
         add(wrappedGuiderSelector, new GridBagConstraints() {{
-            gridx=0; gridy=yPos; anchor=NORTH; fill=HORIZONTAL;
-            insets=new Insets(10, 0, 0, 0);
+            gridx = 0; gridy = yPos; anchor = NORTH; fill = HORIZONTAL;
+            insets = new Insets(10, 0, 0, 0);
         }});
 
         // consume remaining vertical space
-        GridBagConstraints gbc = new GridBagConstraints() {{
-            gridx=0; fill=BOTH; weighty=1.0;
+        final GridBagConstraints gbc = new GridBagConstraints() {{
+            gridx = 0; fill = BOTH; weighty = 1.0;
         }};
         gbc.gridy = 3+i;
         add(new JPanel(), gbc);
@@ -97,16 +90,16 @@ public final class TpeToolBar extends JPanel {
     }
 
     private JPanel wrapPanel(String label, JComponent panel) {
-        JPanel res = new JPanel(new GridBagLayout());
+        final JPanel res = new JPanel(new GridBagLayout());
 
-        JLabel lab = new JLabel(label);
+        final JLabel lab = new JLabel(label);
         res.add(lab, new GridBagConstraints() {{
-            gridx=0; gridy=0; anchor=WEST; fill=HORIZONTAL; weightx=1;
-            insets=new Insets(0, 0, 3, 0);
+            gridx = 0; gridy = 0; anchor = WEST; fill = HORIZONTAL; weightx = 1;
+            insets = new Insets(0, 0, 3, 0);
         }});
         res.add(panel, new GridBagConstraints() {{
-            gridx=0; gridy=1; fill=BOTH; weightx=1;
-            insets=new Insets(0, 5, 0, 0);
+            gridx = 0; gridy = 1; fill = BOTH; weightx = 1;
+            insets = new Insets(0, 5, 0, 0);
         }});
 
         return res;
@@ -122,22 +115,22 @@ public final class TpeToolBar extends JPanel {
         }
     }
 
-    public void addModeButton(JToggleButton button) {
+    void addModeButton(JToggleButton button) {
         _buttonGroup.add(button);
         add(button, _modePanel);
     }
 
-    public void addCreateButton(JToggleButton button) {
+    void addCreateButton(JToggleButton button) {
         _buttonGroup.add(button);
         add(button, _createPanel);
     }
 
-    public void hideCreateButtons() {
+    void hideCreateButtons() {
         hide(_createPanel);
     }
 
-    public static Component createKeyPanel(Component key) {
-        JPanel pan = new JPanel(new GridBagLayout());
+    static Component createKeyPanel(Component key) {
+        final JPanel pan = new JPanel(new GridBagLayout());
 
         final Dimension d = new Dimension(16, 16);
         JPanel spacer = new JPanel() {{
@@ -152,7 +145,7 @@ public final class TpeToolBar extends JPanel {
         return pan;
     }
 
-    public void addViewItem(Component comp, TpeImageFeatureCategory cat) {
+    void addViewItem(Component comp, TpeImageFeatureCategory cat) {
         final JPanel viewPanel = _viewPanel[cat.ordinal()];
         add(comp, viewPanel);
 
@@ -185,11 +178,11 @@ public final class TpeToolBar extends JPanel {
         });
     }
 
-    public void hideViewButtons() {
+    void hideViewButtons() {
         for (JPanel pan : _viewPanel) hide(pan);
     }
 
-    public AgsSelectorControl getGuiderSelector() {
+    AgsSelectorControl getGuiderSelector() {
         return _guiderSelector;
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -95,7 +95,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
     /**
      * Get the "draw position tags" property.
      */
-    public boolean getDrawTags() {
+    boolean getDrawTags() {
         return _props.getBoolean(PROP_SHOW_TAGS, true);
     }
 
@@ -109,7 +109,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
     /**
      * Get the "indicate primary guide star" property value.
      */
-    public boolean getIdentifyPrimary() {
+    boolean getIdentifyPrimary() {
         return _props.getBoolean(PROP_IDENTIFY_PRIMARY, true);
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -177,16 +177,13 @@ public class TpeGuidePosFeature extends TpePositionFeature
             final TargetEnvironment envInit = obsComp.getTargetEnvironment();
             final GuideEnvironment genvInit = envInit.getGuideEnvironment();
             final GuideGroup gpInit         = genvInit.getPrimary();
-            final boolean onlyAuto          = envInit.getGuideEnvironment().manualGroups().isEmpty();
 
             final GuideGroup        gp;
             final TargetEnvironment env;
             final int idx;
 
             if (gpInit.isAutomatic()) {
-                if (!onlyAuto) return;
-
-                // Only the auto group exists, so create a new manual group and add it as the primary group.
+                // Only the auto group is enabled, create a new manual group and add it as the primary group.
                 final ImList<GuideGroup> oldGroups = genvInit.getOptions();
                 gp  = GuideGroup.create(GuideGroup.ManualGroupDefaultName());
                 idx = oldGroups.size();


### PR DESCRIPTION
This PR changes the TPE to let adding Guide Stars always regardless if there is an active manual group. Added guide stars will go to the active manual group or it will create a manual group instead