### PR TITLE
REL-2914: Instrument changes for PIT 2017A.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -8,7 +8,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
   var title = "Select Instrument"
   var description = s"The following instruments are available for semester ${sem.year}${sem.half}. See the Gemini website for information on instrument capabilities and configuration options."
 
-  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, /*Texes,*/ Visitor)
+  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, Texes, Visitor)
 
   def apply(i:Instrument) = i match {
     case Flamingos2 => Left(inst.Flamingos2())

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
@@ -10,7 +10,7 @@ object Dssi {
   class SiteNode extends SingleSelectNode[Unit, VisitorSite, DssiBlueprint](()) {
     val title       = "Site"
     val description = "Select the site."
-    def choices     = GNVisitorSite :: Nil
+    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
 
     def apply(fs: VisitorSite) = Right(DssiBlueprint(fs))
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Texes.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Texes.scala
@@ -10,7 +10,7 @@ object Texes {
   class SiteNode extends SingleSelectNode[Unit, VisitorSite, Site](()) {
     val title       = "Site"
     val description = "Select the site."
-    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
+    def choices     = GNVisitorSite :: Nil
 
     def apply(s: VisitorSite) = Left(new DisperserNode(s.site))
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -11,9 +11,9 @@ class RootSpec extends Specification {
       val root = new Root(Semester(2016, A))
       root.choices must contain(Instrument.Gsaoi)
     }
-    "not include Texes" in {
-      val root = new Root(Semester(2016, A))
-      root.choices must not contain (Instrument.Texes)
+    "include Texes" in {
+      val root = new Root(Semester(2017, A))
+      root.choices must contain(Instrument.Texes)
     }
     "include Speckles" in {
       val root = new Root(Semester(2016, A))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/TexesSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/TexesSpec.scala
@@ -5,12 +5,12 @@ import org.specs2.mutable.Specification
 
 class TexesSpec extends Specification {
   "The Texes decision tree" should {
-      "includes a site choice" in {
+      "include a site choice" in {
         val texes = Texes()
         texes.title must beEqualTo("Site")
-        texes.choices must have size 2
+        texes.choices must have size 1
       }
-      "includes a disperser choice" in {
+      "include a disperser choice" in {
         val texes = Texes()
         val disperserNode = texes.apply(VisitorSite.fromSite(Site.GN)).a
         disperserNode.title must beEqualTo("Disperser")


### PR DESCRIPTION
This PR changes the instrument availability in the PIT for 2017A proposals as follows:
= Allow TEXES for GN only.
= Allow DSSI for both GN and GS (formerly was only allowed for GN).