### PR TITLE
REL-2922: Parallactic angle setting PA at too high a precision

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -4,7 +4,6 @@ import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentBroadType;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.DefaultImList;
-import edu.gemini.shared.util.immutable.Function1;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.skycalc.Angle;
@@ -12,6 +11,7 @@ import edu.gemini.spModel.config.injector.ConfigInjector;
 import edu.gemini.spModel.config.injector.ConfigInjectorCalc3;
 import edu.gemini.spModel.config2.Config;
 import edu.gemini.spModel.config2.ItemKey;
+import edu.gemini.spModel.core.Angle$;
 import edu.gemini.spModel.data.IOffsetPosListProvider;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.data.PreImagingType;
@@ -791,9 +791,9 @@ public abstract class InstGmosCommon<
      * slits.
      */
     @Override
-    public Option<Angle> calculateParallacticAngle(ISPObservation obs) {
+    public Option<edu.gemini.spModel.core.Angle> calculateParallacticAngle(ISPObservation obs) {
         return super.calculateParallacticAngle(obs).map(angle -> _fpu.isWideSlit() ?
-                angle.add(Angle.ANGLE_PI_OVER_2).toPositive() :
+                angle.$plus(Angle$.MODULE$.fromDegrees(90)) :
                 angle);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/parallacticangle/ParallacticAngleSupportInst.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/parallacticangle/ParallacticAngleSupportInst.java
@@ -4,7 +4,8 @@ import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.skycalc.Angle;
+import edu.gemini.spModel.core.Angle;
+import edu.gemini.spModel.core.Angle$;
 import edu.gemini.spModel.inst.ParallacticAngleSupport;
 import edu.gemini.spModel.obs.ObsTargetCalculatorService;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
@@ -29,7 +30,6 @@ public abstract class ParallacticAngleSupportInst extends SPInstObsComp implemen
     public Option<Angle> calculateParallacticAngle(final ISPObservation obs) {
         return ImOption.fromScalaOpt(ObsTargetCalculatorService.targetCalculation(obs))
                 .flatMap(targetCalculator -> ImOption.fromScalaOpt(targetCalculator.weightedMeanParallacticAngle()))
-                .map(angleObj -> (double) angleObj)
-                .map(angle -> (new edu.gemini.skycalc.Angle(angle, edu.gemini.skycalc.Angle.Unit.DEGREES)).toPositive());
+                .map(angleObj -> Angle$.MODULE$.fromDegrees((double)angleObj));
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/parallacticangle/ParallacticAngleSupportInst.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/parallacticangle/ParallacticAngleSupportInst.java
@@ -2,14 +2,12 @@ package edu.gemini.spModel.gemini.parallacticangle;
 
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
-import edu.gemini.shared.util.immutable.None;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.spModel.inst.ParallacticAngleSupport;
 import edu.gemini.spModel.obs.ObsTargetCalculatorService;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
-import edu.gemini.util.skycalc.calc.TargetCalculator;
 
 /**
  * A superclass for instruments that support the parallactic angle feature with most of the implementation in place.
@@ -19,7 +17,7 @@ public abstract class ParallacticAngleSupportInst extends SPInstObsComp implemen
     /**
      * Constructor and methods for parallactic angle support.
      */
-    protected ParallacticAngleSupportInst(SPComponentType type) {
+    protected ParallacticAngleSupportInst(final SPComponentType type) {
         super(type);
     }
 
@@ -28,28 +26,10 @@ public abstract class ParallacticAngleSupportInst extends SPInstObsComp implemen
      * Instruments who need specific modifications based on settings should override this, e.g. GMOS.
      */
     @Override
-    public Option<Angle> calculateParallacticAngle(ISPObservation obs) {
-        final Option<TargetCalculator> targetCalculatorOption = ObsTargetCalculatorService.targetCalculationForJava(obs);
-        if (!targetCalculatorOption.isEmpty()) {
-            final TargetCalculator targetCalculator = targetCalculatorOption.getValue();
-
-            // Calculate the weighted angle.
-            scala.Option<Object> angleOption = targetCalculator.weightedMeanParallacticAngle();
-            if (angleOption.nonEmpty()) {
-                // Calculate the parallactic angle.
-                final double dAngle = (Double) angleOption.get();
-                final edu.gemini.skycalc.Angle angle = (new edu.gemini.skycalc.Angle(dAngle, edu.gemini.skycalc.Angle.Unit.DEGREES)).toPositive();
-                return new Some<>(angle);
-            } else return None.instance();
-        } else return None.instance();
-    }
-
-    /**
-     * By default, assume that the instrument is compatible with the parallactic angle feature unless indicated
-     * otherwise.
-     */
-    @Override
-    public boolean isCompatibleWithMeanParallacticAngleMode() {
-        return true;
+    public Option<Angle> calculateParallacticAngle(final ISPObservation obs) {
+        return ImOption.fromScalaOpt(ObsTargetCalculatorService.targetCalculation(obs))
+                .flatMap(targetCalculator -> ImOption.fromScalaOpt(targetCalculator.weightedMeanParallacticAngle()))
+                .map(angleObj -> (double) angleObj)
+                .map(angle -> (new edu.gemini.skycalc.Angle(angle, edu.gemini.skycalc.Angle.Unit.DEGREES)).toPositive());
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
@@ -12,7 +12,6 @@ import edu.gemini.skycalc.Angle;
  * in ParallacticAngleSupportInst.
  */
 public interface ParallacticAngleSupport {
-
     /**
      * Perform the parallactic angle computation for the observation.
      */
@@ -20,6 +19,10 @@ public interface ParallacticAngleSupport {
 
     /**
      * Determine if the current instrument configuration is compatible or not with parallactic angle support.
+     * By default, assume that the instrument is compatible with the parallactic angle feature unless indicated
+     * otherwise.
      */
-    boolean isCompatibleWithMeanParallacticAngleMode();
+    default boolean isCompatibleWithMeanParallacticAngleMode() {
+        return true;
+    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
@@ -16,10 +16,10 @@ public interface ParallacticAngleSupport {
     /**
      * Perform the parallactic angle computation for the observation.
      */
-    public Option<Angle> calculateParallacticAngle(ISPObservation obs);
+    Option<Angle> calculateParallacticAngle(ISPObservation obs);
 
     /**
      * Determine if the current instrument configuration is compatible or not with parallactic angle support.
      */
-    public boolean isCompatibleWithMeanParallacticAngleMode();
+    boolean isCompatibleWithMeanParallacticAngleMode();
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
@@ -2,7 +2,7 @@ package edu.gemini.spModel.inst;
 
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.skycalc.Angle;
+import edu.gemini.spModel.core.Angle;
 
 /**
  * Support for parallactic angle calculations.

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -13,13 +13,6 @@ import jsky.coords.WorldCoords
 import edu.gemini.skycalc.{TimeUtils, Coordinates}
 import scala.collection.JavaConverters._
 
-/**
- * Created with IntelliJ IDEA.
- * User: sraaphor
- * Date: 3/23/14
- * Time: 1:44 AM
- * To change this template use File | Settings | File Templates.
- */
 object ObsTargetCalculatorService {
   private def create(obs: ISPObservation): Option[TargetCalculator] = {
     // First, determine the Site at which the instrument is located based on
@@ -81,10 +74,6 @@ object ObsTargetCalculatorService {
     val res = lookupOrCreate(obs)
     SPObsCache.setTargetCalculator(obs, res.asGeminiOpt)
     res
-  }
-
-  def targetCalculationForJava(obs: ISPObservation): edu.gemini.shared.util.immutable.Option[TargetCalculator] = {
-    targetCalculation(obs).asGeminiOpt
   }
 
   def calculateRemainingTime(ispObservation: ISPObservation): Long =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -8,7 +8,7 @@ import javax.swing.BorderFactory
 import javax.swing.border.EtchedBorder
 
 import edu.gemini.pot.sp.ISPNode
-import edu.gemini.skycalc.Angle
+import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.inst.ParallacticAngleSupport
 import edu.gemini.spModel.obs.{ObsTargetCalculatorService, SPObservation, SchedulingBlock}
@@ -274,7 +274,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       fmt   <- formatter
     } {
       val explicitlySet = !fmt.format(ParallacticAngleControls.angleToDegrees(angle)).equals(positionAngleText) &&
-                          !fmt.format(ParallacticAngleControls.angleToDegrees(angle.add(Angle.ANGLE_PI))).equals(positionAngleText)
+                          !fmt.format(ParallacticAngleControls.angleToDegrees(angle + Angle.fromDegrees(180))).equals(positionAngleText)
       ui.parallacticAngleFeedback.warningState(explicitlySet)
     }
   }
@@ -358,7 +358,7 @@ object ParallacticAngleControls {
   // Precision limit for which two parallactic angles are considered equivalent.
   val Precision = 0.005
 
-  def angleToDegrees(a: Angle): Double = a.toPositive.toDegrees.getMagnitude
+  def angleToDegrees(a: Angle): Double = a.toDegrees
 
   /** Wrap an IO action with a logging timer. */
   def time[A](io: IO[A])(msg: String): IO[A] =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -16,7 +16,6 @@ import edu.gemini.spModel.obs.SchedulingBlock.Duration
 import edu.gemini.spModel.obs.SchedulingBlock.Duration._
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.shared.util.immutable.{Option => JOption, ImOption}
-import jsky.app.ot.ags.BagsManager
 import jsky.app.ot.editor.OtItemEditor
 import jsky.app.ot.gemini.editor.EphemerisUpdater
 import jsky.app.ot.util.TimeZonePreference
@@ -37,7 +36,9 @@ import scalaz._, Scalaz._, scalaz.effect.IO
 class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publisher {
   import ParallacticAngleControls._
 
-  val Nop = new Runnable { def run = () }
+  val Nop = new Runnable {
+    override def run() = ()
+  }
 
   private var editor:    Option[OtItemEditor[_, _]] = None
   private var site:      Option[Site]   = None
@@ -271,7 +272,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       e     <- editor
       angle <- parallacticAngle
       fmt   <- formatter
-    } yield {
+    } {
       val explicitlySet = !fmt.format(ParallacticAngleControls.angleToDegrees(angle)).equals(positionAngleText) &&
                           !fmt.format(ParallacticAngleControls.angleToDegrees(angle.add(Angle.ANGLE_PI))).equals(positionAngleText)
       ui.parallacticAngleFeedback.warningState(explicitlySet)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -6,7 +6,7 @@ import java.util.Locale
 
 import edu.gemini.pot.sp.{ISPObsComponent, SPComponentType}
 import edu.gemini.shared.gui.EnableDisableComboBox
-import edu.gemini.skycalc.Angle
+import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.inst.ParallacticAngleSupport
 import edu.gemini.spModel.obs.ObsClassService
@@ -271,9 +271,10 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
    * We set the position angle to the parallactic angle.
    */
   private def parallacticAngleChanged(angleOpt: Option[Angle]): Unit =
-    angleOpt.map(_.toDegrees.toPositive.getMagnitude).foreach(angle => {
-      ui.positionAngleTextField.text = numberFormatter.format(angle)
-      setInstPosAngle(angle)
+    angleOpt.foreach(angle => {
+      val degrees = angle.toDegrees
+      ui.positionAngleTextField.text = numberFormatter.format(degrees)
+      setInstPosAngle(degrees)
     })
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -226,7 +226,6 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     val oldAngleDegrees = e.getDataObject.getPosAngle
     if (Math.abs(oldAngleDegrees - newAngleDegrees) >= Precision
       && (e.getDataObject.getPosAngleConstraint != PosAngleConstraint.PARALLACTIC_ANGLE || Math.abs(Math.abs(oldAngleDegrees - newAngleDegrees) - 180) >= Precision)) {
-      println(s"+++ setting pos angle from $oldAngleDegrees to $newAngleDegrees")
       e.getDataObject.setPosAngle(newAngleDegrees)
     }
   }


### PR DESCRIPTION
When using the parallactic angle mode for observations, the resultant PA is calculated at an extremely high precision. This resulted in issues with the instrument configuration: for example, the parallactic angle would be calculated and set on the instrument to a high level of precision, and then BAGS would run, and then set the PA to the "almost equals" angle at a lower precision, which would cause issues with the parallactic angle once again to be calculated and determine itself to be different from the instrument PA. Lather, rinse, repeat.

This change comprises:
1. Using a more standard precision for setting the PA on the instrument for parallactic angle calculations;
2. Not recognizing a 180 flip from the calculated parallactic angle (which can be used by BAGS in GS selection and is permitted) as a new PA; and
3. General cleanup.