### PR TITLE
REL-2909: Changed PIT configuration handling of debug flags

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppMode.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppMode.scala
@@ -7,13 +7,11 @@ import scala.util.Try
 object AppMode {
   private val Log = Logger.getLogger(AppMode.getClass.getName)
 
-  lazy val isTAC  = isDefinedAndTrue("edu.gemini.pit.tac")
-  lazy val isTest = isDefinedAndTrue("edu.gemini.pit.test")
-
-  private def isDefinedAndTrue(prop: String): Boolean = Try {
-    System.getProperty(prop).toBoolean
+  val TestProperty = "edu.gemini.pit.test"
+  lazy val isTest = Try {
+    System.getProperty(TestProperty).toBoolean
   } getOrElse {
-    Log.warning(s"System property $prop should be defined and have a boolean value. Using false as default.")
+    Log.warning(s"System property $TestProperty should be defined and have a boolean value. Using false as default.")
     false
   }
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppMode.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppMode.scala
@@ -1,10 +1,19 @@
 package edu.gemini.pit.model
 
+import java.util.logging.Logger
+
+import scala.util.Try
+
 object AppMode {
+  private val Log = Logger.getLogger(AppMode.getClass.getName)
 
-  lazy val isTAC = isDefined("edu.gemini.pit.tac")
-  lazy val isTest = isDefined("edu.gemini.pit.test")
+  lazy val isTAC  = isDefinedAndTrue("edu.gemini.pit.tac")
+  lazy val isTest = isDefinedAndTrue("edu.gemini.pit.test")
 
-  private def isDefined(prop:String) = Option(System.getProperty(prop)).isDefined
-
+  private def isDefinedAndTrue(prop: String): Boolean = Try {
+    System.getProperty(prop).toBoolean
+  } getOrElse {
+    Log.warning(s"System property $prop should be defined and have a boolean value. Using false as default.")
+    false
+  }
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
@@ -57,10 +57,6 @@ class Activator extends BundleActivator {
 
 }
 
-//object Activator {
-//  val TestProperty = "edu.gemini.pit.test"
-//}
-
 // Track AGS service changes and pass them to the AgsRobot$ singleton. This is a little ugly but it hides the OSGI
 // abstractions, which is what we want.
 class AgsTracker(context:BundleContext) extends ServiceTracker[AgsClient, AgsClient](context, classOf[AgsClient].getName, null) {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
@@ -30,7 +30,7 @@ class Activator extends BundleActivator {
     // TODO: Not sure if this is used anymore.
     \/.fromTryCatchNonFatal(context.getProperty(Activator.TestProperty).toBoolean).fold(
       _ => Log.warning(s"Context property ${Activator.TestProperty} should be defined and have a boolean value."),
-      v => System.setProperty("edu.gemini.pit.test", v.toString)
+      v => System.setProperty(Activator.TestProperty, v.toString)
     )
 
     // The way Workspace works is that you create an IShellAdvisor and register it as a service. Workspace sees this and

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
@@ -2,7 +2,7 @@ package edu.gemini.pit.osgi
 
 import edu.gemini.ui.workspace.IShellAdvisor
 import edu.gemini.pit.ui.ShellAdvisor
-import edu.gemini.pit.model.Model
+import edu.gemini.pit.model.{AppMode, Model}
 import org.osgi.util.tracker.ServiceTracker
 import edu.gemini.ags.client.api.AgsClient
 import org.osgi.framework.{BundleActivator, BundleContext, ServiceReference}
@@ -28,9 +28,9 @@ class Activator extends BundleActivator {
 
     // Turn this bundle property into the system property.
     // TODO: Not sure if this is used anymore.
-    \/.fromTryCatchNonFatal(context.getProperty(Activator.TestProperty).toBoolean).fold(
-      _ => Log.warning(s"Context property ${Activator.TestProperty} should be defined and have a boolean value."),
-      v => System.setProperty(Activator.TestProperty, v.toString)
+    \/.fromTryCatchNonFatal(context.getProperty(AppMode.TestProperty).toBoolean).fold(
+      _ => Log.warning(s"Context property ${AppMode.TestProperty} should be defined and have a boolean value."),
+      v => System.setProperty(AppMode.TestProperty, v.toString)
     )
 
     // The way Workspace works is that you create an IShellAdvisor and register it as a service. Workspace sees this and
@@ -57,9 +57,9 @@ class Activator extends BundleActivator {
 
 }
 
-object Activator {
-  val TestProperty = "edu.gemini.pit.test"
-}
+//object Activator {
+//  val TestProperty = "edu.gemini.pit.test"
+//}
 
 // Track AGS service changes and pass them to the AgsRobot$ singleton. This is a little ugly but it hides the OSGI
 // abstractions, which is what we want.

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
@@ -41,6 +41,8 @@ import edu.gemini.pit.ui.robot.{AgsRobot, CatalogRobot, GsaRobot, ProblemRobot, 
 import edu.gemini.shared.Platform
 import edu.gemini.shared.gui.Browser
 
+import scalaz.\/
+
 // GFace (written for QPT and modeled on Eclipse JFace) is a little awkward to use from Scala, sorry. It depends on
 // lifecycle callbacks and has a bit of mutable state. It works and in practice you don't have to mess with it too
 // often, but it's annoying.
@@ -245,12 +247,9 @@ class ShellAdvisor(
     )
 
     // Debug Menu -- for developers only
-    Option(System.getProperty("edu.gemini.pit.test")).foreach {
-      _ =>
+    if (AppMode.isTest) {
         val debugMenu = Menu("Debug", NextSiblingOf, Some(helpMenu))
-        context.actionManager.add(debugMenu,
-          Some(new ValidateAction(shell))
-        )
+        context.actionManager.add(debugMenu, Some(new ValidateAction(shell)))
     }
 
     // Hack the key bindings for text widgets

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
@@ -41,7 +41,6 @@ import edu.gemini.pit.ui.robot.{AgsRobot, CatalogRobot, GsaRobot, ProblemRobot, 
 import edu.gemini.shared.Platform
 import edu.gemini.shared.gui.Browser
 
-import scalaz.\/
 
 // GFace (written for QPT and modeled on Eclipse JFace) is a little awkward to use from Scala, sorry. It depends on
 // lifecycle callbacks and has a bit of mutable state. It works and in practice you don't have to mess with it too

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/RedoAction.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/RedoAction.scala
@@ -3,11 +3,11 @@ package edu.gemini.pit.ui.action
 import java.awt.event.KeyEvent
 
 import edu.gemini.ui.workspace.scala.RichShell
-import edu.gemini.pit.model.{AppMode, Model}
+import edu.gemini.pit.model.Model
 
 class RedoAction(shell: RichShell[Model]) extends ShellAction(shell, "Redo", Some(KeyEvent.VK_Y)) {
 
-  enabledWhen { shell.canRedo && (AppMode.isTAC || shell.model.map(!_.proposal.isSubmitted).getOrElse(true)) }
+  enabledWhen { shell.canRedo && !shell.model.exists(_.proposal.isSubmitted) }
 
   override def apply() {
     shell.redo()

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/UndoAction.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/action/UndoAction.scala
@@ -4,11 +4,10 @@ import java.awt.event.KeyEvent
 
 import edu.gemini.ui.workspace.scala.RichShell
 import edu.gemini.pit.model.Model
-import edu.gemini.pit.model.AppMode._
 
 class UndoAction(shell: RichShell[Model]) extends ShellAction(shell, "Undo", Some(KeyEvent.VK_Z)) {
 
-  enabledWhen { shell.canUndo && (isTAC || shell.model.map(!_.proposal.isSubmitted).getOrElse(true)) }
+  enabledWhen { shell.canUndo && !shell.model.exists(_.proposal.isSubmitted) }
 
   override def apply() {
     shell.undo()


### PR DESCRIPTION
Originally, a test release of the PIT would be built if `app/pit/build.sbt` had the property `edu.gemini.pit.test` defined at all. This was confusing because in `app/pit/build.sbt`, it was set to `true` and commented out to create an official release: its actual contents were never looked at, so setting it to `false` would make it defined and thus also result in a test release being built.

This cleans that up by ONLY creating a test release / running in test mode if the property is set to `true`.
If it is set to `false`, it is not run in test mode.
If it is set to anything else or undefined, a warning is logged and it is also not run in test mode.