### PR TITLE
REL-2852-B: position angle panel enabled state fix

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2Editor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2Editor.java
@@ -16,6 +16,7 @@ import edu.gemini.spModel.data.YesNoType;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
 import edu.gemini.spModel.telescope.IssPort;
 import edu.gemini.spModel.type.SpTypeUtil;
+import jsky.app.ot.OTOptions;
 import jsky.app.ot.editor.eng.EngEditor;
 import jsky.app.ot.gemini.editor.ComponentEditor;
 import jsky.app.ot.gemini.parallacticangle.PositionAnglePanel;
@@ -584,6 +585,8 @@ public class Flamingos2Editor extends ComponentEditor<ISPObsComponent, Flamingos
         messagePanel.update();
 
         posAnglePanel.init(this, Site.GS);
+        final boolean editable = OTOptions.areRootAndCurrentObsIfAnyEditable(getProgram(), getContextObservation());
+        posAnglePanel.updateEnabledState(editable);
 
         // If the position angle mode or FPU mode properties change, force an update on the parallactic angle mode.
         inst.addPropertyChangeListener(Flamingos2.POS_ANGLE_PROP.getName(), updateParallacticAnglePCL);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
@@ -663,6 +663,7 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
         _w.builtinComboBox.setEnabled(enabled && !customMask);
         _w.focalPlaneMask.setEnabled(enabled && customMask);
         _w.customSlitWidthComboBox.setEnabled(enabled && customMask);
+        _w.posAnglePanel.updateEnabledState(enabled);
     }
 
     protected void _updateCustomSlitWidth() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gnirs/EdCompInstGNIRS.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gnirs/EdCompInstGNIRS.java
@@ -290,6 +290,11 @@ public class EdCompInstGNIRS extends EdCompInstBase<InstGNIRS> implements Action
         inst.addPropertyChangeListener(InstGNIRS.DISPERSER_PROP.getName(),  updateParallacticAnglePCL);
     }
 
+    protected void updateEnabledState(final boolean enabled) {
+        super.updateEnabledState(enabled);
+        _w.posAnglePanel.updateEnabledState(enabled);
+    }
+
     // Return an array of default wavelength description strings (wavelength (order n))
     private String[] _getDefaultWavelengths() {
         final int n = Order.values().length;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -211,6 +211,14 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     updateUnboundedControls()
   }
 
+  /** Sets the enabled state of contained widgets to match the provided value. */
+  def updateEnabledState(enabled: Boolean): Unit = {
+    ui.positionAngleConstraintComboBox.enabled = enabled
+    ui.positionAngleTextField.enabled = enabled
+    ui.parallacticAngleControlsOpt.foreach { p =>
+      p.enabled = enabled
+    }
+  }
 
   /**
    * Copies, if possible, the position angle text field contents to the data object.


### PR DESCRIPTION
This PR addresses an issue with the position angle panel enabled state.  It adds an `updateEnabledState` method to `PositionAnglePanel` and calls it at appropriate points of the instruments that use it.