### PR TITLE
Reduce the amount of logging on Gems AGS

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -79,7 +79,7 @@ object GemsResultsAnalyzer {
           gemsGuideStars
         }
       }
-      sortResultsByRanking(gemsGuideStars.toList).asJava
+      sortResultsByRanking(gemsGuideStars).asJava
     }.getOrElse(List.empty[GemsGuideStars].asJava)
   }
 
@@ -125,14 +125,14 @@ object GemsResultsAnalyzer {
         }
       }
       val gemsGuideStars = go(Nil, TiptiltFlexurePair.pairs(catalogSearch))
-      sortResultsByRanking(gemsGuideStars.toList)
+      sortResultsByRanking(gemsGuideStars)
     }
   }
 
   private def printResults(result: List[GemsGuideStars]) {
-    Log.info("Results:")
+    Log.fine("Results:")
     result.zipWithIndex.foreach { case (s, i) =>
-      Log.info(s"result #$i : $s")
+      Log.fine(s"result #$i : $s")
     }
   }
 
@@ -173,7 +173,7 @@ object GemsResultsAnalyzer {
     val tiptiltTargetList = targetListFromStrehl(strehl)
     // XXX The TPE assumes canopus tiptilt if there are only 2 stars (one of each ODGW and CWFS),
     // So don't add any items to the list that have only 2 stars and GSAOI as tiptilt.
-    (tiptiltGroup, tiptiltTargetList.toList) match {
+    (tiptiltGroup, tiptiltTargetList) match {
       case (GsaoiOdgw.Group.instance, _ :: Nil)                                                  =>
         Nil
       case _ if areAllTargetsValidInGroup(obsContext, tiptiltTargetList, tiptiltGroup, posAngle) =>
@@ -403,7 +403,7 @@ object GemsResultsAnalyzer {
   // Returns true if the target magnitude is within the given limits
   def containsMagnitudeInLimits(target: SiderealTarget, magLimits: MagnitudeConstraints): Boolean =
     // The true default is suspicious but changing it to false breaks backwards compatibility
-    magLimits.searchBands.extract(target).map(m => magLimits.contains(m)).getOrElse(true)
+    magLimits.searchBands.extract(target).forall(magLimits.contains)
 
   def toSPTarget(siderealTarget: SiderealTarget):SPTarget = new SPTarget(siderealTarget)
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
@@ -26,11 +26,11 @@ object Mascot {
 
   // Default progress callback, called for each asterism as it is calculated
   val defaultProgress:ProgressFunction = (s: Strehl, count: Int, total: Int) => {
-    Log.info(s"Asterism #$count")
+    Log.fine(s"Asterism #$count")
     for (i <- s.stars.indices) {
       Log.finer(s"[${s.stars(i).x}%.1f,${s.stars(i).y}%.1f]")
     }
-    Log.info(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f  rms=${s.rmsstrehl * 100}%.1f  min=${s.minstrehl * 100}%.1f  max=${s.maxstrehl * 100}%.1f")
+    Log.fine(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f  rms=${s.rmsstrehl * 100}%.1f  min=${s.minstrehl * 100}%.1f  max=${s.maxstrehl * 100}%.1f")
     true
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
@@ -27,11 +27,11 @@ object MascotCat {
 
   // Default progress callback, called for each asterism as it is calculated
   val defaultProgress: ProgressFunction = (s: Strehl, count: Int, total: Int) => {
-    Log.info(s"Asterism #$count")
+    Log.fine(s"Asterism #$count")
     for (i <- s.stars.indices) {
       Log.finer(s.stars(i).target.coordinates.toString)
     }
-    Log.info(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f rms=${s.rmsstrehl * 100}%.1f min=${s.minstrehl * 100}%.1f max=${s.maxstrehl * 100}%.1f")
+    Log.fine(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f rms=${s.rmsstrehl * 100}%.1f min=${s.minstrehl * 100}%.1f max=${s.maxstrehl * 100}%.1f")
     true
   }
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -378,7 +378,6 @@ class GemsStrategySpec extends Specification {
       selection.map(_.posAngle) should beSome(Angle.fromDegrees(90))
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
-      assignments.foreach(println)
 
       assignments.exists(_.guideProbe == Canopus.Wfs.cwfs1) should beTrue
       val cwfs1 = assignments.find(_.guideProbe == Canopus.Wfs.cwfs1).map(_.guideStar)


### PR DESCRIPTION
This PR reduces the amount of logging produced by Gems AGS which pollutes the build output

I don't think this output is very useful to users  but perhaps @andrewwstephens can chime in about that

There is more output related to AGS that could be removed but I'm not sure, in particular in [SingleProbeStrategy](https://github.com/gemini-hlsw/ocs/blob/develop/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala#L88) 