### PR TITLE
REL-2944: Undo changes to classes that break serializability with 2016B production ODBs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016B", false, 2, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2016B", false, 2, 1, 2)
 
 pitVersion in ThisBuild := OcsVersion("2016B", false, 2, 2, 0)
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -791,9 +791,9 @@ public abstract class InstGmosCommon<
      * slits.
      */
     @Override
-    public Option<edu.gemini.spModel.core.Angle> calculateParallacticAngle(ISPObservation obs) {
+    public Option<Angle> calculateParallacticAngle(ISPObservation obs) {
         return super.calculateParallacticAngle(obs).map(angle -> _fpu.isWideSlit() ?
-                angle.$plus(Angle$.MODULE$.fromDegrees(90)) :
+                angle.add(Angle.ANGLE_PI_OVER_2).toPositive() :
                 angle);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/parallacticangle/ParallacticAngleSupportInst.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/parallacticangle/ParallacticAngleSupportInst.java
@@ -4,8 +4,7 @@ import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.core.Angle;
-import edu.gemini.spModel.core.Angle$;
+import edu.gemini.skycalc.Angle;
 import edu.gemini.spModel.inst.ParallacticAngleSupport;
 import edu.gemini.spModel.obs.ObsTargetCalculatorService;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
@@ -30,6 +29,12 @@ public abstract class ParallacticAngleSupportInst extends SPInstObsComp implemen
     public Option<Angle> calculateParallacticAngle(final ISPObservation obs) {
         return ImOption.fromScalaOpt(ObsTargetCalculatorService.targetCalculation(obs))
                 .flatMap(targetCalculator -> ImOption.fromScalaOpt(targetCalculator.weightedMeanParallacticAngle()))
-                .map(angleObj -> Angle$.MODULE$.fromDegrees((double)angleObj));
+                .map(angleObj -> (double) angleObj)
+                .map(angle -> (new edu.gemini.skycalc.Angle(angle, edu.gemini.skycalc.Angle.Unit.DEGREES)).toPositive());
+    }
+
+    @Override
+    public boolean isCompatibleWithMeanParallacticAngleMode() {
+        return true;
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/inst/ParallacticAngleSupport.java
@@ -2,7 +2,7 @@ package edu.gemini.spModel.inst;
 
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.core.Angle;
+import edu.gemini.skycalc.Angle;
 
 /**
  * Support for parallactic angle calculations.
@@ -22,7 +22,5 @@ public interface ParallacticAngleSupport {
      * By default, assume that the instrument is compatible with the parallactic angle feature unless indicated
      * otherwise.
      */
-    default boolean isCompatibleWithMeanParallacticAngleMode() {
-        return true;
-    }
+    boolean isCompatibleWithMeanParallacticAngleMode();
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -6,7 +6,7 @@ import java.util.Locale
 
 import edu.gemini.pot.sp.{ISPObsComponent, SPComponentType}
 import edu.gemini.shared.gui.EnableDisableComboBox
-import edu.gemini.spModel.core.Angle
+import edu.gemini.skycalc.Angle
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.inst.ParallacticAngleSupport
 import edu.gemini.spModel.obs.ObsClassService
@@ -281,10 +281,9 @@ E <: OtItemEditor[ISPObsComponent, I]](instType: SPComponentType) extends GridBa
     */
   private def parallacticAngleChanged(angleOpt: Option[Angle]): Unit = Swing.onEDT {
     if (editor.exists(_.getDataObject.getPosAngleConstraint == PosAngleConstraint.PARALLACTIC_ANGLE)) {
-      angleOpt.foreach(angle => {
-        val degrees = angle.toDegrees
-        ui.positionAngleTextField.text = numberFormatter.format(degrees)
-        setInstPosAngle(degrees)
+      angleOpt.map(_.toDegrees.toPositive.getMagnitude).foreach(angle => {
+        ui.positionAngleTextField.text = numberFormatter.format(angle)
+        setInstPosAngle(angle)
       })
     }
   }


### PR DESCRIPTION
I had updated the `ParallacticAngleSupport` interface and `ParallacticAngleSupportInst` class to take advantage of Java interface `default`s and to use the new target model `Angle` class, but this, of course, broke serializability with the 2016B production ODB.

Thus, for the patch release for 2016B, we will revert back to the old `Angle` class and implementation of the aforementioned. This solves the problem and allows production ODB programs to be properly serialized / deserialized.

For 2017A, we can safely go ahead with the new and improved implementations, which I have left intact in the develop branch.