### PR TITLE
REL-2945 add new result handler

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -280,12 +280,18 @@ object HorizonsService2 {
               List(Row(HorizonsDesignation.AsteroidNewStyle(m.group(1)) : HorizonsDesignation.Asteroid, m.group(1)))
             } \/> "Could not match '(2016 GB222)' header pattern."
 
+          // Single result with form: JPL/HORIZONS        418993 (2009 MS9)            2016-Sep-07 18:23:54
+          lazy val case4 =
+            """  +\d+\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.AsteroidNewStyle(m.group(1)) : HorizonsDesignation.Asteroid, m.group(1)))
+            } \/> "Could not match '418993 (2009 MS9)' header pattern."
 
           // First one that works!
           case0 orElse
           case1 orElse
           case2 orElse
-          case3 orElse "Could not parse the header line as an asteroid".left
+          case3 orElse
+          case4 orElse "Could not parse the header line as an asteroid".left
 
 
         case Search.MajorBody(_) =>
@@ -358,5 +364,3 @@ object HorizonsService2 {
     }
 
 }
-
-

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -78,6 +78,18 @@ object HS2Spec extends Specification with ScalaCheck {
       ))
     }   
 
+    "handle single result (Format 3) (2016 GB222)" in {
+      runSearch(Search.Asteroid("2016 GB222")) must_== \/-(List(
+        Row(HD.AsteroidNewStyle("2016 GB222"), "2016 GB222")
+      ))
+    }
+
+    "handle single result (Format 4) 418993 (2009 MS9)" in {
+      runSearch(Search.Asteroid("2009 MS9")) must_== \/-(List(
+        Row(HD.AsteroidNewStyle("2009 MS9"), "2009 MS9")
+      ))
+    }
+
   }
 
   "major body search" should {


### PR DESCRIPTION
This adds a handler for a previously-unknown HORIZONS header line that gives the record number but no common name, followed by the primary designation in prens. The examples given (`2009 MS9`, `2013 LU28`, and `2015 DB216`) now resolve properly.

/cc @andrewwstephens 