### PR TITLE
REL-2921: Making BAGS and parallactic angle play nicely.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -260,9 +260,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     } {
       // Set the position angle constraint on the instrument.
       val posAngleConstraint = ui.positionAngleConstraintComboBox.selection.item
-      println(s"+++ Pos angle constraint was: ${e.getDataObject.getPosAngleConstraint}")
       e.getDataObject.setPosAngleConstraint(posAngleConstraint)
-      println(s"+++ Pos angle constraint now: ${e.getDataObject.getPosAngleConstraint}")
 
       // Set up the UI.
       ui.positionAngleTextField.enabled = posAngleConstraint != PosAngleConstraint.UNBOUNDED
@@ -283,7 +281,6 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     if (editor.exists(_.getDataObject.getPosAngleConstraint == PosAngleConstraint.PARALLACTIC_ANGLE)) {
       angleOpt.foreach(angle => {
         val degrees = angle.toDegrees
-        println(s"+++ Parallactic angle changed, now is ${numberFormatter.format(degrees)}")
         ui.positionAngleTextField.text = numberFormatter.format(degrees)
         setInstPosAngle(degrees)
       })
@@ -309,7 +306,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       setOptionEnabled(PosAngleConstraint.PARALLACTIC_ANGLE, canUseAvgPar)
 
       // Now the parallactic angle is in use if it can be used and is selected.
-      if (canUseAvgPar && i.getPosAngleConstraint.equals(PosAngleConstraint.PARALLACTIC_ANGLE)) {
+      if (canUseAvgPar && i.getPosAngleConstraint == PosAngleConstraint.PARALLACTIC_ANGLE) {
         p.ui.relativeTimeMenu.rebuild()
       }
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -142,13 +142,15 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       }
       peer.add(positionAngleFeedbackPanel.peer, positionAngleFeedbackPanel.cardId)
 
-      private def showParallacticAngleControls(): Unit =
+      private def showParallacticAngleControls(): Unit = Swing.onEDT {
         cardLayout.show(this.peer, parallacticAngleControlsPanel.cardId)
+      }
 
-      private def showPositionAngleFeedback(): Unit =
+      private def showPositionAngleFeedback(): Unit = Swing.onEDT {
         cardLayout.show(this.peer, positionAngleFeedbackPanel.cardId)
+      }
 
-      // Convenience method to set the appropriate card.
+      // Set the appropriate card based on the pos angle constraint.
       def updatePanel(): Unit = Swing.onEDT {
         editor.foreach {
           _.getDataObject.getPosAngleConstraint match {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -56,8 +56,9 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       def angle: Option[Double] =
         Try { text.toDouble }.toOption
 
-      override def validate(): Unit =
+      override def validate(): Unit = Swing.onEDT {
         background = angle.fold(if (positionAngleConstraintComboBox.selection.item == PosAngleConstraint.UNBOUNDED) background else badBackground)(_ => defaultBackground)
+      }
     }
 
     layout(positionAngleTextField) = new Constraints() {
@@ -141,16 +142,19 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       }
       peer.add(positionAngleFeedbackPanel.peer, positionAngleFeedbackPanel.cardId)
 
-      def showParallacticAngleControls(): Unit =
+      private def showParallacticAngleControls(): Unit =
         cardLayout.show(this.peer, parallacticAngleControlsPanel.cardId)
 
-      def showPositionAngleFeedback(): Unit =
+      private def showPositionAngleFeedback(): Unit =
         cardLayout.show(this.peer, positionAngleFeedbackPanel.cardId)
 
       // Convenience method to set the appropriate card.
-      def updatePanel(): Unit = editor.foreach { _.getDataObject.getPosAngleConstraint match {
-          case PosAngleConstraint.PARALLACTIC_ANGLE => showParallacticAngleControls()
-          case _                                    => showPositionAngleFeedback()
+      def updatePanel(): Unit = Swing.onEDT {
+        editor.foreach {
+          _.getDataObject.getPosAngleConstraint match {
+            case PosAngleConstraint.PARALLACTIC_ANGLE => showParallacticAngleControls()
+            case _                                    => showPositionAngleFeedback()
+          }
         }
       }
     }
@@ -167,7 +171,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
   /**
    * Initialization of the components.
    */
-  def init(e: E, s: Site): Unit = {
+  def init(e: E, s: Site): Unit = Swing.onEDT {
     editor = Some(e)
     val instrument = e.getDataObject
 
@@ -207,7 +211,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
   }
 
   /** Sets the enabled state of contained widgets to match the provided value. */
-  def updateEnabledState(enabled: Boolean): Unit = {
+  def updateEnabledState(enabled: Boolean): Unit = Swing.onEDT {
     ui.positionAngleConstraintComboBox.enabled = enabled
     ui.positionAngleTextField.enabled = enabled
     ui.parallacticAngleControlsOpt.foreach { p =>
@@ -220,19 +224,21 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     * This is done explicitly to avoid overwriting based on minor differences in double precision and to avoid
     * adding 180 to the position angle for parallactic angle mode, which overrides BAGS flips.
     **/
-  private def setInstPosAngle(newAngleDegrees: Double): Unit =
+  private def setInstPosAngle(newAngleDegrees: Double): Unit = Swing.onEDT {
     editor.foreach(_.getDataObject.setPosAngleDegrees(newAngleDegrees))
+  }
 
   /**
    * Copies, if possible, the position angle text field contents to the data object.
    */
-  private def copyPosAngleToInstrument(): Unit =
+  private def copyPosAngleToInstrument(): Unit = Swing.onEDT {
     ui.positionAngleTextField.angle.foreach(setInstPosAngle)
+  }
 
   /**
     * Copies the position angle in the data object to the position angle text field.
     */
-  private def copyPosAngleToTextField(): Unit =
+  private def copyPosAngleToTextField(): Unit = Swing.onEDT {
     editor.foreach { e =>
       val newAngleStr = numberFormatter.format(e.getDataObject.getPosAngleDegrees)
       val oldAngleStr = ui.positionAngleTextField.text
@@ -240,20 +246,23 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
         ui.positionAngleTextField.text = newAngleStr
       }
     }
+  }
 
   /**
    * Called whenever a selection is made in the position angle constraint combo box.
    * Sets the position angle constraint on the instrument, and sets up the lower controls to account for the new
    * selection.
    */
-  private def positionAngleConstraintSelected(): Unit = {
+  private def positionAngleConstraintSelected(): Unit = Swing.onEDT {
     for {
       e <- editor
       p <- ui.parallacticAngleControlsOpt
     } {
       // Set the position angle constraint on the instrument.
       val posAngleConstraint = ui.positionAngleConstraintComboBox.selection.item
+      println(s"+++ Pos angle constraint was: ${e.getDataObject.getPosAngleConstraint}")
       e.getDataObject.setPosAngleConstraint(posAngleConstraint)
+      println(s"+++ Pos angle constraint now: ${e.getDataObject.getPosAngleConstraint}")
 
       // Set up the UI.
       ui.positionAngleTextField.enabled = posAngleConstraint != PosAngleConstraint.UNBOUNDED
@@ -270,12 +279,16 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
    * A listener method that is called whenever the parallactic angle changes.
    * We set the position angle to the parallactic angle.
    */
-  private def parallacticAngleChanged(angleOpt: Option[Angle]): Unit =
-    angleOpt.foreach(angle => {
-      val degrees = angle.toDegrees
-      ui.positionAngleTextField.text = numberFormatter.format(degrees)
-      setInstPosAngle(degrees)
-    })
+  private def parallacticAngleChanged(angleOpt: Option[Angle]): Unit = Swing.onEDT {
+    if (editor.exists(_.getDataObject.getPosAngleConstraint == PosAngleConstraint.PARALLACTIC_ANGLE)) {
+      angleOpt.foreach(angle => {
+        val degrees = angle.toDegrees
+        println(s"+++ Parallactic angle changed, now is ${numberFormatter.format(degrees)}")
+        ui.positionAngleTextField.text = numberFormatter.format(degrees)
+        setInstPosAngle(degrees)
+      })
+    }
+  }
 
 
   /**
@@ -283,7 +296,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
    * angle to be selected in the position angle constraint combo box, and if it is selected but not allowed,
    * resets to FIXED.
    */
-  def updateParallacticControls(): Unit =
+  def updateParallacticControls(): Unit = Swing.onEDT {
     for {
       p <- ui.parallacticAngleControlsOpt
       i <- editor.map(_.getDataObject)
@@ -292,21 +305,23 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       // Determine if the parallactic angle option can be selected.
       val isParInstAndOk = i.isInstanceOf[ParallacticAngleSupport] &&
                            i.asInstanceOf[ParallacticAngleSupport].isCompatibleWithMeanParallacticAngleMode
-      val canUseAvgPar   = isParInstAndOk &&
-                           !ObsClassService.lookupObsClass(o).equals(ObsClass.DAY_CAL)
+      val canUseAvgPar = isParInstAndOk && !ObsClassService.lookupObsClass(o).equals(ObsClass.DAY_CAL)
       setOptionEnabled(PosAngleConstraint.PARALLACTIC_ANGLE, canUseAvgPar)
 
       // Now the parallactic angle is in use if it can be used and is selected.
-      if (canUseAvgPar && i.getPosAngleConstraint.equals(PosAngleConstraint.PARALLACTIC_ANGLE))
+      if (canUseAvgPar && i.getPosAngleConstraint.equals(PosAngleConstraint.PARALLACTIC_ANGLE)) {
         p.ui.relativeTimeMenu.rebuild()
+      }
     }
+  }
 
 
-  def updateUnboundedControls(): Unit =
+  def updateUnboundedControls(): Unit = Swing.onEDT {
     editor.foreach(e => setOptionEnabled(PosAngleConstraint.UNBOUNDED, e.getDataObject.allowUnboundedPositionAngle()))
+  }
 
 
-  private def setOptionEnabled(option: PosAngleConstraint, enabled: Boolean): Unit = {
+  private def setOptionEnabled(option: PosAngleConstraint, enabled: Boolean): Unit = Swing.onEDT {
     if (enabled)
       ui.positionAngleConstraintComboBox.enableItem(option)
     else {


### PR DESCRIPTION
This task comprises two elements:

1. Making code for the `PositionAnglePanel` and `ParallacticAngleControls` run on the Swing EDT so that it plays nicely with BAGS, which runs on the Swing EDT. Formerly, there were issues where, IIRC, BAGS lookups were not triggered because of this discrepancy.

2. BAGS now triggers changes to instrument configuration, which causes the `PositionAnglePanel.init` method to be called to reinitialize the panel. This causes the `ParallacticAngleControls.init` to be called, which leads to a call to `ParallacticAngleControls.updateSchedulingBlock`. This causes the parallactic angle to be recalculated, which sends an event to the `PositionAnglePanel` to indicate that the parallactic angle has changed. The `PositionAnglePanel` previously naively assumed that this event came only when the `PosAngleConstraint` on the instrument was set to `PARALLACTIC_ANGLE`, which is not always the case. Now when the parallactic angle is recorded as having changed, we explicitly check before we do anything that we are in `PARALLACTIC_ANGLE` mode.

I'm not sure if (2) is the best way to handle this, but this code has become fragile from all of the changes made over time and I think that this is the simplest and best way to make it safe and keep it safe in the future.

Independently, it may be worth trying to minimize the calls to `PositionAnglePanel.init` and `ParallacticAngleControls.init` as this situation is hardly ideal, but I believe that this is probably best left for a later time when the FR this addresses is at least working and is somewhat outside of the scope of this PR.