### PR TITLE
REL-1668: Warn when NOT classical observing at Gemini and GMOS configured to use disperser R600

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -100,7 +100,14 @@ package object immutable {
   object Flamingos2Fpu extends EnumObject[M.Flamingos2Fpu]
 
   type GmosNDisperser = M.GmosNDisperser
-  object GmosNDisperser extends EnumObject[M.GmosNDisperser]
+  object GmosNDisperser extends EnumObject[M.GmosNDisperser] {
+    val B1200 = M.GmosNDisperser.B1200_G5301
+    val R831  = M.GmosNDisperser.R831_G5302
+    val B600  = M.GmosNDisperser.B600_G5307
+    val R600  = M.GmosNDisperser.R600_G5304
+    val R400  = M.GmosNDisperser.R400_G5305
+    val R150  = M.GmosNDisperser.R150_G5306
+  }
 
   type GmosNFilter = M.GmosNFilter
   object GmosNFilter extends EnumObject[M.GmosNFilter] {
@@ -159,7 +166,14 @@ package object immutable {
   object GmosNWavelengthRegime extends EnumObject[M.GmosNWavelengthRegime]
 
   type GmosSDisperser = M.GmosSDisperser
-  object GmosSDisperser extends EnumObject[M.GmosSDisperser]
+  object GmosSDisperser extends EnumObject[M.GmosSDisperser] {
+    val B1200 = M.GmosSDisperser.B1200_G5321
+    val R831  = M.GmosSDisperser.R831_G5322
+    val B600  = M.GmosSDisperser.B600_G5323
+    val R600  = M.GmosSDisperser.R600_G5324
+    val R400  = M.GmosSDisperser.R400_G5325
+    val R150  = M.GmosSDisperser.R150_G5326
+  }
 
   type GmosSFilter = M.GmosSFilter
   object GmosSFilter extends EnumObject[M.GmosSFilter] {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -269,14 +269,15 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       case _                                 => false
     }
 
-    private val gmosR600Check =
-      if (!p.proposalClass.isInstanceOf[ClassicalProposalClass])
+    private val gmosR600Check = p.proposalClass match {
+      case _: ClassicalProposalClass => Nil
+      case _                         =>
         for {
           o <- p.observations
           b <- o.blueprint
           if gmosNDisperser(b, GmosNDisperser.R600) || gmosSDisperser(b, GmosSDisperser.R600)
         } yield new Problem(Severity.Warning, s"The R600 is little used and may be difficult to schedule.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
-      else Nil
+    }
 
     def isBand3(o: Observation) = o.band == Band.BAND_3 && (p.proposalClass match {
                   case q: QueueProposalClass if q.band3request.isDefined => true

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -3,17 +3,18 @@ package edu.gemini.pit.ui.robot
 import edu.gemini.pit.ui._
 import action.AppPreferencesAction
 import edu.gemini.model.p1.immutable._
-import edu.gemini.model.p1.immutable.Partners._
 import edu.gemini.pit.ui.editor.Institutions
 import edu.gemini.pit.util.PDF
 import edu.gemini.pit.catalog._
 import java.util.Date
+
 import edu.gemini.spModel.core.MagnitudeBand
 import view.obs.ObsListGrouping
 import edu.gemini.model.p1.visibility.TargetVisibilityCalc
 import edu.gemini.pit.ui.view.tac.TacView
 import java.text.SimpleDateFormat
 import java.io.File
+
 import edu.gemini.pit.model.{AppPreferences, Model}
 import edu.gemini.pit.catalog.NotFound
 import edu.gemini.pit.catalog.Error
@@ -88,7 +89,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           TacProblems(p, s).all ++
           List(incompleteInvestigator, missingObsElementCheck, cfCheck, emptyTargetCheck, emptyEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck,
             badGuiding, badVisibility, iffyVisibility, singlePointEphemerisCheck, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsCC50Check, lgsIQCheck,
-            texesCCCheck, texesWVCheck, gmosWVCheck, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
+            texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
       ps.sorted
     }
 
@@ -257,6 +258,23 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       if b.isInstanceOf[GmosNBlueprintBase] || b.isInstanceOf[GmosSBlueprintBase]
       if c.wv != WaterVapor.ANY
     } yield new Problem(Severity.Warning, s"GMOS is usually unaffected by atmospheric water vapor", "Observations", s.inObsListView(o.band, _.Fixes.fixConditions(c)))
+
+
+    def gmosNDisperser(b: BlueprintBase, d: GmosNDisperser) = b match {
+      case gn: GmosNBlueprintSpectrosopyBase => gn.disperser == d
+      case _                                 => false
+    }
+    def gmosSDisperser(b: BlueprintBase, d: GmosSDisperser) = b match {
+      case gs: GmosSBlueprintSpectrosopyBase => gs.disperser == d
+      case _                                 => false
+    }
+
+    private val gmosR600Check = for {
+      o <- p.observations
+      b <- o.blueprint
+      if p.proposalClass.isInstanceOf[ClassicalProposalClass]
+      if gmosNDisperser(b, GmosNDisperser.R600) || gmosSDisperser(b, GmosSDisperser.R600)
+    } yield new Problem(Severity.Warning, s"The R600 is little used and may be difficult to schedule.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
     def isBand3(o: Observation) = o.band == Band.BAND_3 && (p.proposalClass match {
                   case q: QueueProposalClass if q.band3request.isDefined => true

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -687,6 +687,19 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
       }
     }
 
+    // Edit the blueprint
+    def fixBlueprint(b: BlueprintBase) {
+      model.foreach { m =>
+        m.elems.find {
+          case g @ BlueprintGroup(_, Some(gb), _) if b == gb =>
+            viewer.edit(g, p => BlueprintEditor.open(p, b.some, canEdit, panel), Observation.blueprint)
+            viewer.selection = Some(g)
+            true
+          case _                                             => false
+        }
+      }
+    }
+
     def indicateObservation(o:Observation) {
       model.foreach { m =>
         m.elems.find {


### PR DESCRIPTION
The subject line pretty much gives what this PR does.

I added vals for `GmosNDisperser` and `GmosSDisperser` to make it easy to check and compare the disperser values to look for `R600`.

I also added the `fixBlueprint` method to `ObsListView` to allow the `BlueprintEditor` to pop open when one double-clicks the warning and allow editing of the instrument configuration, but I'm not sure that this is what we want to do. @cquiroz ?

Finally, I added the `gmosR600Check` to the `ProblemRobot` to handle the identification of this case.