### PR TITLE
REL-2943: ObsoletableSpType cleanup and other warnings

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/CalUnitParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/CalUnitParams.java
@@ -1,33 +1,26 @@
-// Copyright 1997 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: CalUnitParams.java 38751 2011-11-16 19:37:18Z swalker $
-//
 package edu.gemini.spModel.gemini.calunit;
 
 import edu.gemini.shared.util.StringUtil;
-import edu.gemini.shared.util.StringUtil.MapToString;
-
 import edu.gemini.spModel.type.DisplayableSpType;
 import edu.gemini.spModel.type.ObsoletableSpType;
 import edu.gemini.spModel.type.SequenceableSpType;
 import edu.gemini.spModel.type.SpTypeUtil;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class CalUnitParams {
-    public static enum LampType {
+    public enum LampType {
         arc,
-        flat;
+        flat
     }
 
     /**
      * Lamps
      */
-    public static enum Lamp implements DisplayableSpType, SequenceableSpType {
+    public enum Lamp implements DisplayableSpType, SequenceableSpType {
         IR_GREY_BODY_HIGH("IR grey body - high", "GCALflat", LampType.flat),
         IR_GREY_BODY_LOW("IR grey body - low", "GCALflat", LampType.flat),
         QUARTZ("Quartz Halogen", "GCALflat", LampType.flat),
@@ -51,7 +44,7 @@ public final class CalUnitParams {
         // Set to true for arcs
         private LampType _type;
 
-        private Lamp(String displayValue, String tccName, LampType lampType) {
+        Lamp(String displayValue, String tccName, LampType lampType) {
             _displayValue = displayValue;
             _tccName      = tccName;
             _type         = lampType;
@@ -100,11 +93,8 @@ public final class CalUnitParams {
         private static List<Lamp> _arcLamps;
 
         private static List<Lamp> _getLamps(LampType lampType) {
-            List<Lamp> res = new ArrayList<Lamp>();
-            for (Lamp l : values()) {
-                if (l.type() == lampType) res.add(l);
-            }
-            return res;
+            return Arrays.stream(values()).filter(l -> l.type() == lampType)
+                    .collect(Collectors.toList());
         }
 
         public synchronized static List<Lamp> flatLamps() {
@@ -116,18 +106,6 @@ public final class CalUnitParams {
             if (_arcLamps == null) _arcLamps = _getLamps(LampType.arc);
             return _arcLamps;
         }
-
-        public static MapToString<Lamp> NAME_MAPPER = new MapToString<Lamp>() {
-            @Override public String apply(Lamp l) { return l.name(); }
-        };
-
-        public static MapToString<Lamp> DISPLAY_MAPPER = new MapToString<Lamp>() {
-            @Override public String apply(Lamp l) { return l.displayValue(); }
-        };
-
-        public static MapToString<Lamp> TCC_MAPPER = new MapToString<Lamp>() {
-            @Override public String apply(Lamp l) { return l.getTccName(); }
-        };
 
         public static String show(Collection<Lamp> lamps, StringUtil.MapToString<Lamp> mapper) {
             return StringUtil.mkString(lamps, "", ",", "", mapper);
@@ -144,27 +122,31 @@ public final class CalUnitParams {
 
         public static List<Lamp> read(String formattedList) {
             String[] ar = formattedList.split(",");
-            List<Lamp> lst = new ArrayList<Lamp>(ar.length);
-            for (String anAr : ar) lst.add(Lamp.getLamp(anAr));
-            return lst;
+            return Arrays.stream(ar).map(Lamp::getLamp).collect(Collectors.toList());
         }
     }
 
     /**
      * Filters
      */
-    public static enum Filter implements DisplayableSpType, ObsoletableSpType, SequenceableSpType {
+    public enum Filter implements DisplayableSpType, ObsoletableSpType, SequenceableSpType {
 
         NONE("none"),
         ND_10("ND1.0"),
-        ND_16("ND1.6", true),
+        ND_16("ND1.6") {
+            @Override public boolean isObsolete() { return true; }
+        },
         ND_20("ND2.0"),
         ND_30("ND3.0"),
         ND_40("ND4.0"),
         ND_45("ND4-5"),
-        ND_50("ND5.0", true),
+        ND_50("ND5.0") {
+            @Override public boolean isObsolete() { return true; }
+        },
         GMOS("GMOS balance"),
-        HROS("HROS balance", true),
+        HROS("HROS balance") {
+            @Override public boolean isObsolete() { return true; }
+        },
         NIR("NIR balance"),
 
         ;
@@ -173,23 +155,13 @@ public final class CalUnitParams {
         public static Filter DEFAULT = NONE;
 
         private String _displayValue;
-        private boolean _obsolete;
 
-        private Filter(String displayVal) {
-            this(displayVal, false);
-        }
-
-        private Filter(String displayVal, boolean obsolete) {
+        Filter(String displayVal) {
             _displayValue = displayVal;
-            _obsolete     = obsolete;
         }
 
         public String displayValue() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return _obsolete;
         }
 
         public String sequenceValue() {
@@ -220,7 +192,7 @@ public final class CalUnitParams {
     /**
      * Diffusers
      */
-    public static enum Diffuser implements DisplayableSpType, SequenceableSpType {
+    public enum Diffuser implements DisplayableSpType, SequenceableSpType {
         IR("IR"),
         VISIBLE("visible"),
         ;
@@ -230,7 +202,7 @@ public final class CalUnitParams {
 
         private String _displayValue;
 
-        private Diffuser(String displayValue) {
+        Diffuser(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -266,7 +238,7 @@ public final class CalUnitParams {
     /**
      * IR grey body shutter
      */
-    public static enum Shutter implements DisplayableSpType, SequenceableSpType {
+    public enum Shutter implements DisplayableSpType, SequenceableSpType {
 
         OPEN("Open"),
         CLOSED("Closed"),
@@ -277,7 +249,7 @@ public final class CalUnitParams {
 
         private String _displayValue;
 
-        private Shutter(String displayValue) {
+        Shutter(String displayValue) {
             _displayValue = displayValue;
         }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -199,9 +199,15 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         // scientifically useful option, but is used for focusing)
 
         OPEN("f/16 (open)", "f/16", 1.61, 0.18),
-        HIGH("f/32 MCAO high background", "f/32 high", 0.805, 0.09, true),
-        LOW("f/32 MCAO low background", "f/32 low", 0.805, 0.09, true),
-        GEMS("f/33 (Gems)", "f/33 Gems", 0.784, 0.09, true),
+        HIGH("f/32 MCAO high background", "f/32 high", 0.805, 0.09) {
+            @Override public boolean isObsolete() { return true; }
+        },
+        LOW("f/32 MCAO low background", "f/32 low", 0.805, 0.09) {
+            @Override public boolean isObsolete() { return true; }
+        },
+        GEMS("f/33 (Gems)", "f/33 Gems", 0.784, 0.09) {
+            @Override public boolean isObsolete() { return true; }
+        },
         GEMS_UNDER("f/33 (GeMS under-sized)", "GeMS under", 0.784, 0.09),
         GEMS_OVER("f/33 (GeMS over-sized)", "GeMS over", 0.784, 0.09),
         H1("Hartmann A (H1)"),
@@ -218,18 +224,12 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
 
         private final String _displayName;
         private final String _logValue;
-        private final boolean _obsolete;
 
         LyotWheel(String name, String logValue, double plateScale, double pixelScale) {
-            this(name, logValue, plateScale, pixelScale, false);
-        }
-
-        LyotWheel(String name, String logValue, double plateScale, double pixelScale, boolean obsolete) {
             _displayName = name;
             _logValue    = logValue;
             _plateScale  = plateScale;
             _pixelScale  = pixelScale;
-            _obsolete    = obsolete;
         }
 
         LyotWheel(String name) {
@@ -264,11 +264,6 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
 
         public String toString() {
             return displayValue();
-        }
-
-        @Override
-        public boolean isObsolete() {
-            return _obsolete;
         }
 
         // REL-1522
@@ -525,10 +520,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         }
 
         public static Option<WindowCover> valueOf(String name, Option<WindowCover> nvalue) {
-            WindowCover def = nvalue.isEmpty() ? null : nvalue.getValue();
-            WindowCover val = SpTypeUtil.oldValueOf(WindowCover.class, name, def);
-            Option<WindowCover> none = None.instance();
-            return val == null ? none : new Some<>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
@@ -552,10 +544,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         }
 
         public static Option<Decker> valueOf(String name, Option<Decker> nvalue) {
-            Decker def = nvalue.isEmpty() ? null : nvalue.getValue();
-            Decker val = SpTypeUtil.oldValueOf(Decker.class, name, def);
-            Option<Decker> none = None.instance();
-            return val == null ? none : new Some<>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
@@ -578,10 +567,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         }
 
         public static Option<ReadoutMode> valueOf(String name, Option<ReadoutMode> nvalue) {
-            ReadoutMode def = nvalue.isEmpty() ? null : nvalue.getValue();
-            ReadoutMode val = SpTypeUtil.oldValueOf(ReadoutMode.class, name, def);
-            Option<ReadoutMode> none = None.instance();
-            return val == null ? none : new Some<>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
@@ -618,10 +604,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         }
 
         public static Option<Reads> valueOf(String name, Option<Reads> nvalue) {
-            Reads def = nvalue.isEmpty() ? null : nvalue.getValue();
-            Reads val = SpTypeUtil.oldValueOf(Reads.class, name, def);
-            Option<Reads> none = None.instance();
-            return val == null ? none : new Some<>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -1,7 +1,3 @@
-//
-// $Id: GmosCommonType.java 45335 2012-05-17 18:40:04Z nbarriga $
-//
-
 package edu.gemini.spModel.gemini.gmos;
 
 import edu.gemini.shared.util.immutable.None;
@@ -35,7 +31,7 @@ public class GmosCommonType {
         int rulingDensity();
     }
 
-    public static interface DisperserBridge<D extends Enum<D> & Disperser> {
+    public interface DisperserBridge<D extends Enum<D> & Disperser> {
         Class<D> getPropertyType();
         D getDefaultValue();
         D parse(String name, D defaultValue);
@@ -46,30 +42,26 @@ public class GmosCommonType {
         String getWavelength();
     }
 
-    public static interface FilterBridge<F extends Enum<F> & Filter> {
+    public interface FilterBridge<F extends Enum<F> & Filter> {
         Class<F> getPropertyType();
         F getDefaultValue();
         F parse(String name, F defaultValue);
     }
 
     public interface FPUnit extends DisplayableSpType, LoggableSpType, SequenceableSpType {
-    // IFU visualisation in TPE
-    //
-    // nbarriga: For details, see jsky.app.ot.gemini.gmos.GMOS_SciAreaFeature.
-    //          the getWFSOffset() method was moved from there.
-    //
-    // The offset from the base position in arcsec
-     static final double IFU_FOV_OFFSET = 30.;
+        // IFU visualisation in TPE
+        // The offset from the base position in arcsec
+        double IFU_FOV_OFFSET = 30.;
 
-    // The offsets (from the base pos) and dimensions of the IFU FOV (in arcsec)
-     static final Rectangle2D.Double[] IFU_FOV = new Rectangle2D.Double[]{
-        new Rectangle2D.Double(-30. - IFU_FOV_OFFSET, 0., 3.5, 5.),
-        new Rectangle2D.Double(30. - IFU_FOV_OFFSET, 0., 7., 5.)
-    };
+        // The offsets (from the base pos) and dimensions of the IFU FOV (in arcsec)
+        Rectangle2D.Double[] IFU_FOV = new Rectangle2D.Double[]{
+            new Rectangle2D.Double(-30. - IFU_FOV_OFFSET, 0., 3.5, 5.),
+            new Rectangle2D.Double(30. - IFU_FOV_OFFSET, 0., 7., 5.)
+        };
 
-    // Indexes for above array
-     static final int IFU_FOV_SMALLER_RECT_INDEX = 0;
-     static final int IFU_FOV_LARGER_RECT_INDEX = 1;
+        // Indexes for above array
+        int IFU_FOV_SMALLER_RECT_INDEX = 0;
+        int IFU_FOV_LARGER_RECT_INDEX = 1;
 
 
         double getWidth();
@@ -93,7 +85,7 @@ public class GmosCommonType {
         double getWFSOffset();
     }
 
-    public static interface FPUnitBridge<P extends Enum<P> & FPUnit> {
+    public interface FPUnitBridge<P extends Enum<P> & FPUnit> {
         Class<P> getPropertyType();
         P getDefaultValue();
         P parse(String name, P defaultValue);
@@ -106,7 +98,7 @@ public class GmosCommonType {
      * AmpCount indicates the number of amps that should be used
      * when reading out the detectors.
      */
-    public static enum AmpCount implements DisplayableSpType, LoggableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum AmpCount implements DisplayableSpType, LoggableSpType, SequenceableSpType, ObsoletableSpType {
         THREE("Three", DetectorManufacturer.E2V),
         SIX("Six", DetectorManufacturer.E2V, DetectorManufacturer.HAMAMATSU),
         TWELVE("Twelve", DetectorManufacturer.HAMAMATSU),
@@ -120,7 +112,7 @@ public class GmosCommonType {
         private final String _displayValue;
         private final Set<DetectorManufacturer> supportedBy;
 
-        private AmpCount(String displayValue, DetectorManufacturer... supportedBy) {
+        AmpCount(String displayValue, DetectorManufacturer... supportedBy) {
             _displayValue = displayValue;
             Set<DetectorManufacturer> tmp = new HashSet<DetectorManufacturer>(Arrays.asList(supportedBy));
             this.supportedBy = Collections.unmodifiableSet(tmp);
@@ -136,10 +128,6 @@ public class GmosCommonType {
 
         public String logValue() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return false;
         }
 
         // This is backwards, but DetectorManufacturer is a common type
@@ -164,7 +152,7 @@ public class GmosCommonType {
 
     }
 
-    public static interface StageModeBridge<SM extends Enum<SM> & StageMode> {
+    public interface StageModeBridge<SM extends Enum<SM> & StageMode> {
         SM parse(String name, SM defaultValue);
         SM getDefaultValue();
     }
@@ -172,7 +160,7 @@ public class GmosCommonType {
     /**
      * ADC
      */
-    public static enum ADC implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum ADC implements DisplayableSpType, LoggableSpType, SequenceableSpType {
 
         NONE("No Correction"),
         BEST_STATIC("Best Static Correction"),
@@ -184,7 +172,7 @@ public class GmosCommonType {
 
         private String _displayValue;
 
-        private ADC(String displayValue) {
+        ADC(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -271,7 +259,7 @@ public class GmosCommonType {
     /**
      * CCD Gain indicates which gain mode to use
      */
-    public static enum AmpGain implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum AmpGain implements DisplayableSpType, LoggableSpType, SequenceableSpType {
         LOW("Low"),
         HIGH("High"),
         ;
@@ -281,7 +269,7 @@ public class GmosCommonType {
 
         private String _displayValue;
 
-        private AmpGain(String displayValue) {
+        AmpGain(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -311,7 +299,7 @@ public class GmosCommonType {
     /**
      * CCD ReadoutSpead indicates speed of CCD readout.
      */
-    public static enum AmpReadMode implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum AmpReadMode implements DisplayableSpType, LoggableSpType, SequenceableSpType {
         SLOW("Slow", "slow"),
         FAST("Fast", "fast"),
         ;
@@ -322,7 +310,7 @@ public class GmosCommonType {
         public static final AmpReadMode DEFAULT = SLOW;
         public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "ampReadMode");
 
-        private AmpReadMode(String displayValue, String logValue) {
+        AmpReadMode(String displayValue, String logValue) {
             _displayValue = displayValue;
             _logValue     = logValue;
         }
@@ -354,7 +342,7 @@ public class GmosCommonType {
     /**
      * CCD Bin factor.
      */
-    public static enum Binning implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum Binning implements DisplayableSpType, LoggableSpType, SequenceableSpType {
         ONE(1),
         TWO(2),
         FOUR(4),
@@ -364,7 +352,7 @@ public class GmosCommonType {
 
         private int _value;
 
-        private Binning(int value) {
+        Binning(int value) {
             _value = value;
         }
 
@@ -404,7 +392,7 @@ public class GmosCommonType {
     /**
      * Disperser Order
      */
-    public static enum Order implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum Order implements DisplayableSpType, LoggableSpType, SequenceableSpType {
         ZERO("0"),
         ONE("1"),
         TWO("2"),
@@ -414,7 +402,7 @@ public class GmosCommonType {
 
         private String _displayValue;
 
-        private Order(String displayValue) {
+        Order(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -451,7 +439,7 @@ public class GmosCommonType {
      * UseNS is True if using nod & shuffle, otherwise False
      * (XXX Using true/false instead of yes/no for backward compatibility)
      */
-    public static enum UseNS implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum UseNS implements DisplayableSpType, LoggableSpType, SequenceableSpType {
         TRUE("Yes"),
         FALSE("No"),
         ;
@@ -460,7 +448,7 @@ public class GmosCommonType {
 
         private String _displayValue;
 
-        private UseNS(String displayValue) {
+        UseNS(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -493,7 +481,7 @@ public class GmosCommonType {
      * FP unit mode indicates a custom mask is in use or a built in
      * is in use.
      */
-    public static enum FPUnitMode implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum FPUnitMode implements DisplayableSpType, LoggableSpType, SequenceableSpType {
         BUILTIN("Builtin"),
         CUSTOM_MASK("Custom Mask"),
         ;
@@ -502,7 +490,7 @@ public class GmosCommonType {
 
         private String _displayValue;
 
-        private FPUnitMode(String displayValue) {
+        FPUnitMode(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -534,15 +522,21 @@ public class GmosCommonType {
     /**
      * BuiltInROI is a class to select from a small set of selected Regions of Interest.
      */
-    public static enum BuiltinROI implements DisplayableSpType, LoggableSpType, SequenceableSpType, ObsoletableSpType, PartiallyEngineeringSpType {
+    public enum BuiltinROI implements DisplayableSpType, LoggableSpType, SequenceableSpType, ObsoletableSpType, PartiallyEngineeringSpType {
 
-        FULL_FRAME("Full Frame Readout", new Some<ROIDescription>(DEFAULT_BUILTIN_ROID), "full"),
-        CCD2("CCD 2", new Some<ROIDescription>(new ROIDescription(2049, 1, 2048, 4608)), "ccd2"),
-        CENTRAL_SPECTRUM("Central Spectrum", new Some<ROIDescription>(new ROIDescription(1, 1792, 6144, 1024)), "cspec"),
-        CENTRAL_STAMP("Central Stamp", new Some<ROIDescription>(new ROIDescription(2922, 2154, 300, 300)), "stamp"),
-        TOP_SPECTRUM("Top Spectrum", new Some<ROIDescription>(new ROIDescription(1, 3328, 6144, 1024)), "tspec") { public boolean isObsolete() {return true;}},
-        BOTTOM_SPECTRUM("Bottom Spectrum", new Some<ROIDescription>(new ROIDescription(1, 256, 6144, 1024)), "bspec") { public boolean isObsolete() {return true;}},
-        CUSTOM("Custom ROI", None.<ROIDescription>instance(), "custom") { public boolean isEngineering() {return true;}},
+        FULL_FRAME("Full Frame Readout", new Some<>(DEFAULT_BUILTIN_ROID), "full"),
+        CCD2("CCD 2", new Some<>(new ROIDescription(2049, 1, 2048, 4608)), "ccd2"),
+        CENTRAL_SPECTRUM("Central Spectrum", new Some<>(new ROIDescription(1, 1792, 6144, 1024)), "cspec"),
+        CENTRAL_STAMP("Central Stamp", new Some<>(new ROIDescription(2922, 2154, 300, 300)), "stamp"),
+        TOP_SPECTRUM("Top Spectrum", new Some<>(new ROIDescription(1, 3328, 6144, 1024)), "tspec") {
+            @Override public boolean isObsolete() { return true; }
+        },
+        BOTTOM_SPECTRUM("Bottom Spectrum", new Some<>(new ROIDescription(1, 256, 6144, 1024)), "bspec") {
+            @Override public boolean isObsolete() { return true; }
+        },
+        CUSTOM("Custom ROI", None.instance(), "custom") {
+            public boolean isEngineering() { return true; }
+        },
         ;
 
 
@@ -554,7 +548,7 @@ public class GmosCommonType {
         private Option<ROIDescription> _roid;
         private String _logValue;
 
-        private BuiltinROI(String displayValue, Option<ROIDescription> roid, String logValue) {
+        BuiltinROI(String displayValue, Option<ROIDescription> roid, String logValue) {
             _displayValue = displayValue;
             _roid = roid;
             _logValue = logValue;
@@ -584,15 +578,6 @@ public class GmosCommonType {
         /** Return a BuiltinROI by name giving a value to return upon error **/
         public static BuiltinROI getBuiltinROI(String name, BuiltinROI nvalue) {
             return SpTypeUtil.oldValueOf(BuiltinROI.class, name, nvalue);
-        }
-
-        public boolean isObsolete() {
-            return false;
-        }
-
-        @Override
-        public boolean isEngineering() {
-            return false;
         }
     }
 
@@ -635,7 +620,7 @@ public class GmosCommonType {
         }
 
         public List<IParameter> getSysConfig(int i) {
-            List<IParameter> params = new ArrayList<IParameter>();
+            List<IParameter> params = new ArrayList<>();
             params.add(DefaultParameter.getInstance("customROI" + i + paramNames[0], getXStart()));
             params.add(DefaultParameter.getInstance("customROI" + i + paramNames[1], getYStart()));
             params.add(DefaultParameter.getInstance("customROI" + i + paramNames[2], getXSize()));
@@ -765,7 +750,7 @@ public class GmosCommonType {
     /**
      * DTAX Offset Values - restricted to +/- 6, zero default
      */
-    public static enum DTAX implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum DTAX implements DisplayableSpType, LoggableSpType, SequenceableSpType {
 
         MSIX("-6", -6),
         MFIVE("-5", -5),
@@ -787,7 +772,7 @@ public class GmosCommonType {
         private String _displayValue;
         private int _dtax;
 
-        private DTAX(String displayValue, int value) {
+        DTAX(String displayValue, int value) {
             _displayValue = displayValue;
             _dtax = value;
         }
@@ -861,7 +846,7 @@ public class GmosCommonType {
     public static final double HAMAMATSU_PIXEL_SIZE = 0.0809;
     public static final int HAMAMATSU_SHUFFLE_OFFSET = 1392; // pixel
 
-    public static enum DetectorManufacturer implements DisplayableSpType, ObsoletableSpType {
+    public enum DetectorManufacturer implements DisplayableSpType {
         E2V("E2V", E2V_NORTH_PIXEL_SIZE, E2V_SOUTH_PIXEL_SIZE, E2V_SHUFFLE_OFFSET, 6144, 4608, 4),
         HAMAMATSU("HAMAMATSU", HAMAMATSU_PIXEL_SIZE, HAMAMATSU_PIXEL_SIZE, HAMAMATSU_SHUFFLE_OFFSET, 6144, 4224, 5);
 
@@ -876,7 +861,7 @@ public class GmosCommonType {
         private final int ySize;
         private final int maxROIs;
 
-        private DetectorManufacturer(final String displayValue, final double pixelSizeNorth, final double pixelSizeSouth,
+        DetectorManufacturer(final String displayValue, final double pixelSizeNorth, final double pixelSizeSouth,
                                      final int offset, final int xSize, final int ySize, final int maxROIs) {
             this._displayValue = displayValue;
             this._pixelSizeNorth = pixelSizeNorth;
@@ -924,17 +909,13 @@ public class GmosCommonType {
         public int getMaxROIs() {
             return maxROIs;
         }
-
-        public boolean isObsolete() {
-            return false;
-        }
     }
 
 
     /**
      * GMOS custom mask slit widths
      */
-    public static enum CustomSlitWidth implements DisplayableSpType {
+    public enum CustomSlitWidth implements DisplayableSpType {
         OTHER("Other", 0),
         CUSTOM_WIDTH_0_25("0.25 arcsec", 0.25),
         CUSTOM_WIDTH_0_50("0.50 arcsec", 0.50),
@@ -947,7 +928,7 @@ public class GmosCommonType {
         private String _displayValue;
         private double _width;
 
-        private CustomSlitWidth(String displayValue, double width) {
+        CustomSlitWidth(String displayValue, double width) {
             this._displayValue = displayValue;
             this._width = width;
         }
@@ -981,15 +962,13 @@ public class GmosCommonType {
         }
 
         public static CustomROIList create(ParamSet paramSet) {
-            ArrayList<ROIDescription> newList = new ArrayList<ROIDescription>();
-            for (ParamSet p : paramSet.getParamSets()) {
-                newList.add(new ROIDescription(p));
-            }
+            final ArrayList<ROIDescription> newList = new ArrayList<>();
+            paramSet.getParamSets().stream().map(ROIDescription::new).forEach(newList::add);
             return new CustomROIList(newList);
         }
 
         private CustomROIList() {
-            rois = new ArrayList<ROIDescription>();
+            rois = new ArrayList<>();
         }
 
         private CustomROIList(ArrayList<ROIDescription> rois) {
@@ -1001,13 +980,13 @@ public class GmosCommonType {
         }
 
         public CustomROIList add(ROIDescription roi) {
-            ArrayList<ROIDescription> newList = new ArrayList<ROIDescription>(rois);
+            final ArrayList<ROIDescription> newList = new ArrayList<>(rois);
             newList.add(roi);
             return new CustomROIList(newList);
         }
 
         public CustomROIList remove(int i) {
-            ArrayList<ROIDescription> newList= new ArrayList<ROIDescription>(rois);
+            final ArrayList<ROIDescription> newList= new ArrayList<>(rois);
             newList.remove(i);
             return new CustomROIList(newList);
         }
@@ -1017,7 +996,7 @@ public class GmosCommonType {
         }
 
         public CustomROIList update(int i, ROIDescription roi) {
-            ArrayList<ROIDescription> newList= new ArrayList<ROIDescription>(rois);
+            final ArrayList<ROIDescription> newList= new ArrayList<>(rois);
             newList.remove(i);
             newList.add(i, roi);
             return new CustomROIList(newList);
@@ -1048,7 +1027,7 @@ public class GmosCommonType {
         }
 
         public List<IParameter> getSysConfig() {
-            List<IParameter> params = new ArrayList<IParameter>();
+            List<IParameter> params = new ArrayList<>();
             for (int i = 0; i < rois.size(); i++) {
                 params.addAll(rois.get(i).getSysConfig(i+1));
             }
@@ -1081,11 +1060,7 @@ public class GmosCommonType {
          * (0/:rois) { _ + _.getYSize }
          */
         public int totalUnbinnedRows() {
-            int rows = 0;
-            for (ROIDescription roi : rois) {
-                rows = rows + roi.getYSize();
-            }
-            return rows;
+            return rois.stream().reduce(0, (rows, roi) -> rows + roi.getYSize(), (a,b) -> a+b);
         }
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -13,9 +13,13 @@ public class GmosNorthType {
      */
     public enum StageModeNorth implements GmosCommonType.StageMode {
         NO_FOLLOW("Do Not Follow"),
-        FOLLOW_XYZ("Follow in XYZ(focus)") { public boolean isObsolete() { return true;}},
+        FOLLOW_XYZ("Follow in XYZ(focus)") {
+            @Override public boolean isObsolete() { return true; }
+        },
         FOLLOW_XY("Follow in XY"),
-        FOLLOW_Z_ONLY("Follow in Z Only") { public boolean isObsolete() { return true;}}
+        FOLLOW_Z_ONLY("Follow in Z Only") {
+            @Override public boolean isObsolete() { return true; }
+        }
         ;
 
         public static final StageModeNorth DEFAULT = StageModeNorth.FOLLOW_XY;
@@ -47,10 +51,6 @@ public class GmosNorthType {
         public static StageModeNorth getStageMode(String name, StageModeNorth nvalue) {
             return SpTypeUtil.oldValueOf(StageModeNorth.class, name, nvalue);
         }
-
-        public boolean isObsolete() {
-            return false;
-        }
     }
 
     public static GmosCommonType.StageModeBridge<StageModeNorth> STAGE_MODE_BRIDGE = new GmosCommonType.StageModeBridge<StageModeNorth>() {
@@ -71,7 +71,9 @@ public class GmosNorthType {
         MIRROR("Mirror", "mirror", 0),
         B1200_G5301("B1200_G5301", "B1200", 1200),
         R831_G5302("R831_G5302", "R831", 831),
-        B600_G5303("B600_G5303", "B600", 600) {public boolean isObsolete() {return true;}},
+        B600_G5303("B600_G5303", "B600", 600) {
+            @Override public boolean isObsolete() { return true; }
+        },
         B600_G5307("B600_G5307", "B600", 600),
         R600_G5304("R600_G5304", "R600", 600),
         R400_G5305("R400_G5305", "R400", 400),
@@ -116,9 +118,6 @@ public class GmosNorthType {
             return displayValue();
         }
 
-        public boolean isObsolete() {
-            return false;
-        }
 
         /** Return a Disperser by index **/
         public static DisperserNorth getDisperserByIndex(int index) {
@@ -178,9 +177,7 @@ public class GmosNorthType {
         i_G0302_CaT_G0309("i_G0302 + CaT_G0309", "i+CaT", "0.815"),
         z_G0304_CaT_G0309("z_G0304 + CaT_G0309", "z+CaT", "0.890"),
         u_G0308("u_G0308", "u_G0308", "0.350") {
-            public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         }
         ;
 
@@ -200,10 +197,6 @@ public class GmosNorthType {
             _displayValue = displayValue;
             _logValue     = logValue;
             _wavelength   = wavelength;
-        }
-
-        public boolean isObsolete() {
-            return false;
         }
 
         public String displayValue() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
@@ -16,7 +16,9 @@ public class GmosSouthType {
     public enum StageModeSouth implements GmosCommonType.StageMode {
         NO_FOLLOW("Do Not Follow"),
         FOLLOW_XYZ("Follow in XYZ(focus)"),
-        FOLLOW_XY("Follow in XY") { public boolean isObsolete() { return true;}},
+        FOLLOW_XY("Follow in XY") {
+            @Override public boolean isObsolete() { return true; }
+        },
         FOLLOW_Z_ONLY("Follow in Z Only")
         ;
 
@@ -48,10 +50,6 @@ public class GmosSouthType {
         /** Return a StageMode by name giving a value to return upon error **/
         public static StageModeSouth getStageMode(String name, StageModeSouth nvalue) {
             return SpTypeUtil.oldValueOf(StageModeSouth.class, name, nvalue);
-        }
-
-        public boolean isObsolete() {
-            return false;
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
@@ -1,10 +1,3 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: GNIRSParams.java 45360 2012-05-18 19:57:50Z nbarriga $
-//
 package edu.gemini.spModel.gemini.gnirs;
 
 import edu.gemini.spModel.config2.ItemKey;
@@ -28,7 +21,7 @@ public class GNIRSParams {
     /**
      * CrossDispersed values (yes/no).
      */
-    public static enum CrossDispersed implements DisplayableSpType, SequenceableSpType {
+    public enum CrossDispersed implements DisplayableSpType, SequenceableSpType {
 
         NO("No"),
         SXD("SXD"),
@@ -42,8 +35,8 @@ public class GNIRSParams {
 
         private String _displayValue;
 
-        private CrossDispersed(String displayValue) {
-            _displayValue      = displayValue;
+        CrossDispersed(String displayValue) {
+            _displayValue = displayValue;
         }
 
         public String displayValue() {
@@ -87,7 +80,7 @@ public class GNIRSParams {
     /**
      * PixelScale choices
      */
-    public static enum PixelScale implements DisplayableSpType, SequenceableSpType {
+    public enum PixelScale implements DisplayableSpType, SequenceableSpType {
 
         PS_015("0.15\"/pix", 0.15, CrossDispersed.NO, CrossDispersed.SXD),
         PS_005("0.05\"/pix", 0.05, CrossDispersed.values()),
@@ -99,10 +92,10 @@ public class GNIRSParams {
         private String _displayValue;
         private Set<CrossDispersed> _xdOptions;
 
-        private PixelScale(String displayValue, double pixelScale, CrossDispersed... xd) {
+        PixelScale(String displayValue, double pixelScale, CrossDispersed... xd) {
             _displayValue = displayValue;
             _pixelScale   = pixelScale;
-            _xdOptions    = Collections.unmodifiableSet(new HashSet<CrossDispersed>(Arrays.asList(xd)));
+            _xdOptions    = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(xd)));
         }
 
         public String displayValue() {
@@ -150,7 +143,7 @@ public class GNIRSParams {
     /**
      * SlitWidth choices
      */
-    public static enum SlitWidth implements DisplayableSpType, SequenceableSpType, LoggableSpType, ObsoletableSpType {
+    public enum SlitWidth implements DisplayableSpType, SequenceableSpType, LoggableSpType, ObsoletableSpType {
 
         SW_1("0.10 arcsec", 0.10, "0.10"),
         SW_2("0.15 arcsec", 0.15, "0.15"),
@@ -160,14 +153,10 @@ public class GNIRSParams {
         SW_6("0.675 arcsec", 0.675, "0.675"),
         SW_7("1.0 arcsec", 1.0, "1.0"),
         SW_8("3.0 arcsec", 3.0, "3.0") {
-            public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         },
         IFU("IFU", 4.8, "IFU") {
-            public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         },
         ACQUISITION("acquisition", "ACQ"),
         PUPIL_VIEWER("pupil viewer", "PV"),
@@ -185,14 +174,14 @@ public class GNIRSParams {
         private String _displayValue;
         private String _logValue;
 
-        private SlitWidth(String displayValue, double slitWidth, String logValue) {
+        SlitWidth(String displayValue, double slitWidth, String logValue) {
             _displayValue = displayValue;
             _slitWidth = slitWidth;
             _logValue = logValue;
         }
 
         // Note hardcoded default slit width because one can't use static in enum constructor
-        private SlitWidth(String displayValue, String logValue) {
+        SlitWidth(String displayValue, String logValue) {
             this(displayValue, Defaults.DEFAULT_SLIT_WIDTH, logValue);
         }
 
@@ -209,10 +198,6 @@ public class GNIRSParams {
 
         public String sequenceValue() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return false;
         }
 
         public double getValue() {
@@ -261,7 +246,7 @@ public class GNIRSParams {
     /**
      * Disperser choices
      */
-    public static enum Disperser implements DisplayableSpType, SequenceableSpType, LoggableSpType {
+    public enum Disperser implements DisplayableSpType, SequenceableSpType, LoggableSpType {
         //For the disperser, to do the conversion you will need to check pixel scale.
         //The translation is:
         //
@@ -299,7 +284,7 @@ public class GNIRSParams {
 
         // Initialize with the name, grating value and spectral resolutions at
         // 0.05 and 0.15 "/pix
-        private Disperser(String displayValue, int value, int sr005, int sr015, String logValue) {
+        Disperser(String displayValue, int value, int sr005, int sr015, String logValue) {
             _displayValue = displayValue;
             _value = value;
             _sr005 = sr005;
@@ -425,7 +410,7 @@ public class GNIRSParams {
     /**
      * Central Wavelength Order
      */
-    public static enum Order implements DisplayableSpType, SequenceableSpType {
+    public enum Order implements DisplayableSpType, SequenceableSpType {
 
         // Note: If you change the order here, look at EdCompInstGNIRS._getDefaultWavelengths()
         // and the event handler, since the last two items (7,8) are not included in the menu and the
@@ -458,9 +443,9 @@ public class GNIRSParams {
         private String _displayValue;
 
         // Constructor
-        private Order(int order, double defaultWavelength,
-                      double minWavelength, double maxWavelength,
-                      double deltaWavelength, String band, boolean isXD) {
+        Order(int order, double defaultWavelength,
+              double minWavelength, double maxWavelength,
+              double deltaWavelength, String band, boolean isXD) {
 
             _displayValue = String.valueOf(order);
             _order = order;
@@ -592,7 +577,7 @@ public class GNIRSParams {
     /**
      * WollastonPrism values (yes/no).
      */
-    public static enum WollastonPrism implements DisplayableSpType, SequenceableSpType {
+    public enum WollastonPrism implements DisplayableSpType, SequenceableSpType {
 
         NO("No"),
         YES("Yes"),
@@ -604,7 +589,7 @@ public class GNIRSParams {
         public static WollastonPrism DEFAULT = NO;
         private String _displayValue;
 
-        private WollastonPrism(String displayValue) {
+        WollastonPrism(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -646,7 +631,7 @@ public class GNIRSParams {
     /**
      * Read Mode
      */
-    public static enum ReadMode implements DisplayableSpType, SequenceableSpType, LoggableSpType {
+    public enum ReadMode implements DisplayableSpType, SequenceableSpType, LoggableSpType {
         // Updated for REL-175
         BRIGHT("Bright Objects", 1, 0.6, 30, "bright"),
         FAINT("Faint Objects", 16, 9., 10, "faint"),
@@ -666,8 +651,8 @@ public class GNIRSParams {
         private String _logValue;
         private String _displayValue;
 
-        private ReadMode(String displayValue, int lowNoiseReads,
-                         double minExp, double readNoise, String logValue) {
+        ReadMode(String displayValue, int lowNoiseReads,
+                 double minExp, double readNoise, String logValue) {
             _displayValue = displayValue;
             _lowNoiseReads = lowNoiseReads;
             _minExp = minExp;
@@ -747,7 +732,7 @@ public class GNIRSParams {
     /**
      * Filters (for on-site sequencing only)
      */
-    public static enum Filter implements DisplayableSpType, SequenceableSpType, LoggableSpType {
+    public enum Filter implements DisplayableSpType, SequenceableSpType, LoggableSpType {
 
         X_DISPERSED("x-dispersed", "XD"),
         ORDER_6("order 6 (X)", "X", 1.10),
@@ -777,15 +762,15 @@ public class GNIRSParams {
         private String _sequenceValue;
         private Double _wavelength;
 
-        private Filter(String displayValue, String logValue) {
+        Filter(String displayValue, String logValue) {
             this(displayValue, logValue, null);
         }
 
-        private Filter(String displayValue, String logValue, Double wavelength) {
+        Filter(String displayValue, String logValue, Double wavelength) {
             this(displayValue,logValue,displayValue, wavelength);
         }
 
-        private Filter(String displayValue, String logValue, String sequenceValue, Double wavelength) {
+        Filter(String displayValue, String logValue, String sequenceValue, Double wavelength) {
             _displayValue = displayValue;
             _logValue = logValue;
             _sequenceValue = sequenceValue;
@@ -842,7 +827,7 @@ public class GNIRSParams {
      * short red
      * long red
      */
-    public static enum Camera implements DisplayableSpType, SequenceableSpType, LoggableSpType {
+    public enum Camera implements DisplayableSpType, SequenceableSpType, LoggableSpType {
 
         SHORT_BLUE("short blue", "SB"),
         LONG_BLUE("long blue", "LB"),
@@ -857,7 +842,7 @@ public class GNIRSParams {
         private String _logValue;
         private String _displayValue;
 
-        private Camera(String displayValue, String logValue) {
+        Camera(String displayValue, String logValue) {
             _displayValue = displayValue;
             _logValue = logValue;
         }
@@ -913,16 +898,14 @@ public class GNIRSParams {
     /**
      * Deckers (for on-site sequencing only)
      */
-    public static enum Decker implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum Decker implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         ACQUISITION("acquisition"),
         PUPIL_VIEWER("pupil viewer"),
         SHORT_CAM_LONG_SLIT("short camera long slit"),
         SHORT_CAM_X_DISP("short camera x-disp"),
         IFU("IFU") {
-            public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         },
         LONG_CAM_LONG_SLIT("long camera long slit"),
         LONG_CAM_X_DISP("long camera x-disp"),
@@ -935,7 +918,7 @@ public class GNIRSParams {
         public static Decker DEFAULT = ACQUISITION;
         private String _displayValue;
 
-        private Decker(String displayValue) {
+        Decker(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -952,10 +935,6 @@ public class GNIRSParams {
 
         public String sequenceValue() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return false;
         }
 
         public String toString() {
@@ -985,7 +964,7 @@ public class GNIRSParams {
     /**
      * Acquisition Mirror (for on-site sequencing only)
      */
-    public static enum AcquisitionMirror implements DisplayableSpType, SequenceableSpType {
+    public enum AcquisitionMirror implements DisplayableSpType, SequenceableSpType {
 
         IN("in"),
         OUT("out"),
@@ -997,7 +976,7 @@ public class GNIRSParams {
         public static AcquisitionMirror DEFAULT = OUT;
         private String _displayValue;
 
-        private AcquisitionMirror(String displayValue) {
+        AcquisitionMirror(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -1036,7 +1015,7 @@ public class GNIRSParams {
     }
 
     /**Well Depth Values **/
-    public static enum WellDepth implements DisplayableSpType, SequenceableSpType {
+    public enum WellDepth implements DisplayableSpType, SequenceableSpType {
 
         SHALLOW("Shallow", 300),
         DEEP("Deep", 600);
@@ -1046,7 +1025,7 @@ public class GNIRSParams {
         private String _displayValue;
         private int _biasLevel; //in mV
 
-        private WellDepth(String name, int biasLevel) {
+        WellDepth(String name, int biasLevel) {
             _displayValue = name;
             _biasLevel = biasLevel;
         }
@@ -1070,7 +1049,7 @@ public class GNIRSParams {
 
 
     /** Wavelength values **/
-    public static enum WavelengthSuggestion implements DisplayableSpType, SequenceableSpType {
+    public enum WavelengthSuggestion implements DisplayableSpType, SequenceableSpType {
         VAL1("4.85"),
         VAL2("3.4"),
         VAL3("2.22"),
@@ -1085,7 +1064,7 @@ public class GNIRSParams {
 
         private String _displayValue;
 
-        private WavelengthSuggestion(String displayValue) {
+        WavelengthSuggestion(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -1120,7 +1099,7 @@ public class GNIRSParams {
         }
     }
 
-    public  static class Wavelength extends SuggestibleString {
+    public static class Wavelength extends SuggestibleString {
 
         public Wavelength() {
             super(WavelengthSuggestion.class);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -493,18 +493,9 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
      * Disperser: see OT-50
      */
     public enum Disperser implements DisplayableSpType, SequenceableSpType, PartiallyEngineeringSpType, LoggableSpType {
-        PRISM("Prism") {
-            @Override
-            public boolean isEngineering() {
-                return false;
-            }
-        },
-        WOLLASTON("Wollaston") {
-            @Override
-            public boolean isEngineering() {
-                return false;
-            }
-        };
+        PRISM("Prism"),
+        WOLLASTON("Wollaston"),
+        ;
 
         /** The default Disperser value **/
         public static final Disperser DEFAULT = PRISM;
@@ -693,12 +684,9 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
 
         // Returns the DetectorReadoutArea matching the given ReadoutArea values.
         public static DetectorReadoutArea valueOf(ReadoutArea readoutArea) {
-            for(DetectorReadoutArea detectorReadoutArea : values()) {
-                if (detectorReadoutArea.getReadoutArea().equals(readoutArea)) {
-                    return detectorReadoutArea;
-                }
-            }
-            return MANUAL;
+            return Arrays.stream(values())
+                    .filter(dRA -> dRA.getReadoutArea().equals(readoutArea))
+                    .findFirst().orElse(MANUAL);
         }
 
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/MichelleParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/MichelleParams.java
@@ -1,15 +1,6 @@
-// Copyright 2002
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: MichelleParams.java 38186 2011-10-24 13:21:33Z swalker $
-//
-
 package edu.gemini.spModel.gemini.michelle;
 
-import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.Some;
 import static edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY;
 
 import edu.gemini.spModel.config2.ItemKey;
@@ -26,7 +17,7 @@ public final class MichelleParams {
     /**
      * Chop mode.
      */
-    public static enum ChopMode implements SequenceableSpType, DisplayableSpType {
+    public enum ChopMode implements SequenceableSpType, DisplayableSpType {
         CHOP("Chop"),
         NDSTARE("ND Stare"),
         STARE("Stare"),
@@ -54,17 +45,14 @@ public final class MichelleParams {
         }
 
         public static Option<ChopMode> valueOf(String name, Option<ChopMode> nvalue) {
-            ChopMode def = nvalue.isEmpty() ? null : nvalue.getValue();
-            ChopMode val = SpTypeUtil.oldValueOf(ChopMode.class, name, def);
-            Option<ChopMode> none = None.instance();
-            return val == null ? none : new Some<ChopMode>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
     /**
      * Chop waveform.
      */
-    public static enum ChopWaveform implements SequenceableSpType, DisplayableSpType {
+    public enum ChopWaveform implements SequenceableSpType, DisplayableSpType {
         DEEP_WELL("Deep Well"),
         SHALLOW_WELL_NDR("Shallow Well NDR"),
         ;
@@ -91,17 +79,14 @@ public final class MichelleParams {
         }
 
         public static Option<ChopWaveform> valueOf(String name, Option<ChopWaveform> nvalue) {
-            ChopWaveform def = nvalue.isEmpty() ? null : nvalue.getValue();
-            ChopWaveform val = SpTypeUtil.oldValueOf(ChopWaveform.class, name, def);
-            Option<ChopWaveform> none = None.instance();
-            return val == null ? none : new Some<ChopWaveform>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
     /**
      * Grating Order (engineering param).
      */
-    public static enum DisperserOrder implements SequenceableSpType, DisplayableSpType {
+    public enum DisperserOrder implements SequenceableSpType, DisplayableSpType {
         ORDER0("0"),
         ;
 
@@ -127,17 +112,14 @@ public final class MichelleParams {
         }
 
         public static Option<DisperserOrder> valueOf(String name, Option<DisperserOrder> nvalue) {
-            DisperserOrder def = nvalue.isEmpty() ? null : nvalue.getValue();
-            DisperserOrder val = SpTypeUtil.oldValueOf(DisperserOrder.class, name, def);
-            Option<DisperserOrder> none = None.instance();
-            return val == null ? none : new Some<DisperserOrder>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
     /**
      * Mode in which the disperser is used with respect to chopping.
      */
-    public static enum DisperserMode {
+    public enum DisperserMode {
         CHOP,
         NOD
     }
@@ -146,7 +128,7 @@ public final class MichelleParams {
     /**
      * Michelle Dispersers.
      */
-    public static enum Disperser implements StandardSpType {
+    public enum Disperser implements StandardSpType {
 
 
 
@@ -197,7 +179,7 @@ public final class MichelleParams {
         private final int    _order1Steps;
         private final double _lamda;
 
-        private Disperser(String displayValue, DisperserMode mode, double efficiency, int order0Steps, int order1Steps, double lamda) {
+        Disperser(String displayValue, DisperserMode mode, double efficiency, int order0Steps, int order1Steps, double lamda) {
             _displayValue = displayValue;
             _mode         = mode;
             _efficiency   = efficiency;
@@ -274,7 +256,7 @@ public final class MichelleParams {
     /**
      * InjectorPosition (engineering param).
      */
-    public static enum Position implements SequenceableSpType, DisplayableSpType {
+    public enum Position implements SequenceableSpType, DisplayableSpType {
         IMAGING("Imaging"),
         PARK("Park"),
         SPECTROSCOPY("Spectroscopy"),
@@ -292,17 +274,14 @@ public final class MichelleParams {
         }
 
         public static Option<Position> valueOf(String name, Option<Position> nvalue) {
-            Position def = nvalue.isEmpty() ? null : nvalue.getValue();
-            Position val = SpTypeUtil.oldValueOf(Position.class, name, def);
-            Option<Position> none = None.instance();
-            return val == null ? none : new Some<Position>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
     /**
      * Engineering Focal Plane Mask options.
      */
-    public static enum EngMask implements StandardSpType {
+    public enum EngMask implements StandardSpType {
         CLEAR("Clear Slit Mask", "clear", 21,     48),
         PINHOLE("Pinhole Mask", "pinhole", 0.402, 45),
         ;
@@ -312,7 +291,7 @@ public final class MichelleParams {
         private double width;  // arcsec
         private double height; // arcsec
 
-        private EngMask(String displayValue, String log, double width, double height) {
+        EngMask(String displayValue, String log, double width, double height) {
             this.displayValue = displayValue;
             this.logValue     = log;
             this.width        = width;
@@ -354,17 +333,14 @@ public final class MichelleParams {
         }
 
         public static Option<EngMask> valueOf(String name, Option<EngMask> nvalue) {
-            EngMask def = nvalue.isEmpty() ? null : nvalue.getValue();
-            EngMask val = SpTypeUtil.oldValueOf(EngMask.class, name, def);
-            Option<EngMask> none = None.instance();
-            return val == null ? none : new Some<EngMask>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
     /**
      * Masks
      */
-    public static enum Mask implements StandardSpType {
+    public enum Mask implements StandardSpType {
 //        Focal Plane Mask:
 //        1_pixel
 //        2_pixels
@@ -406,7 +382,7 @@ public final class MichelleParams {
         // The height (length) of the mask in arcsec
         private double _height;
 
-        private Mask(String displayValue, double width, double height) {
+        Mask(String displayValue, double width, double height) {
             _displayValue = displayValue;
             _width = width;
             _height = height;
@@ -470,7 +446,7 @@ public final class MichelleParams {
     /**
      * Filter Wheel A (engineering) parameter values.
      */
-    public static enum FilterWheelA implements SequenceableSpType, DisplayableSpType {
+    public enum FilterWheelA implements SequenceableSpType, DisplayableSpType {
         CLEARA1("ClearA1"),
         F22B15,
         F34B9,
@@ -520,17 +496,15 @@ public final class MichelleParams {
         }
 
         public static Option<FilterWheelA> valueOf(String name, Option<FilterWheelA> nvalue) {
-            FilterWheelA def = nvalue.isEmpty() ? null : nvalue.getValue();
-            FilterWheelA val = SpTypeUtil.oldValueOf(FilterWheelA.class, name, def);
-            Option<FilterWheelA> none = None.instance();
-            return val == null ? none : new Some<FilterWheelA>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
+
 
     /**
      * Filter Wheel B (engineering) parameter values.
      */
-    public static enum FilterWheelB implements SequenceableSpType, DisplayableSpType {
+    public enum FilterWheelB implements SequenceableSpType, DisplayableSpType {
         F86B2,
         CLEAR_B("Clear_B"),
         GRID_T("Grid_T"),
@@ -573,17 +547,14 @@ public final class MichelleParams {
         }
 
         public static Option<FilterWheelB> valueOf(String name, Option<FilterWheelB> nvalue) {
-            FilterWheelB def = nvalue.isEmpty() ? null : nvalue.getValue();
-            FilterWheelB val = SpTypeUtil.oldValueOf(FilterWheelB.class, name, def);
-            Option<FilterWheelB> none = None.instance();
-            return val == null ? none : new Some<FilterWheelB>(val);
+            return nvalue.map(def -> valueOf(name, def));
         }
     }
 
     /**
      * User Filters
      */
-    public static enum Filter implements StandardSpType, ObsoletableSpType {
+    public enum Filter implements StandardSpType, ObsoletableSpType {
 
         NONE("None", "none"),
         F86B2("F86B2 8.5um", "8.5"),
@@ -596,12 +567,22 @@ public final class MichelleParams {
         SI_4("Si-4 10.4um", "10.4"),
         SI_5("Si-5 11.7um", "11.7"),
         SI_6("Si-6 12.3um", "12.3"),
-        N_PRIME_SEMI_BROAD("N' (semi-broad)", "11.2", true),
-        Q("Q' (semi-broad)", "19.8", true),
-        Q_BROAD("Q (broad)", "20.9", true),
+        N_PRIME_SEMI_BROAD("N' (semi-broad)", "11.2") {
+            @Override public boolean isObsolete() { return true; }
+        },
+        Q("Q' (semi-broad)", "19.8") {
+            @Override public boolean isObsolete() { return true; }
+        },
+        Q_BROAD("Q (broad)", "20.9") {
+            @Override public boolean isObsolete() { return true; }
+        },
         QA("Qa 18.1um", "18.1"),
-        N10("N 10.4um", "10.4", true),
-        Q20("Q 20.9um", "20.9", true),
+        N10("N 10.4um", "10.4") {
+            @Override public boolean isObsolete() { return true; }
+        },
+        Q20("Q 20.9um", "20.9") {
+            @Override public boolean isObsolete() { return true; }
+        },
         Q19("Q' 19.8um", "20.9"),
         ;
 
@@ -611,16 +592,10 @@ public final class MichelleParams {
 
         private String _wavelength;  // in µm
         private String _displayValue;
-        private boolean _isObsolete;
 
-        private Filter(String displayValue, String wavelength) {
-            this(displayValue, wavelength, false);
-        }
-
-        private Filter(String displayValue, String wavelength, boolean isObsolete) {
+        Filter(String displayValue, String wavelength) {
             _displayValue = displayValue;
             _wavelength = wavelength;
-            _isObsolete = isObsolete;
         }
 
 
@@ -649,10 +624,6 @@ public final class MichelleParams {
             return _displayValue;
         }
 
-        public boolean isObsolete() {
-            return _isObsolete;
-        }
-
         /** Return a Filter by name **/
         static public Filter getFilter(String name) {
             return getFilter(name, DEFAULT);
@@ -678,7 +649,7 @@ public final class MichelleParams {
     /**
      * AutoConfigure values (yes/no).
      */
-    public static enum AutoConfigure implements SequenceableSpType, DisplayableSpType {
+    public enum AutoConfigure implements SequenceableSpType, DisplayableSpType {
 
         NO("No"),
         YES("Yes"),
@@ -689,7 +660,7 @@ public final class MichelleParams {
 
         private String _displayValue;
 
-        private AutoConfigure(String displayValue) {
+        AutoConfigure(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -723,7 +694,7 @@ public final class MichelleParams {
     /**
      * Nod orientation values.
      */
-    public static enum NodOrientation implements SequenceableSpType, DisplayableSpType {
+    public enum NodOrientation implements SequenceableSpType, DisplayableSpType {
 
         PARALLEL("Parallel to Chop"),
         ORTHOGONAL("Orthogonal to Chop"),
@@ -733,7 +704,7 @@ public final class MichelleParams {
         public static NodOrientation DEFAULT = PARALLEL;
         private String _displayValue;
 
-        private NodOrientation(String displayValue) {
+        NodOrientation(String displayValue) {
             _displayValue = displayValue;
         }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NICIParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/NICIParams.java
@@ -11,12 +11,10 @@ import java.util.HashMap;
 
 public final class NICIParams {
 
-    public static enum FocalPlaneMask implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum FocalPlaneMask implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         OPEN("Open") {
-            public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         },
         CLEAR("Clear"),
         MASK_1("0.90 arcsec"),
@@ -32,7 +30,7 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private FocalPlaneMask(String name) {
+        FocalPlaneMask(String name) {
             _displayValue = name;
         }
 
@@ -43,13 +41,9 @@ public final class NICIParams {
         public String sequenceValue() {
             return name();
         }
-
-        public boolean isObsolete() {
-            return false;
-        }
     }
 
-    public static enum PupilMask implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum PupilMask implements DisplayableSpType, SequenceableSpType {
 
         BLOCK("Block"),
         OPEN("Open"),
@@ -67,15 +61,9 @@ public final class NICIParams {
         public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "pupilMask");
 
         private final String _displayName;
-        private final boolean _isObsolete;
 
-        private PupilMask(String name) {
-            this(name,false);
-        }
-
-        private PupilMask(String name, boolean obsolete){
+        PupilMask(String name){
             _displayName = name;
-            _isObsolete=obsolete;
         }
 
         public String displayValue() {
@@ -85,16 +73,11 @@ public final class NICIParams {
         public String sequenceValue() {
             return name();
         }
-
-        @Override
-        public boolean isObsolete() {
-            return _isObsolete;
-        }
     }
 
     private static final Angle DEF_FIXED_ANGLE = new Angle(180, Angle.Unit.DEGREES);
 
-    public static enum CassRotator implements DisplayableSpType, SequenceableSpType {
+    public enum CassRotator implements DisplayableSpType, SequenceableSpType {
 
         FIXED("Fixed") {
             public Angle defaultAngle() { return DEF_FIXED_ANGLE; }
@@ -109,7 +92,7 @@ public final class NICIParams {
 
         private String _displayName;
 
-        private CassRotator(String name) {
+        CassRotator(String name) {
             _displayName = name;
         }
 
@@ -126,7 +109,7 @@ public final class NICIParams {
     }
 
 
-    public static enum ImagingMode implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum ImagingMode implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         MANUAL("Manual"),
         H1SLA("H 1% S,L A"),
@@ -136,9 +119,7 @@ public final class NICIParams {
         H4SLA("H 4% S,L A"),
         H4SLB("H 4% S,L B"),
         PUPIL_IMAGING("Pupil Imaging") {
-            public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         }
 
         ;
@@ -147,7 +128,7 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private ImagingMode(String name) {
+        ImagingMode(String name) {
             _displayValue = name;
         }
 
@@ -158,14 +139,10 @@ public final class NICIParams {
         public String displayValue() {
             return _displayValue;
         }
-
-        public boolean isObsolete() {
-            return false;
-        }
     }
 
 
-    public static enum DichroicWheel implements DisplayableSpType, SequenceableSpType {
+    public enum DichroicWheel implements DisplayableSpType, SequenceableSpType {
 
         H5050_BEAMSPLITTER("H 50-50 Beamsplitter"),
         CH4_H_DICHROIC("CH4 H Dichroic"),
@@ -179,7 +156,7 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private DichroicWheel(String name) {
+        DichroicWheel(String name) {
             _displayValue = name;
         }
 
@@ -198,17 +175,22 @@ public final class NICIParams {
      * NICI Filters
      * </a>
      */
-    public static enum Channel1FW implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum Channel1FW implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         BLOCK("Block", Double.NaN),
-        OPEN("Open", Double.NaN, true),
+        OPEN("Open", Double.NaN) {
+            @Override public boolean isObsolete() { return true; }
+        },
         KS("Ks", 2.15),
         K("K", 2.20),
         K_PRIMMA("Kprime", 2.12),
         L_PRIMMA("Lprime", 3.78),
         M_PRIMMA("Mprime", 4.68),
         K_CONT("Kcont", 2.2718),
-        BR_GAMMA("Br-gamma", 2.1686, true), //moved to blue filter wheel (SCT-231)
+        BR_GAMMA("Br-gamma", 2.1686) {
+            //moved to blue filter wheel (SCT-231)
+            @Override public boolean isObsolete() { return true; }
+        },
         CH4H1S("CH4 H 1% S", 1.587),
         CH4H1SP("CH4 H 1% Sp", 1.603),
         CH4H1L("CH4 H 1% L", 1.628),
@@ -224,16 +206,10 @@ public final class NICIParams {
 
         private final String _displayValue;
         private final double _centralWavelength;
-        private final boolean _isObsolete;
 
-        private Channel1FW(String name, double wavelength) {
-            this(name, wavelength, false);
-        }
-
-        private Channel1FW(String name, double wavelength, boolean isObsolete) {
+        Channel1FW(String name, double wavelength) {
             _displayValue      = name;
             _centralWavelength = wavelength;
-            _isObsolete        = isObsolete;
         }
 
         public String sequenceValue() {
@@ -242,10 +218,6 @@ public final class NICIParams {
 
         public String displayValue() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return _isObsolete;
         }
 
         public double centralWavelength() {
@@ -259,10 +231,12 @@ public final class NICIParams {
      * NICI Filters
      * </a>
      */
-    public static enum Channel2FW implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum Channel2FW implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         BLOCK("Block", Double.NaN),
-        OPEN("Open", Double.NaN, true),
+        OPEN("Open", Double.NaN) {
+            @Override public boolean isObsolete() { return true; }
+        },
         J("J", 1.25),
         H("H", 1.65),
         FE_II("[Fe II]", 1.644),
@@ -275,7 +249,9 @@ public final class NICIParams {
         CH4H4L("CH4 H 4% L", 1.652),
         CH4H65S("CH4 H 6.5% S", 1.596),
         K_CH4("CH4 K 5% S",2.028),
-        H20("H20 Ice",3.1,true),
+        H20("H20 Ice",3.1) {
+            @Override public boolean isObsolete() { return true; }
+        },
         ;
 
         public static final Channel2FW DEFAULT = BLOCK;
@@ -283,16 +259,10 @@ public final class NICIParams {
 
         private String _displayValue;
         private final double _centralWavelength;
-        private boolean _isObsolete = false;
 
-        private Channel2FW(String name, double wavelength) {
-            this(name, wavelength, false);
-        }
-
-        private Channel2FW(String name, double wavelength, boolean isObsolete) {
+        Channel2FW(String name, double wavelength) {
             _displayValue      = name;
             _centralWavelength = wavelength;
-            _isObsolete        = isObsolete;
         }
 
 
@@ -304,17 +274,13 @@ public final class NICIParams {
             return _displayValue;
         }
 
-        public boolean isObsolete() {
-            return _isObsolete;
-        }
-
         public double centralWavelength() {
             return _centralWavelength;
         }
     }
 
 
-    public static enum WellDepth implements DisplayableSpType, SequenceableSpType {
+    public enum WellDepth implements DisplayableSpType, SequenceableSpType {
         SHALLOW("Shallow (200 mV)"),
         NORMAL("Normal (300 mV)"),
         DEEP("Deep (400 mV)"),
@@ -324,7 +290,7 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private WellDepth(String text) {
+        WellDepth(String text) {
             _displayValue = text;
         }
 
@@ -339,7 +305,7 @@ public final class NICIParams {
 
 
     // Obsolete -- replaced by WellDepth
-    public static enum BiasVoltage implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum BiasVoltage implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         LOW("Low 200 mV", WellDepth.SHALLOW),
         MEDIUM("Medium 400 mV", WellDepth.NORMAL),
@@ -348,7 +314,7 @@ public final class NICIParams {
         private String _displayValue;
         private WellDepth _wellDepth;
 
-        private BiasVoltage(String text, WellDepth wellDepth) {
+        BiasVoltage(String text, WellDepth wellDepth) {
             _displayValue = text;
             _wellDepth = wellDepth;
         }
@@ -365,15 +331,13 @@ public final class NICIParams {
             return _wellDepth;
         }
 
-        public boolean isObsolete() {
+        @Override public boolean isObsolete() {
             return true;
         }
     }
 
-    public static enum DHSMode implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum DHSMode implements DisplayableSpType, SequenceableSpType {
 
-//        BOTH("Both", true),
-//        QUICK_LOOK("QuickLook", true),
         SAVE("Save"),
         DISCARD("Discard");
 
@@ -381,14 +345,7 @@ public final class NICIParams {
 
         private String _displayName;
 
-        private boolean _isObsolete = false;
-
-        private DHSMode(String name) {
-            this(name, false);
-        }
-
-        private DHSMode(String name, boolean isObsolete) {
-            _isObsolete = isObsolete;
+        DHSMode(String name) {
             _displayName = name;
         }
 
@@ -401,17 +358,13 @@ public final class NICIParams {
         public String sequenceValue() {
             return name();
         }
-
-        public boolean isObsolete() {
-            return _isObsolete;
-        }
     }
 
     /**
      * Following are the types requested for engineering use
      */
 
-    public static enum Focs implements DisplayableSpType, SequenceableSpType {
+    public enum Focs implements DisplayableSpType, SequenceableSpType {
 
         IN_OFF("In/Off"),
         IN_ON("In/On"),
@@ -424,7 +377,7 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private Focs(String name) {
+        Focs(String name) {
             _displayValue = name;
         }
 
@@ -437,12 +390,14 @@ public final class NICIParams {
         }
     }
 
-    public static enum NDFW implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum NDFW implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         AUTO("Auto"),
         BLOCK("Block"),
         ND5("ND5"),
-        ND4("ND4", true),
+        ND4("ND4") {
+            @Override public boolean isObsolete() { return true; }
+        },
         ND3("ND3"),
         ND2("ND2"),
         RED("Red"),
@@ -452,15 +407,8 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private boolean _isObsolete = false;
-
-        private NDFW(String name) {
-            this(name, false);
-        }
-
-        private NDFW(String name, boolean isObsolete) {
+        NDFW(String name) {
             _displayValue = name;
-            _isObsolete = isObsolete;
         }
 
         public String displayValue() {
@@ -470,13 +418,9 @@ public final class NICIParams {
         public String sequenceValue() {
             return name();
         }
-
-        public boolean isObsolete() {
-            return _isObsolete;
-        }
     }
 
-    public static enum PupilImager implements DisplayableSpType, SequenceableSpType {
+    public enum PupilImager implements DisplayableSpType, SequenceableSpType {
 
         OPEN("Open"),
         PUPIL_IMAGING("Pupil Imaging");
@@ -486,7 +430,7 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private PupilImager(String name) {
+        PupilImager(String name) {
             _displayValue = name;
         }
 
@@ -499,7 +443,7 @@ public final class NICIParams {
         }
     }
 
-    public static enum SpiderMask implements DisplayableSpType, SequenceableSpType {
+    public enum SpiderMask implements DisplayableSpType, SequenceableSpType {
 
         UPDATE("Update between Int."),
         FOLLOW("Cont. Follow"),
@@ -509,7 +453,7 @@ public final class NICIParams {
 
         private String _displayValue;
 
-        private SpiderMask(String name) {
+        SpiderMask(String name) {
             _displayValue = name;
         }
 
@@ -554,7 +498,7 @@ public final class NICIParams {
         private Channel2FW channel2Fw;
         private PupilImager pupilImager;
 
-        private static HashMap<ImagingMode, ImagingModeMetaconfig> metaConfigs = new HashMap<ImagingMode, ImagingModeMetaconfig>();
+        private static HashMap<ImagingMode, ImagingModeMetaconfig> metaConfigs = new HashMap<>();
 
         static {
             metaConfigs.put(ImagingMode.H1SLA,

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/Niri.java
@@ -1,8 +1,3 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
 package edu.gemini.spModel.gemini.niri;
 
 import edu.gemini.spModel.config2.ItemKey;
@@ -624,10 +619,14 @@ public final class Niri {
         BBF_M_ORDER_SORT("Order sorting M", "Order sorting M (5.00 um)", "M/OS", 5.00, Type.broadband),
 
         // narrowband
-        J_CONTINUUM_106("J-continuum (1.065 um)", "J-continuum (1.065 um)", "J-cont(1.065)", 1.065, Type.narrowband, true), //REL-2399 - this filter is now obsolete
+        J_CONTINUUM_106("J-continuum (1.065 um)", "J-continuum (1.065 um)", "J-cont(1.065)", 1.065, Type.narrowband) {
+            @Override public boolean isObsolete() { return true; }
+        },
         NBF_HEI("HeI", "HeI (1.083 um)", "HeI", 1.083, Type.narrowband),
         NBF_PAGAMMA("Pa(gamma)", "Pa(gamma) (1.094 um)", "Pa-gam", 1.094, Type.narrowband),
-        J_CONTINUUM_122("J-continuum (1.122 um)", "J-continuum (1.122 um)", "J-cont(1.122)", 1.122, Type.narrowband, true), //REL-2399 - this filter is now obsolete
+        J_CONTINUUM_122("J-continuum (1.122 um)", "J-continuum (1.122 um)", "J-cont(1.122)", 1.122, Type.narrowband) {
+            @Override public boolean isObsolete() { return true; }
+        },
         NBF_H("J-continuum(1.207)", "J-continuum (1.207 um)", "J-cont", 1.207, Type.narrowband),
         NBF_PABETA("Pa(beta)", "Pa(beta) (1.282 um)", "Pa-beta", 1.282, Type.narrowband),
         NBF_HCONT("H-continuum(1.57)", "H-continuum (1.570 um)", "H-cont", 1.570, Type.narrowband),
@@ -663,23 +662,16 @@ public final class Niri {
         private final String _displayValue;
         private final String _description;
         private final String _logValue;
-        private final boolean _isObsolete;
         private final double _wavelength;
         private final Type _type;
 
         Filter(String displayValue, String desc, String logValue,
                        double wavelength, Type type) {
-            this(displayValue, desc, logValue, wavelength, type, false);
-        }
-
-        Filter(String displayValue, String desc, String logValue,
-                       double wavelength, Type type, boolean isObsolete) {
             _displayValue = displayValue;
             _description = desc;
             _logValue = logValue;
             _wavelength = wavelength;
             _type = type;
-            _isObsolete = isObsolete;
         }
 
         public String displayValue() {
@@ -697,9 +689,6 @@ public final class Niri {
         public String logValue() {
             return _logValue;
         }
-
-        @Override
-        public boolean isObsolete() { return _isObsolete; }
 
         public Type type() {
             return _type;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPSiteQuality.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPSiteQuality.java
@@ -246,11 +246,15 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
      * Cloud Cover Options.
      */
     public enum CloudCover implements DisplayableSpType, ObsoletableSpType, SequenceableSpType, PercentageContainer {
-        PERCENT_20("20%",        20),
+        PERCENT_20("20%",        20) {
+            @Override public boolean isObsolete() { return true; }
+        },
         PERCENT_50("50%/Clear",  50),
         PERCENT_70("70%/Cirrus", 70),
         PERCENT_80("80%/Cloudy", 80),
-        PERCENT_90("90%",        90),
+        PERCENT_90("90%",        90) {
+            @Override public boolean isObsolete() { return true; }
+        },
         ANY(       "Any",       100),
         ;
 
@@ -287,10 +291,6 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
         /** Return a CloudCover by name with a value to return upon error **/
         public static CloudCover getCloudCover(String name, CloudCover nvalue) {
             return SpTypeUtil.oldValueOf(CloudCover.class, name, nvalue);
-        }
-
-        public boolean isObsolete() {
-            return (this == PERCENT_20) || (this == PERCENT_90);
         }
 
         public String toString() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/PhoenixParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/PhoenixParams.java
@@ -30,9 +30,7 @@ public final class PhoenixParams {
         L3290("L3290"),
 
         K4132("K4132") {
-            @Override public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         },
         K4220("K4220"),
         K4308("K4308"),
@@ -47,16 +45,12 @@ public final class PhoenixParams {
 
         J7799("J7799"),
         J8265("J8265") {
-            @Override public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         },
         J9232("J9232"),
         J9440("J9440"),
         J9671("J9671") {
-            @Override public boolean isObsolete() {
-                return true;
-            }
+            @Override public boolean isObsolete() { return true; }
         },
         ;
 
@@ -76,10 +70,6 @@ public final class PhoenixParams {
 
         public String sequenceValue() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return false;
         }
 
         /** Return the Filter by searching through the known types. **/

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatFlatObs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatFlatObs.java
@@ -1,10 +1,3 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: SeqRepeatFlatObs.java 38751 2011-11-16 19:37:18Z swalker $
-//
 package edu.gemini.spModel.gemini.seqcomp;
 
 import edu.gemini.pot.sp.SPComponentType;
@@ -59,7 +52,7 @@ public class SeqRepeatFlatObs extends SeqRepeatCoaddExp
      * Override getTitle to return the observe count.
      */
     public String getTitle() {
-        return (isArc() ? "Manual Arc: " : "Manual Flat: ") + Lamp.show(_lamps, Lamp.DISPLAY_MAPPER) + " (" + getStepCount() + "X)";
+        return (isArc() ? "Manual Arc: " : "Manual Flat: ") + Lamp.show(_lamps, Lamp::displayValue) + " (" + getStepCount() + "X)";
     }
 
     /**
@@ -217,7 +210,7 @@ public class SeqRepeatFlatObs extends SeqRepeatCoaddExp
     public ParamSet getParamSet(PioFactory factory) {
         ParamSet paramSet = super.getParamSet(factory);
 
-        Pio.addParam(factory, paramSet, CalUnitConstants.LAMP_PROP,     Lamp.show(getLamps(), Lamp.NAME_MAPPER));
+        Pio.addParam(factory, paramSet, CalUnitConstants.LAMP_PROP,     Lamp.show(getLamps(), Lamp::name));
         Pio.addParam(factory, paramSet, CalUnitConstants.SHUTTER_PROP,  getShutter().name());
         Pio.addParam(factory, paramSet, CalUnitConstants.FILTER_PROP,   getFilter().name());
         Pio.addParam(factory, paramSet, CalUnitConstants.DIFFUSER_PROP, getDiffuser().name());

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/trecs/TReCSParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/trecs/TReCSParams.java
@@ -1,10 +1,3 @@
-// Copyright 2002
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: TReCSParams.java 38188 2011-10-24 14:17:39Z swalker $
-//
-
 package edu.gemini.spModel.gemini.trecs;
 
 import static edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY;
@@ -25,7 +18,7 @@ public final class TReCSParams {
     /**
      * TReCS Dispersers.
      */
-    public static enum Disperser implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum Disperser implements DisplayableSpType, LoggableSpType, SequenceableSpType {
 
         MIRROR("Mirror", "Mirror"),
         LOW_RES_10("Low Res 10um Grating", "LR10"),
@@ -46,7 +39,7 @@ public final class TReCSParams {
          */
         private String _logValue;
 
-        private Disperser(String displayValue, String logValue) {
+        Disperser(String displayValue, String logValue) {
             _displayValue = displayValue;
             _logValue = logValue;
         }
@@ -94,7 +87,7 @@ public final class TReCSParams {
     /**
      * Masks
      */
-    public static enum Mask implements DisplayableSpType, LoggableSpType, SequenceableSpType {
+    public enum Mask implements DisplayableSpType, LoggableSpType, SequenceableSpType {
 
         MASK_IMAGING("Imaging", 28.5, 21.5, "open"), // according to Kevin
         MASK_IMAGING_W("Imaging w/o Flexure Mask", 28.8, 21.6, "open"),
@@ -124,7 +117,7 @@ public final class TReCSParams {
         // The height (length) of the mask in arcsec
         private double _height;
 
-        private Mask(String displayValue, double width, double height, String logValue) {
+        Mask(String displayValue, double width, double height, String logValue) {
             _displayValue = displayValue;
             _width = width;
             _height = height;
@@ -186,7 +179,7 @@ public final class TReCSParams {
     /**
      * User Filters
      */
-    public static enum Filter implements DisplayableSpType, LoggableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum Filter implements DisplayableSpType, LoggableSpType, SequenceableSpType, ObsoletableSpType {
 
         NONE("None", "None", "none"),
         N("N (broad 10um)", "N", "10"),
@@ -203,7 +196,9 @@ public final class TReCSParams {
         NE_II_CONT("[Ne II] cont 13.10um", "NeII13.1", "13.10"),
         PAH_8_6("PAH 8.6um", "PAH1", "8.6"),
         PAH_11_3("PAH 11.3um", "PAH2", "11.3"),
-        Q_SHORT("Q short 17.65um", "Qone", "17.65", true),
+        Q_SHORT("Q short 17.65um", "Qone", "17.65") {
+            @Override public boolean isObsolete() { return true; }
+        },
         QA("Qa 18.30um", "Qa", "18.30"),
         QB("Qb 24.56um", "Qb", "24.56"),
         Q("Q (broad 20.8um)", "Qw", "20.8"),
@@ -217,17 +212,11 @@ public final class TReCSParams {
         private String _displayValue;
         private String _logValue;
         private String _wavelength;  // in µm
-        private boolean _isObsolete = false;
 
-        private Filter(String displayValue, String logValue, String wavelength) {
+        Filter(String displayValue, String logValue, String wavelength) {
             _displayValue = displayValue;
             _logValue = logValue;
             _wavelength = wavelength;
-        }
-
-        private Filter(String displayValue, String logValue, String wavelength, boolean isObsolete) {
-            this(displayValue, logValue, wavelength);
-            _isObsolete = isObsolete;
         }
 
         /**
@@ -250,10 +239,6 @@ public final class TReCSParams {
 
         public String sequenceValue() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return _isObsolete;
         }
 
 
@@ -288,7 +273,7 @@ public final class TReCSParams {
     /**
      * DataMode values.
      */
-    public static enum DataMode implements SequenceableSpType, DisplayableSpType {
+    public enum DataMode implements SequenceableSpType, DisplayableSpType {
 
         SAVE("Save"),
         DISCARD("Discard"),
@@ -303,7 +288,7 @@ public final class TReCSParams {
 
         private String _displayValue;
 
-        private DataMode(String displayValue) {
+        DataMode(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -346,7 +331,7 @@ public final class TReCSParams {
     /**
      * ObsMode values.
      */
-    public static enum ObsMode implements SequenceableSpType, DisplayableSpType, LoggableSpType {
+    public enum ObsMode implements SequenceableSpType, DisplayableSpType, LoggableSpType {
 
         CHOP_NOD("Chop-Nod", "C-N"),
         STARE("Stare", "S"),
@@ -362,7 +347,7 @@ public final class TReCSParams {
         private String _logValue;
         private String _displayValue;
 
-        private ObsMode(String displayValue, String logValue) {
+        ObsMode(String displayValue, String logValue) {
             _displayValue = displayValue;
             _logValue = logValue;
         }
@@ -416,7 +401,7 @@ public final class TReCSParams {
     /**
      * Window Wheel values.
      */
-    public static enum WindowWheel implements SequenceableSpType,  DisplayableSpType {
+    public enum WindowWheel implements SequenceableSpType,  DisplayableSpType {
 
         AUTO("auto"),
         BLOCK("Block"),
@@ -433,7 +418,7 @@ public final class TReCSParams {
         public static WindowWheel DEFAULT = AUTO;
         private String _displayValue;
 
-        private WindowWheel(String displayValue) {
+        WindowWheel(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -477,7 +462,7 @@ public final class TReCSParams {
     /**
      * Sector Wheel values.
      */
-    public static enum SectorWheel implements SequenceableSpType, DisplayableSpType {
+    public enum SectorWheel implements SequenceableSpType, DisplayableSpType {
 
         OPEN("Open"),
         POLY_115("Poly_115"),
@@ -493,7 +478,7 @@ public final class TReCSParams {
 
         private String _displayValue;
 
-        private SectorWheel(String displayValue) {
+        SectorWheel(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -534,7 +519,7 @@ public final class TReCSParams {
     /**
      * Lyot Wheel Values
      */
-    public static enum LyotWheel implements SequenceableSpType, DisplayableSpType {
+    public enum LyotWheel implements SequenceableSpType, DisplayableSpType {
 
         GRID_MASK("Grid_Mask"),
         SPOT_MASK("Spot_Mask"),
@@ -559,7 +544,7 @@ public final class TReCSParams {
 
         private String _displayValue;
 
-        private LyotWheel(String displayValue) {
+        LyotWheel(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -600,7 +585,7 @@ public final class TReCSParams {
     /**
      * Pupil Imaging Wheel values.
      */
-    public static enum PupilImagingWheel implements DisplayableSpType, SequenceableSpType {
+    public enum PupilImagingWheel implements DisplayableSpType, SequenceableSpType {
 
         OPEN_1("Open-1"),
         PUPIL_IMAGER("Pupil_Imager"),
@@ -615,7 +600,7 @@ public final class TReCSParams {
         public static PupilImagingWheel DEFAULT = OPEN_1;
         private String _displayValue;
 
-        private PupilImagingWheel(String displayValue) {
+        PupilImagingWheel(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -656,11 +641,13 @@ public final class TReCSParams {
     /**
      * Aperture Wheel values.
      */
-    public static enum ApertureWheel implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
+    public enum ApertureWheel implements DisplayableSpType, SequenceableSpType, ObsoletableSpType {
 
         GRID_MASK("Grid_Mask"),
         MATCHED("Matched"),
-        OCCULTING_BAR("Occulting_Bar", true), //SCT-139
+        OCCULTING_BAR("Occulting_Bar") {
+            @Override public boolean isObsolete() { return true; }
+        },
         WINDOW_IMAGER("Window_Imager"),
         SPOT_MASK("Spot_Mask"),
         DATUM("Datum"),
@@ -671,15 +658,9 @@ public final class TReCSParams {
          */
         public static ApertureWheel DEFAULT = MATCHED;
         private String _displayValue;
-        private boolean _isObsolete;
 
-        private ApertureWheel(String displayValue) {
-            this(displayValue, false);
-        }
-
-        private ApertureWheel(String displayValue, boolean isObsolete) {
+        ApertureWheel(String displayValue) {
             _displayValue = displayValue;
-            _isObsolete = isObsolete;
         }
 
         public String displayValue() {
@@ -692,10 +673,6 @@ public final class TReCSParams {
 
         public String toString() {
             return _displayValue;
-        }
-
-        public boolean isObsolete() {
-            return _isObsolete;
         }
 
         /**
@@ -724,7 +701,7 @@ public final class TReCSParams {
     /**
      * Nod orientation values.
      */
-    public static enum NodOrientation implements DisplayableSpType, SequenceableSpType {
+    public enum NodOrientation implements DisplayableSpType, SequenceableSpType {
 
         PARALLEL("Parallel to Chop"),
         ORTHOGONAL("Orthogonal to Chop"),
@@ -736,7 +713,7 @@ public final class TReCSParams {
         public static NodOrientation DEFAULT = PARALLEL;
         private String _displayValue;
 
-        private NodOrientation(String displayValue) {
+        NodOrientation(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -777,7 +754,7 @@ public final class TReCSParams {
     /**
      * ReadoutMode values.
      */
-    public static enum ReadoutMode implements DisplayableSpType, SequenceableSpType {
+    public enum ReadoutMode implements DisplayableSpType, SequenceableSpType {
 
         NORMAL_IMAGING("Normal Imaging and Spectroscopy"),
         FAINT_SOURCE("Faint-source Spectroscopy"),
@@ -789,7 +766,7 @@ public final class TReCSParams {
         public static ReadoutMode DEFAULT = NORMAL_IMAGING;
         private String _displayValue;
 
-        private ReadoutMode(String displayValue) {
+        ReadoutMode(String displayValue) {
             _displayValue = displayValue;
         }
 
@@ -834,7 +811,7 @@ public final class TReCSParams {
     /**
      * Well depth - SCT-109/OT-
      */
-    public static enum WellDepth implements DisplayableSpType, SequenceableSpType {
+    public enum WellDepth implements DisplayableSpType, SequenceableSpType {
 
         AUTO("auto"),
         SHALLOW("Shallow"),
@@ -847,7 +824,7 @@ public final class TReCSParams {
         public static WellDepth DEFAULT = AUTO;
         private String _displayValue;
 
-        private WellDepth(String displayValue) {
+        WellDepth(String displayValue) {
             _displayValue = displayValue;
         }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/type/ObsoletableSpType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/type/ObsoletableSpType.java
@@ -1,7 +1,3 @@
-//
-// $Id: ObsoletableSpType.java 6980 2006-04-27 13:24:45Z shane $
-//
-
 package edu.gemini.spModel.type;
 
 /**
@@ -16,5 +12,7 @@ public interface ObsoletableSpType extends SpType {
      * Returns <code>true</code> if the item should no longer be used;
      * <code>false</code> if it is still valid.
      */
-    boolean isObsolete();
+    default boolean isObsolete() {
+        return false;
+    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/type/PartiallyEngineeringSpType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/type/PartiallyEngineeringSpType.java
@@ -4,5 +4,7 @@ package edu.gemini.spModel.type;
  * Implemented by SpTypes that have some members that are only for engineering use.
  */
 public interface PartiallyEngineeringSpType {
-    boolean isEngineering();
+    default boolean isEngineering() {
+        return false;
+    }
 }


### PR DESCRIPTION
As per my discussion with @cquiroz earlier on https://github.com/gemini-hlsw/ocs/pull/1077, I decided tonight to go ahead and eliminate the many redundant implementations of `ObsoletableSpType.isObsolete` by using Java implementation defaults, which allowed to to remove many unnecessary boolean variables from enums.

I also cleaned up a number of things along the way, trying to eliminate many warnings about `static` being used with `enum` and `private` being used with enum constructors. Furthermore, I eliminated a bunch of redundant simple maps, using lambda expressions instead, and in several places, moved to a stream based solution instead of using loops. 

I also cleaned up what seemed like some ridiculous uses of `Option`.