### PR TITLE
REL-2878: QPT password prompt

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
@@ -91,11 +91,9 @@ public final class Activator implements BundleActivator {
 
                 // If the keychain is locked, give the user the chance to unlock it here. If they
                 // choose not to, they can do it via Edit > Manage Keys
-                SwingUtilities.invokeLater(new Runnable() {
-                    public void run() {
-                        if (ac.asJava().isLocked())
-                            PasswordDialog.unlock(ac, null);
-                    }
+                SwingUtilities.invokeLater(() -> {
+                    if (ac.asJava().isLocked())
+                        PasswordDialog.unlock(ac, null);
                 });
 
                 Activator.this.advisor = new ShellAdvisor("Gemini QPT", Version.current.toString(), root, ac, internal, pachon, ProbeLimitsTable.loadOrThrow());

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
@@ -41,10 +41,7 @@ public final class Activator implements BundleActivator {
     private BundleContext context;
 
     // Credentials for publishing
-    private static final String PROP_INTERNAL_USER = "edu.gemini.qpt.ui.action.destination.internal.user";
-    private static final String PROP_INTERNAL_PASS = "edu.gemini.qpt.ui.action.destination.internal.pass";
-    private static final String PROP_PACHON_USER   = "edu.gemini.qpt.ui.action.destination.pachon.user";
-    private static final String PROP_PACHON_PASS   = "edu.gemini.qpt.ui.action.destination.pachon.pass";
+    private static final String PROP_USER = "edu.gemini.qpt.ui.action.destination.user";
     private ServiceTracker<KeyChain, KeyChain> keyChainServiceTracker = null;
     private final CtrKeyListener ctrKeyListener = new CtrKeyListener();
 
@@ -77,15 +74,13 @@ public final class Activator implements BundleActivator {
 
                 internal = new PublishAction.Destination(
                     "gnconfig.gemini.edu",
-                    getProp(PROP_INTERNAL_USER),
-                    getProp(PROP_INTERNAL_PASS),
+                    getProp(PROP_USER),
                     "/gemsoft/var/data/qpt",
                     "http://internal.gemini.edu/science/");
 
                 pachon = new PublishAction.Destination(
                     "gsconfig.gemini.edu",
-                    getProp(PROP_PACHON_USER),
-                    getProp(PROP_PACHON_PASS),
+                    getProp(PROP_USER),
                     "/gemsoft/var/data/qpt",
                     null);
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/PublishAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/PublishAction.java
@@ -20,7 +20,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.TimeZone;
-import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,11 +39,6 @@ public class PublishAction extends AbstractAsyncAction implements PropertyChange
 //	private static final String[] MONTHS = { "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec" };
 
     private static final long serialVersionUID = 1L;
-    private CountDownLatch latch = new CountDownLatch(1);
-    private boolean utc;
-    private boolean web;
-    private boolean qcMarkers;
-    private boolean cancel;
 
     private final IShell shell;
 
@@ -88,7 +82,7 @@ public class PublishAction extends AbstractAsyncAction implements PropertyChange
 				shell.getPeer(),
 				"Select a publish option.",
 				"Publish Plan",
-				JOptionPane.OK_CANCEL_OPTION,
+				JOptionPane.QUESTION_MESSAGE,
 				SharedIcons.ICON_PUBLISH,
 				OPTIONS,
 				OPTIONS[0]);
@@ -96,8 +90,8 @@ public class PublishAction extends AbstractAsyncAction implements PropertyChange
 			if (option == null)
 				return; // cancelled
 
-			web = option == OPTIONS[2];
-			qcMarkers = option == OPTIONS[1];
+            final boolean web = option == OPTIONS[2];
+            final boolean qcMarkers = option == OPTIONS[1];
 
 
             String[] TIME_OPTIONS = { "Local time at site", "UTC"};
@@ -115,87 +109,8 @@ public class PublishAction extends AbstractAsyncAction implements PropertyChange
             if (timeOption == null)
                 return; // cancelled
 
-            utc = timeOption.equals(1);
+            final boolean utc = timeOption.equals(1);
 
-
-
-//            latch = new CountDownLatch(1);
-//            final JDialog dialog = new JDialog(shell.getPeer(), "Publish Plan");
-//            dialog.setResizable(true);
-//            dialog.setSize(100,50);
-//            CellConstraints cc = new CellConstraints();
-//
-//            JPanel contentPane = new JPanel(new FormLayout(
-//                    new ColumnSpec[] {
-//                            new ColumnSpec("max(min;30dlu)"),
-//                            FormFactory.UNRELATED_GAP_COLSPEC,
-//                            new ColumnSpec("max(min;30dlu)"),
-//                            FormFactory.UNRELATED_GAP_COLSPEC,
-//                            new ColumnSpec("max(min;30dlu)"),
-//                    },
-//                    new RowSpec[] {
-//                            new RowSpec(RowSpec.FILL, Sizes.DLUY1, FormSpec.DEFAULT_GROW),
-//                            FormFactory.RELATED_GAP_ROWSPEC,
-//                            new RowSpec(RowSpec.FILL, Sizes.DLUY1, FormSpec.DEFAULT_GROW),
-//
-//
-//                    }));
-//            final JComboBox combo = new JComboBox(OPTIONS);
-//            contentPane.add(combo, cc.xywh(1, 1, 5, 1));
-//            JButton localBtn;
-//            localBtn = new JButton("Publish in Local Time");
-//            localBtn.addActionListener(new ActionListener() {
-//                @Override
-//                public void actionPerformed(ActionEvent actionEvent) {
-//                    utc = true;
-//                    web = combo.getSelectedIndex() == 2;
-//                    qcMarkers = combo.getSelectedIndex() == 1;
-//                    cancel = false;
-//                    latch.countDown();
-//                    dialog.dispose();
-//                }
-//            });
-//            JButton utcBtn;
-//            utcBtn = new JButton("Publish in UTC");
-//            utcBtn.addActionListener(new ActionListener() {
-//                @Override
-//                public void actionPerformed(ActionEvent actionEvent) {
-//                    utc = true;
-//                    web = combo.getSelectedIndex() == 2;
-//                    qcMarkers = combo.getSelectedIndex() == 1;
-//                    cancel = false;
-//                    latch.countDown();
-//                    dialog.dispose();
-//                }
-//            });
-//
-//            JButton cancelBtn;
-//            cancelBtn = new JButton("Cancel");
-//            cancelBtn.addActionListener(new ActionListener() {
-//                @Override
-//                public void actionPerformed(ActionEvent actionEvent) {
-//                    cancel = true;
-//                    latch.countDown();
-//                    dialog.dispose();
-//                }
-//            });
-//            contentPane.add(localBtn,cc.xywh(1,3,1,1));
-//            contentPane.add(utcBtn,cc.xywh(3,3,1,1));
-//            contentPane.add(cancelBtn,cc.xywh(5,3,1,1));
-//            dialog.setContentPane(contentPane);
-//
-//
-//            dialog.setVisible(true);
-//            try {
-//                latch.await();
-//            } catch (InterruptedException e1) {
-//                System.out.println("sldjfhskfgh");
-//            }
-//            System.out.println("utc " + utc + " web " + web + " qc " + qcMarkers + " cancel " + cancel);
-//
-//            if (cancel) {
-//                return;
-//            }
             final Destination[] destinations;
             if (web) {
 

--- a/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/ui/action/PublishDialog.scala
+++ b/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/ui/action/PublishDialog.scala
@@ -1,0 +1,154 @@
+package edu.gemini.qpt.ui.action
+
+import edu.gemini.qpt.ui.util.SharedIcons
+
+import javax.swing.{BorderFactory, JOptionPane}
+
+import scala.swing.GridBagPanel.{Fill, Anchor}
+import scala.swing.ListView.Renderer
+import scala.swing._
+import scala.swing.event.SelectionChanged
+
+/** Implements the dialog used when publishing QPT plans. It prompts the user
+  * for the publish destination, password (if necessary), and the time zone.
+  */
+object PublishDialog {
+
+  // The publish destination, or type.
+  sealed trait PublishType
+  case object PublishPreview            extends PublishType
+  case object PublishPreviewWithMarkers extends PublishType
+  case object PublishWeb                extends PublishType
+
+  // Time zone to use for the display.
+  sealed trait TimeOption
+  case object Local extends TimeOption
+  case object Utc   extends TimeOption
+
+  case class PublishOptions(publishType: PublishType, password: String, time: TimeOption)
+
+  val defaultOptions = PublishOptions(PublishWeb, "", Utc)
+
+
+  object panel extends GridBagPanel {
+
+    border = BorderFactory.createEmptyBorder(5, 5, 5, 5)
+
+    // Set the panel size explicitly.  Otherwise, when the password field
+    // appears the panel can be cropped because the dialog size doesn't
+    // adjust.
+    preferredSize = new Dimension(345, 105)
+
+    def addRow(text: String, widget: Component, row: Int): Unit =
+      addRow(new Label(text), widget, row)
+
+    def addRow(lab: Label, widget: Component, row: Int): Unit = {
+      add(lab, new Constraints {
+        gridx  = 1
+        gridy  = row
+        anchor = Anchor.West
+        insets = new Insets(3, 0, 0, 5)
+      })
+
+      add(widget, new Constraints {
+        gridx  = 2
+        gridy  = row
+        fill   = Fill.Horizontal
+        insets = new Insets(3, 0, 0, 0)
+      })
+    }
+
+    // Left column (0) icon.
+    val icon = new Label
+    icon.icon = SharedIcons.ICON_PUBLISH
+
+    add(icon, new Constraints {
+      gridx      = 0
+      gridy      = 0
+      gridheight = 4
+      anchor     = Anchor.Center
+      insets     = new Insets(0, 0, 0, 10)
+    })
+
+
+    // Row 0, cols 1 & 2: instructions.
+    add(new Label("Select publish options."), new Constraints {
+      gridx      = 1
+      gridy      = 0
+      gridwidth  = 2
+      anchor     = Anchor.West
+    })
+
+    def updatePasswordVisibility(pt: PublishType): Unit = {
+      passPrompt.visible = pt == PublishWeb
+      passField.visible  = pt == PublishWeb
+    }
+
+
+    // Row 1: publish destination
+    object publishType extends ComboBox[PublishType](List(PublishPreview, PublishPreviewWithMarkers, PublishWeb)) {
+      renderer = Renderer {
+        case PublishPreview            => "Preview Locally"
+        case PublishPreviewWithMarkers => "Preview Locally w/ QC Markers"
+        case PublishWeb                => "Publish to the Web"
+      }
+    }
+    addRow("Destination", publishType, 1)
+
+    listenTo(publishType.selection)
+    reactions += {
+      case SelectionChanged(`publishType`) =>
+        updatePasswordVisibility(publishType.selection.item)
+    }
+
+
+    // Row 2: (invisible except for when publishing to the web) password prompt
+    val passPrompt = new Label("Password")
+    object passField extends PasswordField
+    addRow(passPrompt, passField, 2)
+
+
+    // Row 3: time zone
+    val timeLocal = new ToggleButton("Local Time")
+    val timeUtc   = new ToggleButton("UTC")
+    object timeGroup extends ButtonGroup(timeLocal, timeUtc)
+
+    object timePanel extends GridPanel(1, 2) {
+      contents += timeLocal
+      contents += timeUtc
+    }
+    addRow("Timezone", timePanel, 3)
+
+
+    /** Extract PublishOptions from the widgets in this panel. */
+    def options: PublishOptions = {
+      val pub  = publishType.selection.item
+      val pass = String.valueOf(passField.password)
+      val time = if (timeLocal.selected) Local else Utc
+      PublishOptions(pub, pass, time)
+    }
+
+    /** Configure the widgets to match the provided options. */
+    def options_=(o: PublishOptions) = {
+      publishType.selection.item = o.publishType
+      passField.text             = o.password
+      timeGroup.select(if (options.time == Local) timeLocal else timeUtc)
+
+      updatePasswordVisibility(o.publishType)
+    }
+  }
+
+  /** Displays the publish options and allows the user to confirm the publish
+    * or cancel.
+    *
+    * @return selected PublishOptions, if any (None if cancelled)
+    */
+  def prompt(p: java.awt.Component, o: PublishOptions): Option[PublishOptions] = {
+    val choices   = Array[AnyRef]("Publish", "Cancel")
+    panel.options = o
+    val res       = JOptionPane.showOptionDialog(p, panel.peer, "Publish Plan",
+                      JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE,
+                      null, choices, choices(0))
+    if (res == 0) Some(panel.options) else None
+  }
+}


### PR DESCRIPTION
The purpose of this PR is to add a password prompt when publishing a QPT plan.  The account under which plans are published will have a new password soon, requiring a new QPT release.  The IT department is not comfortable with keeping the password in a plain text file in svn, even if only available to staff members.  This PR updates the publish process to request the password from the user.  It will remember the password that the user provides for subsequent publishes until the application is restarted.

Beyond that simple goal, I rewrote the popup(s) associated with publishing.  Since the process already involved clicking through two separate popups, I felt it would be abusive to ask for the password in a new popup.  Instead I combined all the information in a single dialog as shown below.

![publishtotheweb](https://cloud.githubusercontent.com/assets/4906023/16696681/03af21b8-4514-11e6-88ac-8df30ff4a738.png)

![previewlocally](https://cloud.githubusercontent.com/assets/4906023/16696690/0a0010c2-4514-11e6-9b88-bb25832dc2bc.png)



