### PR TITLE
REL-2890: Catch SIMBAD error response

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -19,8 +19,10 @@ case class MagnitudeQueryFilter(mc: MagnitudeConstraints) extends QueryResultsFi
 
 sealed abstract class CatalogName(val id: String, val displayName: String) {
   def supportedBands: List[MagnitudeBand] = Nil
-  // Indicates what is the band used when a generic R band is requried
+  // Indicates what is the band used when a generic R band is required
   def rBand: MagnitudeBand = MagnitudeBand.UC
+  // Whether we should validate the xml on parsing
+  def checkValidity: Boolean = true
 }
 
 case object SDSS extends CatalogName("sdss9", "SDSS9 @ Gemini")
@@ -34,11 +36,12 @@ case object UCAC4 extends CatalogName("ucac4", "UCAC4 @ Gemini") {
 }
 case object TWOMASS_PSC extends CatalogName("twomass_psc", "TwoMass PSC @ Gemini")
 case object TWOMASS_XSC extends CatalogName("twomass_xsc", "TwoMass XSC @ Gemini")
-case object SIMBAD extends CatalogName("simbad", "Simbad")
+case object SIMBAD extends CatalogName("simbad", "Simbad") {
+  override def checkValidity = false // Simbad sometimes returns non-valid XML, in particular in errors
+}
 
 object CatalogName {
   implicit val equals = Equal.equal[CatalogName]((a, b) => a.id === b.id)
-
 }
 
 /**

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -21,8 +21,6 @@ sealed abstract class CatalogName(val id: String, val displayName: String) {
   def supportedBands: List[MagnitudeBand] = Nil
   // Indicates what is the band used when a generic R band is required
   def rBand: MagnitudeBand = MagnitudeBand.UC
-  // Whether we should validate the xml on parsing
-  def checkValidity: Boolean = true
 }
 
 case object SDSS extends CatalogName("sdss9", "SDSS9 @ Gemini")
@@ -36,9 +34,7 @@ case object UCAC4 extends CatalogName("ucac4", "UCAC4 @ Gemini") {
 }
 case object TWOMASS_PSC extends CatalogName("twomass_psc", "TwoMass PSC @ Gemini")
 case object TWOMASS_XSC extends CatalogName("twomass_xsc", "TwoMass XSC @ Gemini")
-case object SIMBAD extends CatalogName("simbad", "Simbad") {
-  override def checkValidity = false // Simbad sometimes returns non-valid XML, in particular in errors
-}
+case object SIMBAD extends CatalogName("simbad", "Simbad")
 
 object CatalogName {
   implicit val equals = Equal.equal[CatalogName]((a, b) => a.id === b.id)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -2,12 +2,12 @@ package edu.gemini.catalog.votable
 
 import java.io.{ByteArrayInputStream, InputStream}
 
-import edu.gemini.catalog.api.CatalogName
+import edu.gemini.catalog.api.{CatalogName, SIMBAD}
 import edu.gemini.spModel.core._
 
 import scala.io.Source
 import scala.xml.XML
-
+import scala.xml.Node
 import scalaz._
 import Scalaz._
 
@@ -49,14 +49,24 @@ object VoTableParser extends VoTableParser {
   /**
    * parse takes an input stream and attempts to read the xml content and convert it to a VoTable resource
    */
-  def parse(catalog: CatalogName, is: InputStream, checkValidity: Boolean = true): CatalogResult = {
+  def parse(catalog: CatalogName, is: InputStream): CatalogResult = {
     // Load in memory (Could be a problem for large responses)
     val xmlText = Source.fromInputStream(is, "UTF-8").getLines().mkString
 
-    (checkValidity, validate(xmlText)) match {
-      case (true, -\/(e))  => \/.left(ValidationError(catalog))
-      case (false, -\/(e)) => \/.right(parse(XML.loadString(xmlText)))
-      case (_, \/-(r))     => \/.right(parse(XML.loadString(r)))
+    validate(xmlText) match {
+      case -\/(e) if catalog.checkValidity => \/.left(ValidationError(catalog))
+      case -\/(e) if catalog == SIMBAD     =>
+        // Simbad is a special case as it is not fully votable-compliant.
+        // We want to catch some errors at this level to simplify the parses that assumes
+        // we are votable compliant
+        val xml = XML.loadString(xmlText)
+        if (SimbadAdapter.containsExceptions(xml)) {
+          \/.left(ValidationError(catalog))
+        } else {
+          \/.right(parse(xml))
+        }
+      case -\/(e)                          => \/.right(parse(XML.loadString(xmlText)))
+      case \/-(r)                          => \/.right(parse(XML.loadString(r)))
     }
   }
 }
@@ -243,6 +253,12 @@ case object SimbadAdapter extends CatalogAdapter {
       }
     }
     \/-((band.flatten |@| MagnitudeSystem.fromString(p._2))((b, s) => (b, s)))
+  }
+
+  def containsExceptions(xml: Node): Boolean = {
+    // The only case known is with java.lang.NullPointerException but let's make the check
+    // more general.
+    (xml \\ "INFO" \ "@value").text.matches("java\\..*Exception")
   }
 }
 

--- a/bundle/edu.gemini.catalog/src/test/resources/simbad-npe.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/simbad-npe.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<INFO name="Error" value="java.lang.NullPointerException"/>
+</VOTABLE>

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -606,8 +606,14 @@ class VoTableParserSpec extends Specification with VoTableParser {
     "parse simbad with a not-found name" in {
       val xmlFile = "simbad-not-found.xml"
       // Simbad returns non-valid xml when an element is not found, we need to skip validation :S
-      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile"), checkValidity = false)
+      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile"))
       result must beEqualTo(\/.right(ParsedVoResource(List())))
+    }
+    "parse simbad with an npe" in {
+      val xmlFile = "simbad-npe.xml"
+      // Simbad returns non-valid xml when there is an internal error like an NPE
+      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile"))
+      result must beEqualTo(\/.left(ValidationError(SIMBAD)))
     }
     "ppmxl proper motion should be in mas/y. REL-2841" in {
       val xmlFile = "votable-ppmxl-proper-motion.xml"
@@ -628,8 +634,7 @@ class VoTableParserSpec extends Specification with VoTableParser {
     "support simbad repeated magnitude entries, REL-2853" in {
       val xmlFile = "simbad-ngc-2438.xml"
       // Simbad returns an xml with multiple measurements of the same band, use only the first one
-      println(VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile"), checkValidity = false))
-      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile"), checkValidity = false).getOrElse(ParsedVoResource(Nil))
+      val result = VoTableParser.parse(SIMBAD, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil))
 
       val target = (for {
           t <- result.tables.map(TargetsTable.apply)


### PR DESCRIPTION
It was noted that Simbad sometimes returns a bogus response including a java exception. This breaks the parser that doesn't handle this case and instead tells the user that target is not found

This PR addresses that and simplifies some bits of code. The solution is less clean than ideal since Simbad votable is not really compliant, so this particular error needs to be handled in a special case