### PR TITLE
REL-1389: Change AGS step size for F2OI

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
@@ -65,7 +65,6 @@ object SingleProbeStrategyParams {
   case object Flamingos2OiwfsParams extends SingleProbeStrategyParams {
     override val guideProbe = Flamingos2OiwfsGuideProbe.instance
     override val site       = Site.GS
-    override def stepSize   = Angle.fromDegrees(90)
   }
 
   case class GmosOiwfsParams(site: Site) extends SingleProbeStrategyParams {


### PR DESCRIPTION
The PIT uses a servlet to communicate with a running instance of the ODB (gnodb) to obtain estimates for being able to use AGS to find guide stars, which is accomplished by trying a variety of position angles through a series of step sizes.

The default step size for most single probes is in 10 degree increments, as is the default in `SingleProbeStrategyParams`. Flamingoes 2 OIWFS overrode this to instead us 90 degree increments, which was found to be too large and give unsatisfactory estimates.

This reduces the step size to the default of 10 degree increments by removing the overriding step size of 90 degrees. Speed comparisons for 10 degree versus 90 degree increments on a test program provided by Andy were done from GS on an ODB instance installed on `gnodbtest2` and were found to be unremarkable in difference.