### PR TITLE
REL-2918: Added more AU institutions and fixed spacing issues

### DIFF
--- a/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
+++ b/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
@@ -271,6 +271,33 @@
        </contact>
     </site>
     <site>
+        <institution>Curtin University</institution>
+        <address>GPO Box U1987</address>
+        <address>Perth</address>
+        <address>WA 6845</address>
+        <country>Australia</country>
+    </site>
+    <site>
+        <institution>University of Southern Queensland</institution>
+        <address>Toowoomba</address>
+        <address>QLD 4350</address>
+        <country>Australia</country>
+    </site>
+    <site>
+        <institution>University of Western Australia</institution>
+        <address>35 Stirling Highway</address>
+        <address>Crawley</address>
+        <address>WA 6009</address>
+        <country>Australia</country>
+    </site>
+    <site>
+        <institution>Western Sydney University</institution>
+        <address>Locked Bag 1797</address>
+        <address>Penrith</address>
+        <address>NSW 2751</address>
+        <country>Australia</country>
+    </site>
+    <site>
        <institution>Centro de Radio-Astronomia e Apl. Espacias (EPUSP)</institution>
        <address>CRAAE/EPUSP</address>
        <address>C.P. 61548</address>
@@ -2894,7 +2921,7 @@
        </contact>
     </site>
     <site>
-       <institution>University of  New Hampshire</institution>
+       <institution>University of New Hampshire</institution>
        <address>Department of Physics</address>
        <address>Demeritt Hall</address>
        <address>Durham</address>
@@ -3130,7 +3157,7 @@
        </contact>
     </site>
     <site>
-       <institution>University of  Pittsburgh</institution>
+       <institution>University of Pittsburgh</institution>
        <address>Department of Physics and Astronomy</address>
        <address>100 Allen Hall</address>
        <address>Pittsburgh</address>


### PR DESCRIPTION
This PR does two things:
1. Adds four new Australian institutions to the PIT; and
2. Removes some double spaces that were in institution names.