### PR TITLE
REL-2937: Updated p1pdfmaker startup script.

### DIFF
--- a/app/p1pdfmaker/dist/Linux/p1pdfmaker
+++ b/app/p1pdfmaker/dist/Linux/p1pdfmaker
@@ -66,4 +66,4 @@ done
 [ -z "$PDFOUT" ] && PDFOUT="-Dp=${_CWD}"
 [ -z "$XMLIN" ] && usage
 
-$APP_HOME/jre/bin/java -Xmx1024M $COUNTRY $PDFOUT $RECURSIVE $XMLIN -Dedu.gemini.osgi.main.app=p1pdfmaker -jar edu-gemini-osgi-main_2.10-4.2.1.jar  $@
+$APP_HOME/jre/bin/java -Xmx1024M $COUNTRY $PDFOUT $RECURSIVE $XMLIN -Dedu.gemini.osgi.main.app=p1pdfmaker -jar edu-gemini-osgi-main_2.11-4.2.1.jar  $@


### PR DESCRIPTION
The new jar is marked as version 2.11-4.2.1, so startup script must be changed to launch properly.