### PR TITLE
REL-2930: Fixed FT affiliate overriding

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Meta.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Meta.scala
@@ -11,19 +11,23 @@ object Meta {
   // Lenses
   val attachment:Lens[Meta,Option[File]] = Lens.lensu((a, b) => a.copy(attachment = b), _.attachment)
   val band3OptionChosen:Lens[Meta,Boolean] = Lens.lensu((a, b) => a.copy(band3OptionChosen = b), _.band3OptionChosen)
+  val overrideAffiliate:Lens[Meta,Boolean] = Lens.lensu((a, b) => a.copy(overrideAffiliate = b), _.overrideAffiliate)
 
-  val empty = Meta(None, false)
+  val empty = Meta(None, band3OptionChosen = false, overrideAffiliate = false)
   def apply(m:M.Meta):Meta = Option(m).map(new Meta(_)).getOrElse(empty)
 }
 
-case class Meta(attachment:Option[File], band3OptionChosen:Boolean) {
+case class Meta(attachment:Option[File], band3OptionChosen:Boolean, overrideAffiliate:Boolean) {
 
-  private def this(m:M.Meta) = this(Option(m.getAttachment).map(new File(_)), Option(m.isBand3OptionChosen).exists(_.booleanValue))
+  private def this(m:M.Meta) = this(Option(m.getAttachment).map(new File(_)),
+    Option(m.isBand3OptionChosen).exists(_.booleanValue),
+    Option(m.isOverrideAffiliate).exists(_.booleanValue))
 
   def mutable = {
     val m = Factory.createMeta
     m.setAttachment(attachment.map(_.getPath).orNull)
     m.setBand3OptionChosen(band3OptionChosen)
+    m.setOverrideAffiliate(overrideAffiliate)
     m
   }
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ProposalClass.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ProposalClass.scala
@@ -299,17 +299,15 @@ object LargeProgramClass {
 
 }
 
-case class FastTurnaroundProgramClass(itac                       :Option[Itac],
-                                      comment                    :Option[String],
-                                      key                        :Option[UUID],
-                                      sub                        :FastTurnaroundSubmission,
-                                      band3request               :Option[SubmissionRequest],
-                                      tooOption                  :ToOChoice,
-                                      reviewer                   :Option[Investigator],
-                                      mentor                     :Option[Investigator],
-                                      partnerAffiliation         :FtPartner,
-                                      previousPartnerAffiliation :FtPartner = None) extends ProposalClass {
-
+case class FastTurnaroundProgramClass(itac               : Option[Itac],
+                                      comment            : Option[String],
+                                      key                : Option[UUID],
+                                      sub                : FastTurnaroundSubmission,
+                                      band3request       : Option[SubmissionRequest],
+                                      tooOption          : ToOChoice,
+                                      reviewer           : Option[Investigator],
+                                      mentor             : Option[Investigator],
+                                      partnerAffiliation : FtPartner) extends ProposalClass {
   def mutable(n: Namer):M.FastTurnaroundProgramClass = {
     val m = Factory.createFastTurnaroundProgramClass
     m.setItac(itac.map(_.mutable).orNull)
@@ -354,12 +352,14 @@ object FastTurnaroundProgramClass {
   val reviewer:Lens[FastTurnaroundProgramClass, Option[Investigator]] = Lens.lensu((a, b) => a.copy(reviewer = b), _.reviewer)
   val reviewerAndMentor:Lens[FastTurnaroundProgramClass, (Option[Investigator], Option[Investigator])] = Lens.lensu((a, b) => a.copy(reviewer = b._1, mentor = b._2), f => (f.reviewer, f.mentor))
   val mentor:Lens[FastTurnaroundProgramClass, Option[Investigator]] = Lens.lensu((a, b) => a.copy(mentor = b), _.mentor)
-  val affiliation:Lens[FastTurnaroundProgramClass, FtPartner] = Lens.lensu((a, b) => a.copy(partnerAffiliation = b, previousPartnerAffiliation = a.partnerAffiliation), _.partnerAffiliation)
+  val affiliation:Lens[FastTurnaroundProgramClass, FtPartner] = Lens.lensu((a, b) => a.copy(partnerAffiliation = b), _.partnerAffiliation)
 
-  def affiliation(m: M.FastTurnaroundProgramClass): FtPartner = (Option(m.getPartnerAffiliation), Option(m.getExchangeAffiliation)) match {
-    case (Some(p), _)                      => Some(-\/(p))
-    case (_, Some(ExchangePartner.SUBARU)) => Some(\/-(ExchangePartner.SUBARU))
-    case _                                 => None
+  def affiliation(m: M.FastTurnaroundProgramClass): FtPartner = {
+    (Option(m.getPartnerAffiliation), Option(m.getExchangeAffiliation)) match {
+      case (Some(p), _)                      => Some(-\/(p))
+      case (_, Some(ExchangePartner.SUBARU)) => Some(\/-(ExchangePartner.SUBARU))
+      case _                                 => None
+    }
   }
 
   def apply(m:M.FastTurnaroundProgramClass):FastTurnaroundProgramClass = apply(

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -128,7 +128,13 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
  * This converter will upgrade to 2017A
  */
 case object SemesterConverter2016BTo2017A extends SemesterConverter {
-  override val transformers = Nil
+  // Set overrideAffiliate as true by default. It will automatically set to false if current FT affiliate is undefined
+  // or the same as the PI institution affiliate.
+  val overrideAffiliate:TransformFunction = {
+    case m @ <meta>{ns @ _*}</meta> if (m \ "@overrideAffiliate").isEmpty =>
+      StepResult("Affiliate override flag is missing", <meta overrideAffiliate="true">{ns}</meta>).successNel
+  }
+  override val transformers = List(overrideAffiliate)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -1,5 +1,11 @@
 Gemini Phase I Schema Changes
 
+# Version 2017.1.1 - 2017A
+##########################
+
+* Added an overrideAffiliate flag to Meta to allow discrepancy between PI institution affiliate and chosen affiliate.
+  Set to default "true", as if PI institution affiliate and chosen affiliate are the same, it resets to false.
+
 # Version 2016.2.2 - 2016B
 ##########################
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Meta.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Meta.xsd
@@ -8,6 +8,7 @@
             <xsd:element name="attachment" type="xsd:string"/>
         </xsd:sequence>
         <xsd:attribute name="band3optionChosen" type="xsd:boolean" use="required"/>
+        <xsd:attribute name="overrideAffiliate" type="xsd:boolean" use="required"/>
     </xsd:complexType>
 
 </xsd:schema>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -16,11 +16,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have size 3
+          changes must have size 4
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
 
           val proposal = ProposalIo.read(result.toString())
           proposal.meta.band3OptionChosen must beFalse
+          proposal.meta.overrideAffiliate must beTrue
           proposal.title must beEqualTo("Observation with GSAOI")
           proposal.abstrakt must beEmpty
           proposal.scheduling must beEmpty
@@ -46,7 +47,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
         case ConversionResult(transformed, from, changes, root) =>
           transformed must beTrue
           from must beEqualTo(Semester(2014, SemesterOption.A))
-          changes must have length 3
+          changes must have length 4
       }
 
     }
@@ -55,13 +56,14 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have size 3
+          changes must have size 4
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2013A to view the unmodified proposal")
 
           val proposal = ProposalIo.read(result.toString())
           proposal.meta.band3OptionChosen must beFalse
+          proposal.meta.overrideAffiliate must beTrue
           proposal.title must beEqualTo("Observation with GSAOI")
           proposal.abstrakt must beEmpty
           proposal.scheduling must beEmpty
@@ -87,7 +89,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
         case ConversionResult(transformed, from, changes, root) =>
           transformed must beTrue
           from must beEqualTo(Semester(2013, SemesterOption.A))
-          changes must have length 3
+          changes must have length 4
       }
 
     }
@@ -96,7 +98,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have size 3
+          changes must have size 4
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2013A to view the unmodified proposal")
@@ -105,6 +107,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
 
           // Sanity checks
           proposal.meta.band3OptionChosen must beFalse
+          proposal.meta.overrideAffiliate must beTrue
           proposal.title must beEqualTo("Observation with GSAOI")
           proposal.abstrakt must beEmpty
           proposal.scheduling must beEmpty
@@ -135,11 +138,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
           changes must contain("Band3 Option is missing, set as false")
+          changes must contain("Affiliate override flag is missing")
 
           (result \\ "meta") must ==/(<meta band3optionChosen="false">
             <attachment>file.pdf</attachment>
@@ -154,7 +158,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
         case ConversionResult(transformed, from, changes, root) =>
           transformed must beTrue
           from must beEqualTo(Semester(2012, SemesterOption.B))
-          changes must have length 4
+          changes must have length 5
       }
     }
     "Renamed Keyword 'Herbig-Haro stars' to 'Herbig-Haro objects' on 1.0.0" in {
@@ -162,11 +166,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
           changes must contain("Band3 Option is missing, set as false")
+          changes must contain("Affiliate override flag is missing")
           changes must contain("Keyword 'Herbig-Haro stars' renamed to 'Herbig-Haro objects'")
 
           (result \\ "keywords") must ==/(<keywords>
@@ -238,11 +243,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
           changes must contain("Band3 Option is missing, set as false")
+          changes must contain("Affiliate override flag is missing")
           changes must contain("NGO acceptance from the United Kingdom has been removed")
 
           // Sanity check
@@ -261,11 +267,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
           changes must contain("Band3 Option is missing, set as false")
+          changes must contain("Affiliate override flag is missing")
           changes must contain("NGO acceptance from the United Kingdom has been removed")
 
           // Sanity check
@@ -285,11 +292,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
           changes must contain("Band3 Option is missing, set as false")
+          changes must contain("Affiliate override flag is missing")
           changes must contain("NGO acceptance from the United Kingdom has been removed")
           changes must contain("The United Kingdom was marked as ITAC NGO authority and has been removed")
 
@@ -397,7 +405,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain("The original proposal contained T-ReCS observations. The instrument is not available and those resources have been removed.")
           // The texes blueprint must remain
           result must \\("gmosN")
@@ -409,7 +417,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain("The original proposal contained Michelle observations. The instrument is not available and those resources have been removed.")
           // The texes blueprint must remain
           result must \\("gmosN")
@@ -421,7 +429,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain("The original proposal contained NICI observations. The instrument is not available and those resources have been removed.")
           // The texes blueprint must remain
           result must \\("gmosN")
@@ -433,7 +441,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           // The texes blueprint must remain
           result must \\("Texes")
       }
@@ -444,7 +452,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           changes must contain("Dssi proposal has been assigned to Gemini North.")
           // The dssi blueprint must remain and include a site
           result must \\("Dssi", "id")
@@ -458,7 +466,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           changes must contain("Phoenix proposal has been assigned to Gemini South.")
           // The phoenix blueprint must remain and include a site
           result must \\("Phoenix", "id")
@@ -472,7 +480,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           changes must contain("Texes proposal has been assigned to Gemini North.")
           // The texes blueprint must remain and include a site
           result must \\("Texes", "id")
@@ -486,7 +494,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain("The unavailable GMOS-N 0.25\" slit has been converted to the 0.5\" slit.")
           // Check that fpu and name are replaced
           result must \\("fpu") \> "0.5 arcsec slit"
@@ -501,7 +509,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain("A default 1\" slit has been added to the GMOS-S MOS observation.")
           changes must contain("A default 1\" slit has been added to the GMOS-N MOS observation.")
           changes must contain(s"Please use the PIT from semester 2013B to view the unmodified proposal")
@@ -519,7 +527,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain("GNIRS observation doesn't have a central wavelength range, assigning to '< 2.5um'")
           // Check that the centralWavelength node is added
           result must \\("centralWavelength") \> "< 2.5um"
@@ -534,7 +542,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain("The unavailable Flamingos2 filters F1056 (1.056 um)/F1063 (1.063 um) have been converted to Y (1.020 um).")
           // Check that the centralWavelength node is added
           result \\ "flamingos2" must \\("filter") \> "Y (1.020 um)"
@@ -559,7 +567,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           changes must contain("The Flamingos2 filter K-long (2.00 um) has been converted to K-long (2.20 um).")
           // Check that the filter node is added and the name updated
           result \\ "flamingos2" must \\("filter") \> "K-long (2.20 um)"
@@ -574,7 +582,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           changes must contain("GMOS-N observations without an Altair setting have had Adaptive Optics set to None.")
           // Check that fpu and name are replaced
           result must \\("fpu") \> "0.5 arcsec slit"
@@ -590,7 +598,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           // Check that fpu and name are replaced
           result must \\("name") \>~ ".*None.*"
       }
@@ -601,7 +609,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           // Check that fpu and name are replaced
           result must \\("name") \> "GMOS-N LongSlit None B1200 GG455 (> 460 nm) 0.5 arcsec slit"
       }
@@ -612,7 +620,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           // Check that fpu and name are replaced
           result must \\("name") \> "GMOS-N LongSlit N+S None B1200 GG455 (> 460 nm) 0.5 arcsec slit"
       }
@@ -623,7 +631,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           // Check that fpu and name are replaced
           result must \\("name") \> "GMOS-N MOS None 0.75 arcsec slit R400 RG610 (> 615 nm) +Pre"
       }
@@ -634,7 +642,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           // Check that fpu and name are replaced
           result must \\("name") \> "GMOS-N MOS N+S None 1.0 arcsec slit B600 g + GG455 (506 nm) "
       }
@@ -645,7 +653,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           // Check that fpu and name are replaced
           result must \\("name") \> "GMOS-N IFU None B600 i + CaT (815 nm) IFU 1 slit"
       }
@@ -655,7 +663,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2014B to view the unmodified proposal")
@@ -678,7 +686,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           result \\ "graces" must \\("fiberMode") \> "2 fibers (target+sky, R~40k)"
           result \\ "graces" must \\("name") \> "Graces 2 fibers (target+sky, R~40k)"
           result \\ "graces" must \\("fiberMode") \> "1 fiber (target only, R~67.5k)"
@@ -691,7 +699,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           result \\ "niri" must \\("filter") \> "HeI (1.083 um)"
           result \\ "niri" must not(\\("filter") \> "J-continuum (1.122 um)")
           result \\ "niri" must not(\\("filter") \> "Jcont (1.065 um)")
@@ -704,7 +712,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
           result \\ "gpi" must \\("observingMode") \>~ "H.direct"
           result \\ "gpi" must \\("name") \> "GPI H direct Prism"
       }
@@ -715,7 +723,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
     val converted = UpConverter.convert(xml)
     converted must beSuccessful.like {
       case StepResult(changes, result) =>
-        changes must have length 5
+        changes must have length 6
         changes must contain("The unavailable Flamingos2 configuration R3K + Y has been converted to R3K + J-lo.")
         // Check that the centralWavelength node is added
         result \\ "flamingos2" must \\("filter") \> "J-lo (1.122 um)"

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
@@ -1,6 +1,6 @@
 package edu.gemini.pit.ui.editor
 
-import edu.gemini.model.p1.immutable.{ExchangePartner, NgoPartner}
+import edu.gemini.model.p1.immutable.{ExchangePartner, InstitutionAddress, NgoPartner}
 import edu.gemini.model.p1.immutable.Partners.FtPartner
 
 import scalaz.{-\/, \/-}
@@ -47,13 +47,14 @@ object Institutions {
     case _      => None
   }
 
-  def institution2Ngo(institution: String, country: String): FtPartner = {
+  def institution2Ngo(address: InstitutionAddress): FtPartner = {
     val geminiRegex = "Gemini.Observatory.*".r
-    institution match {
+    address.institution match {
       case geminiRegex() => Some(-\/(NgoPartner.US)) // Gemini Staff always go as US
-      case _             => country2Ngo(country)
+      case _             => country2Ngo(address.country)
     }
   }
+
   def country2Ngo(country: String): FtPartner = country match {
     case "Argentina"         => Some(-\/(NgoPartner.AR))
     case "Australia"         => Some(-\/(NgoPartner.AU))

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -552,7 +552,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     }
 
     private lazy val ftReviewerOrMentor = for {
-        f @ FastTurnaroundProgramClass(_, _, _, _, _, _, r, m, _, _) <- Some(p.proposalClass)
+        f @ FastTurnaroundProgramClass(_, _, _, _, _, _, r, m, _) <- Some(p.proposalClass)
         if r.isEmpty || (~r.map(_.status != InvestigatorStatus.PH_D) && m.isEmpty)
       } yield new Problem(Severity.Error,
             "A Fast Turnaround program must select a reviewer or a mentor with PhD degree.", TimeProblems.SCHEDULING_SECTION, {
@@ -560,10 +560,10 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
             })
 
     private lazy val ftAffiliationMismatch = for {
-        pi                                                                      <- Option(p.investigators.pi)
-        piNgo                                                                   <- Option(Institutions.institution2Ngo(pi.address.institution, pi.address.country))
-        f @ FastTurnaroundProgramClass(_, _, _, _, _, _, _, _, affiliateNgo, _) <- Option(p.proposalClass)
-        samePartner                                                             <- (affiliateNgo |@| piNgo){_ === _}
+        pi                                                                   <- Option(p.investigators.pi)
+        piNgo                                                                <- Option(Institutions.institution2Ngo(pi.address))
+        f @ FastTurnaroundProgramClass(_, _, _, _, _, _, _, _, affiliateNgo) <- Option(p.proposalClass)
+        samePartner                                                          <- (affiliateNgo |@| piNgo){_ === _}
         if !samePartner // Show a warning if the PI's institution partner isn't the same as the partner affiliation
       } yield new Problem(Severity.Info,
             s"The Fast Turnaround affiliation country: '${~Partners.nameOfFTPartner(affiliateNgo)}' is different from the PI's country: '${~Partners.nameOfFTPartner(piNgo)}'.", TimeProblems.SCHEDULING_SECTION, {


### PR DESCRIPTION
In previous versions of the PIT, when an institution for the PI is selected, the address is used for FT programs to determine the affiliate.

This can be overridden, in which case, the affiliate should be set to the chosen affiliate in the combobox in `PartnerView`; however, this code was broken, and even if a new affiliate was chosen, when a proposal was saved to XML (which did contain the proper affiliate code in the XML) and then reloaded, the affiliate combo box defaulted to the affiliate of the PI's institution.

There was an attempt to work around this by using a `previousPartnerAffiliation` with the FT program class, but the code to use this was broken in `PartnerView`, and the value was not persistent, so the information was lost when the proposal was saved and then later re-opened.

This fixes that by introducing a simple `overrideAffiliate` flag that does persist. It functions as follows:

1. If set to `true`, it assumes that the current affiliate has been overridden from the PI institution affiliate, in which case:
a. If the current affiliate is different from any new PI institution affiliate, the current affiliate is maintained as the override; or
b. If the current affiliate is the same as the new PI institution affiliate, the override is considered terminated.
Thus, by default, `overrideAffiliate` is set to `true` as this is the desired behaviour since the `PartnerView` initializer will properly maintain this, which would be extremely difficult to do from the `UpConverter`.

2. If set to `false`, it assumes that the current affiliate has not been manually overridden from the PI institution affiliate. Thus, changes to the PI institution affiliate are made to the current affiliate.