### PR TITLE
REL-2910: Update radial range in Catalog Query Tool when WFS changes

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -408,6 +408,13 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
       listenTo(selection)
       reactions += {
         case SelectionChanged(_) =>
+          // REL-2910 Set the radius range to the selected guider settings
+          selection.item.query.headOption.foreach {
+            case ConeSearchCatalogQuery(_, _, rc, _, _) =>
+              radiusStart.updateAngle(rc.minLimit)
+              radiusEnd.updateAngle(rc.maxLimit)
+            case _                                      =>
+          }
           updateGuideSpeedText()
           magnitudeFiltersFromControls(selection.item.query.headOption)
       }
@@ -438,7 +445,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
       listenTo(selection)
       reactions += {
         case SelectionChanged(_) =>
-          foreground = originalConditions.map(_.sb).exists(_ == selection.item) ? Color.black | Color.red
+          foreground = originalConditions.map(_.sb).contains(selection.item) ? Color.black | Color.red
           resultsTable.model match {
             case t: TargetsModel =>
               Swing.onEDT {
@@ -452,13 +459,14 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
       override def text(a: SPSiteQuality.SkyBackground) = a.displayValue()
     }
+
     lazy val ccBox = new ComboBox(List(SPSiteQuality.CloudCover.values().filter(!_.isObsolete): _*)) with TextRenderer[SPSiteQuality.CloudCover] {
       renderer = conditionsRenderer(_.map(_.cc), this)
 
       listenTo(selection)
       reactions += {
         case SelectionChanged(_) =>
-          foreground = originalConditions.map(_.cc).exists(_ == selection.item) ? Color.black | Color.red
+          foreground = originalConditions.map(_.cc).contains(selection.item) ? Color.black | Color.red
           resultsTable.model match {
             case t: TargetsModel =>
               Swing.onEDT {
@@ -472,13 +480,14 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
       override def text(a: SPSiteQuality.CloudCover) = a.displayValue()
     }
+
     lazy val iqBox = new ComboBox(List(SPSiteQuality.ImageQuality.values(): _*)) with TextRenderer[SPSiteQuality.ImageQuality] {
       renderer = conditionsRenderer(_.map(_.iq), this)
 
       listenTo(selection)
       reactions += {
         case SelectionChanged(_) =>
-          foreground = originalConditions.map(_.iq).exists(_ == selection.item) ? Color.black | Color.red
+          foreground = originalConditions.map(_.iq).contains(selection.item) ? Color.black | Color.red
           resultsTable.model match {
             case t: TargetsModel =>
               Swing.onEDT {
@@ -492,6 +501,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
       override def text(a: SPSiteQuality.ImageQuality) = a.displayValue()
     }
+
     lazy val limitsLabel = new Label() {
       font = font.deriveFont(font.getSize2D * 0.8f)
     }


### PR DESCRIPTION
This PR adds a missing feature to the Catalog Query Tool. At the moment, when the user selects a different guider, the search form magnitudes is updated but not the radius range, thus making it necessary to set it manually

This PR acts when the guider's selection is updated and will set the radius range appropriately

![screenshot 2016-08-12 11 54 59](https://cloud.githubusercontent.com/assets/3615303/17628543/c0dd29c6-6083-11e6-93bb-c2f83409b9a3.png)
