### PR TITLE
REL-2691: Changed Korea to ROK.

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
@@ -280,7 +280,7 @@
             <xsl:when test="$partner = 'ca'">Canada</xsl:when>
             <xsl:when test="$partner = 'cl'">Chile</xsl:when>
             <xsl:when test="$partner = 'gs'">Gemini Staff</xsl:when>
-            <xsl:when test="$partner = 'kr'">Korea</xsl:when>
+            <xsl:when test="$partner = 'kr'">Republic of Korea</xsl:when>
             <xsl:when test="$partner = 'uk'">UK</xsl:when>
             <xsl:when test="$partner = 'us'">USA</xsl:when>
             <xsl:when test="$partner = 'uh'">Univ. Hawaii</xsl:when>

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Partners.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Partners.scala
@@ -12,7 +12,7 @@ object Partners {
     NgoPartner.BR -> "Brazil",
     NgoPartner.CA -> "Canada",
     NgoPartner.CL -> "Chile",
-    NgoPartner.KR -> "Korea",
+    NgoPartner.KR -> "Republic of Korea",
     NgoPartner.US -> "United States",
     NgoPartner.UH -> "University of Hawaii",
     ExchangePartner.CFHT -> Site.CFHT.name,

--- a/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
+++ b/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
@@ -3610,7 +3610,7 @@
         <institution>Korea Astronomy and Space Science Institute (KASI)</institution>
         <address>776, Daedeokdae-ro, Yuseong-gu</address>
         <address>Daejeon, 34055</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-42-865-3332</phone>
             <fax>+82-42-861-5610</fax>
@@ -3621,7 +3621,7 @@
         <address>Korea Astronomy and Space Science Institute (KASI)</address>
         <address>San 6-2, Jeonggak-ri, Hwabuk-myeon, Yeongcheon-si</address>
         <address>Gyeongsangbuk-do, 38812</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-54-330-1000</phone>
             <fax>+82-54-336-9450</fax>
@@ -3632,7 +3632,7 @@
         <address>Korea Astronomy and Space Science Institute (KASI)</address>
         <address>Danyang PO Box 132, Danyang-eup, Danyang-gun</address>
         <address>Chungcheongbuk-do, 27010</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-43-422-1108</phone>
             <fax>+82-43-423-4878</fax>
@@ -3643,7 +3643,7 @@
         <address>Korea Astronomy and Space Science Institute (KASI)</address>
         <address>776 Daedeokdae-ro, Yuseong-gu</address>
         <address>Daejeon, 34055</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-42-865-3285</phone>
             <fax>+82-42-865-3304</fax>
@@ -3654,7 +3654,7 @@
         <address>Dept of Astronomy and Space Science</address>
         <address>Chungdae-ro 1, Seowon-Gu, Cheongju</address>
         <address>Chungbuk, 28644</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-43-261-2312</phone>
             <fax>+82-43-274-2312</fax>
@@ -3665,7 +3665,7 @@
         <address>Dept of Astronomy &amp; Space Science</address>
         <address>99, Daehak-ro, Yuseong-gu</address>
         <address>Daejeon, 34134</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-42-821-5461</phone>
             <fax>+82-42-821-8891</fax>
@@ -3676,7 +3676,7 @@
         <address>School of Physics</address>
         <address>85, Hoegiro, Dongdaemun-gu</address>
         <address>Seoul, 02455</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-2-958-3711</phone>
             <phone>+82-2-958-3771</phone>
@@ -3688,7 +3688,7 @@
         <address>Dept of Astronomy &amp; Space Science</address>
         <address>1732, Deogyeong-daero, Giheung-gu, Yongin-si</address>
         <address>Gyeonggi-do, 17104</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-31-201-2440</phone>
             <fax>+82-31-204-8122</fax>
@@ -3699,7 +3699,7 @@
         <address>Kyunghee University</address>
         <address>1732, Deogyeong-daero, Giheung-gu, Yongin-si</address>
         <address>Gyeonggi-do, 17104</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-31-201-2470</phone>
             <fax>+82-31-206-2470</fax>
@@ -3710,7 +3710,7 @@
         <address>Dept of Astronomy &amp; Atmospheric Sciences</address>
         <address>80, Daehak-ro, Buk-gu</address>
         <address>Daegu, 41566</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-53-950-6360</phone>
             <fax>+82-53-950-6359</fax>
@@ -3721,7 +3721,7 @@
         <address>Department of Earth Science</address>
         <address>2, Busandaehak-ro 63beon-gil, Geumjeong-gu</address>
         <address>Busan, 46241</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-51-510-1626</phone>
             <fax>+82-51-513-7495</fax>
@@ -3732,7 +3732,7 @@
         <address>Department of Physics</address>
         <address>2, Busandaehak-ro 63beon-gil, Geumjeong-gu</address>
         <address>Busan, 46241</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-51-510-1769</phone>
             <fax>+82-51-513-7664</fax>
@@ -3743,7 +3743,7 @@
         <address>Department of Physics and Astronomy</address>
         <address>209, Neungdong-ro, Gwangjin-gu</address>
         <address>Seoul, 05006</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-2-3408-3920</phone>
             <fax>+82-2-3408-4335</fax>
@@ -3754,7 +3754,7 @@
         <address>Department of Physics and Astronomy</address>
         <address>1, Gwanak-ro, Gwanak-gu</address>
         <address>Seoul, 08826</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-2-880-6621</phone>
             <phone>+82-2-880-6622</phone>
@@ -3766,7 +3766,7 @@
         <address>Department of Astronomy</address>
         <address>50, Yonsei-ro, Seodaemun-gu</address>
         <address>Seoul, 03722</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-2-2123-2680</phone>
             <fax>+82-2-392-7680</fax>
@@ -3776,7 +3776,7 @@
         <institution>Yonsei University (Center for Galaxy Evolution Research)</institution>
         <address>50, Yonsei-ro, Seodaemun-gu</address>
         <address>Seoul, 03722</address>
-        <country>Korea</country>
+        <country>Republic of Korea</country>
         <contact>
             <phone>+82-2-2123-4143</phone>
             <fax>+82-2-362-5136</fax>

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
@@ -55,15 +55,15 @@ object Institutions {
     }
   }
   def country2Ngo(country: String): FtPartner = country match {
-    case "Argentina" => Some(-\/(NgoPartner.AR))
-    case "Australia" => Some(-\/(NgoPartner.AU))
-    case "Brazil"    => Some(-\/(NgoPartner.BR))
-    case "Canada"    => Some(-\/(NgoPartner.CA))
-    case "Chile"     => Some(-\/(NgoPartner.CL))
-    case "Korea"     => Some(-\/(NgoPartner.KR))
-    case "USA"       => Some(-\/(NgoPartner.US))
-    case "Japan"     => Some(\/-(ExchangePartner.SUBARU))
-    case _           => None
+    case "Argentina"         => Some(-\/(NgoPartner.AR))
+    case "Australia"         => Some(-\/(NgoPartner.AU))
+    case "Brazil"            => Some(-\/(NgoPartner.BR))
+    case "Canada"            => Some(-\/(NgoPartner.CA))
+    case "Chile"             => Some(-\/(NgoPartner.CL))
+    case "Republic of Korea" => Some(-\/(NgoPartner.KR))
+    case "USA"               => Some(-\/(NgoPartner.US))
+    case "Japan"             => Some(\/-(ExchangePartner.SUBARU))
+    case _                   => None
   }
 }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctCategory.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctCategory.java
@@ -19,7 +19,7 @@ public enum TimeAcctCategory implements Serializable {
         BR("Brazil"),
         CA("Canada"),
         CL("Chile"),
-        KR("Korea"),
+        KR("Republic of Korea"),
         DD("Director's Time"),
         DS("Demo Science"),
         GS("Gemini Staff"),

--- a/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/Affiliate.java
+++ b/bundle/edu.gemini.spModel.core/src/main/java/edu/gemini/spModel/core/Affiliate.java
@@ -9,7 +9,7 @@ public enum Affiliate {
     BRAZIL("Brazil", "BR"),
     CANADA("Canada", "CA"),
     CHILE("Chile", "CL"),
-    KOREA("Korea", "KR"),
+    KOREA("Republic of Korea", "KR"),
     UNITED_KINGDOM("United Kingdom", "UK", false),
     UNITED_STATES("United States", "US"),
 


### PR DESCRIPTION
As per discussions, Korea was changed to Republic of Korea.
This will not affect earlier proposals, as there were previously no Korean institutions available for selection, and setting the affiliate manually to Korea simply wrote `kr` in the proposal XML, which should not be affected by this, especially in light of REL-2930.