### PR TITLE
REL-2948: Unused OT preferences

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OTOptions.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OTOptions.java
@@ -1,9 +1,3 @@
-// Copyright 2002 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: OTOptions.java 47000 2012-07-26 19:15:10Z swalker $
-//
 package jsky.app.ot;
 
 import edu.gemini.pot.sp.ISPObservation;
@@ -21,7 +15,6 @@ import edu.gemini.util.security.policy.ImplicitPolicyForJava;
 import jsky.app.ot.userprefs.general.GeneralPreferences;
 import java.security.Permission;
 import java.util.logging.Logger;
-
 
 /**
  * Stores the values of the OT application command line options.
@@ -46,9 +39,7 @@ public class OTOptions {
     }
 
     public static boolean areRootAndCurrentObsIfAnyEditable(ISPProgram prog, ISPObservation obsOrNull) {
-
         // SANITY CLAUSE
-//        if ((obsOrNull != null) && (root != null) && (obsOrNull.getProgram() != root))
         if ((obsOrNull != null) && (obsOrNull.getProgram() != prog))
             throw new IllegalArgumentException("obs is from another program");
 
@@ -129,4 +120,3 @@ public class OTOptions {
     }
 
 }
-

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/general/GeneralPreferences.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/general/GeneralPreferences.java
@@ -21,22 +21,16 @@ public final class GeneralPreferences implements ExternalizablePreferences {
      */
     public static final class Builder {
         private boolean phase2Checking = true;
-        private boolean guideStarAlternatives = true;
         private boolean warnUnsavedChanges = true;
 
-        public Builder() { /* empty */ }
+        Builder() { /* empty */ }
 
-        public Builder phase2Checking(boolean val) {
+        Builder phase2Checking(boolean val) {
             phase2Checking = val;
             return this;
         }
 
-        public Builder guideStarAlternatives(boolean val) {
-            guideStarAlternatives = val;
-            return this;
-        }
-
-        public Builder warnUnsavedChanges(boolean val) {
+        Builder warnUnsavedChanges(boolean val) {
             warnUnsavedChanges = val;
             return this;
         }
@@ -63,26 +57,22 @@ public final class GeneralPreferences implements ExternalizablePreferences {
             Builder b = new Builder();
             ParamSet pset = psetOpt.getValue();
             b.phase2Checking(Pio.getBooleanValue(pset, PHASE_2_CHECKING_PARAM, true));
-            b.guideStarAlternatives(Pio.getBooleanValue(pset, GUIDE_STAR_ALT_PARAM, true));
             b.warnUnsavedChanges(Pio.getBooleanValue(pset, WARN_UNSAVED_CHANGES_PARAM, true));
             return b.build();
         }
     }
 
-    public static final Factory FACTORY = new Factory();
-    public static final String PSET_NAME = "general";
+    private static final Factory FACTORY = new Factory();
+    private static final String PSET_NAME = "general";
 
     private static final String PHASE_2_CHECKING_PARAM = "phase2Checking";
-    private static final String GUIDE_STAR_ALT_PARAM = "guideStarAlt";
     private static final String WARN_UNSAVED_CHANGES_PARAM = "warnUnsavedChanges";
 
     private final boolean phase2Checking;
-    private final boolean guideStarAlternatives;
     private final boolean warnUnsavedChanges;
 
     private GeneralPreferences(Builder builder) {
         this.phase2Checking = builder.phase2Checking;
-        this.guideStarAlternatives = builder.guideStarAlternatives;
         this.warnUnsavedChanges = builder.warnUnsavedChanges;
     }
 
@@ -94,16 +84,6 @@ public final class GeneralPreferences implements ExternalizablePreferences {
         return phase2Checking;
     }
 
-    /**
-     * @return <code>true</code> if guide star alternatives should be
-     *         suggested; <code>false</code> to ignore better alternatives and
-     *         automatically pick an inferior guide star that matches the observing
-     *         context
-     */
-    public boolean showGuideStarAlternatives() {
-        return guideStarAlternatives;
-    }
-
     public boolean warnUnsavedChanges() {
         return warnUnsavedChanges;
     }
@@ -111,17 +91,12 @@ public final class GeneralPreferences implements ExternalizablePreferences {
     private Builder getBuilder() {
         Builder b = new Builder();
         b.phase2Checking(this.phase2Checking);
-        b.guideStarAlternatives(this.guideStarAlternatives);
         b.warnUnsavedChanges(this.warnUnsavedChanges);
         return b;
     }
 
-    public GeneralPreferences withPhase2Checking(boolean val) {
+    GeneralPreferences withPhase2Checking(boolean val) {
         return getBuilder().phase2Checking(val).build();
-    }
-
-    public GeneralPreferences withGuideStarAlternatives(boolean val) {
-        return getBuilder().guideStarAlternatives(val).build();
     }
 
     public GeneralPreferences withWarnUnsavedChanges(boolean val) {
@@ -135,7 +110,6 @@ public final class GeneralPreferences implements ExternalizablePreferences {
     public ParamSet toParamSet(PioFactory factory) {
         ParamSet res = factory.createParamSet(PSET_NAME);
         Pio.addBooleanParam(factory, res, PHASE_2_CHECKING_PARAM, phase2Checking);
-        Pio.addBooleanParam(factory, res, GUIDE_STAR_ALT_PARAM, guideStarAlternatives);
         Pio.addBooleanParam(factory, res, WARN_UNSAVED_CHANGES_PARAM, warnUnsavedChanges);
         return res;
     }
@@ -148,25 +122,23 @@ public final class GeneralPreferences implements ExternalizablePreferences {
         GeneralPreferences that = (GeneralPreferences) o;
 
         if (phase2Checking != that.phase2Checking) return false;
-        if (guideStarAlternatives != that.guideStarAlternatives) return false;
         return warnUnsavedChanges == that.warnUnsavedChanges;
     }
 
     @Override
     public int hashCode() {
         int result = phase2Checking ? 1 : 0;
-        result = 31 * result + (guideStarAlternatives ? 1 : 0);
         result = 31 * result + (warnUnsavedChanges ? 1 : 0);
         return result;
     }
 
     @Override
     public String toString() {
-        return String.format("[phase2Checking=%b, guideStarAlt=%b, warnUnsavedChanges=%b]", phase2Checking, guideStarAlternatives, warnUnsavedChanges);
+        return String.format("[phase2Checking=%b, warnUnsavedChanges=%b]", phase2Checking, warnUnsavedChanges);
     }
 
     private static final PreferencesSupport<GeneralPreferences> sup =
-            new PreferencesSupport<GeneralPreferences>(PSET_NAME, FACTORY);
+            new PreferencesSupport<>(PSET_NAME, FACTORY);
 
     public static GeneralPreferences fetch() {
         return sup.fetch();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/general/GeneralPreferencesPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/general/GeneralPreferencesPanel.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package jsky.app.ot.userprefs.general;
 
 import edu.gemini.shared.util.immutable.None;
@@ -21,9 +17,7 @@ import java.awt.event.ActionListener;
  */
 public class GeneralPreferencesPanel implements PreferencePanel {
     private static final String P2_TEXT = "Select this option to turn on program validity checking.";
-    private static final String GUIDE_TEXT = "If selected, automated guide star search results will notify you when a valid guide star is found yet there are better alternatives available than your current settings allow.";
     private static final String UNSAVED_TEXT = "Warn me if I close a program with unsynchronized changes.";
-
 
     private final SPViewer viewer;
 
@@ -67,46 +61,14 @@ public class GeneralPreferencesPanel implements PreferencePanel {
             insets = new Insets(0, 15, 0, 0);
         }});
 
-        final JCheckBox gsAlt = new JCheckBox("Show alternative guide star options") {{
-            setSelected(GeneralPreferences.fetch().showGuideStarAlternatives());
-            setFocusable(false);
-            addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    GeneralPreferences.fetch().withGuideStarAlternatives(isSelected()).store();
-                }
-            });
-        }};
-        panel.add(gsAlt, new GridBagConstraints() {{
-            gridx = 0;
-            gridy = 2;
-            anchor = WEST;
-            fill = HORIZONTAL;
-            weightx = 1.0;
-            insets = new Insets(10, 0, 0, 0);
-        }});
-
-        final JTextArea gsTxt = PreferenceDialog.mkNote(GUIDE_TEXT);
-        panel.add(gsTxt, new GridBagConstraints() {{
-            gridx = 0;
-            gridy = 3;
-            anchor = WEST;
-            fill = HORIZONTAL;
-            weightx = 1.0;
-            insets = new Insets(0, 15, 0, 0);
-        }});
-
         final JCheckBox usPrompt = new JCheckBox("Warn for unsaved changes on close") {{
             setSelected(GeneralPreferences.fetch().warnUnsavedChanges());
             setFocusable(false);
-            addActionListener(new ActionListener() {
-                @Override public void actionPerformed(ActionEvent e) {
-                    GeneralPreferences.fetch().withWarnUnsavedChanges(isSelected()).store();
-                }
-            });
+            addActionListener(e -> GeneralPreferences.fetch().withWarnUnsavedChanges(isSelected()).store());
         }};
         panel.add(usPrompt, new GridBagConstraints() {{
             gridx   = 0;
-            gridy   = 4;
+            gridy   = 2;
             anchor  = WEST;
             fill    = HORIZONTAL;
             weightx = 1.0;
@@ -116,7 +78,7 @@ public class GeneralPreferencesPanel implements PreferencePanel {
         final JTextArea usTxt = PreferenceDialog.mkNote(UNSAVED_TEXT);
         panel.add(usTxt, new GridBagConstraints() {{
             gridx = 0;
-            gridy = 5;
+            gridy = 3;
             anchor = WEST;
             fill   = HORIZONTAL;
             weightx = 1.0;
@@ -129,7 +91,7 @@ public class GeneralPreferencesPanel implements PreferencePanel {
     }
 
     public Option<String> getToolTip() {
-        return new Some<String>("General preferences.");
+        return new Some<>("General preferences.");
     }
 
     public Option<Icon> getIcon() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/model/PreferencesChangeEvent.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/model/PreferencesChangeEvent.java
@@ -1,19 +1,12 @@
-//
-// $
-//
-
 package jsky.app.ot.userprefs.model;
 
 import edu.gemini.shared.util.immutable.Option;
 
-/**
- *
- */
 public final class PreferencesChangeEvent<T> {
     private final Option<T> oldValue;
     private final T newValue;
 
-    public PreferencesChangeEvent(Option<T> oldValue, T newValue) {
+    PreferencesChangeEvent(Option<T> oldValue, T newValue) {
         this.oldValue = oldValue;
         this.newValue = newValue;
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/model/PreferencesChangeListener.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/model/PreferencesChangeListener.java
@@ -1,14 +1,7 @@
-//
-// $
-//
-
 package jsky.app.ot.userprefs.model;
 
 import java.util.EventListener;
 
-/**
- *
- */
 public interface PreferencesChangeListener<T> extends EventListener {
     void preferencesChanged(PreferencesChangeEvent<T> evt);
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/observer/ObserverPreferences.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/observer/ObserverPreferences.java
@@ -19,14 +19,14 @@ public final class ObserverPreferences implements ExternalizablePreferences {
         private Site observingSite = null;
         private boolean audibleTooAlerts = false;
 
-        public Builder() { /* empty */ }
+        Builder() { /* empty */ }
 
-        public Builder observingSite(Site val) {
+        Builder observingSite(Site val) {
             observingSite = val;
             return this;
         }
 
-        public Builder audibleTooAlerts(boolean val) {
+        Builder audibleTooAlerts(boolean val) {
             audibleTooAlerts = val;
             return this;
         }
@@ -62,9 +62,8 @@ public final class ObserverPreferences implements ExternalizablePreferences {
         }
     }
 
-    public static final Factory FACTORY = new Factory();
-    public static final String PSET_NAME = "observer";
-
+    private static final Factory FACTORY = new Factory();
+    private static final String PSET_NAME = "observer";
 
     private static final String OBSERVING_SITE_PARAM = "observingSite";
     private static final String AUDIBLE_TOO_PARAM = "audibleToo";
@@ -102,11 +101,11 @@ public final class ObserverPreferences implements ExternalizablePreferences {
         return b;
     }
 
-    public ObserverPreferences withObservingSite(Site val) {
+    ObserverPreferences withObservingSite(Site val) {
         return getBuilder().observingSite(val).build();
     }
 
-    public ObserverPreferences withAudibleTooAlerts(boolean val) {
+    ObserverPreferences withAudibleTooAlerts(boolean val) {
         return getBuilder().audibleTooAlerts(val).build();
     }
 
@@ -144,7 +143,7 @@ public final class ObserverPreferences implements ExternalizablePreferences {
     }
 
     private static final PreferencesSupport<ObserverPreferences> sup =
-            new PreferencesSupport<ObserverPreferences>(PSET_NAME, FACTORY);
+            new PreferencesSupport<>(PSET_NAME, FACTORY);
 
     public static ObserverPreferences fetch() {
         return sup.fetch();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/observer/ObserverPreferencesPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/observer/ObserverPreferencesPanel.java
@@ -30,11 +30,7 @@ public class ObserverPreferencesPanel implements PreferencePanel {
         final JCheckBox tooAlerts = new JCheckBox("Enable audible ToO alerts") {{
             setSelected(ObserverPreferences.fetch().isAudibleTooAlerts());
             setFocusable(false);
-            addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e) {
-                    ObserverPreferences.fetch().withAudibleTooAlerts(isSelected()).store();
-                }
-            });
+            addActionListener(e -> ObserverPreferences.fetch().withAudibleTooAlerts(isSelected()).store());
         }};
         panel.add(tooAlerts, new GridBagConstraints() {{
             gridx = 0;
@@ -139,7 +135,7 @@ public class ObserverPreferencesPanel implements PreferencePanel {
     }
 
     public Option<String> getToolTip() {
-        return new Some<String>("Observer preferences.");
+        return new Some<>("Observer preferences.");
     }
 
     public Option<Icon> getIcon() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/observer/ObservingSitePrompt.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/observer/ObservingSitePrompt.java
@@ -12,8 +12,8 @@ import static javax.swing.JOptionPane.YES_NO_OPTION;
  * Prompt the user for an observing site selection.
  */
 public final class ObservingSitePrompt {
-    public static final String TITLE = "Specify Gemini Site";
-    public static final String MESSAGE =
+    private static final String TITLE = "Specify Gemini Site";
+    private static final String MESSAGE =
             "Select the site for queuing observations and monitoring for ToO alerts.";
     private static final String[] OPTIONS = new String[] {
             "Use Gemini North", "Use Gemini South"

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/ui/PreferenceButtonPanelBuilder.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/ui/PreferenceButtonPanelBuilder.java
@@ -1,11 +1,6 @@
-//
-// $
-//
-
 package jsky.app.ot.userprefs.ui;
 
 import edu.gemini.shared.gui.SeparateLineBorder;
-import edu.gemini.shared.util.immutable.ApplyOp;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.PredicateOp;
 
@@ -18,14 +13,14 @@ import java.awt.*;
 public final class PreferenceButtonPanelBuilder {
     private final ImList<Action> actions;
 
-    /** Default {@link #setSelectedBorderColor(java.awt.Color) border color}. */
-    public static final Color SELECTED_BORDER_COLOR = new Color(128, 128, 128);
+    /** Default border color. */
+    static final Color SELECTED_BORDER_COLOR = new Color(128, 128, 128);
 
-    /** Default {@link #setSelectedColor(java.awt.Color)} selected color}. */
-    public static final Color SELECTED_COLOR        = new Color(157, 157, 157);
+    /** Default selected color. */
+    static final Color SELECTED_COLOR        = new Color(157, 157, 157);
 
-    /** Default {@link #setBackgroundColor(java.awt.Color) background color}. */
-    public static final Color BACKGROUND_COLOR      = new Color(191, 191, 191);
+    /** Default background color. */
+    static final Color BACKGROUND_COLOR      = new Color(191, 191, 191);
 
     private Color selectedBorderColor = SELECTED_BORDER_COLOR;
     private Color selectedColor       = SELECTED_COLOR;
@@ -35,35 +30,8 @@ public final class PreferenceButtonPanelBuilder {
      * Constructs with the collection of actions to display as buttons in the
      * panel.
      */
-    public PreferenceButtonPanelBuilder(ImList<Action> actions) {
+    PreferenceButtonPanelBuilder(ImList<Action> actions) {
         this.actions = actions;
-    }
-
-    /**
-     * Sets the color used to highlight the border of the selected button.
-     * Two slim arcs will be drawn, one on the left and one on the right of the
-     * button using this color.  This creates an offset effect.
-     */
-    public void setSelectedBorderColor(Color selectedBorderColor) {
-        this.selectedBorderColor = selectedBorderColor;
-    }
-
-    /**
-     * Sets the color used to highlight the selected button.  This color
-     * will be shown along the horizontal middle of the button, blended from
-     * the top and bottom where the
-     * {@link #setBackgroundColor background color} is shown
-     */
-    public void setSelectedColor(Color selectedColor) {
-        this.selectedColor = selectedColor;
-    }
-
-    /**
-     * Returns the normal background color for unselected buttons or the
-     * toolbar panel in which this button finds itself.
-     */
-    public void setBackgroundColor(Color backgroundColor) {
-        this.backgroundColor = backgroundColor;
     }
 
     public JPanel build() {
@@ -86,31 +54,25 @@ public final class PreferenceButtonPanelBuilder {
         // Figure out what size to show the text in each button.  If there are
         // icons, make it slightly smaller.  If there aren't, make it slightly
         // bigger.
-        PredicateOp<Action> icon = new PredicateOp<Action>() {
-            public Boolean apply(Action act) {
-                return act.getValue(Action.SMALL_ICON) != null;
-            }
-        };
+        PredicateOp<Action> icon = act -> act.getValue(Action.SMALL_ICON) != null;
         final int fontSizeAdjustment = actions.exists(icon) ? -2 : 2;
 
         // Add a button for each action.
         final ButtonGroup grp = new ButtonGroup();
-        actions.foreach(new ApplyOp<Action>() {
-            public void apply(Action action) {
-                final JToggleButton button = new JToggleButton(action) {{
-                    setHorizontalTextPosition(CENTER);
-                    setVerticalTextPosition(BOTTOM);
-                    setFocusable(false);
-                    setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
-                    setOpaque(false);
-                    setFont(getFont().deriveFont(getFont().getSize2D()+fontSizeAdjustment));
-                    setUI(buttonUI);
-                }};
-                grp.add(button);
-                toolBar.add(button, new GridBagConstraints() {{
-                    gridx=toolBar.getComponentCount(); fill=NONE; weightx=0.0;
-                }});
-            }
+        actions.foreach(action -> {
+            final JToggleButton button = new JToggleButton(action) {{
+                setHorizontalTextPosition(CENTER);
+                setVerticalTextPosition(BOTTOM);
+                setFocusable(false);
+                setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
+                setOpaque(false);
+                setFont(getFont().deriveFont(getFont().getSize2D()+fontSizeAdjustment));
+                setUI(buttonUI);
+            }};
+            grp.add(button);
+            toolBar.add(button, new GridBagConstraints() {{
+                gridx=toolBar.getComponentCount(); fill=NONE; weightx=0.0;
+            }});
         });
 
         // Push everything to the left.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/ui/PreferencePanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/userprefs/ui/PreferencePanel.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package jsky.app.ot.userprefs.ui;
 
 import edu.gemini.shared.util.immutable.Option;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
@@ -32,8 +32,6 @@ import jsky.util.Preferences;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.List;
 
@@ -53,9 +51,8 @@ final class SPViewerMenuBar extends JMenuBar {
     /** The OT toolbar with tree related items. */
     private final SPTreeToolBar _treeToolBar;
 
-    final JMenu navMenu;
-    final JMenu pluginMenu;
-
+    private final JMenu navMenu;
+    private final JMenu pluginMenu;
 
     SPViewerMenuBar(final SPViewer viewer, final SPViewerToolBar mainToolBar, final SPTreeToolBar treeToolBar) {
         _viewer = viewer;
@@ -104,18 +101,15 @@ final class SPViewerMenuBar extends JMenuBar {
         return menu;
     }
 
-
     private JMenuItem createPreferencesItem() {
         final JMenuItem menuItem = new JMenuItem("Preferences ...");
-        menuItem.addActionListener(new ActionListener() {
-            public void actionPerformed(final ActionEvent e) {
-                final PreferencePanel pref = new GeneralPreferencesPanel(_viewer);
-                final ImList<PreferencePanel> lst = OTOptions.isStaffGlobally() ?
-                        DefaultImList.create(pref, new ObserverPreferencesPanel()) :
-                        DefaultImList.create(pref);
-                final PreferenceDialog dialog = new PreferenceDialog(lst);
-                dialog.show(getFrame(), pref);
-            }
+        menuItem.addActionListener(e -> {
+            final PreferencePanel pref = new GeneralPreferencesPanel(_viewer);
+            final ImList<PreferencePanel> lst = OTOptions.isStaffGlobally() ?
+                    DefaultImList.create(pref, new ObserverPreferencesPanel()) :
+                    DefaultImList.create(pref);
+            final PreferenceDialog dialog = new PreferenceDialog(lst);
+            dialog.show(getFrame(), pref);
         });
         return menuItem;
     }
@@ -127,22 +121,13 @@ final class SPViewerMenuBar extends JMenuBar {
 
     private JMenuItem createFileSessionQueueMenuItem() {
         final JMenuItem menuItem = new JMenuItem("Display Session Queue");
-        menuItem.addActionListener(new ActionListener() {
-            public void actionPerformed(final ActionEvent e) {
-                SessionQueuePanel.getInstance().showFrame();
-            }
-        });
+        menuItem.addActionListener(e -> SessionQueuePanel.getInstance().showFrame());
         return menuItem;
     }
 
-
     private JMenuItem createFileExitMenuItem() {
         final JMenuItem menuItem = new JMenuItem("Exit");
-        menuItem.addActionListener(new ActionListener() {
-            public void actionPerformed(final ActionEvent ae) {
-                _viewer.exit();
-            }
-        });
+        menuItem.addActionListener(ae -> _viewer.exit());
         return menuItem;
     }
 
@@ -165,19 +150,16 @@ final class SPViewerMenuBar extends JMenuBar {
         return menu;
     }
 
-
     private JCheckBoxMenuItem createViewMainToolBarMenuItem() {
         final JCheckBoxMenuItem menuItem = new JCheckBoxMenuItem("Main Toolbar");
         final String prefName = getClass().getName() + ".ShowMainToolBar";
-        menuItem.addItemListener(new ItemListener() {
-            public void itemStateChanged(final ItemEvent e) {
-                final JCheckBoxMenuItem rb = (JCheckBoxMenuItem) e.getSource();
-                _mainToolBar.setVisible(rb.getState());
-                if (rb.getState())
-                    Preferences.set(prefName, "true");
-                else
-                    Preferences.set(prefName, "false");
-            }
+        menuItem.addItemListener(e -> {
+            final JCheckBoxMenuItem rb = (JCheckBoxMenuItem) e.getSource();
+            _mainToolBar.setVisible(rb.getState());
+            if (rb.getState())
+                Preferences.set(prefName, "true");
+            else
+                Preferences.set(prefName, "false");
         });
         final String pref = Preferences.get(prefName);
         if (pref != null)
@@ -190,15 +172,13 @@ final class SPViewerMenuBar extends JMenuBar {
     private JCheckBoxMenuItem createViewTreeToolBarMenuItem() {
         final JCheckBoxMenuItem menuItem = new JCheckBoxMenuItem("Tree Toolbar");
         final String prefName = getClass().getName() + ".ShowTreeToolBar";
-        menuItem.addItemListener(new ItemListener() {
-            public void itemStateChanged(final ItemEvent e) {
-                final JCheckBoxMenuItem rb = (JCheckBoxMenuItem) e.getSource();
-                _treeToolBar.setVisible(rb.getState());
-                if (rb.getState())
-                    Preferences.set(prefName, "true");
-                else
-                    Preferences.set(prefName, "false");
-            }
+        menuItem.addItemListener(e -> {
+            final JCheckBoxMenuItem rb = (JCheckBoxMenuItem) e.getSource();
+            _treeToolBar.setVisible(rb.getState());
+            if (rb.getState())
+                Preferences.set(prefName, "true");
+            else
+                Preferences.set(prefName, "false");
         });
         final String pref = Preferences.get(prefName);
         if (pref != null)
@@ -230,23 +210,21 @@ final class SPViewerMenuBar extends JMenuBar {
         // name used to store setting in user preferences
         final String prefName = getClass().getName() + ".ShowMainToolBarAs";
 
-        final ItemListener itemListener = new ItemListener() {
-            public void itemStateChanged(final ItemEvent e) {
-                final JRadioButtonMenuItem rb = (JRadioButtonMenuItem) e.getSource();
-                if (rb.isSelected()) {
-                    if (rb.getText().equals("Pictures and Text")) {
-                        _mainToolBar.setShowPictures(true);
-                        _mainToolBar.setShowText(true);
-                        Preferences.set(prefName, "1");
-                    } else if (rb.getText().equals("Pictures Only")) {
-                        _mainToolBar.setShowPictures(true);
-                        _mainToolBar.setShowText(false);
-                        Preferences.set(prefName, "2");
-                    } else if (rb.getText().equals("Text Only")) {
-                        _mainToolBar.setShowPictures(false);
-                        _mainToolBar.setShowText(true);
-                        Preferences.set(prefName, "3");
-                    }
+        final ItemListener itemListener = e -> {
+            final JRadioButtonMenuItem rb = (JRadioButtonMenuItem) e.getSource();
+            if (rb.isSelected()) {
+                if (rb.getText().equals("Pictures and Text")) {
+                    _mainToolBar.setShowPictures(true);
+                    _mainToolBar.setShowText(true);
+                    Preferences.set(prefName, "1");
+                } else if (rb.getText().equals("Pictures Only")) {
+                    _mainToolBar.setShowPictures(true);
+                    _mainToolBar.setShowText(false);
+                    Preferences.set(prefName, "2");
+                } else if (rb.getText().equals("Text Only")) {
+                    _mainToolBar.setShowPictures(false);
+                    _mainToolBar.setShowText(true);
+                    Preferences.set(prefName, "3");
                 }
             }
         };
@@ -268,7 +246,6 @@ final class SPViewerMenuBar extends JMenuBar {
 
         return menu;
     }
-
 
     private JMenu createViewShowTreeToolBarAsMenu() {
         final JMenu menu = new JMenu("Show Tree Toolbar As");
@@ -293,23 +270,21 @@ final class SPViewerMenuBar extends JMenuBar {
         // name used to store setting in user preferences
         final String prefName = getClass().getName() + ".ShowTreeToolBarAs";
 
-        final ItemListener itemListener = new ItemListener() {
-            public void itemStateChanged(final ItemEvent e) {
-                final JRadioButtonMenuItem rb = (JRadioButtonMenuItem) e.getSource();
-                if (rb.isSelected()) {
-                    if (rb.getText().equals("Pictures and Text")) {
-                        _treeToolBar.setShowPictures(true);
-                        _treeToolBar.setShowText(true);
-                        Preferences.set(prefName, "1");
-                    } else if (rb.getText().equals("Pictures Only")) {
-                        _treeToolBar.setShowPictures(true);
-                        _treeToolBar.setShowText(false);
-                        Preferences.set(prefName, "2");
-                    } else if (rb.getText().equals("Text Only")) {
-                        _treeToolBar.setShowPictures(false);
-                        _treeToolBar.setShowText(true);
-                        Preferences.set(prefName, "3");
-                    }
+        final ItemListener itemListener = e -> {
+            final JRadioButtonMenuItem rb = (JRadioButtonMenuItem) e.getSource();
+            if (rb.isSelected()) {
+                if (rb.getText().equals("Pictures and Text")) {
+                    _treeToolBar.setShowPictures(true);
+                    _treeToolBar.setShowText(true);
+                    Preferences.set(prefName, "1");
+                } else if (rb.getText().equals("Pictures Only")) {
+                    _treeToolBar.setShowPictures(true);
+                    _treeToolBar.setShowText(false);
+                    Preferences.set(prefName, "2");
+                } else if (rb.getText().equals("Text Only")) {
+                    _treeToolBar.setShowPictures(false);
+                    _treeToolBar.setShowText(true);
+                    Preferences.set(prefName, "3");
                 }
             }
         };
@@ -331,7 +306,6 @@ final class SPViewerMenuBar extends JMenuBar {
 
         return menu;
     }
-
 
     private JMenu createGoMenu() {
         final JMenu menu = new JMenu("Go");
@@ -462,7 +436,7 @@ final class SPViewerMenuBar extends JMenuBar {
         return menu;
     }
 
-    public void rebuildNavMenu() {
+    void rebuildNavMenu() {
         rebuildNavMenu(navMenu);
     }
 
@@ -492,7 +466,7 @@ final class SPViewerMenuBar extends JMenuBar {
         }
     }
 
-    public void rebuildPluginMenu() {
+    void rebuildPluginMenu() {
         rebuildPluginMenu(pluginMenu);
     }
 
@@ -513,8 +487,3 @@ final class SPViewerMenuBar extends JMenuBar {
         menu.setVisible(plugins.size() > 0);
     }
 }
-
-
-
-
-

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/userprefs/observer/ObservingPeer.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/userprefs/observer/ObservingPeer.scala
@@ -29,6 +29,6 @@ object ObservingPeer {
   def peerFor(site: Site): Option[Peer] =
     OT.getKeyChain.peerForSite(site).unsafeRun.fold(_ => None, identity)
 
-  def peerFor(site: Option[Site]): Option[Peer] = site.flatMap(peerFor(_))
+  def peerFor(site: Option[Site]): Option[Peer] = site.flatMap(peerFor)
   def peerOrNullFor(site: Site): Peer = peerFor(site).orNull
 }


### PR DESCRIPTION
While updating the OT preferences it was noted that one user preference "Show alternative guide star options" was not used in the OT, this is a legacy option that is unused since we have BAGS

This PR removes this option and cleans some of the old preferences-related classes

Here's the option removed:

![screenshot 2016-09-15 11 35 18](https://cloud.githubusercontent.com/assets/3615303/18554661/4e1f41da-7b3b-11e6-878b-027c7ce905b2.png)
