### PR TITLE
REL-403: add missing package

### DIFF
--- a/bundle/jsky.app.ot/build.sbt
+++ b/bundle/jsky.app.ot/build.sbt
@@ -42,6 +42,7 @@ OsgiKeys.privatePackage := Seq(
   "jsky.app.ot.log.*",
   "jsky.app.ot.modelconfig.*",
   "jsky.app.ot.nsp.*",
+  "jsky.app.ot.plot",
   "jsky.app.ot.progadmin.*",
   "jsky.app.ot.scilib.*",
   "jsky.app.ot.session.*",


### PR DESCRIPTION
This is an addendum to the [REL-403 PR](https://github.com/gemini-hlsw/ocs/pull/1096).  Testing the UI only with `TestLauncher` I failed to notice that I needed to add the new OT package `jsky.app.ot.plot` to the private package list.  This results in an OSGi wiring exception on startup from the command line (or in a packaged app of course).