### PR TITLE
REL-2920: Fixing parallactic angle formatting and warning

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -305,7 +305,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       // Parallactic Angle
       val paStr = parallacticAngle
         .map(ParallacticAngleControls.angleToDegrees)
-        .fold(", not visible")(a => f", $a%3.1f°")
+        .fold(", not visible")(a => s", ${fmt.format(a)}°")
 
       ui.parallacticAngleFeedback.text =
         if (isPaUi) dateTimeStr + durStr + paStr


### PR DESCRIPTION
When the parallactic angle mode is chosen, the parallactic angle is calculated based on the scheduling block and the angle entered for the PA.

In the past, if the user "overrode" this PA, a warning would be issued in the form of a small yield sign next to the parallactic angle calculation in the display (see first figure).

If the user restored the value to the parallactic angle calculation, the warning would disappear (see second figure).

This functionality was broken by code changes for the target model (I suspect) along the way, as the number formatter used for parallactic angle display was altered in the code (and used direct string formatting to one decimal place instead of two) and thus was no longer consistent with the internal check. I have restored the code to use the formatter: thus, any changes to angle truncation or formatting are limited to one place.

This simply fixes that to restore the warning to the proper behaviour.
![parangle1](https://cloud.githubusercontent.com/assets/8795653/17750908/26f3a3f0-649b-11e6-8143-07a0d0c508e0.png)
![parangle2](https://cloud.githubusercontent.com/assets/8795653/17750912/28ab3974-649b-11e6-905d-c30f518e50df.png)
