### PR TITLE
REL-2697: GeMS requires IQ 85

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiQueryExecutor.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiQueryExecutor.java
@@ -94,10 +94,6 @@ public enum CgiQueryExecutor implements IQueryExecutor {
             client.executeMethod(method);
             reply = CgiReplyBuilder.buildResponse(method.getResponseBodyAsStream(), method.getRequestCharSet());
             method.releaseConnection();
-        } catch (HorizonsException ex) {
-            throw ex;
-        } catch (HttpException ex) {
-            throw HorizonsException.create(ex);
         } catch (IOException ex) {
             throw HorizonsException.create(ex);
         }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -359,6 +359,7 @@ package object immutable {
   object ImageQuality extends EnumObject[M.ImageQuality] {
     val BEST = M.ImageQuality.iq20
     val IQ70 = M.ImageQuality.iq70
+    val IQ85 = M.ImageQuality.iq85
   }
 
   type InvestigatorStatus = M.InvestigatorStatus

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Horizons.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Horizons.scala
@@ -56,10 +56,10 @@ class Horizons private (/*host: String, port: Int,*/ site: Site, start: Date, en
           // Ambiguous
           case MUTLIPLE_ANSWER =>
             val table = hr.getResultsTable
-            val header = table.getHeader.asScala.toSeq
+            val header = table.getHeader.asScala
 
             val options = for {
-              row <- table.getResults.asScala.map(_.asScala.toSeq).toSeq
+              row <- table.getResults.asScala.map(_.asScala.toSeq)
               map = Map(header.zip(row): _*)
               id <- map.get("ID#")
               name <- map.get("Name")

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -156,7 +156,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       (sev, msg) = f match {
         case Offline      => (Severity.Error, s"Catalog lookup failed for ${t.name} due to network connectivity problems.")
         case NotFound(n)  => (Severity.Error, s"""Catalog lookup returned no results for target "$n".""")
-        case Error(e)     => (Severity.Error, s"Catalog lookup failed for ${t.name} due to an unexpected error: ${e.getMessage}.")
+        case Error(e)     => (Severity.Error, s"Catalog lookup failed for ${t.name} due to an unexpected error.")
       }
     } yield new Problem(sev, msg, "Targets", s.inTargetsView(_.edit(t)))
 


### PR DESCRIPTION
Previously, the PIT would issue a warning for use of AO with IQ that was worse than 70.
New requirements allow GeMS based instruments to accept IQ up to 85.
This code checks for GeMS use (GSAOI) and implements the new rule.

Additionally:
1. Small cleanup of exception handling in `CgiQueryExecturor`; and
2. `Problem` messages were previous inconsistent with regards to punctuation. This has been fixed so that all problems now have a trailing period.
3. `Problem`s from catalog lookups that generate an `Error` did not do anything with the error message, but the format of the `Problem` message suggests that it should be included, so this has been added.