### PR TITLE
REL-2924: Make PA text field uneditable in parallactic angle mode

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -200,7 +200,8 @@ E <: OtItemEditor[ISPObsComponent, I]](instType: SPComponentType) extends GridBa
     if (!ui.positionAngleTextField.hasFocus) {
       copyPosAngleToTextField()
     }
-    ui.positionAngleTextField.enabled = instrument.getPosAngleConstraint != PosAngleConstraint.UNBOUNDED
+
+    updatePATextFieldEditableState(instrument.getPosAngleConstraint)
     ui.controlsPanel.updatePanel()
     listenTo(ui.positionAngleConstraintComboBox.selection)
 
@@ -220,6 +221,9 @@ E <: OtItemEditor[ISPObsComponent, I]](instType: SPComponentType) extends GridBa
       p.enabled = enabled
     }
   }
+
+  def updatePATextFieldEditableState(pac: PosAngleConstraint) =
+    ui.positionAngleTextField.editable = pac == PosAngleConstraint.FIXED || pac == PosAngleConstraint.FIXED_180
 
   /**
     * The actual copying of a given pos angle to the data object.
@@ -265,7 +269,7 @@ E <: OtItemEditor[ISPObsComponent, I]](instType: SPComponentType) extends GridBa
       e.getDataObject.setPosAngleConstraint(posAngleConstraint)
 
       // Set up the UI.
-      ui.positionAngleTextField.enabled = posAngleConstraint != PosAngleConstraint.UNBOUNDED
+      updatePATextFieldEditableState(posAngleConstraint)
       ui.controlsPanel.updatePanel()
       ui.positionAngleConstraintComboBox.selection.item match {
         case PosAngleConstraint.PARALLACTIC_ANGLE => p.resetComponents()

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -222,7 +222,7 @@ E <: OtItemEditor[ISPObsComponent, I]](instType: SPComponentType) extends GridBa
     }
   }
 
-  def updatePATextFieldEditableState(pac: PosAngleConstraint) =
+  private def updatePATextFieldEditableState(pac: PosAngleConstraint) =
     ui.positionAngleTextField.editable = pac == PosAngleConstraint.FIXED || pac == PosAngleConstraint.FIXED_180
 
   /**


### PR DESCRIPTION
Since the functionality to override the parallactic angle is currently broken and may be somewhat complicated to fix, for the patch release, we are going to leave this functionality out.

Bryan sensibly suggested that we thus make the PA text field uneditable in parallactic angle mode to indicate this. This PR simply does that.