### PR TITLE
REL-2886: Include OT installation link in incompatibility warning

### DIFF
--- a/bundle/edu.gemini.pit/build.sbt
+++ b/bundle/edu.gemini.pit/build.sbt
@@ -14,11 +14,11 @@ libraryDependencies ++= Seq(
   "org.scalaz"     %% "scalaz-core"       % ScalaZVersion,
   "org.scalaz"     %% "scalaz-concurrent" % ScalaZVersion,
   "org.scalaz"     %% "scalaz-effect"     % ScalaZVersion,
-  "org.scala-lang" % "scala-actors"       % "2.11.7",
+  "org.scala-lang" %  "scala-actors"      % "2.11.7",
   "org.scala-lang" %  "scala-compiler"    % "2.11.7" // required to pull the dependencies via edu.gemini.util.security
 )
 
-osgiSettings 
+osgiSettings
 
 ocsBundleSettings
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
@@ -7,20 +7,22 @@ import edu.gemini.pit.ui.CommonActions._
 import edu.gemini.pit.ui.view.proposal._
 import edu.gemini.pit.ui.view.problem._
 import edu.gemini.pit.ui.view.obs._
-import edu.gemini.pit.ui.util.Platform.MENU_ACTION_MASK
+import edu.gemini.shared.Platform.MENU_ACTION_MASK
 import edu.gemini.pit.ui.action._
 import edu.gemini.ui.workspace.IViewAdvisor.Relation._
 import edu.gemini.ui.workspace.IActionManager.Relation._
 import edu.gemini.ui.workspace.scala.{RichShell, RichShellAdvisor, RichShellContext}
 import edu.gemini.ui.workspace.util.{InternalFrameHelp, RetargetAction}
 import java.awt.event.KeyEvent._
-import java.lang.reflect.{Method, Proxy, InvocationHandler}
-import java.util.logging.{Logger, Level}
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.util.logging.{Level, Logger}
 import javax.swing.KeyStroke.getKeyStroke
-import javax.swing.JOptionPane.{showConfirmDialog, YES_OPTION, YES_NO_CANCEL_OPTION, WARNING_MESSAGE, NO_OPTION}
+import javax.swing.JOptionPane.{NO_OPTION, WARNING_MESSAGE, YES_NO_CANCEL_OPTION, YES_OPTION, showConfirmDialog}
+
 import edu.gemini.pit.ui.util._
 import edu.gemini.pit.model._
 import java.awt.BorderLayout
+
 import view.partner.PartnerView
 import view.scheduling.SchedulingView
 import view.submit.SubmitView
@@ -28,12 +30,16 @@ import edu.gemini.model.p1.immutable._
 import java.io.File
 import java.awt.event.ActionEvent
 import javax.swing.{AbstractAction, JFrame}
+
 import view.tac.TacView
 import view.target.TargetView
-import java.util.{Optional, Locale}
+import java.util.{Locale, Optional}
+
 import edu.gemini.model.p1.submit.SubmitClient
 import edu.gemini.pit.ui.binding._
-import edu.gemini.pit.ui.robot.{ProblemRobot, AgsRobot, GsaRobot, VisibilityRobot, CatalogRobot}
+import edu.gemini.pit.ui.robot.{AgsRobot, CatalogRobot, GsaRobot, ProblemRobot, VisibilityRobot}
+import edu.gemini.shared.Platform
+import edu.gemini.shared.gui.Browser
 
 // GFace (written for QPT and modeled on Eclipse JFace) is a little awkward to use from Scala, sorry. It depends on
 // lifecycle callbacks and has a bit of mutable state. It works and in practice you don't have to mess with it too

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/BrowseAction.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/BrowseAction.scala
@@ -2,9 +2,10 @@ package edu.gemini.pit.ui.action
 
 import java.net.URI
 import javax.swing.Action.ACCELERATOR_KEY
-import javax.swing.{KeyStroke, AbstractAction}
+import javax.swing.{AbstractAction, KeyStroke}
 import java.awt.event.ActionEvent
-import edu.gemini.pit.ui.util.Browser
+
+import edu.gemini.shared.gui.Browser
 
 class BrowseAction(uri: URI, text: String, vkey:Int = 0, modifiers: Int = 0) extends AbstractAction(text) {
   if (vkey != 0) putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(vkey, modifiers))

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/BlueprintEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/BlueprintEditor.scala
@@ -1,15 +1,17 @@
 package edu.gemini.pit.ui.editor
 
 import edu.gemini.model.p1.dtree._
-import edu.gemini.pit.ui.util.Platform
 import edu.gemini.pit.ui.util.StdModalWizard
+
 import scala.swing._
 import scala.swing.Swing._
 import javax.swing
 import java.awt
 import swing.JLabel
+
 import edu.gemini.model.p1.immutable._
-import edu.gemini.model.p1.dtree.exchange.{Subaru, Keck}
+import edu.gemini.model.p1.dtree.exchange.{Keck, Subaru}
+import edu.gemini.shared.Platform
 
 import scalaz._
 import Scalaz._

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/VisitorSelector.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/VisitorSelector.scala
@@ -2,7 +2,10 @@ package edu.gemini.pit.ui.editor
 
 import edu.gemini.model.p1.immutable._
 import javax.swing.BorderFactory
-import edu.gemini.pit.ui.util.{Platform, StdModalEditor}
+
+import edu.gemini.pit.ui.util.StdModalEditor
+import edu.gemini.shared.Platform
+
 import swing._
 import Swing._
 import BorderPanel.Position._

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/ShellAction.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/ShellAction.scala
@@ -1,8 +1,9 @@
 package edu.gemini.pit.ui.util
 
 import java.awt.event.ActionEvent
-import javax.swing.{ KeyStroke, Action, AbstractAction }
+import javax.swing.{AbstractAction, Action, KeyStroke}
 
+import edu.gemini.shared.Platform
 import edu.gemini.ui.workspace.scala._
 
 abstract class ShellAction[A](shell: RichShell[A], caption: String, key: Option[Int] = None, mask: Int = 0) extends AbstractAction(caption) with (() => Unit) {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -7,19 +7,23 @@ import edu.gemini.pit.ui.util.SharedIcons._
 import edu.gemini.pit.ui.util._
 import java.awt.datatransfer._
 import javax.swing.TransferHandler._
+
 import scala.swing._
 import scalaz.Scalaz._
 import scalaz._
 import javax.swing.{Action => _, _}
+
 import edu.gemini.gsa.client.api.GsaParams
 import edu.gemini.gsa.client.impl.GsaUrl
 import edu.gemini.pit.ui.CommonActions._
 import java.awt.Color
+
 import edu.gemini.pit.ui.{HackClipboard, ShellAdvisor}
 import edu.gemini.pit.ui.binding._
 import edu.gemini.pit.ui.robot.{AgsRobot, GsaRobot}
 import edu.gemini.pit.ui.DataFlavors._
 import edu.gemini.pit.ui.util.gface.SimpleListViewer
+import edu.gemini.shared.gui.Browser
 
 // The observation list/tree, which has two visible instances (Band 1/2 and Band 3). This is by far the most complex
 // view, in particular because of drag/drop and copy/paste. The main structure we use here is an ObsListModel which is

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
@@ -3,7 +3,7 @@ package edu.gemini.pit.ui.view.proposal
 import com.jgoodies.forms.factories.Borders.DLU4_BORDER
 import edu.gemini.model.p1.immutable._
 import edu.gemini.pit.model.Model
-import edu.gemini.pit.ui.{URLConstants, ShellAdvisor}
+import edu.gemini.pit.ui.{ShellAdvisor, URLConstants}
 import edu.gemini.pit.ui.binding.BoundControls._
 import edu.gemini.pit.ui.binding._
 import edu.gemini.pit.ui.editor._
@@ -11,13 +11,16 @@ import edu.gemini.pit.ui.util.SimpleToolbar.StaticText
 import edu.gemini.pit.ui.util._
 import edu.gemini.pit.util._
 import java.io.File
-import javax.swing.{Icon, BorderFactory}
+import javax.swing.{BorderFactory, Icon}
+
 import scalaz._
 import swing._
 import event.ButtonClicked
 import Scalaz._
 import edu.gemini.pit.ui.util.gface.SimpleListViewer
 import java.net.URI
+
+import edu.gemini.shared.gui.Browser
 
 class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Proposal] {panel =>
   implicit val boolMonoid = Monoid.instance[Boolean](_ || _,  false)

--- a/bundle/edu.gemini.shared.gui/build.sbt
+++ b/bundle/edu.gemini.shared.gui/build.sbt
@@ -23,6 +23,7 @@ OsgiKeys.bundleSymbolicName := name.value
 OsgiKeys.dynamicImportPackage := Seq("")
 
 OsgiKeys.exportPackage := Seq(
+  "edu.gemini.shared",
   "edu.gemini.shared.gui",
   "edu.gemini.shared.gui.bean",
   "edu.gemini.shared.gui.calendar",

--- a/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/Platform.scala
+++ b/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/Platform.scala
@@ -1,11 +1,10 @@
-package edu.gemini.pit.ui.util
+package edu.gemini.shared
 
-import java.awt.event.InputEvent
 import java.awt.Toolkit
+import java.awt.event.InputEvent
 import java.net.URL
 import java.util.logging.Logger
-
-import javax.swing.{ KeyStroke, JTextField, JTextArea, InputMap }
+import javax.swing.{InputMap, JTextArea, JTextField, KeyStroke}
 
 object Platform extends Enumeration {
 
@@ -42,7 +41,7 @@ object Platform extends Enumeration {
         ks <- keys
 
         // And new modifiers
-        mod = ks.getModifiers if ((mod & CTRL) != 0)
+        mod = ks.getModifiers if (mod & CTRL) != 0
         newMod = (mod & ~CTRL) | MENU_ACTION_MASK
         newKs = KeyStroke.getKeyStroke(ks.getKeyCode, newMod, ks.isOnKeyRelease)
         action = map.get(ks)
@@ -62,8 +61,8 @@ object Platform extends Enumeration {
   }
 
   /*
-	 * Derived from http://www.javaworld.com/javaworld/javatips/jw-javatip66.html
-	 */
+   * Derived from http://www.javaworld.com/javaworld/javatips/jw-javatip66.html
+   */
   def displayURL(url: URL) { displayURL(url.toString) }
   def displayURL(url: String) {
     current match {

--- a/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/Browser.scala
+++ b/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/Browser.scala
@@ -1,15 +1,17 @@
-package edu.gemini.pit.ui.util
+package edu.gemini.shared.gui
 
-import java.net.{URL, URI}
 import java.awt.Desktop._
-import java.util.logging.{Logger, Level}
+import java.net.{URI, URL}
+import java.util.logging.{Level, Logger}
+
+import edu.gemini.shared.Platform
 
 /**
  * Utility for launching a browser on a URL, which is problematic on Linux.
  * This utility first tries to use the java.awt.Desktop method and then resorts
  * to low-level OS-specific exec if that doesn't work.
  */
-object  Browser {
+object Browser {
   private val LOG = Logger.getLogger(Browser.getClass.getName)
 
   def open(url: URL) {

--- a/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/ErrorBoxWithHyperlink.scala
+++ b/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/ErrorBoxWithHyperlink.scala
@@ -1,0 +1,32 @@
+package edu.gemini.shared.gui
+
+import javax.swing.{JEditorPane, JLabel, JOptionPane}
+import javax.swing.event.{HyperlinkEvent, HyperlinkListener}
+
+object ErrorBoxWithHyperlink {
+
+  def showErrorBoxWithLink(msg: String): Unit = {
+    // for copying style
+    val label = new JLabel()
+    val font = label.getFont
+
+    // create some css from the label's font
+    val style = s"font-family:${font.getFamily};font-weight:${if (font.isBold) "bold" else "normal"};font-size:${font.getSize}pt;"
+
+    // JEditor pane to display text with a hyperlink
+    val ep = new JEditorPane("text/html", s"""<html><body style="$style">$msg</body></html>""")
+    // Open de hiperlink when clicked
+    ep.addHyperlinkListener(new HyperlinkListener() {
+      override def hyperlinkUpdate(e: HyperlinkEvent): Unit = {
+        if (e.getEventType == HyperlinkEvent.EventType.ACTIVATED) {
+          Browser.open(e.getURL.toURI)
+        }
+      }
+    })
+    // No editing...
+    ep.setEditable(false)
+    ep.setBackground(label.getBackground)
+    // Display
+    JOptionPane.showMessageDialog(null, ep, "Error", JOptionPane.ERROR_MESSAGE)
+  }
+}

--- a/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/VersionException.java
+++ b/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/VersionException.java
@@ -1,5 +1,8 @@
 package edu.gemini.spModel.core;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class VersionException extends Exception {
 
     // N.B. we're not storing the version objects themselves because they might not be
@@ -7,19 +10,38 @@ public class VersionException extends Exception {
 
     static final long serialVersionUID = 42L;
 
-    public VersionException(Version expected, Version.Compatibility compatability) {
-        super(String.format("Incompatible versions (%s): expected %s, actual was (unknown).", compatability, expected));
+    private static final Pattern matcher = Pattern.compile(".*: expected ([\\w|\\p{Punct}]*), .*");
+
+    public VersionException(Version expected, Version.Compatibility compatibility) {
+        super(String.format("Incompatible versions (%s): expected %s, actual was (unknown).", compatibility, expected));
     }
 
-    public VersionException(Version expected, Version actual, Version.Compatibility compatability) {
-        super(String.format("Incompatible versions (%s): expected %s, actual was %s", compatability, expected, actual));
+    public VersionException(Version expected, Version actual, Version.Compatibility compatibility) {
+        super(String.format("Incompatible versions (%s): expected %s, actual was %s", compatibility, expected, actual));
     }
 
     /** Returns a multi-line message suitable for showing to the user. */
     public String getLongMessage() {
         return getLongMessage("the remote server."); // :-\
     }
-        /** Returns a multi-line message suitable for showing to the user. */
+
+    /** Returns an html-based message for displaying to the user */
+    public String getHtmlMessage(String peerName) {
+        // We cannot transmit the actual version created on the server, the only hope to extract
+        // that information is to parse the content of the error message
+        Matcher match = matcher.matcher(getMessage());
+        String remoteVersion = "Unknown";
+        if (match.matches()) {
+            remoteVersion = match.group(1);
+        }
+        return String.format(
+            "Your software is incompatible with the service provided by %s.<br/>" +
+            "To upgrade to the latest version please go to <br/>" +
+            "<a href=\"http://www.gemini.edu/node/11172\">http://www.gemini.edu/node/11172</a><br/><br/>" +
+            "Details:<br/>Local OT version: %s<br/>Server version: %s", peerName, CurrentVersion.get().toString(), remoteVersion);
+    }
+
+    /** Returns a multi-line message suitable for showing to the user. */
     public String getLongMessage(String peerName) {
         return String.format(
             "Your software is incompatible with the service provided by %s.\n" +

--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/ui/AddKeyDialog.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/ui/AddKeyDialog.scala
@@ -5,17 +5,18 @@ import edu.gemini.util.security.auth.keychain.KeyException
 import edu.gemini.util.security.auth.keychain.KeyFailure
 import edu.gemini.util.security.auth.keychain.Action.ActionOps
 import edu.gemini.util.security.auth.keychain.{Action => KAction}
+
 import scala.swing._
-import event.{ValueChanged, SelectionChanged}
+import event.{SelectionChanged, ValueChanged}
 import java.awt
 import javax.swing
 import javax.swing.{Icon, ImageIcon}
-import java.util.UUID
-import java.security.Principal
+
 import edu.gemini.util.security.principal._
-import java.util.logging.{Logger, Level}
+import java.util.logging.{Level, Logger}
 import java.io.IOException
-import edu.gemini.spModel.core.{SPProgramID, Affiliate, VersionException, Peer}
+
+import edu.gemini.spModel.core.{Affiliate, Peer, SPProgramID, VersionException}
 
 object AddKeyDialog {
 
@@ -183,7 +184,7 @@ class AddKeyDialog(ac: KeyChain) extends Dialog with CloseOnEsc { dialog =>
 
     // Space things out a little more
     peer.setLayout(new awt.BorderLayout(8, 8))
-    border = swing.BorderFactory.createEmptyBorder(8, 8, 8, 8);
+    border = swing.BorderFactory.createEmptyBorder(8, 8, 8, 8)
 
     // Add our content, defined below
     add(Header, BorderPanel.Position.North)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/ProgTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/ProgTableModel.scala
@@ -31,7 +31,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.swing._
 import scala.swing.Swing._
 import scala.util.{Failure, Success}
-import scalaz.{-\/, \/-, Failure => _, Success => _}
+import scalaz.{-\/, \/-}
 
 object ProgTableModel {
   lazy val Log = java.util.logging.Logger.getLogger(getClass.getName)


### PR DESCRIPTION
This changes the error display shown when the OT/SPDB have incompatible versions to show on one hand the actual versions involved and an link to let the users download the current version of the OT

This PR requires quite a bit of swing dark magic. The second commit d393b59 is the relevant one

The new box looks like:

<img width="504" alt="screenshot 2016-07-19 21 50 56" src="https://cloud.githubusercontent.com/assets/3615303/16973267/5f0462c2-4e00-11e6-9002-f50870007b19.png">
