### PR TITLE
REL-1217: Fixed PIT ephemeris check issues and reporting.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/EphemerisElement.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/EphemerisElement.scala
@@ -1,6 +1,6 @@
 package edu.gemini.model.p1.immutable
 
-import edu.gemini.model.p1.{ mutable => M }
+import edu.gemini.model.p1.{mutable => M}
 import java.util.GregorianCalendar
 
 import edu.gemini.spModel.core.Coordinates

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Semester.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Semester.scala
@@ -1,7 +1,7 @@
 package edu.gemini.model.p1.immutable
 
-import edu.gemini.model.p1.{ mutable => M }
-import java.util.{TimeZone, Calendar}
+import edu.gemini.model.p1.{mutable => M}
+import java.util.{Calendar, TimeZone}
 
 object Semester {
 
@@ -65,8 +65,8 @@ case class Semester(year: Int, half: SemesterOption) {
     cal.setTimeZone(TimeZone.getTimeZone("UTC"))
     cal.set(Calendar.YEAR, year)
     cal.set(Calendar.MONTH, half.firstMonth)
-    cal.set(Calendar.DAY_OF_MONTH, 0)
-    cal.set(Calendar.HOUR, 0)
+    cal.set(Calendar.DAY_OF_MONTH, 1)
+    cal.set(Calendar.HOUR_OF_DAY, 0)
     cal.set(Calendar.MINUTE, 0)
     cal.set(Calendar.SECOND, 0)
     cal.set(Calendar.MILLISECOND, 0)
@@ -81,8 +81,8 @@ case class Semester(year: Int, half: SemesterOption) {
       case SemesterOption.B => year + 1
     })
     cal.set(Calendar.MONTH, half.lastMonth)
-    cal.set(Calendar.DAY_OF_MONTH, 0)
-    cal.set(Calendar.HOUR, 0)
+    cal.set(Calendar.DAY_OF_MONTH, 1)
+    cal.set(Calendar.HOUR_OF_DAY, 0)
     cal.set(Calendar.MINUTE, 0)
     cal.set(Calendar.SECOND, 0)
     cal.set(Calendar.MILLISECOND, 0)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/EphemerisElementEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/EphemerisElementEditor.scala
@@ -1,14 +1,13 @@
 package edu.gemini.pit.ui.editor
 
 import edu.gemini.model.p1.immutable.EphemerisElement
-
 import edu.gemini.pit.ui.util._
 import edu.gemini.shared.gui.textComponent.NumberField
 import edu.gemini.spModel.core.Coordinates
 
 import scala.swing._
 import scala.swing.event.ValueChanged
-import java.util.{TimeZone, Date}
+import java.util.{Date, TimeZone}
 import javax.swing.{JSpinner, SpinnerDateModel}
 
 import scalaz._

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -36,6 +36,9 @@ import javax.swing.{Icon, BorderFactory, ListSelectionModel}
 import java.util.{TimeZone, Date}
 import java.text.{SimpleDateFormat, DecimalFormat}
 
+import scalaz._
+import Scalaz._
+
 object TargetEditor {
 
   def open(sem:Semester, t0:Option[Target], canEdit:Boolean, parent:UIElement):Option[Target] = {
@@ -504,11 +507,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean) e
 
             val defaultDay = {
               val now = System.currentTimeMillis()
-              if (now < semester.firstDay || now > semester.lastDay) {
-                semester.firstDay + 1000 * 60 * 60 * 24
-              } else {
-                now
-              }
+              (now < semester.firstDay || now > semester.lastDay) ? semester.firstDay | now
             }
 
             for {


### PR DESCRIPTION
As per the REL task, the PIT was mis-reporting missing ephemeris data.
This PR fixes that, and a number of other bugs that were discovered in the process.

1. One of the main issues was misuse of `java.util.Calendar`, which was being used with the assumption that the `Calendar.DAY_OF_MONTH` field is indexed starting at 0, when it is actually indexed starting at 1. (Using a `DAY_OF_MONTH` of 0 will actually give the last day of the previous month, delightfully confusingly.) Thus, `Semester.firstDay` and `Semester.lastDay` both occurred one day too early.
2. Additionally, `Calendar.HOUR` was used instead of `Calendar.HOUR_OF_DAY`, which made the `Semester.firstDay` and `Semester.lastDay` flip from time `00:00:00` to `12:00:00` after noon.
3. There was a contradiction in the `emptyEphemerisCheck` so that it was never being generated: the `for` loop had `if !t.isEmpty` (for `t: NonSiderealTarget`) and `if e.isEmpty` (for `e: List[EphemerisElement]` for `t`) as conditions for execution, and `NonSiderealTarget.isEmpty` simply checks that its `List[EphemerisElement]` is empty, so these calls could never both be true. This was fixed and the list is now only checked for emptiness.
4. General cleanup: redundant variables were either removed or used instead of alternatives, and ephemeris checks were grouped together in the list of problems.
5. `TargetEditor.defaultDay` would add a day to `Semester.firstDay`, I assume, to work around the incorrect use of `Calendar` that made `Semester.firstDay` one day too early. This was removed and the code simplified.