### PR TITLE
REL-2893: GPI TLC wrong name in TLC APODIZER entry

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -44,6 +44,7 @@ import edu.gemini.spModel.type.*;
 import java.beans.PropertyDescriptor;
 import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY;
 
@@ -741,7 +742,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
      * <p/>
      * And the default is CLEAR      *
      */
-    public enum Apodizer implements DisplayableSpType, SequenceableSpType, LoggableSpType {
+    public enum Apodizer implements DisplayableSpType, SequenceableSpType, LoggableSpType, ObsoletableSpType {
         CLEAR("Clear"),
         CLEARGP("CLEAR GP"),
         APOD_Y("APOD_Y_56"),
@@ -751,7 +752,12 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         APOD_K2("APOD_K2_56"),
         NRM("NRM"),
         APOD_HL("APOD_HL"),
-        APOD_STAR("APOD_star"),
+        APOD_STAR("APOD_star") {
+            public boolean isObsolete() {
+                return true;
+            }
+        },
+        ND3("ND3")
         ;
 
         public static Apodizer DEFAULT = CLEAR;
@@ -775,6 +781,11 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         }
 
         @Override
+        public boolean isObsolete() {
+                    return false;
+                }
+
+        @Override
         public String logValue() {
             return displayValue();
         }
@@ -791,6 +802,10 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
                 }
             }
             return None.instance();
+        }
+
+        public static Apodizer[] validValues() {
+            return Arrays.stream(values()).filter(a -> !a.isObsolete()).toArray(Apodizer[]::new);
         }
     }
 

--- a/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/bean/ComboPropertyCtrl.java
+++ b/bundle/edu.gemini.shared.gui/src/main/java/edu/gemini/shared/gui/bean/ComboPropertyCtrl.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.gui.bean;
 
 import edu.gemini.shared.util.immutable.None;
@@ -36,7 +32,7 @@ public final class ComboPropertyCtrl<B, T> extends PropertyCtrl<B, T> {
     public static <B, T> ComboPropertyCtrl<B, T> enumInstance(PropertyDescriptor pd) {
         Class c = pd.getPropertyType();
         T[] vals = (T[]) c.getEnumConstants();
-        return new ComboPropertyCtrl<B, T>(pd, vals);
+        return new ComboPropertyCtrl<>(pd, vals);
     }
 
     /**
@@ -79,11 +75,11 @@ public final class ComboPropertyCtrl<B, T> extends PropertyCtrl<B, T> {
         vals[0] = None.instance();
         int i = 1;
         for (T enumVal : enumVals) {
-            vals[i++] = new Some<T>(enumVal);
+            vals[i++] = new Some<>(enumVal);
         }
 
         ComboPropertyCtrl<B, Option<T>> res;
-        res = new ComboPropertyCtrl<B, Option<T>>(pd, vals);
+        res = new ComboPropertyCtrl<>(pd, vals);
         ((JComboBox) res.getComponent()).setRenderer(new OptionRenderer());
         return res;
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
@@ -381,7 +381,7 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
         // Disperser
         disperserCtrl = ComboPropertyCtrl.enumInstance(Gpi.DISPERSER_PROP);
         // See OT-50: Disperser.OPEN only available in engineering screen
-        ((JComboBox)disperserCtrl.getComponent()).setModel(new DefaultComboBoxModel<>(Gpi.Disperser.nonEngineeringValues()));
+        ((JComboBox<Gpi.Disperser>)disperserCtrl.getComponent()).setModel(new DefaultComboBoxModel<>(Gpi.Disperser.nonEngineeringValues()));
         addCtrl(pan, leftLabelCol, row, disperserCtrl);
 
         // ADC
@@ -451,7 +451,7 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
         calEntranceShutterCtrl = ComboPropertyCtrl.enumInstance(Gpi.CAL_ENTRANCE_SHUTTER_PROP);
         referenceArmShutterCtrl = ComboPropertyCtrl.enumInstance(Gpi.REFERENCE_ARM_SHUTTER_PROP);
 
-        apodizerCtrl = ComboPropertyCtrl.enumInstance(Gpi.APODIZER_PROP);
+        apodizerCtrl = new ComboPropertyCtrl<>(Gpi.APODIZER_PROP, Gpi.Apodizer.validValues());
         lyotCtrl = ComboPropertyCtrl.enumInstance(Gpi.LYOT_PROP);
 
         artificialSourceLabel = new JLabel("                   Artificial Source");

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gpi/GpiEditor.java
@@ -451,7 +451,7 @@ public class GpiEditor extends ComponentEditor<ISPObsComponent, Gpi> implements 
         calEntranceShutterCtrl = ComboPropertyCtrl.enumInstance(Gpi.CAL_ENTRANCE_SHUTTER_PROP);
         referenceArmShutterCtrl = ComboPropertyCtrl.enumInstance(Gpi.REFERENCE_ARM_SHUTTER_PROP);
 
-        apodizerCtrl = new ComboPropertyCtrl<>(Gpi.APODIZER_PROP, Gpi.Apodizer.validValues());
+        apodizerCtrl = new ComboPropertyCtrl<>(Gpi.APODIZER_PROP, Gpi.Apodizer.nonObsoleteValues());
         lyotCtrl = ComboPropertyCtrl.enumInstance(Gpi.LYOT_PROP);
 
         artificialSourceLabel = new JLabel("                   Artificial Source");


### PR DESCRIPTION
This PR updates GPI marking the `APOD_star` apodizer and `H_star` observing mode as obsolete and adds the `ND3` apodizer, which can be set on the engineering mode

Note that there are no existing programs using the obsolete options, so there is no need to convert existing data.