### PR TITLE
REL-2879: Warning for missing PI phone number (and other investigator improvements)

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/CoiEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/CoiEditor.scala
@@ -14,10 +14,14 @@ import edu.gemini.pit.ui.util._
 import swing.event.ValueChanged
 
 object CoiEditor {
-  def open(coi: CoInvestigator, editable:Boolean, parent: UIElement) = new CoiEditor(coi, editable).open(parent)
+  def open(coi: CoInvestigator, editable: Boolean, parent: UIElement, setup: CoiEditor => Unit = _ => {}) = {
+    val editor = new CoiEditor(coi, editable)
+    setup(editor)
+    editor.open(parent)
+  }
 }
 
-class CoiEditor private (coi: CoInvestigator, editable:Boolean) extends StdModalEditor[CoInvestigator]("Edit Co-Investigator") {
+class CoiEditor(coi: CoInvestigator, editable:Boolean) extends StdModalEditor[CoInvestigator]("Edit Co-Investigator") {
 
   // Our main editor component
   object Editor extends GridBagPanel with Rows {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/CoiEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/CoiEditor.scala
@@ -14,7 +14,7 @@ import edu.gemini.pit.ui.util._
 import swing.event.ValueChanged
 
 object CoiEditor {
-  def open(coi: CoInvestigator, editable: Boolean, parent: UIElement, setup: CoiEditor => Unit = _ => {}) = {
+  def open(coi: CoInvestigator, editable: Boolean, parent: UIElement, setup: CoiEditor => Unit = _ => ()): Option[CoInvestigator] = {
     val editor = new CoiEditor(coi, editable)
     setup(editor)
     editor.open(parent)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
@@ -13,10 +13,14 @@ import swing._
 import event.ValueChanged
 
 object PiEditor {
-  def open(pi: PrincipalInvestigator, editable:Boolean,  parent: UIElement) = new PiEditor(pi, editable).open(parent)
+  def open(coi: PrincipalInvestigator, editable: Boolean, parent: UIElement, setup: PiEditor => Unit = _ => {}) = {
+    val editor = new PiEditor(coi, editable)
+    setup(editor)
+    editor.open(parent)
+  }
 }
 
-class PiEditor private (pi: PrincipalInvestigator, editable:Boolean) extends StdModalEditor[PrincipalInvestigator]("Edit Principal Investigator") {
+class PiEditor(pi: PrincipalInvestigator, editable:Boolean) extends StdModalEditor[PrincipalInvestigator]("Edit Principal Investigator") {
 
   // Our editor
   object Editor extends GridBagPanel with Rows {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
@@ -13,7 +13,7 @@ import swing._
 import event.ValueChanged
 
 object PiEditor {
-  def open(coi: PrincipalInvestigator, editable: Boolean, parent: UIElement, setup: PiEditor => Unit = _ => {}) = {
+  def open(coi: PrincipalInvestigator, editable: Boolean, parent: UIElement, setup: PiEditor => Unit = _ => ()): Option[PrincipalInvestigator] = {
     val editor = new PiEditor(coi, editable)
     setup(editor)
     editor.open(parent)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
@@ -112,7 +112,7 @@ class PiEditor private (pi: PrincipalInvestigator, editable:Boolean) extends Std
       address = Institution.Address.text,
       country = Institution.Country.text),
     status = Status.selection.item.asInstanceOf[InvestigatorStatus], // :-/
-    phone = Phone.text.split(",").map(_.trim).toList,
+    phone = Phone.text.split(",").map(_.trim).filter(_.nonEmpty).toList,
     email = Email.text)
 
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -82,8 +82,9 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
 
     lazy val all = {
       val ps =
-        List(noObs, nonUpdatedInvestigatorName, titleCheck, band3option, abstractCheck, tacCategoryCheck, keywordCheck, attachmentCheck, attachmentValidityCheck,
-          attachmentSizeCheck, missingObsDetailsCheck, duplicateInvestigatorCheck, ftReviewerOrMentor, ftAffiliationMismatch, band3Obs).flatten ++
+        List(noObs, nonUpdatedInvestigatorName, noPIPhoneNumber, titleCheck, band3option, abstractCheck, tacCategoryCheck,
+          keywordCheck, attachmentCheck, attachmentValidityCheck, attachmentSizeCheck, missingObsDetailsCheck,
+          duplicateInvestigatorCheck, ftReviewerOrMentor, ftAffiliationMismatch, band3Obs).flatten ++
           TimeProblems(p, s).all ++
           TimeProblems.partnerZeroTimeRequest(p, s) ++
           TacProblems(p, s).all ++
@@ -586,21 +587,26 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       new Problem(Severity.Todo, "Please create observations with conditions, targets, and resources.", "Observations", ())
     }
 
+    private def investigatorFullName(i: Investigator, default: String = "Investigator"): String = i.fullName.trim match {
+      case ""                       => default
+      case "Principal Investigator" => "PI"
+      case n                        => n
+    }
+
     private lazy val incompleteInvestigator = for {
       i <- p.investigators.all if !i.isComplete
-    } yield new Problem(Severity.Todo, s"Please provide full contact information for ${i.fullName}.", "Overview", s.inOverview {
-        v =>
-          v.edit(i)
-      })
+    } yield new Problem(Severity.Todo, s"Please provide full contact information for ${investigatorFullName(i)}.", "Overview", s.inOverview{_.edit(i)})
 
     private val nonUpdatedInvestigatorName = when(p.investigators.pi.firstName === "Principal" && p.investigators.pi.lastName === "Investigator") {
-      new Problem(Severity.Todo, s"Please provide PI's full name.", "Overview", s.inOverview {
-        _.edit(p.investigators.pi)
-      })
+      new Problem(Severity.Todo, s"Please provide PI's full name.", "Overview", s.inOverview{_.edit(p.investigators.pi)})
+    }
+
+    private val noPIPhoneNumber = when (p.investigators.pi.phone.isEmpty) {
+      new Problem(Severity.Warning, s"No phone number given for ${investigatorFullName(p.investigators.pi, "PI")}. This is for improved user support.",
+        "Overview", s.inOverview{_.edit(p.investigators.pi)})
     }
 
   }
-
 }
 
 import ProblemRobot._

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -3,7 +3,7 @@ package edu.gemini.pit.ui.robot
 import edu.gemini.pit.ui._
 import action.AppPreferencesAction
 import edu.gemini.model.p1.immutable._
-import edu.gemini.pit.ui.editor.{Institutions, PiEditor}
+import edu.gemini.pit.ui.editor.Institutions
 import edu.gemini.pit.util.PDF
 import edu.gemini.pit.catalog._
 import java.util.Date

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -588,11 +588,11 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     }
 
     private def investigatorFullName(i: Investigator, default: String = "Investigator"): String = {
-      val piEmptyName = PrincipalInvestigator.empty.fullName
+      val PiEmptyName = PrincipalInvestigator.empty.fullName
       i.fullName.trim match {
-        case ""            => default
-        case `piEmptyName` => "PI"
-        case n             => n
+        case ""          => default
+        case PiEmptyName => "PI"
+        case n           => n
       }
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -3,7 +3,7 @@ package edu.gemini.pit.ui.robot
 import edu.gemini.pit.ui._
 import action.AppPreferencesAction
 import edu.gemini.model.p1.immutable._
-import edu.gemini.pit.ui.editor.Institutions
+import edu.gemini.pit.ui.editor.{Institutions, PiEditor}
 import edu.gemini.pit.util.PDF
 import edu.gemini.pit.catalog._
 import java.util.Date
@@ -607,7 +607,9 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
 
     private val noPIPhoneNumber = when (p.investigators.pi.phone.isEmpty) {
       new Problem(Severity.Warning, s"No phone number given for ${investigatorFullName(p.investigators.pi, "PI")}. This is for improved user support.",
-        "Overview", s.inOverview{_.edit(p.investigators.pi)})
+        "Overview", s.inOverview{
+          _.editPi(_.Phone.requestFocus)
+        })
     }
 
   }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
@@ -409,6 +409,4 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
 
   // public edit method for quick fix
   def edit(i:Investigator) = investigators.listViewer.edit(i)
-
-
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
@@ -344,7 +344,7 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
     object listViewer extends SimpleListViewer[Proposal, Investigators, Investigator] {
 
       // Our action handlers
-      onDoubleClick { editInv(_) }
+      onDoubleClick { edit(_) }
 
       def editPi(setup: PiEditor => Unit = _ => {}) =
         for {
@@ -358,10 +358,11 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
           i <- CoiEditor.open(inv, canEdit, panel, setup)
         } model = Some(Investigators.cois.set(m, m.cois.replace(inv, i)))
 
-      def editInv(inv: Investigator) = inv match {
+      def edit[A <: Investigator](inv: A) = inv match {
         case pi: PrincipalInvestigator => editPi()
         case coi: CoInvestigator       => editCoi(coi)
       }
+
       // One-liners
       val lens = Proposal.investigators
       def all(m:Investigators) = m.pi :: m.cois
@@ -405,8 +406,8 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
 
   }
 
-  // public edit method for quick fix
+  // public edit methods for quick fixes
   def editPi(setup: PiEditor => Unit = _ => {}) = investigators.listViewer.editPi(setup)
   def editCoi(i: CoInvestigator, setup: CoiEditor => Unit = _ => {}) = investigators.listViewer.editCoi(i, setup)
-  def edit(i: Investigator) = investigators.listViewer.editInv(i)
+  def edit(i: Investigator) = investigators.listViewer.edit(i)
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
@@ -346,13 +346,13 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
       // Our action handlers
       onDoubleClick { edit(_) }
 
-      def editPi(setup: PiEditor => Unit = _ => {}) =
+      def editPi(setup: PiEditor => Unit = _ => ()) =
         for {
           m <- model
           i <- PiEditor.open(m.pi, canEdit, panel, setup)
         } model = Some(Investigators.pi.set(m, i))
 
-      def editCoi(inv: CoInvestigator, setup: CoiEditor => Unit = _ => {}) =
+      def editCoi(inv: CoInvestigator, setup: CoiEditor => Unit = _ => ()) =
         for {
           m <- model
           i <- CoiEditor.open(inv, canEdit, panel, setup)
@@ -407,7 +407,7 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
   }
 
   // public edit methods for quick fixes
-  def editPi(setup: PiEditor => Unit = _ => {}) = investigators.listViewer.editPi(setup)
-  def editCoi(i: CoInvestigator, setup: CoiEditor => Unit = _ => {}) = investigators.listViewer.editCoi(i, setup)
+  def editPi(setup: PiEditor => Unit = _ => ()) = investigators.listViewer.editPi(setup)
+  def editCoi(i: CoInvestigator, setup: CoiEditor => Unit = _ => ()) = investigators.listViewer.editCoi(i, setup)
   def edit(i: Investigator) = investigators.listViewer.edit(i)
 }


### PR DESCRIPTION
REL-2879 requests that a warning be generated when the PI phone number is missing, and that double-clicking on the warning launch the PI editor with the focus in the Phone field.

This PR takes care of that (and more) through the following:
1. A bug has been fixed in the phone list parsing, which resulted in a `List("")` being returned when no phone numbers were specified.
2. Warning added to `ProblemRobot` as required.
3. Cleaned up problems generated by `ProblemRobot` to ensure that we never display empty strings as investigator names.
4. Removed hard-coded strings from `ProblemRobot` for PIs.
5. Changed `CoiEditor` and `PIEditor` to allow for setup code so that the `Phone` text field can request the focus.

I'm not sure that (5) was done in the best way possible, so if anyone has alternative suggestions, I would much appreciate this.