### PR TITLE
REL-2852 improve mean parallactic angle calculation usability

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -45,7 +45,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     // for serialization
     private static final long serialVersionUID = 4L;
 
-    public static final String VERSION = "2016B-1";
+    public static final String VERSION = "2016B-2";
 
     /** This property records the program queue/classical state. */
     public static final String PROGRAM_MODE_PROP = "programMode";

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsParamSetCodecs.scala
@@ -1,0 +1,56 @@
+package edu.gemini.spModel.obs
+
+import edu.gemini.spModel.obs.SchedulingBlock.Duration
+import edu.gemini.spModel.obs.SchedulingBlock.Duration._
+import edu.gemini.spModel.pio.codec._
+import edu.gemini.spModel.pio.xml.PioXmlFactory
+import edu.gemini.spModel.pio.{ParamSet, Pio}
+
+import scalaz.Scalaz._
+import scalaz._
+
+object ObsParamSetCodecs {
+
+  implicit val UnstatedParamSetCodec: ParamSetCodec[Unstated.type] =
+    ParamSetCodec.initial(Unstated)
+
+  implicit val ExplicitParamSetCodec: ParamSetCodec[Explicit] =
+    ParamSetCodec.initial(Explicit(0L))
+      .withParam("ms", Explicit.ms)
+
+  implicit val ComputedParamSetCodec: ParamSetCodec[Computed] =
+    ParamSetCodec.initial(Computed(0L))
+      .withParam("ms", Computed.ms)
+
+  implicit val DurationParamSetCodec: ParamSetCodec[Duration] =
+    new ParamSetCodec[Duration] {
+      val pf = new PioXmlFactory
+      def encode(key: String, d: Duration): ParamSet = {
+        val (tag, ps) = d match {
+          case u @ Unstated     => ("unstated", UnstatedParamSetCodec.encode(key, Unstated))
+          case e @ Explicit(ms) => ("explicit", ExplicitParamSetCodec.encode(key, e))
+          case c @ Computed(ms) => ("computed", ComputedParamSetCodec.encode(key, c))
+        }
+        Pio.addParam(pf, ps, "tag", tag)
+        ps
+      }
+      def decode(ps: ParamSet): PioError \/ Duration = {
+        (Option(ps.getParam("tag")).map(_.getValue) \/> MissingKey("tag")) flatMap {
+          case "unstated" => UnstatedParamSetCodec.decode(ps)
+          case "explicit" => ExplicitParamSetCodec.decode(ps)
+          case "computed" => ComputedParamSetCodec.decode(ps)
+          case hmm        => UnknownTag(hmm, "Target").left
+        }
+      }
+    }
+
+  implicit val SchedulingBlockParamSetCodec: ParamSetCodec[SchedulingBlock] =
+    ParamSetCodec.initial(SchedulingBlock(0L, Unstated))
+      .withParam("start", SchedulingBlock.start)
+      .withParamSet("duration", SchedulingBlock.duration)
+
+}
+
+
+
+

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -11,6 +11,7 @@ import edu.gemini.util.skycalc.calc.{Interval, TargetCalculator}
 
 import jsky.coords.WorldCoords
 import edu.gemini.skycalc.{TimeUtils, Coordinates}
+import scala.collection.JavaConverters._
 
 /**
  * Created with IntelliJ IDEA.
@@ -43,7 +44,6 @@ object ObsTargetCalculatorService {
 
     def calc(s: Site, b: SchedulingBlock, c: Coordinates): TargetCalculator = {
       val st = SiderealTarget(new WorldCoords(c.getRaDeg, c.getDecDeg))
-      val plannedTime = PlannedTimeCalculator.instance.calc(obs)
 
       // Andy says:
       // duration is equivalent to science time, if specific explicitly
@@ -51,7 +51,7 @@ object ObsTargetCalculatorService {
       // Ideally, if you hover over duration box in GUI, should say acquisition + science time OR not.
 
       // Since we need start < end explicitly, if the duration is None, we cannot use it.
-      val duration = b.duration getOrElse plannedTime.totalTime
+      val duration = b.duration.map(_.abs) getOrElse calculateRemainingTime(obs)
       val end      = b.start + duration
 
       // If the duration is going to be smaller than the default step size of 30 seconds used by the
@@ -86,4 +86,13 @@ object ObsTargetCalculatorService {
   def targetCalculationForJava(obs: ISPObservation): edu.gemini.shared.util.immutable.Option[TargetCalculator] = {
     targetCalculation(obs).asGeminiOpt
   }
+
+  def calculateRemainingTime(ispObservation: ISPObservation): Long =
+    PlannedTimeCalculator.instance
+      .calc(ispObservation)
+      .steps.asScala
+      .filterNot(_.executed)
+      .map(_.totalTime)
+      .sum
+
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -51,7 +51,7 @@ object ObsTargetCalculatorService {
       // Ideally, if you hover over duration box in GUI, should say acquisition + science time OR not.
 
       // Since we need start < end explicitly, if the duration is None, we cannot use it.
-      val duration = b.duration.map(_.abs) getOrElse calculateRemainingTime(obs)
+      val duration = b.duration.toOption getOrElse calculateRemainingTime(obs)
       val end      = b.start + duration
 
       // If the duration is going to be smaller than the default step size of 30 seconds used by the

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/SchedulingBlock.scala
@@ -9,7 +9,7 @@ sealed abstract class SchedulingBlock {
   /** A point in time. */
   def start: Long
 
-  /** An optional duration, always positive if present. */
+  /** An optional duration, positive if explicit, negative if computed. */
   def duration: Option[Long]
 
   /** Duration, if any, otherwise zero. */
@@ -41,7 +41,7 @@ object SchedulingBlock {
     apply(start, Some(duration))
 
   def apply(start: Long, duration: Option[Long]): SchedulingBlock =
-    new Impl(start, duration.filter(_ >= 0))
+    new Impl(start, duration)
 
   def unsafeFromStrings(startString: String, durationString: String): SchedulingBlock =
     apply(startString.toLong, durationString.toLong)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obs/Arbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obs/Arbitraries.scala
@@ -1,0 +1,29 @@
+package edu.gemini.spModel.obs
+
+import edu.gemini.spModel.obs.SchedulingBlock.Duration
+import edu.gemini.spModel.obs.SchedulingBlock.Duration._
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+trait Arbitraries {
+
+  implicit val arbExplicit: Arbitrary[Explicit] =
+    Arbitrary(arbitrary[Long].map(n => Explicit(n.abs)))
+
+  implicit val arbComputed: Arbitrary[Computed] =
+    Arbitrary(arbitrary[Long].map(n => Computed(n.abs)))
+
+  implicit val arbDuration: Arbitrary[Duration] =
+    Arbitrary(oneOf(arbitrary[Explicit], arbitrary[Computed], Gen.const(Unstated)))
+
+  implicit val arbSchedulingBlock: Arbitrary[SchedulingBlock] =
+    Arbitrary {
+      for {
+        start    <- arbitrary[Long]
+        duration <- arbitrary[Duration]
+      } yield SchedulingBlock(start, duration)
+    }
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obs/ObsParamSetCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obs/ObsParamSetCodecSpec.scala
@@ -1,0 +1,34 @@
+package edu.gemini.spModel.obs
+
+import edu.gemini.spModel.obs.SchedulingBlock.Duration
+import edu.gemini.spModel.pio.codec._
+
+import scalaz._
+import Scalaz._
+
+import org.scalacheck.{ Properties, Gen, Arbitrary }
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop._
+import org.scalacheck.Gen
+
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object ObsParamSetCodecsSpec extends Specification with ScalaCheck with Arbitraries {
+  import ObsParamSetCodecs._
+
+  def exact[A: ParamSetCodec: Arbitrary](implicit mf: Manifest[A]) =
+    mf.runtimeClass.getName ! forAll { (key: String, value: A) =>
+      val c = ParamSetCodec[A]
+      c.decode(c.encode(key, value)) must_== \/-(value)
+    }
+
+  "Obs ParamSet Codecs" >> {
+    exact[Duration]
+    exact[SchedulingBlock]
+  }
+
+}
+
+
+

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
@@ -19,6 +19,7 @@ import edu.gemini.spModel.io.impl.migration.to2015A.To2015A;
 import edu.gemini.spModel.io.impl.migration.to2015B.To2015B;
 import edu.gemini.spModel.io.impl.migration.to2016A.To2016A;
 import edu.gemini.spModel.io.impl.migration.to2016B.To2016B;
+import edu.gemini.spModel.io.impl.migration.to2016B.To2016B2;
 import edu.gemini.spModel.io.impl.migration.toPalote.Grillo2Palote;
 import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obscomp.SPGroup;
@@ -222,6 +223,9 @@ public final class PioSpXmlParser {
 
         // Update pre-2016B programs
         To2016B.updateProgram(doc);
+
+        // Update pre-2016B-2 programs
+        To2016B2.updateProgram(doc);
 
         // We will special case the Phase 1 container.
         Container p1Container = null;

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
@@ -61,6 +61,11 @@ trait Migration {
       ps  <- env.allParamSets if ps.getName == ParamSetBase
     } yield (obs.getParamSet(ParamSetObservation), ps)
 
+  /** all observation paramsets **/
+  protected def obs(d: Document): List[ParamSet] =
+    d.findContainers(SPComponentType.OBSERVATION_BASIC)
+     .map(_.getParamSet(ParamSetObservation))
+
   /** Writes the document to an XML String for debugging. */
   protected def formatDocument(d: Document): String = {
     val writer = new StringWriter()

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
@@ -51,6 +51,9 @@ object PioSyntax {
     def value(key: String): Option[String] =
       Option(p.getParam(key)).map(_.getValue)
 
+    def long(key: String): Option[Long] =
+      Option(p.getParam(key)).map(_.getValue.toLong)
+
     def double(key: String): Option[Double] =
       Option(p.getParam(key)).map(_.getValue.toDouble)
 

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B2.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2016B/To2016B2.scala
@@ -1,0 +1,41 @@
+package edu.gemini.spModel.io.impl.migration.to2016B
+
+import edu.gemini.spModel.io.impl.migration.Migration
+import edu.gemini.spModel.obs.ObsParamSetCodecs._
+import edu.gemini.spModel.obs.SchedulingBlock
+import edu.gemini.spModel.obs.SchedulingBlock.Duration
+import edu.gemini.spModel.obs.SchedulingBlock.Duration._
+import edu.gemini.spModel.pio.{Document, Version}
+import edu.gemini.spModel.pio.codec._
+import edu.gemini.spModel.io.impl.migration.PioSyntax._
+
+object To2016B2 extends Migration {
+
+  val version = Version.`match`("2016B-2")
+
+  val kSb         = "schedulingBlock";
+  val kSbStart    = "schedulingBlockStart";
+  val kSbDuration = "schedulingBlockDuration";
+
+  val conversions: List[Document => Unit] = List(
+    updateSchedulingBlocks // order matters!
+  )
+
+  // If there is a scheduling block, replace the old 2-Param encoding with the new ParamSet
+  // encoding, interpreting any existing duration as explicit. There is no way to distinguish in
+  // the old model.
+  def updateSchedulingBlocks(d: Document): Unit =
+    for {
+      o <- obs(d)
+      s <- o.long(kSbStart)
+      d <- List(o.long(kSbDuration).fold[Duration](Unstated)(Explicit(_)))
+    } {
+      o.removeChild(kSbStart)
+      o.removeChild(kSbDuration)
+      o.addParamSet(SchedulingBlock(s, d).encode(kSb))
+    }
+
+}
+
+
+

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
@@ -26,7 +26,7 @@ class SchedulingBlockMigrationTest extends Specification with MigrationTest {
     }
 
     "Use Valid-At For Non-Sidereal Base Positions" in withTestProgram2("schedulingBlock.xml") { p =>
-      p.findSchedulingBlock("nonsidereal") must_== Some(SchedulingBlock(1454284800000L))
+      p.findSchedulingBlock("nonsidereal") must_== Some(SchedulingBlock(1454284800000L, SchedulingBlock.Duration.Unstated))
     }
 
     "Ignore Sidereal Observations" in withTestProgram2("schedulingBlock.xml") { p =>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016B/SchedulingBlockMigrationTest.scala
@@ -22,7 +22,7 @@ class SchedulingBlockMigrationTest extends Specification with MigrationTest {
   "2016B Schedling Block Migration" should {
 
     "Preserve Existing Scheduling Blocks" in withTestProgram2("schedulingBlock.xml") { p =>
-      p.findSchedulingBlock("some") must_== Some(SchedulingBlock(1457551614113L, Some(92500L)))
+      p.findSchedulingBlock("some") must_== Some(SchedulingBlock(1457551614113L, SchedulingBlock.Duration.Explicit(92500L)))
     }
 
     "Use Valid-At For Non-Sidereal Base Positions" in withTestProgram2("schedulingBlock.xml") { p =>

--- a/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamSetCodec.scala
+++ b/bundle/edu.gemini.spModel.pio/src/main/scala/edu/gemini/spModel/pio/codec/ParamSetCodec.scala
@@ -12,6 +12,9 @@ trait ParamSetCodec[A] { outer =>
   
   def decode(ps: ParamSet): PioError \/ A
 
+  def unsafeDecode(ps: ParamSet): A =
+    outer.decode(ps).fold(e => throw new PioParseException(e.toString), a => a)
+
   def withParam[B](key: String, lens: A @> B)(implicit pc: ParamCodec[B]): ParamSetCodec[A] =
     new ParamSetCodec[A] {
       def encode(key0: String, a: A): ParamSet = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -63,7 +63,7 @@ class TpeEphemerisFeature extends TpeImageFeature("Ephemeris", "Show interpolate
     toScreenEphemeris(getEphemeris)
 
   def obsTime: Option[Long] =
-    getContext.schedulingBlock.flatMap(_.duration).map(_.abs) orElse
+    getContext.schedulingBlock.flatMap(_.duration.toOption) orElse
     getContext.obsShell.map(remainingTime)
 
   def obsScreenEphemeris(e: Ephemeris): Option[List[ScreenEphemeris]] =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -63,7 +63,7 @@ class TpeEphemerisFeature extends TpeImageFeature("Ephemeris", "Show interpolate
     toScreenEphemeris(getEphemeris)
 
   def obsTime: Option[Long] =
-    getContext.schedulingBlock.flatMap(_.duration) orElse
+    getContext.schedulingBlock.flatMap(_.duration).map(_.abs) orElse
     getContext.obsShell.map(remainingTime)
 
   def obsScreenEphemeris(e: Ephemeris): Option[List[ScreenEphemeris]] =


### PR DESCRIPTION
This PR improves the usability for mean parallactic angle computations as follows:

- The duration used for the computation is retained, even if it is a snapshot of the current remaining time. We do this by storing it as a negative value, in order to maintain binary compatibility with the existing `SchedulingBlock` class.
- When no duration is specified, remaining observe time is used instead and is *not* recorded in the scheduling block. This is a corner case that happens only once in practice, when you first select the mean parallactic angle option. Since this is never the final answer I don't think it matters … it would end up being a potentially risky change to update the scheduling block in this case.

This needs monkey testing.