### PR TITLE
REL-2907: Affiliate for FT can now be specified independently from country

### DIFF
--- a/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
+++ b/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
@@ -600,6 +600,7 @@
         <address>HI</address>
         <address>96743</address>
         <country>USA</country>
+        <affiliate>Canada</affiliate>
         <contact>
             <phone>808-885-7944</phone>
             <phone>808-885-7288</phone>
@@ -2093,7 +2094,7 @@
         </contact>
     </site>
     <site>
-        <institution>Carnegie Institution of Washington (Headquartes)</institution>
+        <institution>Carnegie Institution of Washington (Headquarters)</institution>
         <address>Carnegie Observatories</address>
         <address>Headquarters</address>
         <address>813 Santa Barbara Street</address>
@@ -2114,6 +2115,7 @@
         <address>Casilla 601</address>
         <address>La Serena</address>
         <country>Chile</country>
+        <affiliate>USA</affiliate>
         <contact>
             <phone>+56-51-213032</phone>
             <email>user@ociw.edu</email>
@@ -2166,6 +2168,7 @@
         <address>Casilla 603</address>
         <address>La Serena</address>
         <country>Chile</country>
+        <affiliate>USA</affiliate>
         <contact>
             <phone>56-51-225-415</phone>
             <fax>56-51-205-212</fax>
@@ -3588,6 +3591,7 @@
         <address>Colina El Pino s/n</address>
         <address>La Serena</address>
         <country>Chile</country>
+        <affiliate>USA</affiliate>
         <contact>
             <phone>011-5651-205-600</phone>
             <fax>011-5651-205-650</fax>

--- a/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
+++ b/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
@@ -836,7 +836,7 @@
         <address>Department of Astronomy</address>
         <address>London</address>
         <address>Ontario</address>
-        <address>N6A  3K7</address>
+        <address>N6A 3K7</address>
         <country>Canada</country>
         <contact>
             <phone>519-661-3183</phone>
@@ -1003,6 +1003,7 @@
         <address>Alonso de Cordova 3107</address>
         <address>Vitacura, Santiago 7630355</address>
         <country>Chile</country>
+        <affiliate>Japan</affiliate>
     </site>
     <site>
         <institution>Mizusawa VLBI Observatory (NAOJ)</institution>
@@ -2015,7 +2016,7 @@
         </contact>
     </site>
     <site>
-        <institution>Caltech (Physics, Maths  and Astronomy)</institution>
+        <institution>Caltech (Physics, Maths and Astronomy)</institution>
         <address>Division of Physics, Mathematics and Astronomy</address>
         <address>MS 103-33</address>
         <address>Pasadena</address>
@@ -2094,7 +2095,7 @@
         </contact>
     </site>
     <site>
-        <institution>Carnegie Institution of Washington (Headquarters)</institution>
+        <institution>Carnegie Institution for Science (Observatories)</institution>
         <address>Carnegie Observatories</address>
         <address>Headquarters</address>
         <address>813 Santa Barbara Street</address>
@@ -2109,7 +2110,7 @@
         </contact>
     </site>
     <site>
-        <institution>Carnegie Institution of Washington (Carnegie Obs.)</institution>
+        <institution>Carnegie Institution for Science (Las Campanas)</institution>
         <address>Carnegie Observatories</address>
         <address>Las Campanas Observatory</address>
         <address>Casilla 601</address>
@@ -2122,7 +2123,7 @@
         </contact>
     </site>
     <site>
-        <institution>Carnegie Institution of Washington (Terrestrial Magn.)</institution>
+        <institution>Carnegie Institution for Science (Terrestrial Magn.)</institution>
         <address>Department of Terrestrial Magnetism</address>
         <address>5241 Broad Branch Road, NW</address>
         <address>Washington</address>
@@ -2507,6 +2508,7 @@
         <address>HI</address>
         <address>96822</address>
         <country>USA</country>
+        <affiliate>University of Hawaii</affiliate>
         <contact>
             <phone>808-956-8312</phone>
             <phone>808-988-2790</phone>
@@ -3605,6 +3607,7 @@
         <address>HI</address>
         <address>96720</address>
         <country>USA</country>
+        <affiliate>Japan</affiliate>
         <contact>
             <phone>808-934-7788</phone>
             <fax>808-934-5099</fax>

--- a/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
+++ b/bundle/edu.gemini.pit/src/main/resources/edu/gemini/pit/ui/editor/institutions.xml
@@ -1,274 +1,274 @@
 <institutions>
     <site>
-       <institution>Instituto de Astronomia y Fisica del Espacio (IAFE)</institution>
-       <address>Casilla de Correos 67</address>
-       <address>Sucursal 28</address>
-       <address>1428 Buenos Aires</address>
-       <country>Argentina</country>
-       <contact>
-          <phone>+54-1-783-2642</phone>
-          <fax>+54-1-786-8114</fax>
-          <email>user@iafe.uba.ar</email>
-       </contact>
+        <institution>Instituto de Astronomia y Fisica del Espacio (IAFE)</institution>
+        <address>Casilla de Correos 67</address>
+        <address>Sucursal 28</address>
+        <address>1428 Buenos Aires</address>
+        <country>Argentina</country>
+        <contact>
+            <phone>+54-1-783-2642</phone>
+            <fax>+54-1-786-8114</fax>
+            <email>user@iafe.uba.ar</email>
+        </contact>
     </site>
     <site>
-       <institution>Centro Regional de Investigaciones (CRICYT)</institution>
-       <address>Casilla de Correo 131</address>
-       <address>5500 Mendoza</address>
-       <country>Argentina</country>
-       <contact>
-          <phone>+54-61-288314</phone>
-          <fax>+54-61-287370</fax>
-          <email>user@criba.edu.ar</email>
-       </contact>
+        <institution>Centro Regional de Investigaciones (CRICYT)</institution>
+        <address>Casilla de Correo 131</address>
+        <address>5500 Mendoza</address>
+        <country>Argentina</country>
+        <contact>
+            <phone>+54-61-288314</phone>
+            <fax>+54-61-287370</fax>
+            <email>user@criba.edu.ar</email>
+        </contact>
     </site>
     <site>
-       <institution>Complejo Astronomico El Leoncito (CASLEO)</institution>
-       <address>Casillo de Correo 467</address>
-       <address>Santa Fe 198 oeste</address>
-       <address>5400 San Juan</address>
-       <country>Argentina</country>
-       <contact>
-          <phone>+54-64-213653</phone>
-          <email>user@castec.edu.ar</email>
-       </contact>
+        <institution>Complejo Astronomico El Leoncito (CASLEO)</institution>
+        <address>Casillo de Correo 467</address>
+        <address>Santa Fe 198 oeste</address>
+        <address>5400 San Juan</address>
+        <country>Argentina</country>
+        <contact>
+            <phone>+54-64-213653</phone>
+            <email>user@castec.edu.ar</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidad Nacional de Cordoba (Facultad)</institution>
-       <address>Facultad de Mathematica, Astronomia y Fisica</address>
-       <address>Valparaiso y R. Martinez</address>
-       <address>Cuidad Universitaria</address>
-       <address>5000 Cordoba</address>
-       <country>Argentina</country>
-       <contact>
-          <email>user@famaf.edu.ar</email>
-       </contact>
+        <institution>Universidad Nacional de Cordoba (Facultad)</institution>
+        <address>Facultad de Mathematica, Astronomia y Fisica</address>
+        <address>Valparaiso y R. Martinez</address>
+        <address>Cuidad Universitaria</address>
+        <address>5000 Cordoba</address>
+        <country>Argentina</country>
+        <contact>
+            <email>user@famaf.edu.ar</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidad Nacional de Cordoba (Observatorio)</institution>
-       <address>Observatorio Astronomica</address>
-       <address>Laprida 854</address>
-       <address>5000 Cordoba</address>
-       <country>Argentina</country>
-       <contact>
-          <phone>+54-51-33-1064</phone>
-          <fax>+54-51-33-1063</fax>
-          <email>user@oac.uncor.edu</email>
-       </contact>
+        <institution>Universidad Nacional de Cordoba (Observatorio)</institution>
+        <address>Observatorio Astronomica</address>
+        <address>Laprida 854</address>
+        <address>5000 Cordoba</address>
+        <country>Argentina</country>
+        <contact>
+            <phone>+54-51-33-1064</phone>
+            <fax>+54-51-33-1063</fax>
+            <email>user@oac.uncor.edu</email>
+        </contact>
     </site>
     <site>
-       <institution>Observatorio Astronomico de La Plata</institution>
-       <address>Paseo del Bosque</address>
-       <address>1900 La Plata</address>
-       <address>Prov. de Buenos Aires</address>
-       <country>Argentina</country>
-       <contact>
-          <phone>+54-21-21-7308</phone>
-          <fax>+54-21-21-1761</fax>
-          <email>user@fcaglp.edu.ar</email>
-       </contact>
+        <institution>Observatorio Astronomico de La Plata</institution>
+        <address>Paseo del Bosque</address>
+        <address>1900 La Plata</address>
+        <address>Prov. de Buenos Aires</address>
+        <country>Argentina</country>
+        <contact>
+            <phone>+54-21-21-7308</phone>
+            <fax>+54-21-21-1761</fax>
+            <email>user@fcaglp.edu.ar</email>
+        </contact>
     </site>
     <site>
-       <institution>Observatorio Astronomico "F. Aguilar"</institution>
-       <address>Av. Benavidez 8175 Oeste</address>
-       <address>Chimbas</address>
-       <address>5413 San Juan</address>
-       <country>Argentina</country>
-       <contact>
-          <phone>+54-231494/67</phone>
-       </contact>
+        <institution>Observatorio Astronomico "F. Aguilar"</institution>
+        <address>Av. Benavidez 8175 Oeste</address>
+        <address>Chimbas</address>
+        <address>5413 San Juan</address>
+        <country>Argentina</country>
+        <contact>
+            <phone>+54-231494/67</phone>
+        </contact>
     </site>
     <site>
-       <institution>Instituto Argentino de Radioastronomia (IAR)</institution>
-       <address>Casilla de Correo No. 5</address>
-       <address>1894 Villa, Elisa-La Plata</address>
-       <address>Pcia. de Buenas Aires</address>
-       <country>Argentina</country>
-       <contact>
-          <phone>+54-21-25-4909/-87-0230</phone>
-          <fax>+54-21-78-68114</fax>
-          <email>user@irma.edu.ar</email>
-       </contact>
+        <institution>Instituto Argentino de Radioastronomia (IAR)</institution>
+        <address>Casilla de Correo No. 5</address>
+        <address>1894 Villa, Elisa-La Plata</address>
+        <address>Pcia. de Buenas Aires</address>
+        <country>Argentina</country>
+        <contact>
+            <phone>+54-21-25-4909/-87-0230</phone>
+            <fax>+54-21-78-68114</fax>
+            <email>user@irma.edu.ar</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Adelaide</institution>
-       <address>Department of Physics and Mathematical Physics</address>
-       <address>Adelaide</address>
-       <address>SA 5005</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-8-8303-4748</phone>
-          <fax>+61-8-8303-4380</fax>
-          <email>user@physics.adelaide.edu.au</email>
-       </contact>
+        <institution>University of Adelaide</institution>
+        <address>Department of Physics and Mathematical Physics</address>
+        <address>Adelaide</address>
+        <address>SA 5005</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-8-8303-4748</phone>
+            <fax>+61-8-8303-4380</fax>
+            <email>user@physics.adelaide.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>Australia Telescope National Facility (ATNF)</institution>
-       <address>P.O. Box 76</address>
-       <address>Epping</address>
-       <address>NSW 2121</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-2-9372-4100</phone>
-          <fax>+61-2-9372-4310</fax>
-          <email>user@atnf.csiro.au</email>
-       </contact>
+        <institution>Australia Telescope National Facility (ATNF)</institution>
+        <address>P.O. Box 76</address>
+        <address>Epping</address>
+        <address>NSW 2121</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-2-9372-4100</phone>
+            <fax>+61-2-9372-4310</fax>
+            <email>user@atnf.csiro.au</email>
+        </contact>
     </site>
     <site>
-       <institution>ATNF Mopra</institution>
-       <address>Coonabarabran</address>
-       <address>NSW 2357</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-68-49-1800</phone>
-          <fax>+61-68-49-1888</fax>
-          <email>user@atnf.csiro.au</email>
-       </contact>
+        <institution>ATNF Mopra</institution>
+        <address>Coonabarabran</address>
+        <address>NSW 2357</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-68-49-1800</phone>
+            <fax>+61-68-49-1888</fax>
+            <email>user@atnf.csiro.au</email>
+        </contact>
     </site>
     <site>
-       <institution>ATNF Parkes Radio Observatory</institution>
-       <address>Parkes</address>
-       <address>NSW 2870</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-68-61-1700</phone>
-          <fax>+61-68-61-1730</fax>
-          <email>user@atnf.csiro.au</email>
-       </contact>
+        <institution>ATNF Parkes Radio Observatory</institution>
+        <address>Parkes</address>
+        <address>NSW 2870</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-68-61-1700</phone>
+            <fax>+61-68-61-1730</fax>
+            <email>user@atnf.csiro.au</email>
+        </contact>
     </site>
     <site>
-       <institution>ATNF Paul Wild Observatory</institution>
-       <address>Narrabri</address>
-       <address>NSW 2390</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-67-90-4000</phone>
-          <fax>+61-68-61-1730</fax>
-          <email>user@atnf.csiro.au</email>
-       </contact>
+        <institution>ATNF Paul Wild Observatory</institution>
+        <address>Narrabri</address>
+        <address>NSW 2390</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-67-90-4000</phone>
+            <fax>+61-68-61-1730</fax>
+            <email>user@atnf.csiro.au</email>
+        </contact>
     </site>
     <site>
-       <institution>Australian Astronomical Observatory</institution>
-       <address>P.O. Box 915</address>
-       <address>North Ryde</address>
-       <address>NSW 1670</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-2-372-4800</phone>
-          <fax>+61-2-372-4880</fax>
-          <email>user@aaoepp.aao.gov.au</email>
-       </contact>
+        <institution>Australian Astronomical Observatory</institution>
+        <address>P.O. Box 915</address>
+        <address>North Ryde</address>
+        <address>NSW 1670</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-2-372-4800</phone>
+            <fax>+61-2-372-4880</fax>
+            <email>user@aaoepp.aao.gov.au</email>
+        </contact>
     </site>
     <site>
-       <institution>Australian National University</institution>
-       <address>Research School of Astronomy &amp; Astrophysics</address>
-       <address>Mount Stromlo Observatory</address>
-       <address>Cotter Road</address>
-       <address>Weston Creek</address>
-       <address>ACT 2611</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-2-6249-0230</phone>
-          <fax>+61-2-6249-0233</fax>
-          <email>user@mso.anu.edu.au</email>
-       </contact>
+        <institution>Australian National University</institution>
+        <address>Research School of Astronomy &amp; Astrophysics</address>
+        <address>Mount Stromlo Observatory</address>
+        <address>Cotter Road</address>
+        <address>Weston Creek</address>
+        <address>ACT 2611</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-2-6249-0230</phone>
+            <fax>+61-2-6249-0233</fax>
+            <email>user@mso.anu.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>Macquarie University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>NSW 2109</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-2-9850-6000</phone>
-          <fax>+61-2-9850-8115</fax>
-          <email>user@mq.edu.au</email>
-       </contact>
+        <institution>Macquarie University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>NSW 2109</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-2-9850-6000</phone>
+            <fax>+61-2-9850-8115</fax>
+            <email>user@mq.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Melbourne</institution>
-       <address>Department of Physics</address>
-       <address>Parkville</address>
-       <address>Victoria 3052</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-3-9344-7670</phone>
-          <fax>+61-3-9347-4783</fax>
-          <email>user@physics.unimelb.edu.au</email>
-       </contact>
+        <institution>University of Melbourne</institution>
+        <address>Department of Physics</address>
+        <address>Parkville</address>
+        <address>Victoria 3052</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-3-9344-7670</phone>
+            <fax>+61-3-9347-4783</fax>
+            <email>user@physics.unimelb.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>Monash University</institution>
-       <address>Department of Mathematics</address>
-       <address>Clayton</address>
-       <address>Victoria 3168</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-3-9905-4431</phone>
-          <fax>+61-3-9905-3867</fax>
-          <email>user@maths.monash.edu.au</email>
-       </contact>
+        <institution>Monash University</institution>
+        <address>Department of Mathematics</address>
+        <address>Clayton</address>
+        <address>Victoria 3168</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-3-9905-4431</phone>
+            <fax>+61-3-9905-3867</fax>
+            <email>user@maths.monash.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>University of New South Wales</institution>
-       <address>Department of Astrophysics</address>
-       <address>School of Physics</address>
-       <address>Sydney</address>
-       <address>New South Wales 2052</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-2-385-xxxx</phone>
-          <fax>+61-2-385-6060</fax>
-          <email>user@phys.unsw.edu.au</email>
-       </contact>
+        <institution>University of New South Wales</institution>
+        <address>Department of Astrophysics</address>
+        <address>School of Physics</address>
+        <address>Sydney</address>
+        <address>New South Wales 2052</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-2-385-xxxx</phone>
+            <fax>+61-2-385-6060</fax>
+            <email>user@phys.unsw.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Queensland</institution>
-       <address>Astrophysics Department</address>
-       <address>Saint Lucia</address>
-       <address>Brisbane</address>
-       <address>QLD 4072</address>
-       <country>Australia</country>
-       <contact>
-          <email>user@physics.uq.edu.au</email>
-       </contact>
+        <institution>University of Queensland</institution>
+        <address>Astrophysics Department</address>
+        <address>Saint Lucia</address>
+        <address>Brisbane</address>
+        <address>QLD 4072</address>
+        <country>Australia</country>
+        <contact>
+            <email>user@physics.uq.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Sydney</institution>
-       <address>Sydney Institute for Astronomy</address>
-       <address>School of Physics A28</address>
-       <address>NSW 2006</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-2-9351-2537</phone>
-          <fax>+61-2-9351-7726</fax>
-          <email>user@physics.usyd.edu.au</email>
-       </contact>
+        <institution>University of Sydney</institution>
+        <address>Sydney Institute for Astronomy</address>
+        <address>School of Physics A28</address>
+        <address>NSW 2006</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-2-9351-2537</phone>
+            <fax>+61-2-9351-7726</fax>
+            <email>user@physics.usyd.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Sydney (RCfTA)</institution>
-       <address>Research Centre for Theoretical Astrophysics</address>
-       <address>School of Physics, A28</address>
-       <address>Sydney</address>
-       <address>New South Wales 2006</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-2-9351-2542</phone>
-          <fax>+61-2-9351-7726</fax>
-          <email>user@physics.usyd.edu.au</email>
-       </contact>
+        <institution>University of Sydney (RCfTA)</institution>
+        <address>Research Centre for Theoretical Astrophysics</address>
+        <address>School of Physics, A28</address>
+        <address>Sydney</address>
+        <address>New South Wales 2006</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-2-9351-2542</phone>
+            <fax>+61-2-9351-7726</fax>
+            <email>user@physics.usyd.edu.au</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Tasmania</institution>
-       <address>School of Mathematics &amp; Physics</address>
-       <address>Private Bag 21</address>
-       <address>Hobart</address>
-       <address>TAS 7001</address>
-       <country>Australia</country>
-       <contact>
-          <phone>+61-002-20-2401</phone>
-          <fax>+61-002-20-2410</fax>
-          <email>user@utas.edu.au</email>
-       </contact>
+        <institution>University of Tasmania</institution>
+        <address>School of Mathematics &amp; Physics</address>
+        <address>Private Bag 21</address>
+        <address>Hobart</address>
+        <address>TAS 7001</address>
+        <country>Australia</country>
+        <contact>
+            <phone>+61-002-20-2401</phone>
+            <fax>+61-002-20-2410</fax>
+            <email>user@utas.edu.au</email>
+        </contact>
     </site>
     <site>
         <institution>Curtin University</institution>
@@ -298,564 +298,564 @@
         <country>Australia</country>
     </site>
     <site>
-       <institution>Centro de Radio-Astronomia e Apl. Espacias (EPUSP)</institution>
-       <address>CRAAE/EPUSP</address>
-       <address>C.P. 61548</address>
-       <address>05424-970 Sao Paulo SP</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-11-815-6289</phone>
-          <fax>+55-11-815-6289</fax>
-          <email>user@usp.br</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Centro de Radio-Astronomia e Apl. Espacias (NUCATE)</institution>
-       <address>CRAAE-NUCATE/UNICAMP</address>
-       <address>Cidade Universitaria</address>
-       <address>B. Geraldo</address>
-       <address>13083-592 Campinas SP</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-19-239-3125</phone>
-          <fax>+55-19-239-3125</fax>
-          <email>user@nucate.unicamp.br</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Universidade Federal do Espirito Santo (UFES)</institution>
-       <address>Observatorio Astronomico</address>
-       <address>Departamento de Fisica - CCE</address>
-       <address>Av. Fernando Ferrari, 514</address>
-       <address>Campus de Goiabeiras</address>
-       <address>29075-910 - Vitoria - ES</address>
-       <country>Brazil</country>
-       <contact>
-         <phone>+55-21-27-335-2484</phone>
-         <email>user@cce.ufes.br</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Instituto Nacional de Pesquisas Espaciais (INPE)</institution>
-       <address>Divisao de Astrofisica</address>
-       <address>Av. dos Astronautas, 1758 - Jardim da Granja</address>
-       <address>12227-010 - Sao Jose dos Campos - SP</address>
+        <institution>Centro de Radio-Astronomia e Apl. Espacias (EPUSP)</institution>
+        <address>CRAAE/EPUSP</address>
+        <address>C.P. 61548</address>
+        <address>05424-970 Sao Paulo SP</address>
         <country>Brazil</country>
-       <contact>
-          <phone>+55-21-12-341-8977</phone>
-          <fax>+55-21-12-321-8743</fax>
-          <email>user@inpe.br</email>
-       </contact>
+        <contact>
+            <phone>+55-11-815-6289</phone>
+            <fax>+55-11-815-6289</fax>
+            <email>user@usp.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Laboratorio Nacional de Astrofisica (LNA/MCT)</institution>
-       <address>Rua Estados Unidos, 154 - Bairro das Nacoes</address>
-       <address>37504-364 - Itajuba - MG</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-21-35-623-1500</phone>
-          <fax>+55-21-35-623-2535</fax>
-          <email>user@lna.br</email>
-       </contact>
+        <institution>Centro de Radio-Astronomia e Apl. Espacias (NUCATE)</institution>
+        <address>CRAAE-NUCATE/UNICAMP</address>
+        <address>Cidade Universitaria</address>
+        <address>B. Geraldo</address>
+        <address>13083-592 Campinas SP</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-19-239-3125</phone>
+            <fax>+55-19-239-3125</fax>
+            <email>user@nucate.unicamp.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Federal de Minas Gerais (UFMG)</institution>
-       <address>Departamento de Fisica - ICEX</address>
-       <address>Campus da Pampulha</address>
-       <address>Av. Antonio Carlos, 6627</address>
-       <address>31270-901 - Belo Horizonte - MG</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-21-31-441-2541</phone>
-          <fax>+55-21-31-448-1372</fax>
-          <email>user@fisica.ufmg.br</email>
-       </contact>
+        <institution>Universidade Federal do Espirito Santo (UFES)</institution>
+        <address>Observatorio Astronomico</address>
+        <address>Departamento de Fisica - CCE</address>
+        <address>Av. Fernando Ferrari, 514</address>
+        <address>Campus de Goiabeiras</address>
+        <address>29075-910 - Vitoria - ES</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-27-335-2484</phone>
+            <email>user@cce.ufes.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Observatorio Nacional (ON/MCT)</institution>
-       <address>Rua General Jose Cristino, 77 - Sao Cristovao</address>
-       <address>20921-400 - Rio de Janeiro - RJ</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-21-585-3215</phone>
-          <fax>+55-21-580-6041</fax>
-          <email>user@on.br</email>
-       </contact>
+        <institution>Instituto Nacional de Pesquisas Espaciais (INPE)</institution>
+        <address>Divisao de Astrofisica</address>
+        <address>Av. dos Astronautas, 1758 - Jardim da Granja</address>
+        <address>12227-010 - Sao Jose dos Campos - SP</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-12-341-8977</phone>
+            <fax>+55-21-12-321-8743</fax>
+            <email>user@inpe.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Federal do Rio de Janeiro (UFRJ)</institution>
-       <address>Observatorio do Valongo</address>
-       <address>Ladeira do Pedro Antonio, 43 - Saude</address>
-       <address>20080-090 - Rio de Janeiro - RJ</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-21-263-0685</phone>
-          <fax>+55-21-263-0685</fax>
-          <email>user@ov.ufrg.br</email>
-       </contact>
+        <institution>Laboratorio Nacional de Astrofisica (LNA/MCT)</institution>
+        <address>Rua Estados Unidos, 154 - Bairro das Nacoes</address>
+        <address>37504-364 - Itajuba - MG</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-35-623-1500</phone>
+            <fax>+55-21-35-623-2535</fax>
+            <email>user@lna.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Federal do Rio Grande do Norte (UFRN)</institution>
-       <address>Departamento de Fisica Teorica e Experimental - CCET</address>
-       <address>Campus Universitario</address>
-       <address>59072-970 - Natal - RN</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-21-84-215-3800</phone>
-          <fax>+55-21-84-215-3791</fax>
-          <email>user@dfte.ufrn.br</email>
-       </contact>
+        <institution>Universidade Federal de Minas Gerais (UFMG)</institution>
+        <address>Departamento de Fisica - ICEX</address>
+        <address>Campus da Pampulha</address>
+        <address>Av. Antonio Carlos, 6627</address>
+        <address>31270-901 - Belo Horizonte - MG</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-31-441-2541</phone>
+            <fax>+55-21-31-448-1372</fax>
+            <email>user@fisica.ufmg.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Federal do Rio Grande do Sul (UFRGS)</institution>
-       <address>Departamento de Astronomia - IF</address>
-       <address>Av. Bento Gonçalves, 9500</address>
-       <address>Campus do Vale</address>
-       <address>91540-000 - Porto Alegre - RS</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-51-316-6439</phone>
-          <fax>+55-51-336-1762</fax>
-          <email>user@if.ufrgs.br</email>
-       </contact>
+        <institution>Observatorio Nacional (ON/MCT)</institution>
+        <address>Rua General Jose Cristino, 77 - Sao Cristovao</address>
+        <address>20921-400 - Rio de Janeiro - RJ</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-585-3215</phone>
+            <fax>+55-21-580-6041</fax>
+            <email>user@on.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Federal Santa Maria (UFSM)</institution>
-       <address>Centro de Ciencias Naturais e Exatas</address>
-       <address>Av. Roraima, 100</address>
-       <address>Cidade Universitaria - Bairro Camobi</address>
-       <address>97105-900 - Santa Maria - RS</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-21-55-226-2013</phone>
-          <fax>+55-21-55-226-2013</fax>
-          <email>user@brufsm.bitnet</email>
-       </contact>
+        <institution>Universidade Federal do Rio de Janeiro (UFRJ)</institution>
+        <address>Observatorio do Valongo</address>
+        <address>Ladeira do Pedro Antonio, 43 - Saude</address>
+        <address>20080-090 - Rio de Janeiro - RJ</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-263-0685</phone>
+            <fax>+55-21-263-0685</fax>
+            <email>user@ov.ufrg.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade de Sao Paulo</institution>
-       <address>Instituto de Astronomia, Geofisica e Ciencias Atmosfericas (IAG)</address>
-       <address>Cidade Universitaria</address>
-       <address>Rua do Matao, 1226</address>
-       <address>05508-090 - Sao Paulo - SP</address>
-       <country>Brazil</country>
-       <contact>
-          <phone>+55-11-577-8599</phone>
-          <fax>+55-11-276-3848</fax>
-          <email>user@iagusp.usp.br</email>
-       </contact>
+        <institution>Universidade Federal do Rio Grande do Norte (UFRN)</institution>
+        <address>Departamento de Fisica Teorica e Experimental - CCET</address>
+        <address>Campus Universitario</address>
+        <address>59072-970 - Natal - RN</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-84-215-3800</phone>
+            <fax>+55-21-84-215-3791</fax>
+            <email>user@dfte.ufrn.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Estadual de Feira de Santana (UEFS)</institution>
-       <address>Departamento de Fisica</address>
-       <address>Campus Universitario - Km 03, BR 116</address>
-       <address>44031-460 - Feira de Santana - BA</address>
-       <country>Brazil</country>
+        <institution>Universidade Federal do Rio Grande do Sul (UFRGS)</institution>
+        <address>Departamento de Astronomia - IF</address>
+        <address>Av. Bento Gonçalves, 9500</address>
+        <address>Campus do Vale</address>
+        <address>91540-000 - Porto Alegre - RS</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-51-316-6439</phone>
+            <fax>+55-51-336-1762</fax>
+            <email>user@if.ufrgs.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Estadual de Santa Cruz (UESC)</institution>
-       <address>Laboratorio de Astrofisica Teorica e Observacional - DCET</address>
-       <address>Campus Soane Nazare de Andrade</address>
-       <address>km 16 Rodovia Ilheus-Itabuna</address>
-       <address>45662-000 - lheus - BA</address>
-       <country>Brazil</country>
+        <institution>Universidade Federal Santa Maria (UFSM)</institution>
+        <address>Centro de Ciencias Naturais e Exatas</address>
+        <address>Av. Roraima, 100</address>
+        <address>Cidade Universitaria - Bairro Camobi</address>
+        <address>97105-900 - Santa Maria - RS</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-21-55-226-2013</phone>
+            <fax>+55-21-55-226-2013</fax>
+            <email>user@brufsm.bitnet</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade Federal de Santa Catarina (UFSC)</institution>
-       <address>Departamento de Fisica - CFM</address>
-       <address>Caixa Postal 476</address>
-       <address>Campus Universitario - Trindade</address>
-       <address>88019-970 - Florianopolis - SC</address>
-       <country>Brazil</country>
+        <institution>Universidade de Sao Paulo</institution>
+        <address>Instituto de Astronomia, Geofisica e Ciencias Atmosfericas (IAG)</address>
+        <address>Cidade Universitaria</address>
+        <address>Rua do Matao, 1226</address>
+        <address>05508-090 - Sao Paulo - SP</address>
+        <country>Brazil</country>
+        <contact>
+            <phone>+55-11-577-8599</phone>
+            <fax>+55-11-276-3848</fax>
+            <email>user@iagusp.usp.br</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidade do Vale do Paraiba (UNIVAP)</institution>
-       <address>Departamento de Ciencias Exatas e da Terra</address>
-       <address>Av. Shishime Hijumi, 2911 - Urbanova</address>
-       <address>12244-000 - Sao Jose dos Campos - SP</address>
-       <country>Brazil</country>
+        <institution>Universidade Estadual de Feira de Santana (UEFS)</institution>
+        <address>Departamento de Fisica</address>
+        <address>Campus Universitario - Km 03, BR 116</address>
+        <address>44031-460 - Feira de Santana - BA</address>
+        <country>Brazil</country>
     </site>
     <site>
-       <institution>Universidad de Chile</institution>
-       <address>Department de Astronomia</address>
-       <address>Casilla 36-D</address>
-       <address>Santiago</address>
-       <country>Chile</country>
-       <contact>
-          <phone>+56-2-229-4101</phone>
-          <fax>+56-2-229-4101</fax>
-          <email>user@das.uchile.cl</email>
-       </contact>
+        <institution>Universidade Estadual de Santa Cruz (UESC)</institution>
+        <address>Laboratorio de Astrofisica Teorica e Observacional - DCET</address>
+        <address>Campus Soane Nazare de Andrade</address>
+        <address>km 16 Rodovia Ilheus-Itabuna</address>
+        <address>45662-000 - lheus - BA</address>
+        <country>Brazil</country>
     </site>
     <site>
-       <institution>Instituto Isaac Newton</institution>
-       <address>Casilla 8-9</address>
-       <address>Correo 9</address>
-       <address>Santiago</address>
-       <country>Chile</country>
-       <contact>
-          <phone>+56-2-2172013</phone>
-          <fax>+56-2-2172352</fax>
-          <email>user@reuna.cl</email>
-       </contact>
+        <institution>Universidade Federal de Santa Catarina (UFSC)</institution>
+        <address>Departamento de Fisica - CFM</address>
+        <address>Caixa Postal 476</address>
+        <address>Campus Universitario - Trindade</address>
+        <address>88019-970 - Florianopolis - SC</address>
+        <country>Brazil</country>
     </site>
     <site>
-       <institution>Pontificia Universidad Catolica de Chile</institution>
-       <address>Departamento de Astronomia y Astrofisica</address>
-       <address>Casilla 306</address>
-       <address>Santiago 22</address>
-       <country>Chile</country>
-       <contact>
-          <phone>+56-2-552-3272</phone>
-          <fax>+56-2-686-4948</fax>
-          <email>user@astro.puc.cl</email>
-       </contact>
+        <institution>Universidade do Vale do Paraiba (UNIVAP)</institution>
+        <address>Departamento de Ciencias Exatas e da Terra</address>
+        <address>Av. Shishime Hijumi, 2911 - Urbanova</address>
+        <address>12244-000 - Sao Jose dos Campos - SP</address>
+        <country>Brazil</country>
     </site>
     <site>
-       <institution>Universidad de Concepcion</institution>
-       <address>Departamento de Astronomia</address>
-       <address>Casilla 160 - C</address>
-       <address>Concepcion - Chile</address>
-       <country>Chile</country>
+        <institution>Universidad de Chile</institution>
+        <address>Department de Astronomia</address>
+        <address>Casilla 36-D</address>
+        <address>Santiago</address>
+        <country>Chile</country>
+        <contact>
+            <phone>+56-2-229-4101</phone>
+            <fax>+56-2-229-4101</fax>
+            <email>user@das.uchile.cl</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidad de Valparaiso</institution>
-       <address>Departamento de Fisica y Astronomia</address>
-       <address>Avenida Gran Bretana 1111</address>
-       <address>Valparaiso, Chile</address>
-       <country>Chile</country>
+        <institution>Instituto Isaac Newton</institution>
+        <address>Casilla 8-9</address>
+        <address>Correo 9</address>
+        <address>Santiago</address>
+        <country>Chile</country>
+        <contact>
+            <phone>+56-2-2172013</phone>
+            <fax>+56-2-2172352</fax>
+            <email>user@reuna.cl</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidad de La Serena</institution>
-       <address>Departamento de Fisica</address>
-       <address>Facultad de Ciencias</address>
-       <address>La Serena, Chile.</address>
-       <country>Chile</country>
+        <institution>Pontificia Universidad Catolica de Chile</institution>
+        <address>Departamento de Astronomia y Astrofisica</address>
+        <address>Casilla 306</address>
+        <address>Santiago 22</address>
+        <country>Chile</country>
+        <contact>
+            <phone>+56-2-552-3272</phone>
+            <fax>+56-2-686-4948</fax>
+            <email>user@astro.puc.cl</email>
+        </contact>
     </site>
     <site>
-       <institution>Universidad Andres Bello</institution>
-       <address>Av. Republica 252</address>
-       <address>Santiago</address>
-       <country>Chile</country>
-       <contact>
-           <phone>+56-2-8370134</phone>
-       </contact>
+        <institution>Universidad de Concepcion</institution>
+        <address>Departamento de Astronomia</address>
+        <address>Casilla 160 - C</address>
+        <address>Concepcion - Chile</address>
+        <country>Chile</country>
     </site>
     <site>
-       <institution>University of Alberta</institution>
-       <address>Department of Physics</address>
-       <address>Edmonton</address>
-       <address>Alberta</address>
-       <address>T6G 2J1</address>
-       <country>Canada</country>
-       <contact>
-          <phone>403-492-5286</phone>
-          <phone>403-492-0714</phone>
-          <email>user@phys.ualberta.ca</email>
-       </contact>
+        <institution>Universidad de Valparaiso</institution>
+        <address>Departamento de Fisica y Astronomia</address>
+        <address>Avenida Gran Bretana 1111</address>
+        <address>Valparaiso, Chile</address>
+        <country>Chile</country>
     </site>
     <site>
-       <institution>Brandon University</institution>
-       <address>Dept. of Physics and Astronomy</address>
-       <address>Brandon</address>
-       <address>Manitoba</address>
-       <address>R7A 6A9</address>
-       <country>Canada</country>
-       <contact>
-          <email>user@brandonu.ca</email>
-       </contact>
+        <institution>Universidad de La Serena</institution>
+        <address>Departamento de Fisica</address>
+        <address>Facultad de Ciencias</address>
+        <address>La Serena, Chile.</address>
+        <country>Chile</country>
     </site>
     <site>
-       <institution>University of British Columbia</institution>
-       <address>Dept. of Physics and Astronomy</address>
-       <address>6224 Agricultural Road</address>
-       <address>Vancouver</address>
-       <address>British Columbia</address>
-       <address>V6T 1Z1</address>
-       <country>Canada</country>
-       <contact>
-          <phone>604-822-3853</phone>
-          <phone>604-822-5324</phone>
-          <email>user@astro.ubc.ca</email>
-       </contact>
+        <institution>Universidad Andres Bello</institution>
+        <address>Av. Republica 252</address>
+        <address>Santiago</address>
+        <country>Chile</country>
+        <contact>
+            <phone>+56-2-8370134</phone>
+        </contact>
     </site>
     <site>
-       <institution>University of Calgary</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>2500 University Drive,NW</address>
-       <address>Calgary</address>
-       <address>Alberta</address>
-       <address>T2N 1N4</address>
-       <country>Canada</country>
-       <contact>
-          <phone>403-220-5410/-5385</phone>
-          <phone>403-289-3331</phone>
-          <email>user@phas.ucalgary.ca</email>
-       </contact>
+        <institution>University of Alberta</institution>
+        <address>Department of Physics</address>
+        <address>Edmonton</address>
+        <address>Alberta</address>
+        <address>T6G 2J1</address>
+        <country>Canada</country>
+        <contact>
+            <phone>403-492-5286</phone>
+            <phone>403-492-0714</phone>
+            <email>user@phys.ualberta.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Canada-France-Hawaii Telescope Corporation</institution>
-       <address>PO Box 1597 (65-1238 Mamalahoa Highway)</address>
-       <address>Kamuela</address>
-       <address>HI</address>
-       <address>96743</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-885-7944</phone>
-          <phone>808-885-7288</phone>
-          <email>user@cfht.hawaii.edu</email>
-       </contact>
+        <institution>Brandon University</institution>
+        <address>Dept. of Physics and Astronomy</address>
+        <address>Brandon</address>
+        <address>Manitoba</address>
+        <address>R7A 6A9</address>
+        <country>Canada</country>
+        <contact>
+            <email>user@brandonu.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Canadian Institute for Theoretical Astrophysics</institution>
-       <address>University of Toronto</address>
-       <address>60 St. George Street</address>
-       <address>Toronto</address>
-       <address>Ontario</address>
-       <address>M5S 3H8</address>
-       <country>Canada</country>
-       <contact>
-          <phone>416-978-6879</phone>
-          <phone>416-978-3921</phone>
-          <email>user@cita.utoronto.ca</email>
-       </contact>
+        <institution>University of British Columbia</institution>
+        <address>Dept. of Physics and Astronomy</address>
+        <address>6224 Agricultural Road</address>
+        <address>Vancouver</address>
+        <address>British Columbia</address>
+        <address>V6T 1Z1</address>
+        <country>Canada</country>
+        <contact>
+            <phone>604-822-3853</phone>
+            <phone>604-822-5324</phone>
+            <email>user@astro.ubc.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Herzberg Institute of Astrophysics</institution>
-       <address>National Research Council of Canada</address>
-       <address>5071 West Saanich Road, RR. 5</address>
-       <address>Victoria</address>
-       <address>British Columbia</address>
-       <address>V9E 2E7</address>
-       <country>Canada</country>
-       <contact>
-          <phone>250-363-0001</phone>
-          <phone>250-363-0045</phone>
-          <email>user@dao.nrc.ca</email>
-       </contact>
+        <institution>University of Calgary</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>2500 University Drive,NW</address>
+        <address>Calgary</address>
+        <address>Alberta</address>
+        <address>T2N 1N4</address>
+        <country>Canada</country>
+        <contact>
+            <phone>403-220-5410/-5385</phone>
+            <phone>403-289-3331</phone>
+            <email>user@phas.ucalgary.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Dominion Radio Astrophysical Observatory</institution>
-       <address>Herzberg Institute of Astrophysics</address>
-       <address>National Research Council of Canada</address>
-       <address>PO Box 248</address>
-       <address>Penticton</address>
-       <address>British Columbia</address>
-       <address>V2A 6K3</address>
-       <country>Canada</country>
-       <contact>
-          <phone>250-493-2277</phone>
-          <phone>205-493-7767</phone>
-          <email>user@drao.nrc.ca</email>
-       </contact>
+        <institution>Canada-France-Hawaii Telescope Corporation</institution>
+        <address>PO Box 1597 (65-1238 Mamalahoa Highway)</address>
+        <address>Kamuela</address>
+        <address>HI</address>
+        <address>96743</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-885-7944</phone>
+            <phone>808-885-7288</phone>
+            <email>user@cfht.hawaii.edu</email>
+        </contact>
     </site>
     <site>
-       <institution>Universite Laval</institution>
-       <address>Department of Physics</address>
-       <address>Quebec</address>
-       <address>G1K 7P4</address>
-       <country>Canada</country>
-       <contact>
-          <phone>418-656-2652</phone>
-          <phone>418-656-2040</phone>
-          <email>user@phy.ulaval.ca</email>
-       </contact>
+        <institution>Canadian Institute for Theoretical Astrophysics</institution>
+        <address>University of Toronto</address>
+        <address>60 St. George Street</address>
+        <address>Toronto</address>
+        <address>Ontario</address>
+        <address>M5S 3H8</address>
+        <country>Canada</country>
+        <contact>
+            <phone>416-978-6879</phone>
+            <phone>416-978-3921</phone>
+            <email>user@cita.utoronto.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Lethbridge</institution>
-       <address>Department of Physics</address>
-       <address>4401 University Drive</address>
-       <address>Lethbridge</address>
-       <address>Alberta</address>
-       <address>T1K 3M4</address>
-       <country>Canada</country>
-       <contact>
-          <email>user@uleth.ca</email>
-       </contact>
+        <institution>Herzberg Institute of Astrophysics</institution>
+        <address>National Research Council of Canada</address>
+        <address>5071 West Saanich Road, RR. 5</address>
+        <address>Victoria</address>
+        <address>British Columbia</address>
+        <address>V9E 2E7</address>
+        <country>Canada</country>
+        <contact>
+            <phone>250-363-0001</phone>
+            <phone>250-363-0045</phone>
+            <email>user@dao.nrc.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Manitoba</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Winnipeg</address>
-       <address>Manitoba</address>
-       <address>R3T 2N2</address>
-       <country>Canada</country>
-       <contact>
-          <email>user@physics.umanitoba.ca</email>
-       </contact>
+        <institution>Dominion Radio Astrophysical Observatory</institution>
+        <address>Herzberg Institute of Astrophysics</address>
+        <address>National Research Council of Canada</address>
+        <address>PO Box 248</address>
+        <address>Penticton</address>
+        <address>British Columbia</address>
+        <address>V2A 6K3</address>
+        <country>Canada</country>
+        <contact>
+            <phone>250-493-2277</phone>
+            <phone>205-493-7767</phone>
+            <email>user@drao.nrc.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>McGill University</institution>
-       <address>Physics Department</address>
-       <address>Ernest Rutherford Physics Building</address>
-       <address>3600 University Street</address>
-       <address>Montreal</address>
-       <address>Quebec</address>
-       <address>H3A 2T8</address>
-       <country>Canada</country>
-       <contact>
-          <email>user@physics.mcgill.ca</email>
-       </contact>
+        <institution>Universite Laval</institution>
+        <address>Department of Physics</address>
+        <address>Quebec</address>
+        <address>G1K 7P4</address>
+        <country>Canada</country>
+        <contact>
+            <phone>418-656-2652</phone>
+            <phone>418-656-2040</phone>
+            <email>user@phy.ulaval.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>McMaster University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Hamilton</address>
-       <address>Ontario</address>
-       <address>L8S 4M1</address>
-       <country>Canada</country>
-       <contact>
-          <phone>905-525-9140</phone>
-          <phone>905-546-1252</phone>
-          <email>user@physics.mcmaster.ca</email>
-       </contact>
+        <institution>University of Lethbridge</institution>
+        <address>Department of Physics</address>
+        <address>4401 University Drive</address>
+        <address>Lethbridge</address>
+        <address>Alberta</address>
+        <address>T1K 3M4</address>
+        <country>Canada</country>
+        <contact>
+            <email>user@uleth.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Montreal</institution>
-       <address>Department of Physics</address>
-       <address>PO Box 6128</address>
-       <address>Station Centreville</address>
-       <address>Montreal</address>
-       <address>Quebec</address>
-       <address>H3C 3J7</address>
-       <country>Canada</country>
-       <contact>
-          <phone>514-343-6111x3183</phone>
-          <phone>514-343-2071</phone>
-          <email>user@astro.umontreal.ca</email>
-       </contact>
+        <institution>University of Manitoba</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Winnipeg</address>
+        <address>Manitoba</address>
+        <address>R3T 2N2</address>
+        <country>Canada</country>
+        <contact>
+            <email>user@physics.umanitoba.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Memorial University of Newfoundland</institution>
-       <address>Department of Physics</address>
-       <address>Sir Wilfred Grenfell College</address>
-       <address>Corner Brook</address>
-       <address>Newfoundland</address>
-       <address>A2H 6P9</address>
-       <country>Canada</country>
-       <contact>
-          <email>user@swgc.mun.ca</email>
-       </contact>
+        <institution>McGill University</institution>
+        <address>Physics Department</address>
+        <address>Ernest Rutherford Physics Building</address>
+        <address>3600 University Street</address>
+        <address>Montreal</address>
+        <address>Quebec</address>
+        <address>H3A 2T8</address>
+        <country>Canada</country>
+        <contact>
+            <email>user@physics.mcgill.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Queen's University</institution>
-       <address>Department of Physics</address>
-       <address>Astronomy Research Group</address>
-       <address>Kingston</address>
-       <address>Ontario</address>
-       <address>K7L 3N6</address>
-       <country>Canada</country>
-       <contact>
-          <phone>613-545-2706</phone>
-          <phone>613-545-6463</phone>
-          <email>user@astro.queensu.ca</email>
-       </contact>
+        <institution>McMaster University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Hamilton</address>
+        <address>Ontario</address>
+        <address>L8S 4M1</address>
+        <country>Canada</country>
+        <contact>
+            <phone>905-525-9140</phone>
+            <phone>905-546-1252</phone>
+            <email>user@physics.mcmaster.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Royal Military College of Canada</institution>
-       <address>Department of Physics</address>
-       <address>PO Box 17000, Station Forces</address>
-       <address>Kingston</address>
-       <address>Ontario</address>
-       <address>K7K 7B4</address>
-       <country>Canada</country>
-       <contact>
-          <email>user@rmc.ca</email>
-       </contact>
+        <institution>University of Montreal</institution>
+        <address>Department of Physics</address>
+        <address>PO Box 6128</address>
+        <address>Station Centreville</address>
+        <address>Montreal</address>
+        <address>Quebec</address>
+        <address>H3C 3J7</address>
+        <country>Canada</country>
+        <contact>
+            <phone>514-343-6111x3183</phone>
+            <phone>514-343-2071</phone>
+            <email>user@astro.umontreal.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Saint Mary's University</institution>
-       <address>Department of Astronomy and Physics</address>
-       <address>Halifax</address>
-       <address>NS</address>
-       <address>B3H 3C3</address>
-       <country>Canada</country>
-       <contact>
-          <phone>902-420-5828</phone>
-          <phone>902-420-5141</phone>
-          <email>user@stmarys.ca</email>
-       </contact>
+        <institution>Memorial University of Newfoundland</institution>
+        <address>Department of Physics</address>
+        <address>Sir Wilfred Grenfell College</address>
+        <address>Corner Brook</address>
+        <address>Newfoundland</address>
+        <address>A2H 6P9</address>
+        <country>Canada</country>
+        <contact>
+            <email>user@swgc.mun.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Toronto</institution>
-       <address>Department of Astronomy</address>
-       <address>60 St. George Street</address>
-       <address>Toronto</address>
-       <address>Ontario</address>
-       <address>M5S 1A1</address>
-       <country>Canada</country>
-       <contact>
-          <phone>416-978-3149</phone>
-          <fax>416-971-2026</fax>
-          <email>user@astro.utoronto.ca</email>
-       </contact>
+        <institution>Queen's University</institution>
+        <address>Department of Physics</address>
+        <address>Astronomy Research Group</address>
+        <address>Kingston</address>
+        <address>Ontario</address>
+        <address>K7L 3N6</address>
+        <country>Canada</country>
+        <contact>
+            <phone>613-545-2706</phone>
+            <phone>613-545-6463</phone>
+            <email>user@astro.queensu.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>Trent University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>1600 West Bank Drive</address>
-       <address>Peterborough</address>
-       <address>Ontario</address>
-       <address>K9J 7B8</address>
-       <country>Canada</country>
-       <contact>
-          <email>user@trentu.ca</email>
-       </contact>
+        <institution>Royal Military College of Canada</institution>
+        <address>Department of Physics</address>
+        <address>PO Box 17000, Station Forces</address>
+        <address>Kingston</address>
+        <address>Ontario</address>
+        <address>K7K 7B4</address>
+        <country>Canada</country>
+        <contact>
+            <email>user@rmc.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Victoria</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>PO Box 3055</address>
-       <address>Victoria</address>
-       <address>BC</address>
-       <address>V8W 3P6</address>
-       <country>Canada</country>
-       <contact>
-          <phone>250-721-7700</phone>
-          <phone>250-721-7715</phone>
-          <email>user@phys.uvic.ca</email>
-       </contact>
+        <institution>Saint Mary's University</institution>
+        <address>Department of Astronomy and Physics</address>
+        <address>Halifax</address>
+        <address>NS</address>
+        <address>B3H 3C3</address>
+        <country>Canada</country>
+        <contact>
+            <phone>902-420-5828</phone>
+            <phone>902-420-5141</phone>
+            <email>user@stmarys.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Waterloo</institution>
-       <address>Department of Physics</address>
-       <address>Astronomy Group</address>
-       <address>Waterloo</address>
-       <address>Ontario</address>
-       <address>N2L 3G1</address>
-       <country>Canada</country>
-       <contact>
-          <phone>519-885-1211x2215</phone>
-          <phone>519-746-8115</phone>
-          <email>user@uwaterloo.ca</email>
-       </contact>
+        <institution>University of Toronto</institution>
+        <address>Department of Astronomy</address>
+        <address>60 St. George Street</address>
+        <address>Toronto</address>
+        <address>Ontario</address>
+        <address>M5S 1A1</address>
+        <country>Canada</country>
+        <contact>
+            <phone>416-978-3149</phone>
+            <fax>416-971-2026</fax>
+            <email>user@astro.utoronto.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>University of Western Ontario</institution>
-       <address>Department of Astronomy</address>
-       <address>London</address>
-       <address>Ontario</address>
-       <address>N6A  3K7</address>
-       <country>Canada</country>
-       <contact>
-          <phone>519-661-3183</phone>
-          <fax>519-661-2009</fax>
-          <email>user@uwo.ca</email>
-       </contact>
+        <institution>Trent University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>1600 West Bank Drive</address>
+        <address>Peterborough</address>
+        <address>Ontario</address>
+        <address>K9J 7B8</address>
+        <country>Canada</country>
+        <contact>
+            <email>user@trentu.ca</email>
+        </contact>
     </site>
     <site>
-       <institution>York University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>4700 Keele Street</address>
-       <address>North York</address>
-       <address>Ontario</address>
-       <address>M3J 1P3</address>
-       <country>Canada</country>
-       <contact>
-          <phone>416-736-5249</phone>
-          <phone>416-736-5516</phone>
-          <email>user@pjys.yorku.ca</email>
-       </contact>
+        <institution>University of Victoria</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>PO Box 3055</address>
+        <address>Victoria</address>
+        <address>BC</address>
+        <address>V8W 3P6</address>
+        <country>Canada</country>
+        <contact>
+            <phone>250-721-7700</phone>
+            <phone>250-721-7715</phone>
+            <email>user@phys.uvic.ca</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Waterloo</institution>
+        <address>Department of Physics</address>
+        <address>Astronomy Group</address>
+        <address>Waterloo</address>
+        <address>Ontario</address>
+        <address>N2L 3G1</address>
+        <country>Canada</country>
+        <contact>
+            <phone>519-885-1211x2215</phone>
+            <phone>519-746-8115</phone>
+            <email>user@uwaterloo.ca</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Western Ontario</institution>
+        <address>Department of Astronomy</address>
+        <address>London</address>
+        <address>Ontario</address>
+        <address>N6A  3K7</address>
+        <country>Canada</country>
+        <contact>
+            <phone>519-661-3183</phone>
+            <fax>519-661-2009</fax>
+            <email>user@uwo.ca</email>
+        </contact>
+    </site>
+    <site>
+        <institution>York University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>4700 Keele Street</address>
+        <address>North York</address>
+        <address>Ontario</address>
+        <address>M3J 1P3</address>
+        <country>Canada</country>
+        <contact>
+            <phone>416-736-5249</phone>
+            <phone>416-736-5516</phone>
+            <email>user@pjys.yorku.ca</email>
+        </contact>
     </site>
     <site>
         <institution>Chiba University</institution>
@@ -1325,2286 +1325,2286 @@
         <country>Japan</country>
     </site>
     <site>
-       <institution>Armagh Observatory</institution>
-       <address>College Hill</address>
-       <address>Armagh BT61 9DG</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1861-522928</phone>
-          <fax>+44-1861-527174</fax>
-          <email>user@star.arm.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Birmingham</institution>
-       <address>School of Physics and Space Research</address>
-       <address>Edgbaston</address>
-       <address>Birmingham B15 2TT</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-121-4146453</phone>
-          <fax>+44-121-4143722</fax>
-          <email>user@star.sr.bham.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Bristol</institution>
-       <address>Department of Physics</address>
-       <address>Royal Fort, Tyndall Avenue</address>
-       <address>Bristol BS8 1TL</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-117-928-8314</phone>
-          <fax>+44-117-925-5624</fax>
-          <email>user@bristol.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Cambridge</institution>
-       <address>Institute of Astronomy</address>
-       <address>Madingley Road</address>
-       <address>Cambridge CB3 0HA</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1223-337548</phone>
-          <fax>+44-1223-337523</fax>
-          <email>user@ast.cam.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Central Lancashire</institution>
-       <address>Center for Astrophysics</address>
-       <address>Preston</address>
-       <address>Lancashire</address>
-       <address>PR1 2HE</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1772-8933569</phone>
-          <fax>+44-1722-892903</fax>
-          <email>user@star.uclan.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Durham</institution>
-       <address>Department of Physics</address>
-       <address>South Road</address>
-       <address>Durham DH1 3LE</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-191-374-2165</phone>
-          <fax>+44-191-374-7465</fax>
-          <email>user@durham.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Edinburgh</institution>
-       <address>Institute for Astronomy</address>
-       <address>Blackford Hill</address>
-       <address>Edinburgh EH9 3HJ</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-131-668-8356</phone>
-          <fax>+44-131-668-8356</fax>
-          <email>user@roe.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Glasgow</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Glasgow G12 8QQ</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-141-330-4152</phone>
-          <fax>+44-141-334-9029</fax>
-          <email>user@astro.gla.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Hertfordshire</institution>
-       <address>Department of Physical Sciences</address>
-       <address>College Lane</address>
-       <address>Hatfield</address>
-       <address>Hertfordshire AL10 9AB</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1707-284601</phone>
-          <fax>+44-1707-284514</fax>
-          <email>user@star.herts.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Imperial College of Science, Technology and Medicine</institution>
-       <address>Astrophysics Group</address>
-       <address>The Blackett Laboratory</address>
-       <address>Prince Consort Road</address>
-       <address>London SW7 2BZ</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-171-594-7531</phone>
-          <fax>+44-171-594-7777</fax>
-          <email>user@ic.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Keele University</institution>
-       <address>Department of Physics</address>
-       <address>Keele</address>
-       <address>Staffordshire ST5 5BG</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1782-583319</phone>
-          <fax>+44-1782-711093</fax>
-          <email>user@astro.keele.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Kent</institution>
-       <address>Electronic Engineering Lab</address>
-       <address>Canterbury</address>
-       <address>Kent CT2 7NT</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1227-823190</phone>
-          <fax>+44-1227-456084</fax>
-          <email>user@star.ukc.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Leeds</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>E. C. Stoner Building</address>
-       <address>Leeds LS2 9JT</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-113-233-3860</phone>
-          <fax>+44-113-233-3900</fax>
-          <email>user@physics.leeds.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Leicester</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>University Road</address>
-       <address>Leicester LE1 7RH</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-116-252-3540</phone>
-          <fax>+44-116-252-3311</fax>
-          <email>user@star.le.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Liverpool John Moores University</institution>
-       <address>Astrophysics Group</address>
-       <address>Division of Engineering and Science</address>
-       <address>Byrom Street</address>
-       <address>Liverpool L3 3AF</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-151-231-2337</phone>
-          <fax>+44-151-231-2337</fax>
-          <email>user@staru1.livjm.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University College London</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Gower Street</address>
-       <address>London WC1E 6BT</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-171-387-7050</phone>
-          <fax>+44-171-380-7145</fax>
-          <email>user@star.ucl.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Manchester</institution>
-       <address>Department of Astronomy</address>
-       <address>Manchester M13 9PL</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-161-275-4224</phone>
-          <fax>+44-161-275-4223</fax>
-          <email>user@ast.man.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Mullard Radio Astronomy Observatory</institution>
-       <address>Cavendish Laboratory</address>
-       <address>Madingley Road</address>
-       <address>Cambridge CB3 0HE</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1223-337294</phone>
-          <fax>+44-1223-354599</fax>
-          <email>user@mrao.cam.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Mullard Space Science Laboratory</institution>
-       <address>Holmbury St. Mary</address>
-       <address>Nr Dorking</address>
-       <address>Surrey RH5 6NT</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-10483-274111</phone>
-          <fax>+44-10483-278312</fax>
-          <email>user@mss1.ucl.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Nottingham</institution>
-       <address>Astronomy and Astrophysical Chemistry Group</address>
-       <address>Department of Chemistry</address>
-       <address>University Park</address>
-       <address>Nottingham NG7 2RD</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-115-951-3460</phone>
-          <fax>+44-115-951-3466</fax>
-          <email>user@nottingham.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Nuffield Radio Astronomy Laboratories</institution>
-       <address>University of Manchester</address>
-       <address>Jodrell Bank</address>
-       <address>Cheshire SK11 9DL</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1477-571-321</phone>
-          <fax>+44-1477-571-618</fax>
-          <email>user@jb.man.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Open University</institution>
-       <address>Astronomy Group</address>
-       <address>Physics Department</address>
-       <address>Walton Hall</address>
-       <address>Milton Keynes</address>
-       <address>MK7 6AA</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1908-653229</phone>
-          <fax>+44-1908-654192</fax>
-          <email>user@open.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Oxford</institution>
-       <address>Department of Physics, Astrophysics, Nuclear and Astrophysics Laboratory</address>
-       <address>Keble Road</address>
-       <address>Oxford</address>
-       <address>OX1 3RH</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1865-273303</phone>
-          <fax>+44-1865-273418</fax>
-          <email>user@physics.oxford.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Queen's University of Belfast</institution>
-       <address>Department of Pure and Applied Physics</address>
-       <address>Belfast BT7 1NN</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1232-245133</phone>
-          <fax>+44-1232-438918</fax>
-          <email>user@qub.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Queen Mary and Westfield College</institution>
-       <address>Department of Physics</address>
-       <address>Mile End Road</address>
-       <address>London E1 4NS</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-171-975-5555</phone>
-          <fax>+44-171-975-5500</fax>
-          <email>user@qmw.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Royal Greenwich Observatory</institution>
-       <address>Madingley Road</address>
-       <address>Cambridge CB3 0EZ</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1223-374000</phone>
-          <fax>+44-1223-374700</fax>
-          <email>user@ast.cam.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Royal Observatory Edinburgh and ATC</institution>
-       <address>Blackford Hill</address>
-       <address>Edinburgh EH9 3HJ</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-131-668-8100</phone>
-          <fax>+44-131-668-1668</fax>
-          <email>user@roe.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Sheffield</institution>
-       <address>Department of Physics</address>
-       <address>Hounsfield Road</address>
-       <address>Sheffield S3 7RH</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-114-222-2000</phone>
-          <fax>+44-114-272-8079</fax>
-          <email>user@sheffield.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Southampton</institution>
-       <address>Department of Physics</address>
-       <address>Southampton</address>
-       <address>S017 1BJ</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1703-595000</phone>
-          <fax>+44-1703-593910</fax>
-          <email>user@phastr.soton.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of St. Andrews</institution>
-       <address>School of Physics and Astronomy</address>
-       <address>North Haugh</address>
-       <address>St. Andrews KY16 9SS</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1334-46-3103</phone>
-          <fax>+44-1334-46-3104</fax>
-          <email>user@st-and.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Sussex</institution>
-       <address>Astronomy Centre</address>
-       <address>CPES</address>
-       <address>Brighton</address>
-       <address>BN1 9QH</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1273-678117</phone>
-          <fax>+44-1273-678097</fax>
-          <email>user@star.cpes.susx.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Wales Cardiff</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>PO Box 913</address>
-       <address>Cardiff CF2 3YB</address>
-       <country>United Kingdom</country>
-       <contact>
-          <phone>+44-1222-87-4458</phone>
-          <fax>+44-1222-87-4056</fax>
-          <email>user@astro.cf.ac.uk</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Alabama</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>206 Gallalee Hall</address>
-       <address>Box 870324</address>
-       <address>Tuscaloosa</address>
-       <address>AL</address>
-       <address>35487-0324</address>
-       <country>USA</country>
-       <contact>
-          <phone>205-348-5050</phone>
-          <fax>205-348-5051</fax>
-          <email>user@astr.ua.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Apache Point Observatory</institution>
-       <address>Astrophysical Research Consortium</address>
-       <address>2001 Apache Point Road</address>
-       <address>PO Box 59</address>
-       <address>Sunspot</address>
-       <address>NM</address>
-       <address>88349-0059</address>
-       <country>USA</country>
-       <contact>
-          <phone>505-437-6822</phone>
-          <fax>505-434-5555</fax>
-          <email>user@galileo.apo.nmsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Appalachian State University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Boone</address>
-       <address>NC</address>
-       <address>28608</address>
-       <country>USA</country>
-       <contact>
-          <phone>704-262-3090</phone>
-          <fax>704-262-2409</fax>
-          <email>user@appstate.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Arecibo Observatory</institution>
-       <address>National Astronomy and Ionosphere Center (NAIC)</address>
-       <address>PO Box 995</address>
-       <address>Arecibo</address>
-       <address>PR</address>
-       <address>00613</address>
-       <country>USA</country>
-       <contact>
-          <phone>787-878-2612</phone>
-          <fax>787-878-1861</fax>
-          <email>user@naic.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Arizona State University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Box 871504</address>
-       <address>Tempe</address>
-       <address>AZ</address>
-       <address>85287-1504</address>
-       <country>USA</country>
-       <contact>
-          <phone>602-965-3561</phone>
-          <fax>602-965-7954</fax>
-          <email>user@asu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Arizona (Astronomy)</institution>
-       <address>Department of Astronomy and Steward Observatory</address>
-       <address>933 North Cherry Avenue</address>
-       <address>Tucson</address>
-       <address>AZ</address>
-       <address>85721-0065</address>
-       <country>USA</country>
-       <contact>
-          <phone>520-621-2288</phone>
-          <fax>520-621-1532</fax>
-          <email>user@as.arizona.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Arizona (Lunar and Planetary Lab)</institution>
-       <address>Lunar and Planetary Laboratory</address>
-       <address>Space Sciences Building</address>
-       <address>PO Box 210092</address>
-       <address>Tucson</address>
-       <address>AZ</address>
-       <address>85721-0092</address>
-       <country>USA</country>
-       <contact>
-          <phone>520-621-6963</phone>
-          <fax>520-621-4933</fax>
-       </contact>
-    </site>
-    <site>
-       <institution>Bowling Green State University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Bowling Green</address>
-       <address>OH</address>
-       <address>43403</address>
-       <country>USA</country>
-       <contact>
-          <phone>419-372-2421</phone>
-          <fax>419-372-9938</fax>
-          <email>user@bgnet.bgsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Brandeis University</institution>
-       <address>Department of Physics</address>
-       <address>Waltham</address>
-       <address>MA</address>
-       <address>02254</address>
-       <country>USA</country>
-       <contact>
-          <phone>617-736-2800/-2835</phone>
-          <email>user@brandeis.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Berkeley (EUV Astrophysics)</institution>
-       <address>Center for EUV Astrophysics</address>
-       <address>2150 Kittredge Street</address>
-       <address>Berkeley</address>
-       <address>CA</address>
-       <address>94720-3411</address>
-       <country>USA</country>
-       <contact>
-          <phone>510-643-5637</phone>
-          <fax>510-643-5660</fax>
-          <email>user@ssl.berkeley.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Berkeley (Astronomy)</institution>
-       <address>Department of Astronomy</address>
-       <address>601 Campbell Hall #3411</address>
-       <address>Berkeley</address>
-       <address>CA</address>
-       <address>94720-3411</address>
-       <country>USA</country>
-       <contact>
-          <phone>510-642-5275</phone>
-          <fax>510-642-3411</fax>
-          <email>user@astro.berkeley.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Berkeley (Physics)</institution>
-       <address>Department of Physics</address>
-       <address>366 LeConte Hall, #730</address>
-       <address>Berkeley</address>
-       <address>CA</address>
-       <address>94720-7300</address>
-       <country>USA</country>
-       <contact>
-          <phone>510-642-3316</phone>
-          <fax>510-643-8497</fax>
-          <email>user@berkeley.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Berkeley (Hat Creek)</institution>
-       <address>Hat Creek Radio Observatory</address>
-       <address>42231 Bidwell Road</address>
-       <address>Hat Creek</address>
-       <address>CA</address>
-       <address>96040</address>
-       <country>USA</country>
-       <contact>
-          <phone>916-335-2364</phone>
-          <fax>916-335-4944</fax>
-          <email>user@bima.berkeley.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Irvine</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Irvine</address>
-       <address>CA</address>
-       <address>92697-4575</address>
-       <country>USA</country>
-       <contact>
-          <phone>714-824-6911</phone>
-          <fax>714-824-2174</fax>
-          <email>user@uci.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Los Angeles</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>8371 Math Sciences</address>
-       <address>Los Angeles</address>
-       <address>CA</address>
-       <address>90095-1562</address>
-       <country>USA</country>
-       <contact>
-          <phone>310-825-4435</phone>
-          <fax>310-206-2096</fax>
-          <email>user@astro.ucla.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Riverside</institution>
-       <address>Department of Physics</address>
-       <address>Riverside</address>
-       <address>CA</address>
-       <address>92521</address>
-       <country>USA</country>
-       <contact>
-          <phone>909-787-5331</phone>
-          <fax>909-787-4529</fax>
-          <email>user@ucr.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC San Diego</institution>
-       <address>Center for Astrophysics and Space Sciences</address>
-       <address>9500 Gilman Drive</address>
-       <address>Code 0424</address>
-       <address>La Jolla</address>
-       <address>CA</address>
-       <address>92093-0424</address>
-       <country>USA</country>
-       <contact>
-          <phone>619-534-3460</phone>
-          <fax>619-534-2294</fax>
-          <email>user@ucsd.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Santa Barbara</institution>
-       <address>Department of Physics</address>
-       <address>Broida Hall, Building 572</address>
-       <address>Santa Barbara</address>
-       <address>CA</address>
-       <address>93106-9530</address>
-       <country>USA</country>
-       <contact>
-          <phone>805-893-3888</phone>
-          <fax>805-893-3307</fax>
-          <email>user@physics.ucsb.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>UC Santa Cruz</institution>
-       <address>Astronomy and Astrophysics Board of Study</address>
-       <address>Natural Sciences II</address>
-       <address>Santa Cruz</address>
-       <address>CA</address>
-       <address>95064</address>
-       <country>USA</country>
-       <contact>
-          <phone>408-459-2844</phone>
-          <fax>408-426-3115</fax>
-          <email>user@ucsc.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech Astronomy</institution>
-       <address>MS 105-24</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91125</address>
-       <country>USA</country>
-       <contact>
-          <phone>626-395-4169</phone>
-          <fax>626-568-9352</fax>
-          <email>user@caltech.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech Submillimeter Observatory</institution>
-       <address>111 Nowelo Street</address>
-       <address>Hilo</address>
-       <address>HI</address>
-       <address>96720</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-935-1909</phone>
-          <fax>808-961-6273</fax>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech (Geo. and Planetary)</institution>
-       <address>Division of Geological and Planetary Science</address>
-       <address>MS 170-25</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91125</address>
-       <country>USA</country>
-       <contact>
-          <phone>626-395-6108</phone>
-          <fax>626-568-0935</fax>
-          <email>user@caltech.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech (Physics, Maths  and Astronomy)</institution>
-       <address>Division of Physics, Mathematics and Astronomy</address>
-       <address>MS 103-33</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91125</address>
-       <country>USA</country>
-       <contact>
-          <phone>626-395-4241</phone>
-          <fax>626-564-0267</fax>
-          <email>user@caltech.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech IPAC</institution>
-       <address>MS 100-22</address>
-       <address>770 South Wilson Avenue</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91125</address>
-       <country>USA</country>
-       <contact>
-          <phone>626-397-7105</phone>
-          <fax>626-397-9600</fax>
-          <email>user@ipac.caltech.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech Owens Valley Radio Observatory</institution>
-       <address>MS 105-24</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91125</address>
-       <country>USA</country>
-       <contact>
-          <phone>619-938-2075</phone>
-          <fax>619-938-2297</fax>
-          <email>user@ovro.caltech.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech Physics</institution>
-       <address>MS 103-33</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91125</address>
-       <country>USA</country>
-       <contact>
-          <phone>626-395-4633</phone>
-          <email>user@caltech.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Caltech Radio Astronomy</institution>
-       <address>Pasadena Office</address>
-       <address>MS 105-24</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91125</address>
-       <country>USA</country>
-       <contact>
-          <phone>626-395-4973</phone>
-          <fax>626-568-9352</fax>
-          <email>user@caltech.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>California State University at Davis</institution>
-       <address>Department of Physics</address>
-       <address>Davis</address>
-       <address>CA</address>
-       <address>95616-8677</address>
-       <country>USA</country>
-       <contact>
-          <phone>916-752-1501</phone>
-          <email>user@physics.ucdavis.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Carnegie Institution of Washington (Headquartes)</institution>
-       <address>Carnegie Observatories</address>
-       <address>Headquarters</address>
-       <address>813 Santa Barbara Street</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91101-1292</address>
-       <country>USA</country>
-       <contact>
-          <phone>818-577-1122</phone>
-          <fax>818-795-8136</fax>
-          <email>user@ociw.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Carnegie Institution of Washington (Carnegie Obs.)</institution>
-       <address>Carnegie Observatories</address>
-       <address>Las Campanas Observatory</address>
-       <address>Casilla 601</address>
-       <address>La Serena</address>
-       <country>Chile</country>
-       <contact>
-          <phone>+56-51-213032</phone>
-          <email>user@ociw.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Carnegie Institution of Washington (Terrestrial Magn.)</institution>
-       <address>Department of Terrestrial Magnetism</address>
-       <address>5241 Broad Branch Road, NW</address>
-       <address>Washington</address>
-       <address>DC</address>
-       <address>20015-1305</address>
-       <country>USA</country>
-       <contact>
-          <phone>202-686-4370</phone>
-          <fax>202-364-8726</fax>
-          <email>user@dtm.ciw.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Carnegie Mellon University</institution>
-       <address>Department of Physics</address>
-       <address>5000 Forbes Avenue</address>
-       <address>Pittsburgh</address>
-       <address>PA</address>
-       <address>15213-3890</address>
-       <country>USA</country>
-       <contact>
-          <phone>412-268-2740</phone>
-          <fax>412-681-0648</fax>
-          <email>user@astro.phys.cmu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Case Western Reserve University</institution>
-       <address>Department of Astronomy</address>
-       <address>10900 Euclid Avenue</address>
-       <address>Cleveland</address>
-       <address>OH</address>
-       <address>44106-7215</address>
-       <country>USA</country>
-       <contact>
-          <phone>216-368-3728</phone>
-          <fax>216-368-5406</fax>
-          <email>user@po.cwru.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Cerro Tololo Interamerican Observatory</institution>
-       <address>Casilla 603</address>
-       <address>La Serena</address>
-       <country>Chile</country>
-       <contact>
-          <phone>56-51-225-415</phone>
-          <fax>56-51-205-212</fax>
-          <email>user@noao.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Chicago</institution>
-       <address>Department of Astronomy and Astrophysics</address>
-       <address>5640 South Ellis Avenue</address>
-       <address>Chicago</address>
-       <address>IL</address>
-       <address>60637</address>
-       <country>USA</country>
-       <contact>
-          <phone>312-702-8203</phone>
-          <fax>312-702-8212</fax>
-          <email>user@oddjob.uchicago.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Cincinnati</institution>
-       <address>Department of Physics</address>
-       <address>Cincinnati</address>
-       <address>OH</address>
-       <address>45221-0011</address>
-       <country>USA</country>
-       <contact>
-          <phone>513-556-0501</phone>
-          <fax>513-556-3425</fax>
-          <email>user@physunc.phy.uc.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Colorado at Boulder (CASA)</institution>
-       <address>Center for Astrophysics and Space Astronomy (CASA)</address>
-       <address>Campus Box 389</address>
-       <address>Boulder</address>
-       <address>CO</address>
-       <address>80309</address>
-       <country>USA</country>
-       <contact>
-          <phone>303-492-4050</phone>
-          <fax>303-492-7178</fax>
-          <email>user@casa.colorado.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Colorado at Boulder (Astrophysics)</institution>
-       <address>Department of Astrophysical and Planetary Sciences</address>
-       <address>Campus Box 391</address>
-       <address>Boulder</address>
-       <address>CO</address>
-       <address>80309-0391</address>
-       <country>USA</country>
-       <contact>
-          <phone>303-492-8915</phone>
-          <fax>303-492-3822</fax>
-          <email>user@colorado.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>JILA</institution>
-       <address>Campus Box 440</address>
-       <address>Boulder</address>
-       <address>CO</address>
-       <address>80309-0440</address>
-       <country>USA</country>
-       <contact>
-          <phone>303-492-7789</phone>
-          <fax>303-492-5235</fax>
-          <email>user@jila.colorado.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Colorado at Boulder</institution>
-       <address>Laboratory for Atmospheric and Space Physics (LASP)</address>
-       <address>Duane Physics Building</address>
-       <address>Campus Box 392</address>
-       <address>Boulder</address>
-       <address>CO</address>
-       <address>80309-0392</address>
-       <country>USA</country>
-       <contact>
-          <phone>303-492-7677</phone>
-          <fax>303-492-6946</fax>
-          <email>user@lasp.colorado.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Columbia University</institution>
-       <address>Department of Astronomy and Physics</address>
-       <address>550 West 120th Street</address>
-       <address>New York City</address>
-       <address>NY</address>
-       <address>10027</address>
-       <country>USA</country>
-       <contact>
-          <phone>212-854-3278</phone>
-          <fax>212-854-8121</fax>
-          <email>user@astro.columbia.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Cornell University</institution>
-       <address>Department of Astronomy</address>
-       <address>512 Space Sciences Building</address>
-       <address>Ithaca</address>
-       <address>NY</address>
-       <address>14853-6801</address>
-       <country>USA</country>
-       <contact>
-          <phone>607-255-2000</phone>
-          <fax>607-255-9817</fax>
-          <email>user@astrosun.tn.cornell.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Dartmouth College</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>6127 Wilder Laboratory</address>
-       <address>Hanover</address>
-       <address>NH</address>
-       <address>03755-3528</address>
-       <country>USA</country>
-       <contact>
-          <phone>603-646-2854</phone>
-          <fax>603-646-1446</fax>
-          <email>user@dartmouth.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Delaware</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Newark</address>
-       <address>DE</address>
-       <address>19716</address>
-       <country>USA</country>
-       <contact>
-          <phone>302-831-2661</phone>
-          <fax>302-831-1637</fax>
-          <email>user@udel.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Denver</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>2112 East Wesley Avenue</address>
-       <address>Denver</address>
-       <address>CO</address>
-       <address>80208</address>
-       <country>USA</country>
-       <contact>
-          <phone>303-871-2238</phone>
-          <fax>303-871-4405</fax>
-          <email>user@du.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Drake University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>25th and University</address>
-       <address>Des Moines</address>
-       <address>IA</address>
-       <address>50311</address>
-       <country>USA</country>
-       <contact>
-          <phone>515-271-3141</phone>
-          <fax>515-271-3977</fax>
-          <email>user@acad.drake.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Fermi National Accelerator Laboratory</institution>
-       <address>PO Box 500</address>
-       <address>Batavia</address>
-       <address>IL</address>
-       <address>60510</address>
-       <country>USA</country>
-       <contact>
-          <phone>630-840-3000</phone>
-          <email>user@fnal.gov</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Five College Radio Astronomy Observatory</institution>
-       <address>University of Massachusetts</address>
-       <address>Amherst</address>
-       <address>MA</address>
-       <address>01003</address>
-       <country>USA</country>
-       <contact>
-          <phone>413-545-0789</phone>
-          <fax>413-545-4223</fax>
-          <email>user@fcrao1.phast.umass.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Florida Institute of Technology</institution>
-       <address>Physics and Space Sciences Department</address>
-       <address>150 W. University Boulevard</address>
-       <address>Melbourne</address>
-       <address>FL</address>
-       <address>32901-6988</address>
-       <country>USA</country>
-       <contact>
-          <phone>407-768-8098</phone>
-          <fax>407-984-8461</fax>
-          <email>user@pss.fit.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Florida</institution>
-       <address>Department of Astronomy</address>
-       <address>PO Box 112055</address>
-       <address>211 Bryant Space Science Center</address>
-       <address>Gainesville</address>
-       <address>FL</address>
-       <address>32611-2055</address>
-       <country>USA</country>
-       <contact>
-          <phone>352-392-2052</phone>
-          <fax>352-392-5089</fax>
-          <email>user@astro.ufl.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Franklin and Marshall College</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>PO Box 3003</address>
-       <address>Lancaster</address>
-       <address>PA</address>
-       <address>17604</address>
-       <country>USA</country>
-       <contact>
-          <phone>717-291-3800</phone>
-          <fax>717-399-4474</fax>
-          <email>user@acad.fandm.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>George Mason University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>4400 University Drive</address>
-       <address>Fairfax</address>
-       <address>VA</address>
-       <address>22030</address>
-       <country>USA</country>
-       <contact>
-          <phone>703-993-1280</phone>
-          <fax>703-993-1269</fax>
-          <email>user@gmu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Georgia State University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Atlanta</address>
-       <address>GA</address>
-       <address>30303</address>
-       <country>USA</country>
-       <contact>
-          <phone>404-651-2932</phone>
-          <fax>404-651-1389</fax>
-          <email>user@gsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Georgia</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Athens</address>
-       <address>GA</address>
-       <address>30602</address>
-       <country>USA</country>
-       <contact>
-          <phone>706-542-2485</phone>
-          <phone>706-542-2492</phone>
-          <email>user@hal.phyast.uga.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Harvard-Smithsonian Center for Astrophysics</institution>
-       <address>60 Garden Street</address>
-       <address>Cambridge</address>
-       <address>MA</address>
-       <address>02138</address>
-       <country>USA</country>
-       <contact>
-          <phone>617-495-7101</phone>
-          <fax>617-495-7468</fax>
-          <email>user@cfa.harvard.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Harvard-Smithsonian Submillimeter Array</institution>
-       <address>PO Box 824</address>
-       <address>Hilo</address>
-       <address>HI</address>
-       <address>96721</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-933-6947</phone>
-          <fax>808-933-6948</fax>
-       </contact>
-    </site>
-    <site>
-       <institution>Harvard University</institution>
-       <address>Department of Physics</address>
-       <address>17A Oxford Street</address>
-       <address>Cambridge</address>
-       <address>MA</address>
-       <address>02138</address>
-       <country>USA</country>
-       <contact>
-          <email>user@physics.harvard.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Haverford College</institution>
-       <address>Department of Astronomy</address>
-       <address>Harverford</address>
-       <address>PA</address>
-       <address>19041</address>
-       <country>USA</country>
-       <contact>
-          <phone>610-896-1145</phone>
-          <fax>610-896-4904</fax>
-          <email>user@haverford.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Hawaii (IfA)</institution>
-       <address>Institute for Astronomy</address>
-       <address>2680 Woodlawn Drive</address>
-       <address>Honolulu</address>
-       <address>HI</address>
-       <address>96822</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-956-8312</phone>
-          <phone>808-988-2790</phone>
-          <email>usern@ifa.hawaii.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Hawaii (IRTF)</institution>
-       <address>NASA Infrared Telescope Facility</address>
-       <address>Institute for Astronomy</address>
-       <address>2680 Woodlawn Drive</address>
-       <address>Honolulu</address>
-       <address>HI</address>
-       <address>96822</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-956-8101</phone>
-          <fax>808-988-3893</fax>
-          <email>user@ifa.hawaii.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Haystack Observatory</institution>
-       <address>NEROC</address>
-       <address>Route 40</address>
-       <address>Westford</address>
-       <address>MA</address>
-       <address>01886</address>
-       <country>USA</country>
-       <contact>
-          <phone>508-692-4764</phone>
-          <fax>617-981-0590</fax>
-          <email>user@newton.haystack.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Illinois at Urbana-Champaign</institution>
-       <address>Department of Astronomy</address>
-       <address>103 Astronomy Building</address>
-       <address>1002 West Green Street</address>
-       <address>Urbana</address>
-       <address>IL</address>
-       <address>61801</address>
-       <country>USA</country>
-       <contact>
-          <phone>217-333-3090</phone>
-          <fax>217-244-7638</fax>
-          <email>user@astro.uiuc.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Indiana University</institution>
-       <address>Department of Astronomy</address>
-       <address>319 Swain West</address>
-       <address>Bloomington</address>
-       <address>IN</address>
-       <address>47405</address>
-       <country>USA</country>
-       <contact>
-          <phone>812-855-6911</phone>
-          <fax>812-855-8725</fax>
-          <email>user@astro.indiana.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Institute for Advanced Study</institution>
-       <address>Princeton</address>
-       <address>NJ</address>
-       <address>08540</address>
-       <country>USA</country>
-       <contact>
-          <phone>609-734-8000</phone>
-          <fax>609-924-8399</fax>
-          <email>user@ias.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Iowa State University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Ames</address>
-       <address>IA</address>
-       <address>50011-3160</address>
-       <country>USA</country>
-       <contact>
-          <phone>515-294-5441</phone>
-          <fax>515-294-6027</fax>
-          <email>user@iastate.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Iowa</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>203 Van Allen Hall</address>
-       <address>Iowa City</address>
-       <address>IA</address>
-       <address>52242</address>
-       <country>USA</country>
-       <contact>
-          <phone>319-335-1686</phone>
-          <fax>319-335-1753</fax>
-          <email>user@uiowa.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Jet Propulsion Laboratory</institution>
-       <address>California Institute of Technology</address>
-       <address>4800 Oak Grove Drive</address>
-       <address>Pasadena</address>
-       <address>CA</address>
-       <address>91109</address>
-       <country>USA</country>
-       <contact>
-          <phone>818-354-4321</phone>
-          <fax>818-516-8260</fax>
-          <email>user@jpl.nasa.gov</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Johns Hopkins University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Charles and 34th Street</address>
-       <address>Bloomberg Center</address>
-       <address>Baltimore</address>
-       <address>MD</address>
-       <address>21218</address>
-       <country>USA</country>
-       <contact>
-          <phone>410-516-7346</phone>
-          <fax>410-516-7239</fax>
-          <email>user@pha.jhu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Joint Astronomy Centre</institution>
-       <address>660 North Aohoku Place</address>
-       <address>University Park</address>
-       <address>HI</address>
-       <address>96720</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-935-4332</phone>
-          <fax>808-961-6516</fax>
-          <email>user@jach.hawaii.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Univ. of Kansas</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Lawrence</address>
-       <address>KS</address>
-       <address>66045</address>
-       <country>USA</country>
-       <contact>
-          <phone>913-864-4626</phone>
-          <fax>913-864-5262</fax>
-          <email>user@kuphsx.phsx.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>W M Keck Observatory</institution>
-       <address>65-1120 Mamalahoa Highway</address>
-       <address>Kamuela</address>
-       <address>HI</address>
-       <address>96743</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-885-7887</phone>
-          <fax>808-885-4464</fax>
-          <email>user@keck.hawaii.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Kentucky</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>177 Chemistry/Physics Building</address>
-       <address>Lexington</address>
-       <address>KY</address>
-       <address>40506-0055</address>
-       <country>USA</country>
-       <contact>
-          <phone>606-257-6722</phone>
-          <fax>606-323-2846</fax>
-          <email>user@pa.uky.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Lawrence Livermore National Laboratory</institution>
-       <address>Livermore</address>
-       <address>CA</address>
-       <address>94551-9900</address>
-       <country>USA</country>
-       <contact>
-          <phone>510-423-0666</phone>
-          <fax>510-423-0238</fax>
-          <email>user@llnl.gov</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Lowell Observatory</institution>
-       <address>1400 W. Mars Hill Road</address>
-       <address>Flagstaff</address>
-       <address>AZ</address>
-       <address>86001</address>
-       <country>USA</country>
-       <contact>
-          <phone>602-774-3358</phone>
-          <fax>602-774-6296</fax>
-          <email>user@lowell.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Maryland</institution>
-       <address>Department of Astronomy</address>
-       <address>College Park</address>
-       <address>MD</address>
-       <address>20742 Phone</address>
-       <address>301-405-3001</address>
-       <country>USA</country>
-       <contact>
-          <fax>301-314-9067</fax>
-          <email>user@astro.umd.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Massachusetts Institute of Technology (EAPS)</institution>
-       <address>Department of Earth, Atmospheric and Planetary Sciences (EAPS)</address>
-       <address>EAPS Headquarters</address>
-       <address>77 Massachusetts Ave., Bldg 54-918</address>
-       <address>Cambridge</address>
-       <address>MA</address>
-       <address>02139</address>
-       <country>USA</country>
-       <contact>
-          <phone>617-253-2127</phone>
-          <fax>617-253-2886</fax>
-          <email>user@mit.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Massachusetts Institute of Technology (Astrophysics)</institution>
-       <address>Division of Astrophysics</address>
-       <address>Department of Physics</address>
-       <address>Cambridge</address>
-       <address>MA</address>
-       <address>02139</address>
-       <country>USA</country>
-       <contact>
-          <phone>617-253-4801</phone>
-          <email>user@mit.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Michigan State University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>East Lansing</address>
-       <address>MI</address>
-       <address>48824-1116</address>
-       <country>USA</country>
-       <contact>
-          <phone>517-353-4540</phone>
-          <fax>517-353-4500</fax>
-          <email>user@msupa.pa.msu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Michigan</institution>
-       <address>Department of Astronomy</address>
-       <address>830 Dennison</address>
-       <address>501 East University Avenue</address>
-       <address>Ann Arbor</address>
-       <address>MI</address>
-       <address>48109-1090</address>
-       <country>USA</country>
-       <contact>
-          <phone>313-764-3440</phone>
-          <fax>313-763-6317</fax>
-          <email>user@astro.lsa.umich.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Minnesota</institution>
-       <address>School of Physics and Astronomy</address>
-       <address>116 Church Street</address>
-       <address>SE</address>
-       <address>Minneapolis</address>
-       <address>MN</address>
-       <address>55455</address>
-       <country>USA</country>
-       <contact>
-          <phone>612-624-0211</phone>
-          <fax>612-626-2029</fax>
-          <email>user@ast1.spa.umn.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Montana</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Missoula</address>
-       <address>MT</address>
-       <address>59812</address>
-       <country>USA</country>
-       <contact>
-          <phone>406-243-2073</phone>
-          <fax>406-243-4076</fax>
-          <email>user@umt.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>NOAO</institution>
-       <address>PO Box 26732</address>
-       <address>950 North Cherry Avenue</address>
-       <address>Tucson</address>
-       <address>AZ</address>
-       <address>85726-6732</address>
-       <country>USA</country>
-       <contact>
-          <phone>520-318-8000</phone>
-          <fax>520-318-8360</fax>
-          <email>user@noao.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>NRAO Arizona Facility</institution>
-       <address>949 North Cherry Avenue</address>
-       <address>Campus Building 65</address>
-       <address>Tucson</address>
-       <address>AZ</address>
-       <address>85721-0665</address>
-       <country>USA</country>
-       <contact>
-          <phone>520-882-8250</phone>
-          <fax>520-882-7955</fax>
-          <email>user@nrao.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>NRAO Greenbank Facility</institution>
-       <address>PO Box 2</address>
-       <address>Green Bank</address>
-       <address>WV</address>
-       <address>24944</address>
-       <country>USA</country>
-       <contact>
-          <phone>304-456-2011</phone>
-          <fax>304-456-2271</fax>
-          <email>user@nrao.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>NRAO Headquarters</institution>
-       <address>520 Edgemont Road</address>
-       <address>Charlottesville</address>
-       <address>VA</address>
-       <address>22903-2475</address>
-       <country>USA</country>
-       <contact>
-          <phone>804-296-0211</phone>
-          <fax>804-296-0278</fax>
-          <email>user@nrao.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>NRAO New Mexico Facilities</institution>
-       <address>VLA Site</address>
-       <address>PO Box O, 1003 Lopezville Road</address>
-       <address>Socorro</address>
-       <address>NM</address>
-       <address>87801</address>
-       <country>USA</country>
-       <contact>
-          <phone>505-772-4011</phone>
-          <fax>505-772-4243</fax>
-          <email>user@nrao.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Naval Research Laboratory</institution>
-       <address>Code 7600</address>
-       <address>4555 Overlook Avenue, SW</address>
-       <address>Washington</address>
-       <address>DC</address>
-       <address>20375-5352</address>
-       <country>USA</country>
-       <contact>
-          <phone>202-767-6343</phone>
-          <fax>202-404-7296</fax>
-          <email>user@nrl.navy.mil</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Nebraska</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Lincoln</address>
-       <address>NE</address>
-       <address>68588-0111</address>
-       <country>USA</country>
-       <contact>
-          <phone>402-472-2770</phone>
-          <fax>402-472-2879</fax>
-          <email>user@unlinfo.unl.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Nevada at Las Vegas</institution>
-       <address>Physics Department</address>
-       <address>4505 South Maryland Parkway</address>
-       <address>Las Vegas</address>
-       <address>NV</address>
-       <address>89154</address>
-       <country>USA</country>
-       <contact>
-          <phone>702-895-0868</phone>
-          <fax>702-895-0804</fax>
-          <email>user@physics.unlv.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of New Hampshire</institution>
-       <address>Department of Physics</address>
-       <address>Demeritt Hall</address>
-       <address>Durham</address>
-       <address>NH</address>
-       <address>03824</address>
-       <country>USA</country>
-       <contact>
-          <phone>603-862-1950</phone>
-          <fax>603-862-2998</fax>
-          <email>user@unh.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>New Mexico Institute of Mining and Technology</institution>
-       <address>Astrophysics Research Center</address>
-       <address>Department of Physics</address>
-       <address>Socorro</address>
-       <address>NM</address>
-       <address>87801</address>
-       <country>USA</country>
-       <contact>
-          <phone>505-835-5328</phone>
-          <fax>505-835-5707</fax>
-          <email>user@kestrel.nmt.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>New Mexico State University</institution>
-       <address>Astronomy Department</address>
-       <address>Box 30001/Department 4500</address>
-       <address>Las Cruces</address>
-       <address>NM</address>
-       <address>88003-8001</address>
-       <country>USA</country>
-       <contact>
-          <phone>505-646-4438</phone>
-          <fax>505-646-1602</fax>
-          <email>user@nmsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of New Mexico</institution>
-       <address>Department of Physics and Astronomy and Institute for Astrophysics</address>
-       <address>Albuquerque</address>
-       <address>NM</address>
-       <address>87131</address>
-       <country>USA</country>
-       <contact>
-          <phone>505-277-2616</phone>
-          <fax>505-277-1520</fax>
-          <email>user@phys.unm.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>State University of New York at Stony Brook</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Stony Brook</address>
-       <address>NY</address>
-       <address>11794-2100</address>
-       <country>USA</country>
-       <contact>
-          <phone>516-632-8200</phone>
-          <fax>516-632-8240</fax>
-          <email>user@astro.sunysb.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>North Carolina State University</institution>
-       <address>Department of Physics</address>
-       <address>Box 8202</address>
-       <address>Raleigh</address>
-       <address>NC</address>
-       <address>27695-8202</address>
-       <country>USA</country>
-       <contact>
-          <phone>919-515-2521</phone>
-          <fax>919-515-6538</fax>
-          <email>user@ncsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of North Carolina</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>CB# 3255 Phillips Hall</address>
-       <address>Chapel Hill</address>
-       <address>NC</address>
-       <address>27599-3255</address>
-       <country>USA</country>
-       <contact>
-          <phone>919-962-2078</phone>
-          <fax>919-962-0480</fax>
-          <email>user@physics.unc.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Northern Arizona University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Box 6010</address>
-       <address>Flagstaff</address>
-       <address>AZ</address>
-       <address>86011-6010</address>
-       <country>USA</country>
-       <contact>
-          <phone>520-523-2661</phone>
-          <fax>520-523-1371</fax>
-          <email>user@nau.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Northwestern University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Dearborn Observatory</address>
-       <address>2131 Sheridan Road</address>
-       <address>Evanston</address>
-       <address>IL</address>
-       <address>60208-2900</address>
-       <country>USA</country>
-       <contact>
-          <phone>847-491-7650</phone>
-          <phone>847-491-3135</phone>
-          <email>user@astro.nwu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Ohio State University</institution>
-       <address>Department of Astronomy</address>
-       <address>174 W. 18th Avenue</address>
-       <address>Columbus</address>
-       <address>OH</address>
-       <address>43210-1106</address>
-       <country>USA</country>
-       <contact>
-          <phone>614-292-1773</phone>
-          <fax>614-292--2928</fax>
-          <email>user@astronomy.ohio-state.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Ohio University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Clippinger Research Labs. 251B</address>
-       <address>Athens</address>
-       <address>OH</address>
-       <address>45701-2979</address>
-       <country>USA</country>
-       <contact>
-          <phone>614-593-1718</phone>
-          <fax>614-593-0433</fax>
-          <email>user@helios.phy.ohiou.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Oklahoma State University</institution>
-       <address>Department of Physics</address>
-       <address>Astrophysics Group</address>
-       <address>Stillwater</address>
-       <address>OK</address>
-       <address>74078-3072</address>
-       <country>USA</country>
-       <contact>
-          <phone>405-744-5796</phone>
-          <fax>405-744-6811</fax>
-          <email>user@okstate.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Oklahoma</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Room 131 Nielsen Hall</address>
-       <address>Norman</address>
-       <address>OK</address>
-       <address>73019-0225</address>
-       <country>USA</country>
-       <contact>
-          <phone>405-325-3961</phone>
-          <fax>405-325-7557</fax>
-          <email>user@phyast.nhn.ou.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Oregon</institution>
-       <address>Physics Department</address>
-       <address>Eugene</address>
-       <address>OR</address>
-       <address>97403</address>
-       <country>USA</country>
-       <contact>
-          <phone>541-346-5826/5225</phone>
-          <fax>541-346-5861</fax>
-          <email>user@uoregon.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Pennsylvania State University</institution>
-       <address>Department of Astronomy and Astrophysics</address>
-       <address>525 Davey Laboratory</address>
-       <address>University Park</address>
-       <address>PA</address>
-       <address>16802</address>
-       <country>USA</country>
-       <contact>
-          <phone>814-865-0418</phone>
-          <fax>814-863-3399</fax>
-          <email>user@astro.psu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Behrend College, Pennsylvania State University</institution>
-       <address>Division of Science</address>
-       <address>Station Road</address>
-       <address>Erie</address>
-       <address>PA</address>
-       <address>16563</address>
-       <country>USA</country>
-       <contact>
-          <phone>814-898-6105</phone>
-          <fax>814-898-6213</fax>
-          <email>user@psu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Pennsylvania</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>209 South 33rd Street</address>
-       <address>Philadelphia</address>
-       <address>PA</address>
-       <address>19104-6396</address>
-       <country>USA</country>
-       <contact>
-          <phone>215-898-8141</phone>
-          <fax>215-898-2010</fax>
-          <email>user@upenn.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Pittsburgh</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>100 Allen Hall</address>
-       <address>Pittsburgh</address>
-       <address>PA</address>
-       <address>15260</address>
-       <country>USA</country>
-       <contact>
-          <phone>412-624-9000</phone>
-          <fax>412-624-9163</fax>
-          <email>user@pitt.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Princeton University (Astrophysics)</institution>
-       <address>Department of Astrophysical Sciences</address>
-       <address>Peyton Hall</address>
-       <address>Princeton</address>
-       <address>NJ</address>
-       <address>08544-1001</address>
-       <country>USA</country>
-       <contact>
-          <phone>609-258-3801</phone>
-          <fax>609-258-1020</fax>
-          <email>user@astro.princeton.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Princeton University (Physics)</institution>
-       <address>Department of Physics</address>
-       <address>Joseph Henry Laboratories</address>
-       <address>Jadwin Hall, PO Box 708</address>
-       <address>Princeton</address>
-       <address>NJ</address>
-       <address>08544-0708</address>
-       <country>USA</country>
-       <contact>
-          <phone>609-258-4400</phone>
-          <fax>609-258-1124</fax>
-          <email>user@princeton.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Rensselaer Polytechnic Institute</institution>
-       <address>Department of Physics</address>
-       <address>110 Eighth Street</address>
-       <address>Troy</address>
-       <address>NY</address>
-       <address>12180-3590</address>
-       <country>USA</country>
-       <contact>
-          <phone>518-276-6320</phone>
-          <fax>518-276-6680</fax>
-          <email>user@rpi.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Rice University</institution>
-       <address>Department of Space Physics and Astronomy</address>
-       <address>MS 108</address>
-       <address>6100 South Main</address>
-       <address>Houston</address>
-       <address>TX</address>
-       <address>77005-1892</address>
-       <country>USA</country>
-       <contact>
-          <phone>713-527-4939</phone>
-          <fax>713-285-5143</fax>
-          <email>user@rice.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Rochester Institute of Technology (CIS)</institution>
-       <address>Center for Imaging Science</address>
-       <address>54 Lomb Memorial Drive</address>
-       <address>Rochester</address>
-       <address>NY</address>
-       <address>14623-5604</address>
-       <country>USA</country>
-       <contact>
-          <phone>716-475-5944</phone>
-          <email>user@rit.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Rochester Institute of Technology (Physics)</institution>
-       <address>Department of Physics</address>
-       <address>College of Science</address>
-       <address>85 Lomb Memorial Drive</address>
-       <address>Rochester</address>
-       <address>NY</address>
-       <address>14623-5603</address>
-       <country>USA</country>
-       <contact>
-          <phone>716-475-5763</phone>
-          <fax>716-475-5766</fax>
-          <email>user@rit.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Rochester</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Rochester</address>
-       <address>NY</address>
-       <address>14627-0011</address>
-       <country>USA</country>
-       <contact>
-          <phone>716-275-4405</phone>
-          <fax>716-275-8527</fax>
-          <email>user@pas.rochester.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Rutgers University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>PO Box 849</address>
-       <address>Piscataway</address>
-       <address>NJ</address>
-       <address>08855-0849</address>
-       <country>USA</country>
-       <contact>
-          <phone>908-445-2503</phone>
-          <fax>908-445-4343</fax>
-          <email>user@physics.rutgers.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>San Diego State University</institution>
-       <address>Department of Astronomy</address>
-       <address>San Diego</address>
-       <address>CA</address>
-       <address>92182-1221</address>
-       <country>USA</country>
-       <contact>
-          <phone>619-594-6182</phone>
-          <fax>619-594-1413</fax>
-          <email>user@mintaka.sdsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>San Francisco State University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>San Francisco</address>
-       <address>CA</address>
-       <address>94132</address>
-       <country>USA</country>
-       <contact>
-          <phone>415-338-1659</phone>
-          <fax>415-338-2178</fax>
-          <email>user@stars.sfsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>San Juan Capistrano Research Institute</institution>
-       <address>Planetary Science Institute</address>
-       <address>620 North 6th Avenue</address>
-       <address>Tucson</address>
-       <address>AZ</address>
-       <address>85705-8331</address>
-       <country>USA</country>
-       <contact>
-          <phone>520-622-6300</phone>
-          <fax>520-622-8060</fax>
-          <email>user@psi.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>SETI Institute</institution>
-       <address>2035 Landings Drive</address>
-       <address>Mountain View</address>
-       <address>CA</address>
-       <address>94043</address>
-       <country>USA</country>
-       <contact>
-          <phone>415-961-6633</phone>
-          <fax>415-961-7099</fax>
-          <email>user@seti-inst.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Space Telescope Science Institute</institution>
-       <address>3700 San Martin Drive</address>
-       <address>Baltimore</address>
-       <address>MD</address>
-       <address>21218</address>
-       <country>USA</country>
-       <contact>
-          <phone>410-338-4700</phone>
-          <fax>410-338-4767</fax>
-          <email>user@stsci.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Spaces Sciences Center</institution>
-       <address>University Park</address>
-       <address>Los Angeles</address>
-       <address>CA</address>
-       <address>90089-1341</address>
-       <country>USA</country>
-       <contact>
-          <phone>213-740-6340</phone>
-          <fax>213-740-6342</fax>
-          <email>user@usc.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Stanford University</institution>
-       <address>Astronomy Program</address>
-       <address>Varian Building</address>
-       <address>Room 302c</address>
-       <address>Stanford</address>
-       <address>CA</address>
-       <address>94305-4060</address>
-       <country>USA</country>
-       <contact>
-          <phone>415-723-1436</phone>
-          <fax>415-723-4840</fax>
-          <email>user@bigbang.stanford.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Stanford University</institution>
-       <address>Astronomy Program</address>
-       <address>Varian Building</address>
-       <address>Room 302c</address>
-       <address>Stanford</address>
-       <address>CA</address>
-       <address>94305-4060</address>
-       <country>USA</country>
-       <contact>
-          <phone>415-723-1436</phone>
-          <fax>415-723-4840</fax>
-          <email>user@bigbang.stanford.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Swinburne University of Technology</institution>
-       <address>Swinburne Centre for Astrophysics and Supercomputing</address>
-       <address>Mail number 31</address>
-       <address>PO Box 218</address>
-       <address>Hawthorne</address>
-       <address>Victoria</address>
-       <address>3122</address>
-       <country>Australia</country>
-       <contact>
-          <phone>61-392148782</phone>
-          <fax>61-392148797</fax>
-          <email>mbailes@swin.edu.au</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Toledo</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Toledo</address>
-       <address>OH</address>
-       <address>43606</address>
-       <country>USA</country>
-       <contact>
-          <phone>419-530-2241</phone>
-          <phone>419-530-2723</phone>
-          <email>user@utoledo.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Vanderbilt University</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>PO Box 1803 Station B</address>
-       <address>Nashville</address>
-       <address>TN</address>
-       <address>37235</address>
-       <country>USA</country>
-       <contact>
-          <phone>615-373-4897</phone>
-          <fax>615-343-7263</fax>
-          <email>user@vanderbilt.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Villanova University</institution>
-       <address>Department of Astronomy and Astrophysics</address>
-       <address>Villanova</address>
-       <address>PA</address>
-       <address>19085</address>
-       <country>USA</country>
-       <contact>
-          <phone>610-519-4820</phone>
-          <fax>610-519-6132</fax>
-          <email>user@ucis.vill.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Virginia</institution>
-       <address>Department of Astronomy</address>
-       <address>PO Box 3818</address>
-       <address>Charlottesville</address>
-       <address>VA</address>
-       <address>22903-0818</address>
-       <country>USA</country>
-       <contact>
-          <phone>804-924-7494</phone>
-          <fax>804-921-3104</fax>
-          <email>user@virginia.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Washington State University</institution>
-       <address>Program in Astronomy</address>
-       <address>PO Box 643113</address>
-       <address>Pullman</address>
-       <address>WA</address>
-       <address>99164-3113</address>
-       <country>USA</country>
-       <contact>
-          <phone>509-335-8518</phone>
-          <fax>509-335-1188</fax>
-          <email>user@math.wsu.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Washington</institution>
-       <address>Department of Astronomy</address>
-       <address>Box 351580</address>
-       <address>Seattle</address>
-       <address>WA</address>
-       <address>98195-1580</address>
-       <country>USA</country>
-       <contact>
-          <phone>206-543-2888</phone>
-          <fax>206-685-0403</fax>
-          <email>user@astro.washington.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Wesleyan University</institution>
-       <address>Department of Astronomy</address>
-       <address>Middletown</address>
-       <address>CT</address>
-       <address>06459-0123</address>
-       <country>USA</country>
-       <contact>
-          <phone>860-685-2130</phone>
-          <fax>860-685-2131</fax>
-          <email>user@astro.wesleyan.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Williams College</institution>
-       <address>Department of Astronomy</address>
-       <address>Williamstown</address>
-       <address>MA</address>
-       <address>01267</address>
-       <country>USA</country>
-       <contact>
-          <phone>413-597-2482</phone>
-          <fax>413-597-3200</fax>
-          <email>user@williams.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Wisconsin at Madison (Astronomy)</institution>
-       <address>Department of Astronomy</address>
-       <address>475 North Charter Street</address>
-       <address>Madison</address>
-       <address>WI</address>
-       <address>53706</address>
-       <country>USA</country>
-       <contact>
-          <email>user@wisc.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Wisconsin at Madison (Physics)</institution>
-       <address>Department of Physics</address>
-       <address>2531 Sterling Hall</address>
-       <address>Madison</address>
-       <address>WI</address>
-       <address>53706</address>
-       <country>USA</country>
-       <contact>
-          <phone>608-262-4526</phone>
-          <fax>608-262-3077</fax>
-          <email>user@wisc.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>University of Wyoming</institution>
-       <address>Department of Physics and Astronomy</address>
-       <address>Laramie</address>
-       <address>WY</address>
-       <address>82071</address>
-       <country>USA</country>
-       <contact>
-          <phone>307-766-6150</phone>
-          <fax>307-766-2652</fax>
-          <email>user@uwyo.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Yale University</institution>
-       <address>Department of Astronomy</address>
-       <address>PO Box 208101</address>
-       <address>New Haven</address>
-       <address>CT</address>
-       <address>06520-8101</address>
-       <country>USA</country>
-       <contact>
-          <phone>203-432-3000</phone>
-          <fax>203-432-5048</fax>
-          <email>user@astro.yale.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Gemini Observatory - North</institution>
-       <address>Gemini Observatory</address>
-       <address>670 N. Aohoku Place</address>
-       <address>Hilo</address>
-       <address>HI</address>
-       <address>96720</address>
-       <country>USA</country>
-       <contact>
-          <phone>808-974-2500</phone>
-          <fax>808-935-9235</fax>
-          <email>user@gemini.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Gemini Observatory - South</institution>
-       <address>Gemini Observatory</address>
-       <address>Colina El Pino s/n</address>
-       <address>La Serena</address>
-       <country>Chile</country>
-       <contact>
-          <phone>011-5651-205-600</phone>
-          <fax>011-5651-205-650</fax>
-          <email>user@gemini.edu</email>
-       </contact>
-    </site>
-    <site>
-       <institution>Subaru Telescope, NAOJ</institution>
-       <address>650 North A'ohoku Place</address>
-       <address>Hilo</address>
-       <address>HI</address>
-       <address>96720</address>
-       <country>USA</country>
-       <contact>
-           <phone>808-934-7788</phone>
-           <fax>808-934-5099</fax>
-       </contact>
+        <institution>Armagh Observatory</institution>
+        <address>College Hill</address>
+        <address>Armagh BT61 9DG</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1861-522928</phone>
+            <fax>+44-1861-527174</fax>
+            <email>user@star.arm.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Birmingham</institution>
+        <address>School of Physics and Space Research</address>
+        <address>Edgbaston</address>
+        <address>Birmingham B15 2TT</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-121-4146453</phone>
+            <fax>+44-121-4143722</fax>
+            <email>user@star.sr.bham.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Bristol</institution>
+        <address>Department of Physics</address>
+        <address>Royal Fort, Tyndall Avenue</address>
+        <address>Bristol BS8 1TL</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-117-928-8314</phone>
+            <fax>+44-117-925-5624</fax>
+            <email>user@bristol.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Cambridge</institution>
+        <address>Institute of Astronomy</address>
+        <address>Madingley Road</address>
+        <address>Cambridge CB3 0HA</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1223-337548</phone>
+            <fax>+44-1223-337523</fax>
+            <email>user@ast.cam.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Central Lancashire</institution>
+        <address>Center for Astrophysics</address>
+        <address>Preston</address>
+        <address>Lancashire</address>
+        <address>PR1 2HE</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1772-8933569</phone>
+            <fax>+44-1722-892903</fax>
+            <email>user@star.uclan.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Durham</institution>
+        <address>Department of Physics</address>
+        <address>South Road</address>
+        <address>Durham DH1 3LE</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-191-374-2165</phone>
+            <fax>+44-191-374-7465</fax>
+            <email>user@durham.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Edinburgh</institution>
+        <address>Institute for Astronomy</address>
+        <address>Blackford Hill</address>
+        <address>Edinburgh EH9 3HJ</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-131-668-8356</phone>
+            <fax>+44-131-668-8356</fax>
+            <email>user@roe.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Glasgow</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Glasgow G12 8QQ</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-141-330-4152</phone>
+            <fax>+44-141-334-9029</fax>
+            <email>user@astro.gla.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Hertfordshire</institution>
+        <address>Department of Physical Sciences</address>
+        <address>College Lane</address>
+        <address>Hatfield</address>
+        <address>Hertfordshire AL10 9AB</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1707-284601</phone>
+            <fax>+44-1707-284514</fax>
+            <email>user@star.herts.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Imperial College of Science, Technology and Medicine</institution>
+        <address>Astrophysics Group</address>
+        <address>The Blackett Laboratory</address>
+        <address>Prince Consort Road</address>
+        <address>London SW7 2BZ</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-171-594-7531</phone>
+            <fax>+44-171-594-7777</fax>
+            <email>user@ic.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Keele University</institution>
+        <address>Department of Physics</address>
+        <address>Keele</address>
+        <address>Staffordshire ST5 5BG</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1782-583319</phone>
+            <fax>+44-1782-711093</fax>
+            <email>user@astro.keele.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Kent</institution>
+        <address>Electronic Engineering Lab</address>
+        <address>Canterbury</address>
+        <address>Kent CT2 7NT</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1227-823190</phone>
+            <fax>+44-1227-456084</fax>
+            <email>user@star.ukc.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Leeds</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>E. C. Stoner Building</address>
+        <address>Leeds LS2 9JT</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-113-233-3860</phone>
+            <fax>+44-113-233-3900</fax>
+            <email>user@physics.leeds.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Leicester</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>University Road</address>
+        <address>Leicester LE1 7RH</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-116-252-3540</phone>
+            <fax>+44-116-252-3311</fax>
+            <email>user@star.le.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Liverpool John Moores University</institution>
+        <address>Astrophysics Group</address>
+        <address>Division of Engineering and Science</address>
+        <address>Byrom Street</address>
+        <address>Liverpool L3 3AF</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-151-231-2337</phone>
+            <fax>+44-151-231-2337</fax>
+            <email>user@staru1.livjm.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University College London</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Gower Street</address>
+        <address>London WC1E 6BT</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-171-387-7050</phone>
+            <fax>+44-171-380-7145</fax>
+            <email>user@star.ucl.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Manchester</institution>
+        <address>Department of Astronomy</address>
+        <address>Manchester M13 9PL</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-161-275-4224</phone>
+            <fax>+44-161-275-4223</fax>
+            <email>user@ast.man.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Mullard Radio Astronomy Observatory</institution>
+        <address>Cavendish Laboratory</address>
+        <address>Madingley Road</address>
+        <address>Cambridge CB3 0HE</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1223-337294</phone>
+            <fax>+44-1223-354599</fax>
+            <email>user@mrao.cam.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Mullard Space Science Laboratory</institution>
+        <address>Holmbury St. Mary</address>
+        <address>Nr Dorking</address>
+        <address>Surrey RH5 6NT</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-10483-274111</phone>
+            <fax>+44-10483-278312</fax>
+            <email>user@mss1.ucl.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Nottingham</institution>
+        <address>Astronomy and Astrophysical Chemistry Group</address>
+        <address>Department of Chemistry</address>
+        <address>University Park</address>
+        <address>Nottingham NG7 2RD</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-115-951-3460</phone>
+            <fax>+44-115-951-3466</fax>
+            <email>user@nottingham.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Nuffield Radio Astronomy Laboratories</institution>
+        <address>University of Manchester</address>
+        <address>Jodrell Bank</address>
+        <address>Cheshire SK11 9DL</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1477-571-321</phone>
+            <fax>+44-1477-571-618</fax>
+            <email>user@jb.man.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Open University</institution>
+        <address>Astronomy Group</address>
+        <address>Physics Department</address>
+        <address>Walton Hall</address>
+        <address>Milton Keynes</address>
+        <address>MK7 6AA</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1908-653229</phone>
+            <fax>+44-1908-654192</fax>
+            <email>user@open.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Oxford</institution>
+        <address>Department of Physics, Astrophysics, Nuclear and Astrophysics Laboratory</address>
+        <address>Keble Road</address>
+        <address>Oxford</address>
+        <address>OX1 3RH</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1865-273303</phone>
+            <fax>+44-1865-273418</fax>
+            <email>user@physics.oxford.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Queen's University of Belfast</institution>
+        <address>Department of Pure and Applied Physics</address>
+        <address>Belfast BT7 1NN</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1232-245133</phone>
+            <fax>+44-1232-438918</fax>
+            <email>user@qub.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Queen Mary and Westfield College</institution>
+        <address>Department of Physics</address>
+        <address>Mile End Road</address>
+        <address>London E1 4NS</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-171-975-5555</phone>
+            <fax>+44-171-975-5500</fax>
+            <email>user@qmw.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Royal Greenwich Observatory</institution>
+        <address>Madingley Road</address>
+        <address>Cambridge CB3 0EZ</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1223-374000</phone>
+            <fax>+44-1223-374700</fax>
+            <email>user@ast.cam.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Royal Observatory Edinburgh and ATC</institution>
+        <address>Blackford Hill</address>
+        <address>Edinburgh EH9 3HJ</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-131-668-8100</phone>
+            <fax>+44-131-668-1668</fax>
+            <email>user@roe.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Sheffield</institution>
+        <address>Department of Physics</address>
+        <address>Hounsfield Road</address>
+        <address>Sheffield S3 7RH</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-114-222-2000</phone>
+            <fax>+44-114-272-8079</fax>
+            <email>user@sheffield.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Southampton</institution>
+        <address>Department of Physics</address>
+        <address>Southampton</address>
+        <address>S017 1BJ</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1703-595000</phone>
+            <fax>+44-1703-593910</fax>
+            <email>user@phastr.soton.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of St. Andrews</institution>
+        <address>School of Physics and Astronomy</address>
+        <address>North Haugh</address>
+        <address>St. Andrews KY16 9SS</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1334-46-3103</phone>
+            <fax>+44-1334-46-3104</fax>
+            <email>user@st-and.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Sussex</institution>
+        <address>Astronomy Centre</address>
+        <address>CPES</address>
+        <address>Brighton</address>
+        <address>BN1 9QH</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1273-678117</phone>
+            <fax>+44-1273-678097</fax>
+            <email>user@star.cpes.susx.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Wales Cardiff</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>PO Box 913</address>
+        <address>Cardiff CF2 3YB</address>
+        <country>United Kingdom</country>
+        <contact>
+            <phone>+44-1222-87-4458</phone>
+            <fax>+44-1222-87-4056</fax>
+            <email>user@astro.cf.ac.uk</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Alabama</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>206 Gallalee Hall</address>
+        <address>Box 870324</address>
+        <address>Tuscaloosa</address>
+        <address>AL</address>
+        <address>35487-0324</address>
+        <country>USA</country>
+        <contact>
+            <phone>205-348-5050</phone>
+            <fax>205-348-5051</fax>
+            <email>user@astr.ua.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Apache Point Observatory</institution>
+        <address>Astrophysical Research Consortium</address>
+        <address>2001 Apache Point Road</address>
+        <address>PO Box 59</address>
+        <address>Sunspot</address>
+        <address>NM</address>
+        <address>88349-0059</address>
+        <country>USA</country>
+        <contact>
+            <phone>505-437-6822</phone>
+            <fax>505-434-5555</fax>
+            <email>user@galileo.apo.nmsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Appalachian State University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Boone</address>
+        <address>NC</address>
+        <address>28608</address>
+        <country>USA</country>
+        <contact>
+            <phone>704-262-3090</phone>
+            <fax>704-262-2409</fax>
+            <email>user@appstate.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Arecibo Observatory</institution>
+        <address>National Astronomy and Ionosphere Center (NAIC)</address>
+        <address>PO Box 995</address>
+        <address>Arecibo</address>
+        <address>PR</address>
+        <address>00613</address>
+        <country>USA</country>
+        <contact>
+            <phone>787-878-2612</phone>
+            <fax>787-878-1861</fax>
+            <email>user@naic.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Arizona State University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Box 871504</address>
+        <address>Tempe</address>
+        <address>AZ</address>
+        <address>85287-1504</address>
+        <country>USA</country>
+        <contact>
+            <phone>602-965-3561</phone>
+            <fax>602-965-7954</fax>
+            <email>user@asu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Arizona (Astronomy)</institution>
+        <address>Department of Astronomy and Steward Observatory</address>
+        <address>933 North Cherry Avenue</address>
+        <address>Tucson</address>
+        <address>AZ</address>
+        <address>85721-0065</address>
+        <country>USA</country>
+        <contact>
+            <phone>520-621-2288</phone>
+            <fax>520-621-1532</fax>
+            <email>user@as.arizona.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Arizona (Lunar and Planetary Lab)</institution>
+        <address>Lunar and Planetary Laboratory</address>
+        <address>Space Sciences Building</address>
+        <address>PO Box 210092</address>
+        <address>Tucson</address>
+        <address>AZ</address>
+        <address>85721-0092</address>
+        <country>USA</country>
+        <contact>
+            <phone>520-621-6963</phone>
+            <fax>520-621-4933</fax>
+        </contact>
+    </site>
+    <site>
+        <institution>Bowling Green State University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Bowling Green</address>
+        <address>OH</address>
+        <address>43403</address>
+        <country>USA</country>
+        <contact>
+            <phone>419-372-2421</phone>
+            <fax>419-372-9938</fax>
+            <email>user@bgnet.bgsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Brandeis University</institution>
+        <address>Department of Physics</address>
+        <address>Waltham</address>
+        <address>MA</address>
+        <address>02254</address>
+        <country>USA</country>
+        <contact>
+            <phone>617-736-2800/-2835</phone>
+            <email>user@brandeis.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Berkeley (EUV Astrophysics)</institution>
+        <address>Center for EUV Astrophysics</address>
+        <address>2150 Kittredge Street</address>
+        <address>Berkeley</address>
+        <address>CA</address>
+        <address>94720-3411</address>
+        <country>USA</country>
+        <contact>
+            <phone>510-643-5637</phone>
+            <fax>510-643-5660</fax>
+            <email>user@ssl.berkeley.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Berkeley (Astronomy)</institution>
+        <address>Department of Astronomy</address>
+        <address>601 Campbell Hall #3411</address>
+        <address>Berkeley</address>
+        <address>CA</address>
+        <address>94720-3411</address>
+        <country>USA</country>
+        <contact>
+            <phone>510-642-5275</phone>
+            <fax>510-642-3411</fax>
+            <email>user@astro.berkeley.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Berkeley (Physics)</institution>
+        <address>Department of Physics</address>
+        <address>366 LeConte Hall, #730</address>
+        <address>Berkeley</address>
+        <address>CA</address>
+        <address>94720-7300</address>
+        <country>USA</country>
+        <contact>
+            <phone>510-642-3316</phone>
+            <fax>510-643-8497</fax>
+            <email>user@berkeley.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Berkeley (Hat Creek)</institution>
+        <address>Hat Creek Radio Observatory</address>
+        <address>42231 Bidwell Road</address>
+        <address>Hat Creek</address>
+        <address>CA</address>
+        <address>96040</address>
+        <country>USA</country>
+        <contact>
+            <phone>916-335-2364</phone>
+            <fax>916-335-4944</fax>
+            <email>user@bima.berkeley.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Irvine</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Irvine</address>
+        <address>CA</address>
+        <address>92697-4575</address>
+        <country>USA</country>
+        <contact>
+            <phone>714-824-6911</phone>
+            <fax>714-824-2174</fax>
+            <email>user@uci.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Los Angeles</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>8371 Math Sciences</address>
+        <address>Los Angeles</address>
+        <address>CA</address>
+        <address>90095-1562</address>
+        <country>USA</country>
+        <contact>
+            <phone>310-825-4435</phone>
+            <fax>310-206-2096</fax>
+            <email>user@astro.ucla.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Riverside</institution>
+        <address>Department of Physics</address>
+        <address>Riverside</address>
+        <address>CA</address>
+        <address>92521</address>
+        <country>USA</country>
+        <contact>
+            <phone>909-787-5331</phone>
+            <fax>909-787-4529</fax>
+            <email>user@ucr.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC San Diego</institution>
+        <address>Center for Astrophysics and Space Sciences</address>
+        <address>9500 Gilman Drive</address>
+        <address>Code 0424</address>
+        <address>La Jolla</address>
+        <address>CA</address>
+        <address>92093-0424</address>
+        <country>USA</country>
+        <contact>
+            <phone>619-534-3460</phone>
+            <fax>619-534-2294</fax>
+            <email>user@ucsd.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Santa Barbara</institution>
+        <address>Department of Physics</address>
+        <address>Broida Hall, Building 572</address>
+        <address>Santa Barbara</address>
+        <address>CA</address>
+        <address>93106-9530</address>
+        <country>USA</country>
+        <contact>
+            <phone>805-893-3888</phone>
+            <fax>805-893-3307</fax>
+            <email>user@physics.ucsb.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>UC Santa Cruz</institution>
+        <address>Astronomy and Astrophysics Board of Study</address>
+        <address>Natural Sciences II</address>
+        <address>Santa Cruz</address>
+        <address>CA</address>
+        <address>95064</address>
+        <country>USA</country>
+        <contact>
+            <phone>408-459-2844</phone>
+            <fax>408-426-3115</fax>
+            <email>user@ucsc.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech Astronomy</institution>
+        <address>MS 105-24</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91125</address>
+        <country>USA</country>
+        <contact>
+            <phone>626-395-4169</phone>
+            <fax>626-568-9352</fax>
+            <email>user@caltech.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech Submillimeter Observatory</institution>
+        <address>111 Nowelo Street</address>
+        <address>Hilo</address>
+        <address>HI</address>
+        <address>96720</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-935-1909</phone>
+            <fax>808-961-6273</fax>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech (Geo. and Planetary)</institution>
+        <address>Division of Geological and Planetary Science</address>
+        <address>MS 170-25</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91125</address>
+        <country>USA</country>
+        <contact>
+            <phone>626-395-6108</phone>
+            <fax>626-568-0935</fax>
+            <email>user@caltech.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech (Physics, Maths  and Astronomy)</institution>
+        <address>Division of Physics, Mathematics and Astronomy</address>
+        <address>MS 103-33</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91125</address>
+        <country>USA</country>
+        <contact>
+            <phone>626-395-4241</phone>
+            <fax>626-564-0267</fax>
+            <email>user@caltech.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech IPAC</institution>
+        <address>MS 100-22</address>
+        <address>770 South Wilson Avenue</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91125</address>
+        <country>USA</country>
+        <contact>
+            <phone>626-397-7105</phone>
+            <fax>626-397-9600</fax>
+            <email>user@ipac.caltech.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech Owens Valley Radio Observatory</institution>
+        <address>MS 105-24</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91125</address>
+        <country>USA</country>
+        <contact>
+            <phone>619-938-2075</phone>
+            <fax>619-938-2297</fax>
+            <email>user@ovro.caltech.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech Physics</institution>
+        <address>MS 103-33</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91125</address>
+        <country>USA</country>
+        <contact>
+            <phone>626-395-4633</phone>
+            <email>user@caltech.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Caltech Radio Astronomy</institution>
+        <address>Pasadena Office</address>
+        <address>MS 105-24</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91125</address>
+        <country>USA</country>
+        <contact>
+            <phone>626-395-4973</phone>
+            <fax>626-568-9352</fax>
+            <email>user@caltech.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>California State University at Davis</institution>
+        <address>Department of Physics</address>
+        <address>Davis</address>
+        <address>CA</address>
+        <address>95616-8677</address>
+        <country>USA</country>
+        <contact>
+            <phone>916-752-1501</phone>
+            <email>user@physics.ucdavis.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Carnegie Institution of Washington (Headquartes)</institution>
+        <address>Carnegie Observatories</address>
+        <address>Headquarters</address>
+        <address>813 Santa Barbara Street</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91101-1292</address>
+        <country>USA</country>
+        <contact>
+            <phone>818-577-1122</phone>
+            <fax>818-795-8136</fax>
+            <email>user@ociw.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Carnegie Institution of Washington (Carnegie Obs.)</institution>
+        <address>Carnegie Observatories</address>
+        <address>Las Campanas Observatory</address>
+        <address>Casilla 601</address>
+        <address>La Serena</address>
+        <country>Chile</country>
+        <contact>
+            <phone>+56-51-213032</phone>
+            <email>user@ociw.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Carnegie Institution of Washington (Terrestrial Magn.)</institution>
+        <address>Department of Terrestrial Magnetism</address>
+        <address>5241 Broad Branch Road, NW</address>
+        <address>Washington</address>
+        <address>DC</address>
+        <address>20015-1305</address>
+        <country>USA</country>
+        <contact>
+            <phone>202-686-4370</phone>
+            <fax>202-364-8726</fax>
+            <email>user@dtm.ciw.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Carnegie Mellon University</institution>
+        <address>Department of Physics</address>
+        <address>5000 Forbes Avenue</address>
+        <address>Pittsburgh</address>
+        <address>PA</address>
+        <address>15213-3890</address>
+        <country>USA</country>
+        <contact>
+            <phone>412-268-2740</phone>
+            <fax>412-681-0648</fax>
+            <email>user@astro.phys.cmu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Case Western Reserve University</institution>
+        <address>Department of Astronomy</address>
+        <address>10900 Euclid Avenue</address>
+        <address>Cleveland</address>
+        <address>OH</address>
+        <address>44106-7215</address>
+        <country>USA</country>
+        <contact>
+            <phone>216-368-3728</phone>
+            <fax>216-368-5406</fax>
+            <email>user@po.cwru.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Cerro Tololo Interamerican Observatory</institution>
+        <address>Casilla 603</address>
+        <address>La Serena</address>
+        <country>Chile</country>
+        <contact>
+            <phone>56-51-225-415</phone>
+            <fax>56-51-205-212</fax>
+            <email>user@noao.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Chicago</institution>
+        <address>Department of Astronomy and Astrophysics</address>
+        <address>5640 South Ellis Avenue</address>
+        <address>Chicago</address>
+        <address>IL</address>
+        <address>60637</address>
+        <country>USA</country>
+        <contact>
+            <phone>312-702-8203</phone>
+            <fax>312-702-8212</fax>
+            <email>user@oddjob.uchicago.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Cincinnati</institution>
+        <address>Department of Physics</address>
+        <address>Cincinnati</address>
+        <address>OH</address>
+        <address>45221-0011</address>
+        <country>USA</country>
+        <contact>
+            <phone>513-556-0501</phone>
+            <fax>513-556-3425</fax>
+            <email>user@physunc.phy.uc.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Colorado at Boulder (CASA)</institution>
+        <address>Center for Astrophysics and Space Astronomy (CASA)</address>
+        <address>Campus Box 389</address>
+        <address>Boulder</address>
+        <address>CO</address>
+        <address>80309</address>
+        <country>USA</country>
+        <contact>
+            <phone>303-492-4050</phone>
+            <fax>303-492-7178</fax>
+            <email>user@casa.colorado.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Colorado at Boulder (Astrophysics)</institution>
+        <address>Department of Astrophysical and Planetary Sciences</address>
+        <address>Campus Box 391</address>
+        <address>Boulder</address>
+        <address>CO</address>
+        <address>80309-0391</address>
+        <country>USA</country>
+        <contact>
+            <phone>303-492-8915</phone>
+            <fax>303-492-3822</fax>
+            <email>user@colorado.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>JILA</institution>
+        <address>Campus Box 440</address>
+        <address>Boulder</address>
+        <address>CO</address>
+        <address>80309-0440</address>
+        <country>USA</country>
+        <contact>
+            <phone>303-492-7789</phone>
+            <fax>303-492-5235</fax>
+            <email>user@jila.colorado.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Colorado at Boulder</institution>
+        <address>Laboratory for Atmospheric and Space Physics (LASP)</address>
+        <address>Duane Physics Building</address>
+        <address>Campus Box 392</address>
+        <address>Boulder</address>
+        <address>CO</address>
+        <address>80309-0392</address>
+        <country>USA</country>
+        <contact>
+            <phone>303-492-7677</phone>
+            <fax>303-492-6946</fax>
+            <email>user@lasp.colorado.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Columbia University</institution>
+        <address>Department of Astronomy and Physics</address>
+        <address>550 West 120th Street</address>
+        <address>New York City</address>
+        <address>NY</address>
+        <address>10027</address>
+        <country>USA</country>
+        <contact>
+            <phone>212-854-3278</phone>
+            <fax>212-854-8121</fax>
+            <email>user@astro.columbia.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Cornell University</institution>
+        <address>Department of Astronomy</address>
+        <address>512 Space Sciences Building</address>
+        <address>Ithaca</address>
+        <address>NY</address>
+        <address>14853-6801</address>
+        <country>USA</country>
+        <contact>
+            <phone>607-255-2000</phone>
+            <fax>607-255-9817</fax>
+            <email>user@astrosun.tn.cornell.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Dartmouth College</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>6127 Wilder Laboratory</address>
+        <address>Hanover</address>
+        <address>NH</address>
+        <address>03755-3528</address>
+        <country>USA</country>
+        <contact>
+            <phone>603-646-2854</phone>
+            <fax>603-646-1446</fax>
+            <email>user@dartmouth.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Delaware</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Newark</address>
+        <address>DE</address>
+        <address>19716</address>
+        <country>USA</country>
+        <contact>
+            <phone>302-831-2661</phone>
+            <fax>302-831-1637</fax>
+            <email>user@udel.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Denver</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>2112 East Wesley Avenue</address>
+        <address>Denver</address>
+        <address>CO</address>
+        <address>80208</address>
+        <country>USA</country>
+        <contact>
+            <phone>303-871-2238</phone>
+            <fax>303-871-4405</fax>
+            <email>user@du.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Drake University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>25th and University</address>
+        <address>Des Moines</address>
+        <address>IA</address>
+        <address>50311</address>
+        <country>USA</country>
+        <contact>
+            <phone>515-271-3141</phone>
+            <fax>515-271-3977</fax>
+            <email>user@acad.drake.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Fermi National Accelerator Laboratory</institution>
+        <address>PO Box 500</address>
+        <address>Batavia</address>
+        <address>IL</address>
+        <address>60510</address>
+        <country>USA</country>
+        <contact>
+            <phone>630-840-3000</phone>
+            <email>user@fnal.gov</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Five College Radio Astronomy Observatory</institution>
+        <address>University of Massachusetts</address>
+        <address>Amherst</address>
+        <address>MA</address>
+        <address>01003</address>
+        <country>USA</country>
+        <contact>
+            <phone>413-545-0789</phone>
+            <fax>413-545-4223</fax>
+            <email>user@fcrao1.phast.umass.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Florida Institute of Technology</institution>
+        <address>Physics and Space Sciences Department</address>
+        <address>150 W. University Boulevard</address>
+        <address>Melbourne</address>
+        <address>FL</address>
+        <address>32901-6988</address>
+        <country>USA</country>
+        <contact>
+            <phone>407-768-8098</phone>
+            <fax>407-984-8461</fax>
+            <email>user@pss.fit.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Florida</institution>
+        <address>Department of Astronomy</address>
+        <address>PO Box 112055</address>
+        <address>211 Bryant Space Science Center</address>
+        <address>Gainesville</address>
+        <address>FL</address>
+        <address>32611-2055</address>
+        <country>USA</country>
+        <contact>
+            <phone>352-392-2052</phone>
+            <fax>352-392-5089</fax>
+            <email>user@astro.ufl.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Franklin and Marshall College</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>PO Box 3003</address>
+        <address>Lancaster</address>
+        <address>PA</address>
+        <address>17604</address>
+        <country>USA</country>
+        <contact>
+            <phone>717-291-3800</phone>
+            <fax>717-399-4474</fax>
+            <email>user@acad.fandm.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>George Mason University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>4400 University Drive</address>
+        <address>Fairfax</address>
+        <address>VA</address>
+        <address>22030</address>
+        <country>USA</country>
+        <contact>
+            <phone>703-993-1280</phone>
+            <fax>703-993-1269</fax>
+            <email>user@gmu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Georgia State University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Atlanta</address>
+        <address>GA</address>
+        <address>30303</address>
+        <country>USA</country>
+        <contact>
+            <phone>404-651-2932</phone>
+            <fax>404-651-1389</fax>
+            <email>user@gsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Georgia</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Athens</address>
+        <address>GA</address>
+        <address>30602</address>
+        <country>USA</country>
+        <contact>
+            <phone>706-542-2485</phone>
+            <phone>706-542-2492</phone>
+            <email>user@hal.phyast.uga.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Harvard-Smithsonian Center for Astrophysics</institution>
+        <address>60 Garden Street</address>
+        <address>Cambridge</address>
+        <address>MA</address>
+        <address>02138</address>
+        <country>USA</country>
+        <contact>
+            <phone>617-495-7101</phone>
+            <fax>617-495-7468</fax>
+            <email>user@cfa.harvard.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Harvard-Smithsonian Submillimeter Array</institution>
+        <address>PO Box 824</address>
+        <address>Hilo</address>
+        <address>HI</address>
+        <address>96721</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-933-6947</phone>
+            <fax>808-933-6948</fax>
+        </contact>
+    </site>
+    <site>
+        <institution>Harvard University</institution>
+        <address>Department of Physics</address>
+        <address>17A Oxford Street</address>
+        <address>Cambridge</address>
+        <address>MA</address>
+        <address>02138</address>
+        <country>USA</country>
+        <contact>
+            <email>user@physics.harvard.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Haverford College</institution>
+        <address>Department of Astronomy</address>
+        <address>Harverford</address>
+        <address>PA</address>
+        <address>19041</address>
+        <country>USA</country>
+        <contact>
+            <phone>610-896-1145</phone>
+            <fax>610-896-4904</fax>
+            <email>user@haverford.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Hawaii (IfA)</institution>
+        <address>Institute for Astronomy</address>
+        <address>2680 Woodlawn Drive</address>
+        <address>Honolulu</address>
+        <address>HI</address>
+        <address>96822</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-956-8312</phone>
+            <phone>808-988-2790</phone>
+            <email>usern@ifa.hawaii.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Hawaii (IRTF)</institution>
+        <address>NASA Infrared Telescope Facility</address>
+        <address>Institute for Astronomy</address>
+        <address>2680 Woodlawn Drive</address>
+        <address>Honolulu</address>
+        <address>HI</address>
+        <address>96822</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-956-8101</phone>
+            <fax>808-988-3893</fax>
+            <email>user@ifa.hawaii.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Haystack Observatory</institution>
+        <address>NEROC</address>
+        <address>Route 40</address>
+        <address>Westford</address>
+        <address>MA</address>
+        <address>01886</address>
+        <country>USA</country>
+        <contact>
+            <phone>508-692-4764</phone>
+            <fax>617-981-0590</fax>
+            <email>user@newton.haystack.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Illinois at Urbana-Champaign</institution>
+        <address>Department of Astronomy</address>
+        <address>103 Astronomy Building</address>
+        <address>1002 West Green Street</address>
+        <address>Urbana</address>
+        <address>IL</address>
+        <address>61801</address>
+        <country>USA</country>
+        <contact>
+            <phone>217-333-3090</phone>
+            <fax>217-244-7638</fax>
+            <email>user@astro.uiuc.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Indiana University</institution>
+        <address>Department of Astronomy</address>
+        <address>319 Swain West</address>
+        <address>Bloomington</address>
+        <address>IN</address>
+        <address>47405</address>
+        <country>USA</country>
+        <contact>
+            <phone>812-855-6911</phone>
+            <fax>812-855-8725</fax>
+            <email>user@astro.indiana.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Institute for Advanced Study</institution>
+        <address>Princeton</address>
+        <address>NJ</address>
+        <address>08540</address>
+        <country>USA</country>
+        <contact>
+            <phone>609-734-8000</phone>
+            <fax>609-924-8399</fax>
+            <email>user@ias.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Iowa State University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Ames</address>
+        <address>IA</address>
+        <address>50011-3160</address>
+        <country>USA</country>
+        <contact>
+            <phone>515-294-5441</phone>
+            <fax>515-294-6027</fax>
+            <email>user@iastate.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Iowa</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>203 Van Allen Hall</address>
+        <address>Iowa City</address>
+        <address>IA</address>
+        <address>52242</address>
+        <country>USA</country>
+        <contact>
+            <phone>319-335-1686</phone>
+            <fax>319-335-1753</fax>
+            <email>user@uiowa.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Jet Propulsion Laboratory</institution>
+        <address>California Institute of Technology</address>
+        <address>4800 Oak Grove Drive</address>
+        <address>Pasadena</address>
+        <address>CA</address>
+        <address>91109</address>
+        <country>USA</country>
+        <contact>
+            <phone>818-354-4321</phone>
+            <fax>818-516-8260</fax>
+            <email>user@jpl.nasa.gov</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Johns Hopkins University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Charles and 34th Street</address>
+        <address>Bloomberg Center</address>
+        <address>Baltimore</address>
+        <address>MD</address>
+        <address>21218</address>
+        <country>USA</country>
+        <contact>
+            <phone>410-516-7346</phone>
+            <fax>410-516-7239</fax>
+            <email>user@pha.jhu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Joint Astronomy Centre</institution>
+        <address>660 North Aohoku Place</address>
+        <address>University Park</address>
+        <address>HI</address>
+        <address>96720</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-935-4332</phone>
+            <fax>808-961-6516</fax>
+            <email>user@jach.hawaii.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Univ. of Kansas</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Lawrence</address>
+        <address>KS</address>
+        <address>66045</address>
+        <country>USA</country>
+        <contact>
+            <phone>913-864-4626</phone>
+            <fax>913-864-5262</fax>
+            <email>user@kuphsx.phsx.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>W M Keck Observatory</institution>
+        <address>65-1120 Mamalahoa Highway</address>
+        <address>Kamuela</address>
+        <address>HI</address>
+        <address>96743</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-885-7887</phone>
+            <fax>808-885-4464</fax>
+            <email>user@keck.hawaii.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Kentucky</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>177 Chemistry/Physics Building</address>
+        <address>Lexington</address>
+        <address>KY</address>
+        <address>40506-0055</address>
+        <country>USA</country>
+        <contact>
+            <phone>606-257-6722</phone>
+            <fax>606-323-2846</fax>
+            <email>user@pa.uky.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Lawrence Livermore National Laboratory</institution>
+        <address>Livermore</address>
+        <address>CA</address>
+        <address>94551-9900</address>
+        <country>USA</country>
+        <contact>
+            <phone>510-423-0666</phone>
+            <fax>510-423-0238</fax>
+            <email>user@llnl.gov</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Lowell Observatory</institution>
+        <address>1400 W. Mars Hill Road</address>
+        <address>Flagstaff</address>
+        <address>AZ</address>
+        <address>86001</address>
+        <country>USA</country>
+        <contact>
+            <phone>602-774-3358</phone>
+            <fax>602-774-6296</fax>
+            <email>user@lowell.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Maryland</institution>
+        <address>Department of Astronomy</address>
+        <address>College Park</address>
+        <address>MD</address>
+        <address>20742 Phone</address>
+        <address>301-405-3001</address>
+        <country>USA</country>
+        <contact>
+            <fax>301-314-9067</fax>
+            <email>user@astro.umd.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Massachusetts Institute of Technology (EAPS)</institution>
+        <address>Department of Earth, Atmospheric and Planetary Sciences (EAPS)</address>
+        <address>EAPS Headquarters</address>
+        <address>77 Massachusetts Ave., Bldg 54-918</address>
+        <address>Cambridge</address>
+        <address>MA</address>
+        <address>02139</address>
+        <country>USA</country>
+        <contact>
+            <phone>617-253-2127</phone>
+            <fax>617-253-2886</fax>
+            <email>user@mit.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Massachusetts Institute of Technology (Astrophysics)</institution>
+        <address>Division of Astrophysics</address>
+        <address>Department of Physics</address>
+        <address>Cambridge</address>
+        <address>MA</address>
+        <address>02139</address>
+        <country>USA</country>
+        <contact>
+            <phone>617-253-4801</phone>
+            <email>user@mit.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Michigan State University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>East Lansing</address>
+        <address>MI</address>
+        <address>48824-1116</address>
+        <country>USA</country>
+        <contact>
+            <phone>517-353-4540</phone>
+            <fax>517-353-4500</fax>
+            <email>user@msupa.pa.msu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Michigan</institution>
+        <address>Department of Astronomy</address>
+        <address>830 Dennison</address>
+        <address>501 East University Avenue</address>
+        <address>Ann Arbor</address>
+        <address>MI</address>
+        <address>48109-1090</address>
+        <country>USA</country>
+        <contact>
+            <phone>313-764-3440</phone>
+            <fax>313-763-6317</fax>
+            <email>user@astro.lsa.umich.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Minnesota</institution>
+        <address>School of Physics and Astronomy</address>
+        <address>116 Church Street</address>
+        <address>SE</address>
+        <address>Minneapolis</address>
+        <address>MN</address>
+        <address>55455</address>
+        <country>USA</country>
+        <contact>
+            <phone>612-624-0211</phone>
+            <fax>612-626-2029</fax>
+            <email>user@ast1.spa.umn.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Montana</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Missoula</address>
+        <address>MT</address>
+        <address>59812</address>
+        <country>USA</country>
+        <contact>
+            <phone>406-243-2073</phone>
+            <fax>406-243-4076</fax>
+            <email>user@umt.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>NOAO</institution>
+        <address>PO Box 26732</address>
+        <address>950 North Cherry Avenue</address>
+        <address>Tucson</address>
+        <address>AZ</address>
+        <address>85726-6732</address>
+        <country>USA</country>
+        <contact>
+            <phone>520-318-8000</phone>
+            <fax>520-318-8360</fax>
+            <email>user@noao.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>NRAO Arizona Facility</institution>
+        <address>949 North Cherry Avenue</address>
+        <address>Campus Building 65</address>
+        <address>Tucson</address>
+        <address>AZ</address>
+        <address>85721-0665</address>
+        <country>USA</country>
+        <contact>
+            <phone>520-882-8250</phone>
+            <fax>520-882-7955</fax>
+            <email>user@nrao.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>NRAO Greenbank Facility</institution>
+        <address>PO Box 2</address>
+        <address>Green Bank</address>
+        <address>WV</address>
+        <address>24944</address>
+        <country>USA</country>
+        <contact>
+            <phone>304-456-2011</phone>
+            <fax>304-456-2271</fax>
+            <email>user@nrao.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>NRAO Headquarters</institution>
+        <address>520 Edgemont Road</address>
+        <address>Charlottesville</address>
+        <address>VA</address>
+        <address>22903-2475</address>
+        <country>USA</country>
+        <contact>
+            <phone>804-296-0211</phone>
+            <fax>804-296-0278</fax>
+            <email>user@nrao.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>NRAO New Mexico Facilities</institution>
+        <address>VLA Site</address>
+        <address>PO Box O, 1003 Lopezville Road</address>
+        <address>Socorro</address>
+        <address>NM</address>
+        <address>87801</address>
+        <country>USA</country>
+        <contact>
+            <phone>505-772-4011</phone>
+            <fax>505-772-4243</fax>
+            <email>user@nrao.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Naval Research Laboratory</institution>
+        <address>Code 7600</address>
+        <address>4555 Overlook Avenue, SW</address>
+        <address>Washington</address>
+        <address>DC</address>
+        <address>20375-5352</address>
+        <country>USA</country>
+        <contact>
+            <phone>202-767-6343</phone>
+            <fax>202-404-7296</fax>
+            <email>user@nrl.navy.mil</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Nebraska</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Lincoln</address>
+        <address>NE</address>
+        <address>68588-0111</address>
+        <country>USA</country>
+        <contact>
+            <phone>402-472-2770</phone>
+            <fax>402-472-2879</fax>
+            <email>user@unlinfo.unl.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Nevada at Las Vegas</institution>
+        <address>Physics Department</address>
+        <address>4505 South Maryland Parkway</address>
+        <address>Las Vegas</address>
+        <address>NV</address>
+        <address>89154</address>
+        <country>USA</country>
+        <contact>
+            <phone>702-895-0868</phone>
+            <fax>702-895-0804</fax>
+            <email>user@physics.unlv.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of New Hampshire</institution>
+        <address>Department of Physics</address>
+        <address>Demeritt Hall</address>
+        <address>Durham</address>
+        <address>NH</address>
+        <address>03824</address>
+        <country>USA</country>
+        <contact>
+            <phone>603-862-1950</phone>
+            <fax>603-862-2998</fax>
+            <email>user@unh.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>New Mexico Institute of Mining and Technology</institution>
+        <address>Astrophysics Research Center</address>
+        <address>Department of Physics</address>
+        <address>Socorro</address>
+        <address>NM</address>
+        <address>87801</address>
+        <country>USA</country>
+        <contact>
+            <phone>505-835-5328</phone>
+            <fax>505-835-5707</fax>
+            <email>user@kestrel.nmt.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>New Mexico State University</institution>
+        <address>Astronomy Department</address>
+        <address>Box 30001/Department 4500</address>
+        <address>Las Cruces</address>
+        <address>NM</address>
+        <address>88003-8001</address>
+        <country>USA</country>
+        <contact>
+            <phone>505-646-4438</phone>
+            <fax>505-646-1602</fax>
+            <email>user@nmsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of New Mexico</institution>
+        <address>Department of Physics and Astronomy and Institute for Astrophysics</address>
+        <address>Albuquerque</address>
+        <address>NM</address>
+        <address>87131</address>
+        <country>USA</country>
+        <contact>
+            <phone>505-277-2616</phone>
+            <fax>505-277-1520</fax>
+            <email>user@phys.unm.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>State University of New York at Stony Brook</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Stony Brook</address>
+        <address>NY</address>
+        <address>11794-2100</address>
+        <country>USA</country>
+        <contact>
+            <phone>516-632-8200</phone>
+            <fax>516-632-8240</fax>
+            <email>user@astro.sunysb.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>North Carolina State University</institution>
+        <address>Department of Physics</address>
+        <address>Box 8202</address>
+        <address>Raleigh</address>
+        <address>NC</address>
+        <address>27695-8202</address>
+        <country>USA</country>
+        <contact>
+            <phone>919-515-2521</phone>
+            <fax>919-515-6538</fax>
+            <email>user@ncsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of North Carolina</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>CB# 3255 Phillips Hall</address>
+        <address>Chapel Hill</address>
+        <address>NC</address>
+        <address>27599-3255</address>
+        <country>USA</country>
+        <contact>
+            <phone>919-962-2078</phone>
+            <fax>919-962-0480</fax>
+            <email>user@physics.unc.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Northern Arizona University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Box 6010</address>
+        <address>Flagstaff</address>
+        <address>AZ</address>
+        <address>86011-6010</address>
+        <country>USA</country>
+        <contact>
+            <phone>520-523-2661</phone>
+            <fax>520-523-1371</fax>
+            <email>user@nau.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Northwestern University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Dearborn Observatory</address>
+        <address>2131 Sheridan Road</address>
+        <address>Evanston</address>
+        <address>IL</address>
+        <address>60208-2900</address>
+        <country>USA</country>
+        <contact>
+            <phone>847-491-7650</phone>
+            <phone>847-491-3135</phone>
+            <email>user@astro.nwu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Ohio State University</institution>
+        <address>Department of Astronomy</address>
+        <address>174 W. 18th Avenue</address>
+        <address>Columbus</address>
+        <address>OH</address>
+        <address>43210-1106</address>
+        <country>USA</country>
+        <contact>
+            <phone>614-292-1773</phone>
+            <fax>614-292--2928</fax>
+            <email>user@astronomy.ohio-state.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Ohio University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Clippinger Research Labs. 251B</address>
+        <address>Athens</address>
+        <address>OH</address>
+        <address>45701-2979</address>
+        <country>USA</country>
+        <contact>
+            <phone>614-593-1718</phone>
+            <fax>614-593-0433</fax>
+            <email>user@helios.phy.ohiou.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Oklahoma State University</institution>
+        <address>Department of Physics</address>
+        <address>Astrophysics Group</address>
+        <address>Stillwater</address>
+        <address>OK</address>
+        <address>74078-3072</address>
+        <country>USA</country>
+        <contact>
+            <phone>405-744-5796</phone>
+            <fax>405-744-6811</fax>
+            <email>user@okstate.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Oklahoma</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Room 131 Nielsen Hall</address>
+        <address>Norman</address>
+        <address>OK</address>
+        <address>73019-0225</address>
+        <country>USA</country>
+        <contact>
+            <phone>405-325-3961</phone>
+            <fax>405-325-7557</fax>
+            <email>user@phyast.nhn.ou.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Oregon</institution>
+        <address>Physics Department</address>
+        <address>Eugene</address>
+        <address>OR</address>
+        <address>97403</address>
+        <country>USA</country>
+        <contact>
+            <phone>541-346-5826/5225</phone>
+            <fax>541-346-5861</fax>
+            <email>user@uoregon.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Pennsylvania State University</institution>
+        <address>Department of Astronomy and Astrophysics</address>
+        <address>525 Davey Laboratory</address>
+        <address>University Park</address>
+        <address>PA</address>
+        <address>16802</address>
+        <country>USA</country>
+        <contact>
+            <phone>814-865-0418</phone>
+            <fax>814-863-3399</fax>
+            <email>user@astro.psu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Behrend College, Pennsylvania State University</institution>
+        <address>Division of Science</address>
+        <address>Station Road</address>
+        <address>Erie</address>
+        <address>PA</address>
+        <address>16563</address>
+        <country>USA</country>
+        <contact>
+            <phone>814-898-6105</phone>
+            <fax>814-898-6213</fax>
+            <email>user@psu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Pennsylvania</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>209 South 33rd Street</address>
+        <address>Philadelphia</address>
+        <address>PA</address>
+        <address>19104-6396</address>
+        <country>USA</country>
+        <contact>
+            <phone>215-898-8141</phone>
+            <fax>215-898-2010</fax>
+            <email>user@upenn.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Pittsburgh</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>100 Allen Hall</address>
+        <address>Pittsburgh</address>
+        <address>PA</address>
+        <address>15260</address>
+        <country>USA</country>
+        <contact>
+            <phone>412-624-9000</phone>
+            <fax>412-624-9163</fax>
+            <email>user@pitt.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Princeton University (Astrophysics)</institution>
+        <address>Department of Astrophysical Sciences</address>
+        <address>Peyton Hall</address>
+        <address>Princeton</address>
+        <address>NJ</address>
+        <address>08544-1001</address>
+        <country>USA</country>
+        <contact>
+            <phone>609-258-3801</phone>
+            <fax>609-258-1020</fax>
+            <email>user@astro.princeton.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Princeton University (Physics)</institution>
+        <address>Department of Physics</address>
+        <address>Joseph Henry Laboratories</address>
+        <address>Jadwin Hall, PO Box 708</address>
+        <address>Princeton</address>
+        <address>NJ</address>
+        <address>08544-0708</address>
+        <country>USA</country>
+        <contact>
+            <phone>609-258-4400</phone>
+            <fax>609-258-1124</fax>
+            <email>user@princeton.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Rensselaer Polytechnic Institute</institution>
+        <address>Department of Physics</address>
+        <address>110 Eighth Street</address>
+        <address>Troy</address>
+        <address>NY</address>
+        <address>12180-3590</address>
+        <country>USA</country>
+        <contact>
+            <phone>518-276-6320</phone>
+            <fax>518-276-6680</fax>
+            <email>user@rpi.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Rice University</institution>
+        <address>Department of Space Physics and Astronomy</address>
+        <address>MS 108</address>
+        <address>6100 South Main</address>
+        <address>Houston</address>
+        <address>TX</address>
+        <address>77005-1892</address>
+        <country>USA</country>
+        <contact>
+            <phone>713-527-4939</phone>
+            <fax>713-285-5143</fax>
+            <email>user@rice.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Rochester Institute of Technology (CIS)</institution>
+        <address>Center for Imaging Science</address>
+        <address>54 Lomb Memorial Drive</address>
+        <address>Rochester</address>
+        <address>NY</address>
+        <address>14623-5604</address>
+        <country>USA</country>
+        <contact>
+            <phone>716-475-5944</phone>
+            <email>user@rit.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Rochester Institute of Technology (Physics)</institution>
+        <address>Department of Physics</address>
+        <address>College of Science</address>
+        <address>85 Lomb Memorial Drive</address>
+        <address>Rochester</address>
+        <address>NY</address>
+        <address>14623-5603</address>
+        <country>USA</country>
+        <contact>
+            <phone>716-475-5763</phone>
+            <fax>716-475-5766</fax>
+            <email>user@rit.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Rochester</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Rochester</address>
+        <address>NY</address>
+        <address>14627-0011</address>
+        <country>USA</country>
+        <contact>
+            <phone>716-275-4405</phone>
+            <fax>716-275-8527</fax>
+            <email>user@pas.rochester.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Rutgers University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>PO Box 849</address>
+        <address>Piscataway</address>
+        <address>NJ</address>
+        <address>08855-0849</address>
+        <country>USA</country>
+        <contact>
+            <phone>908-445-2503</phone>
+            <fax>908-445-4343</fax>
+            <email>user@physics.rutgers.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>San Diego State University</institution>
+        <address>Department of Astronomy</address>
+        <address>San Diego</address>
+        <address>CA</address>
+        <address>92182-1221</address>
+        <country>USA</country>
+        <contact>
+            <phone>619-594-6182</phone>
+            <fax>619-594-1413</fax>
+            <email>user@mintaka.sdsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>San Francisco State University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>San Francisco</address>
+        <address>CA</address>
+        <address>94132</address>
+        <country>USA</country>
+        <contact>
+            <phone>415-338-1659</phone>
+            <fax>415-338-2178</fax>
+            <email>user@stars.sfsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>San Juan Capistrano Research Institute</institution>
+        <address>Planetary Science Institute</address>
+        <address>620 North 6th Avenue</address>
+        <address>Tucson</address>
+        <address>AZ</address>
+        <address>85705-8331</address>
+        <country>USA</country>
+        <contact>
+            <phone>520-622-6300</phone>
+            <fax>520-622-8060</fax>
+            <email>user@psi.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>SETI Institute</institution>
+        <address>2035 Landings Drive</address>
+        <address>Mountain View</address>
+        <address>CA</address>
+        <address>94043</address>
+        <country>USA</country>
+        <contact>
+            <phone>415-961-6633</phone>
+            <fax>415-961-7099</fax>
+            <email>user@seti-inst.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Space Telescope Science Institute</institution>
+        <address>3700 San Martin Drive</address>
+        <address>Baltimore</address>
+        <address>MD</address>
+        <address>21218</address>
+        <country>USA</country>
+        <contact>
+            <phone>410-338-4700</phone>
+            <fax>410-338-4767</fax>
+            <email>user@stsci.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Spaces Sciences Center</institution>
+        <address>University Park</address>
+        <address>Los Angeles</address>
+        <address>CA</address>
+        <address>90089-1341</address>
+        <country>USA</country>
+        <contact>
+            <phone>213-740-6340</phone>
+            <fax>213-740-6342</fax>
+            <email>user@usc.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Stanford University</institution>
+        <address>Astronomy Program</address>
+        <address>Varian Building</address>
+        <address>Room 302c</address>
+        <address>Stanford</address>
+        <address>CA</address>
+        <address>94305-4060</address>
+        <country>USA</country>
+        <contact>
+            <phone>415-723-1436</phone>
+            <fax>415-723-4840</fax>
+            <email>user@bigbang.stanford.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Stanford University</institution>
+        <address>Astronomy Program</address>
+        <address>Varian Building</address>
+        <address>Room 302c</address>
+        <address>Stanford</address>
+        <address>CA</address>
+        <address>94305-4060</address>
+        <country>USA</country>
+        <contact>
+            <phone>415-723-1436</phone>
+            <fax>415-723-4840</fax>
+            <email>user@bigbang.stanford.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Swinburne University of Technology</institution>
+        <address>Swinburne Centre for Astrophysics and Supercomputing</address>
+        <address>Mail number 31</address>
+        <address>PO Box 218</address>
+        <address>Hawthorne</address>
+        <address>Victoria</address>
+        <address>3122</address>
+        <country>Australia</country>
+        <contact>
+            <phone>61-392148782</phone>
+            <fax>61-392148797</fax>
+            <email>mbailes@swin.edu.au</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Toledo</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Toledo</address>
+        <address>OH</address>
+        <address>43606</address>
+        <country>USA</country>
+        <contact>
+            <phone>419-530-2241</phone>
+            <phone>419-530-2723</phone>
+            <email>user@utoledo.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Vanderbilt University</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>PO Box 1803 Station B</address>
+        <address>Nashville</address>
+        <address>TN</address>
+        <address>37235</address>
+        <country>USA</country>
+        <contact>
+            <phone>615-373-4897</phone>
+            <fax>615-343-7263</fax>
+            <email>user@vanderbilt.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Villanova University</institution>
+        <address>Department of Astronomy and Astrophysics</address>
+        <address>Villanova</address>
+        <address>PA</address>
+        <address>19085</address>
+        <country>USA</country>
+        <contact>
+            <phone>610-519-4820</phone>
+            <fax>610-519-6132</fax>
+            <email>user@ucis.vill.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Virginia</institution>
+        <address>Department of Astronomy</address>
+        <address>PO Box 3818</address>
+        <address>Charlottesville</address>
+        <address>VA</address>
+        <address>22903-0818</address>
+        <country>USA</country>
+        <contact>
+            <phone>804-924-7494</phone>
+            <fax>804-921-3104</fax>
+            <email>user@virginia.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Washington State University</institution>
+        <address>Program in Astronomy</address>
+        <address>PO Box 643113</address>
+        <address>Pullman</address>
+        <address>WA</address>
+        <address>99164-3113</address>
+        <country>USA</country>
+        <contact>
+            <phone>509-335-8518</phone>
+            <fax>509-335-1188</fax>
+            <email>user@math.wsu.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Washington</institution>
+        <address>Department of Astronomy</address>
+        <address>Box 351580</address>
+        <address>Seattle</address>
+        <address>WA</address>
+        <address>98195-1580</address>
+        <country>USA</country>
+        <contact>
+            <phone>206-543-2888</phone>
+            <fax>206-685-0403</fax>
+            <email>user@astro.washington.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Wesleyan University</institution>
+        <address>Department of Astronomy</address>
+        <address>Middletown</address>
+        <address>CT</address>
+        <address>06459-0123</address>
+        <country>USA</country>
+        <contact>
+            <phone>860-685-2130</phone>
+            <fax>860-685-2131</fax>
+            <email>user@astro.wesleyan.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Williams College</institution>
+        <address>Department of Astronomy</address>
+        <address>Williamstown</address>
+        <address>MA</address>
+        <address>01267</address>
+        <country>USA</country>
+        <contact>
+            <phone>413-597-2482</phone>
+            <fax>413-597-3200</fax>
+            <email>user@williams.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Wisconsin at Madison (Astronomy)</institution>
+        <address>Department of Astronomy</address>
+        <address>475 North Charter Street</address>
+        <address>Madison</address>
+        <address>WI</address>
+        <address>53706</address>
+        <country>USA</country>
+        <contact>
+            <email>user@wisc.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Wisconsin at Madison (Physics)</institution>
+        <address>Department of Physics</address>
+        <address>2531 Sterling Hall</address>
+        <address>Madison</address>
+        <address>WI</address>
+        <address>53706</address>
+        <country>USA</country>
+        <contact>
+            <phone>608-262-4526</phone>
+            <fax>608-262-3077</fax>
+            <email>user@wisc.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>University of Wyoming</institution>
+        <address>Department of Physics and Astronomy</address>
+        <address>Laramie</address>
+        <address>WY</address>
+        <address>82071</address>
+        <country>USA</country>
+        <contact>
+            <phone>307-766-6150</phone>
+            <fax>307-766-2652</fax>
+            <email>user@uwyo.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Yale University</institution>
+        <address>Department of Astronomy</address>
+        <address>PO Box 208101</address>
+        <address>New Haven</address>
+        <address>CT</address>
+        <address>06520-8101</address>
+        <country>USA</country>
+        <contact>
+            <phone>203-432-3000</phone>
+            <fax>203-432-5048</fax>
+            <email>user@astro.yale.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Gemini Observatory - North</institution>
+        <address>Gemini Observatory</address>
+        <address>670 N. Aohoku Place</address>
+        <address>Hilo</address>
+        <address>HI</address>
+        <address>96720</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-974-2500</phone>
+            <fax>808-935-9235</fax>
+            <email>user@gemini.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Gemini Observatory - South</institution>
+        <address>Gemini Observatory</address>
+        <address>Colina El Pino s/n</address>
+        <address>La Serena</address>
+        <country>Chile</country>
+        <contact>
+            <phone>011-5651-205-600</phone>
+            <fax>011-5651-205-650</fax>
+            <email>user@gemini.edu</email>
+        </contact>
+    </site>
+    <site>
+        <institution>Subaru Telescope, NAOJ</institution>
+        <address>650 North A'ohoku Place</address>
+        <address>Hilo</address>
+        <address>HI</address>
+        <address>96720</address>
+        <country>USA</country>
+        <contact>
+            <phone>808-934-7788</phone>
+            <fax>808-934-5099</fax>
+        </contact>
     </site>
     <site>
         <institution>Korea Astronomy and Space Science Institute (KASI)</institution>

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
@@ -13,6 +13,12 @@ object Institutions {
     res.sortBy(_.name)
   }
 
+  // Institutions whose affiliation is different from the one dictated by their location.
+  lazy val alternateAffiliates = (for {
+    i <- all
+    a <- i.affiliate
+  } yield (i.name, a)).toMap
+
   private def strList(n: Node, tag: String): List[String] =
     (n \ tag).map(_.text).toList
 
@@ -51,20 +57,21 @@ object Institutions {
     val geminiRegex = "Gemini.Observatory.*".r
     address.institution match {
       case geminiRegex() => Some(-\/(NgoPartner.US)) // Gemini Staff always go as US
-      case _             => country2Ngo(address.country)
+      case _             => country2Ngo(alternateAffiliates.getOrElse(address.institution, address.country))
     }
   }
 
   def country2Ngo(country: String): FtPartner = country match {
-    case "Argentina"         => Some(-\/(NgoPartner.AR))
-    case "Australia"         => Some(-\/(NgoPartner.AU))
-    case "Brazil"            => Some(-\/(NgoPartner.BR))
-    case "Canada"            => Some(-\/(NgoPartner.CA))
-    case "Chile"             => Some(-\/(NgoPartner.CL))
-    case "Republic of Korea" => Some(-\/(NgoPartner.KR))
-    case "USA"               => Some(-\/(NgoPartner.US))
-    case "Japan"             => Some(\/-(ExchangePartner.SUBARU))
-    case _                   => None
+    case "Argentina"            => Some(-\/(NgoPartner.AR))
+    case "Australia"            => Some(-\/(NgoPartner.AU))
+    case "Brazil"               => Some(-\/(NgoPartner.BR))
+    case "Canada"               => Some(-\/(NgoPartner.CA))
+    case "Chile"                => Some(-\/(NgoPartner.CL))
+    case "Republic of Korea"    => Some(-\/(NgoPartner.KR))
+    case "USA"                  => Some(-\/(NgoPartner.US))
+    case "University of Hawaii" => Some(-\/(NgoPartner.UH))
+    case "Japan"                => Some(\/-(ExchangePartner.SUBARU))
+    case _                      => None
   }
 }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
@@ -20,13 +20,13 @@ object Institutions {
     val name    = (n \ "institution").text
     val address = strList(n, "address")
     val country = (n \ "country").text
-
+    val affiliate = (n \ "affiliate").headOption.map(_.text)
     val contact = (n \ "contact").toList match {
       case h :: _ => toContact(h)
       case _ => Contact.empty
     }
 
-    Institution(name, address, country, contact)
+    Institution(name, address, country, affiliate, contact)
   }
 
   private def toContact(n: Node): Contact = {
@@ -74,6 +74,6 @@ object Contact {
 case class Contact(phone: List[String], email: List[String])
 
 object Institution {
-  val empty = Institution("", Nil, "", Contact.empty)
+  val empty = Institution("", Nil, "", None, Contact.empty)
 }
-case class Institution(name: String, addr: List[String], country: String, contact: Contact)
+case class Institution(name: String, addr: List[String], country: String, affiliate: Option[String], contact: Contact)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
@@ -26,7 +26,7 @@ object Institutions {
     val name    = (n \ "institution").text
     val address = strList(n, "address")
     val country = (n \ "country").text
-    val affiliate = (n \ "affiliate").headOption.map(_.text)
+    val affiliate = (n \ "affiliate").headOption.map(a => country2Ngo(a.text))
     val contact = (n \ "contact").toList match {
       case h :: _ => toContact(h)
       case _ => Contact.empty
@@ -57,7 +57,7 @@ object Institutions {
     val geminiRegex = "Gemini.Observatory.*".r
     address.institution match {
       case geminiRegex() => Some(-\/(NgoPartner.US)) // Gemini Staff always go as US
-      case _             => country2Ngo(alternateAffiliates.getOrElse(address.institution, address.country))
+      case _             => alternateAffiliates.getOrElse(address.institution, country2Ngo(address.country))
     }
   }
 
@@ -83,4 +83,4 @@ case class Contact(phone: List[String], email: List[String])
 object Institution {
   val empty = Institution("", Nil, "", None, Contact.empty)
 }
-case class Institution(name: String, addr: List[String], country: String, affiliate: Option[String], contact: Contact)
+case class Institution(name: String, addr: List[String], country: String, affiliate: Option[FtPartner], contact: Contact)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/gface/SimpleListViewer.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/gface/SimpleListViewer.scala
@@ -63,7 +63,7 @@ abstract class SimpleListViewer[A, B, C <: Object](implicit ev: Null <:< B, ev2:
   def elementAt(b: B, i: Int): C
 
   override lazy val peer = {
-    val p = Factory.createStrippedScrollPane(viewer.getTable);
+    val p = Factory.createStrippedScrollPane(viewer.getTable)
     ScrollPanes.setViewportWidth(p)
     ScrollPanes.setViewportHeight(p, 5)
     p

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
@@ -241,7 +241,7 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
             def defaultInstitution(n: String): InstitutionAddress = {
               val inst = Institutions.bestMatch(coi.institution)
               def toIa(inst: Institution) = InstitutionAddress(inst.name, inst.addr.mkString("\n"), inst.country)
-              inst.map(toIa(_)).getOrElse(InstitutionAddress(n))
+              inst.map(toIa).getOrElse(InstitutionAddress(n))
             }
 
             coi.toPi.copy(address = addrMap.getOrElse(coi, defaultInstitution(coi.institution)))
@@ -344,7 +344,7 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
     object listViewer extends SimpleListViewer[Proposal, Investigators, Investigator] {
 
       // Our action handlers
-      onDoubleClick { edit(_) }
+      onDoubleClick(edit)
 
       def editPi(setup: PiEditor => Unit = _ => ()) =
         for {

--- a/bundle/edu.gemini.pit/src/test/scala/edu/gemini/pit/ui/editor/InstitutionsSpec.scala
+++ b/bundle/edu.gemini.pit/src/test/scala/edu/gemini/pit/ui/editor/InstitutionsSpec.scala
@@ -10,6 +10,14 @@ class InstitutionsSpec extends Specification {
       val uab = Institutions.all.find(_.name == "Universidad Andres Bello").head
       uab.country must beEqualTo("Chile")
       uab.contact.phone must containMatch("\\+56-2-8370134")
+      uab.affiliate must beNone
+    }
+
+    "include Subaru Telescope, NAOJ, with a country of USA but an affiliate of Japan" in {
+      Institutions.all must contain((i: Institution) => i.name must beEqualTo("Subaru Telescope, NAOJ"))
+      val subaru = Institutions.all.find(_.name == "Subaru Telescope, NAOJ").head
+      subaru.country must beEqualTo("USA")
+      subaru.affiliate must beSome("Japan")
     }
   }
 

--- a/bundle/edu.gemini.pit/src/test/scala/edu/gemini/pit/ui/editor/InstitutionsSpec.scala
+++ b/bundle/edu.gemini.pit/src/test/scala/edu/gemini/pit/ui/editor/InstitutionsSpec.scala
@@ -1,23 +1,35 @@
 package edu.gemini.pit.ui.editor
 
+import edu.gemini.model.p1.immutable.InstitutionAddress
 import org.specs2.mutable._
 
 class InstitutionsSpec extends Specification {
 
   "The Institutions object" should {
     "include Universidad Andres Bello, REL-550" in {
-      Institutions.all must contain((i: Institution) => i.name must beEqualTo("Universidad Andres Bello"))
-      val uab = Institutions.all.find(_.name == "Universidad Andres Bello").head
+      val UniversidadAndresBello = "Universidad Andres Bello"
+      Institutions.all must contain((i: Institution) => i.name must beEqualTo(UniversidadAndresBello))
+      val uab = Institutions.all.find(_.name == UniversidadAndresBello).head
       uab.country must beEqualTo("Chile")
       uab.contact.phone must containMatch("\\+56-2-8370134")
       uab.affiliate must beNone
     }
 
     "include Subaru Telescope, NAOJ, with a country of USA but an affiliate of Japan" in {
-      Institutions.all must contain((i: Institution) => i.name must beEqualTo("Subaru Telescope, NAOJ"))
-      val subaru = Institutions.all.find(_.name == "Subaru Telescope, NAOJ").head
+      val SubaruNAOJ = "Subaru Telescope, NAOJ"
+      Institutions.all must contain((i: Institution) => i.name must beEqualTo(SubaruNAOJ))
+      val subaru = Institutions.all.find(_.name == SubaruNAOJ).head
       subaru.country must beEqualTo("USA")
       subaru.affiliate must beSome("Japan")
+    }
+
+    "include the Canada-France-Hawaii Telescope Corporation, with a country of US but an NGO partner of Canada" in {
+      val CFT = "Canada-France-Hawaii Telescope Corporation"
+      Institutions.all must contain((i: Institution) => i.name must beEqualTo(CFT))
+      val cft = Institutions.all.find(_.name == CFT).head
+      cft.country must beEqualTo("USA")
+      val cftAddr = InstitutionAddress(cft.name, cft.addr.map(_.trim).mkString("\n"), cft.country)
+      Institutions.institution2Ngo(cftAddr) must beEqualTo(Institutions.country2Ngo("Canada"))
     }
   }
 

--- a/bundle/edu.gemini.pit/src/test/scala/edu/gemini/pit/ui/editor/InstitutionsSpec.scala
+++ b/bundle/edu.gemini.pit/src/test/scala/edu/gemini/pit/ui/editor/InstitutionsSpec.scala
@@ -20,7 +20,7 @@ class InstitutionsSpec extends Specification {
       Institutions.all must contain((i: Institution) => i.name must beEqualTo(SubaruNAOJ))
       val subaru = Institutions.all.find(_.name == SubaruNAOJ).head
       subaru.country must beEqualTo("USA")
-      subaru.affiliate must beSome("Japan")
+      subaru.affiliate must beSome(Institutions.country2Ngo("Japan"))
     }
 
     "include the Canada-France-Hawaii Telescope Corporation, with a country of US but an NGO partner of Canada" in {


### PR DESCRIPTION
In the past, the PIT used the country of location of an institution to do a lookup for the affiliate for FT programs.

This was problematic in several instances, because there are a small number of institutions where the country in which an institution is located should not dictate the affiliate. (Example: Gemini South is located in Chile, but the affiliate should be US.)

This PR introduces an optional `affiliate` XML tag for the `institutions.xml` file that allows an affiliate to be specified that, if given, is used instead of the `country` tag when doing affiliate lookups.

The appropriate institutions have been given `affiliate` tags in `institutions.xml`, along with a few typo fixes, as well as some cosmetic name changes as per the comments in the JIRA task. As well, `University of Hawaii` has been re-added as an affiliate as per Bryan's list.

A test case for CFT was also added to the `InstitutionsSpec` to make sure that the country of location is USA but the affiliate is Canada.