### PR TITLE
REL-2922B: Set the minimum number of fractional digits to 2.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -30,6 +30,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
 
   private val numberFormatter = NumberFormat.getInstance(Locale.US) <|
     (_.setMaximumFractionDigits(2)) <|
+    (_.setMinimumFractionDigits(2)) <|
     (_.setMaximumIntegerDigits(3))
 
   private object ui {


### PR DESCRIPTION
Bryan requested that the minimum number of fractional digits for the PA text field be set to two.