### PR TITLE
REL-2920: REL-2920: Fixing parallactic angle formatting so warning when overridden works as expected.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -305,7 +305,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       // Parallactic Angle
       val paStr = parallacticAngle
         .map(ParallacticAngleControls.angleToDegrees)
-        .fold(", not visible")(a => f", $a%3.1f°")
+        .fold(", not visible")(a => s", ${fmt.format(a)}°")
 
       ui.parallacticAngleFeedback.text =
         if (isPaUi) dateTimeStr + durStr + paStr


### PR DESCRIPTION
Simply moving the code from `develop` to `release/ocs-2016B` to do a test release, with the plan on making a new build.