### PR TITLE
REL-2955: BAGS/Sync bug

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/package.scala
@@ -41,7 +41,8 @@ package object sp {
     t.drawTree(ev).zipWithIndex.collect { case (s, n0) if n0 % 2 == 0 => s}.mkString("\n")
   }
 
-  implicit def SpNodeKeyEqual: Equal[SPNodeKey] = Equal.equalA
+  implicit def SpNodeKeyOrder: Order[SPNodeKey] =
+    Order.order((k0, k1) => Ordering.fromInt(k0.compareTo(k1)))
 
   implicit class RichDataObject[A <: ISPDataObject](dob: A) {
     def copy: A = dob.clone(dob)

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsResurrectionCorrection.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsResurrectionCorrection.scala
@@ -3,7 +3,7 @@ package edu.gemini.sp.vcs2
 import edu.gemini.pot.sp.SPNodeKey
 import edu.gemini.pot.sp.version.EmptyNodeVersions
 import edu.gemini.sp.vcs2.MergeCorrection.CorrectionFunction
-import edu.gemini.spModel.rich.pot.sp.SpNodeKeyEqual
+import edu.gemini.spModel.rich.pot.sp.SpNodeKeyOrder
 
 import scalaz._
 import Scalaz._

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -349,8 +349,6 @@ object BagsManager {
     * observations for consideration for a BAGS lookup.
     */
   def watch(prog: ISPProgram): Unit = Swing.onEDT {
-    Log.info("watch")
-
     // Remove existing listeners, if any.
     prog.removeStructureChangeListener(StructureListener)
     prog.removeCompositeChangeListener(ChangeListener)
@@ -409,7 +407,6 @@ object BagsManager {
   /** Remove a program from our watch list and remove listeners.
     */
   def unwatch(prog: ISPProgram): Unit = Swing.onEDT {
-    Log.info("unwatch")
     prog.removeStructureChangeListener(StructureListener)
     prog.removeCompositeChangeListener(ChangeListener)
     stateMap = stateMap - ProgKey(prog)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -1,5 +1,7 @@
 package jsky.app.ot.ags
 
+import edu.gemini.pot.client.SPDB
+import edu.gemini.spModel.core.SPProgramID
 import jsky.app.ot.ags.BagsState._
 import java.beans.{PropertyChangeEvent, PropertyChangeListener}
 import java.time.Instant
@@ -15,6 +17,7 @@ import edu.gemini.spModel.guide.GuideProbe
 import edu.gemini.spModel.obs.{ObsClassService, ObservationStatus}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.obsclass.ObsClass
+import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.env.{AutomaticGroup, GuideEnv, GuideEnvironment}
 import jsky.app.ot.OT
@@ -65,6 +68,20 @@ object BagsState {
   type StateTransition = (BagsState, IO[Unit]) // Next BagsState, side-effects
   val ErrorTransition  = (ErrorState, ioUnit)  // Default transition for unexpected events
 
+  def hashObs(ctx: ObsContext): AgsHashVal = {
+    val when = ctx.getSchedulingBlockStart.asScalaOpt | Instant.now.toEpochMilli
+    AgsHash.hash(ctx, when)
+  }
+
+  def hashObs(o: ISPObservation): Option[AgsHashVal] =
+    ObsContext.create(o).asScalaOpt.map(hashObs)
+
+  def fetchObs(k: ObsKey): Option[ISPObservation] =
+    Option(SPDB.get().lookupProgram(k.prog.key)).flatMap { p =>
+      p.allObservations.find(_.getNodeKey === k.key)
+    }
+
+
   /** Error.  This state represents a logic error.  There are no transitions out
     * of the error state.
     */
@@ -75,9 +92,9 @@ object BagsState {
     * another AGS search.  We hang on to the last known AGS hash value so that
     * we can discard irrelevant edits if possible.
     */
-  case class IdleState(obs: ISPObservation, hash: Option[AgsHashVal]) extends BagsState {
+  case class IdleState(k: ObsKey, hash: Option[AgsHashVal]) extends BagsState {
     private[ags] override val edit: StateTransition =
-      (PendingState(obs, hash), BagsManager.wakeUpAction(obs, 0))
+      (PendingState(k, hash), BagsManager.wakeUpAction(k, 0))
   }
 
   /** Pending.  When pending, we assume we've been edited and that a new AGS
@@ -85,39 +102,44 @@ object BagsState {
     * the timer to go off, wake us up and then we'll decide whether to do an
     * AGS lookup, update the AGS hash code, etc.
     */
-  case class PendingState(obs: ISPObservation, hash: Option[AgsHashVal]) extends BagsState {
+  case class PendingState(k: ObsKey, hash: Option[AgsHashVal]) extends BagsState {
     private[ags] override val edit: StateTransition =
       (this, ioUnit)
 
     private[ags] override def wakeUp: StateTransition = {
-      def notObserved: Boolean =
-        ObservationStatus.computeFor(obs) != ObservationStatus.OBSERVED
+      def wakeUp(obs: ISPObservation): StateTransition = {
+        def notObserved: Boolean =
+          ObservationStatus.computeFor(obs) != ObservationStatus.OBSERVED
 
-      // Get the ObsContext and AgsStrategy, if possible.  If not possible,
-      // we won't be able to do AGS for this observation.
-      val tup = for {
-        c <- ObsContext.create(obs).asScalaOpt
-        s <- agsStrategy(obs, c)
-      } yield (c, s)
+        // Get the ObsContext and AgsStrategy, if possible.  If not possible,
+        // we won't be able to do AGS for this observation.
+        val tup = for {
+          c <- ObsContext.create(obs).asScalaOpt
+          s <- agsStrategy(obs, c)
+        } yield (c, s)
 
-      // Compute the new hash value of the observation, if possible.  It may
-      // be possible to (re)run AGS but not necessary if the hash hasn't
-      // changed.
-      val newHash = tup.map { case (ctx, _) => hashObs(ctx) }
+        // Compute the new hash value of the observation, if possible.  It may
+        // be possible to (re)run AGS but not necessary if the hash hasn't
+        // changed.
+        val newHash = tup.map { case (ctx, _) => hashObs(ctx) }
 
-      // Here we figure out what the transition to the RunningState should be,
-      // assuming we aren't already observed and that the hash differs.
-      val runningTransition = for {
-        (c, s) <- tup
-        h      <- newHash
-        if !hash.contains(h) && notObserved
-      } yield (RunningState(obs, h), BagsManager.triggerAgsAction(obs, c, s)): StateTransition
+        // Here we figure out what the transition to the RunningState should be,
+        // assuming we aren't already observed and that the hash differs.
+        val runningTransition = for {
+          (c, s) <- tup
+          h      <- newHash
+          if !hash.contains(h) && notObserved
+        } yield (RunningState(k, h), BagsManager.triggerAgsAction(k, c, s)): StateTransition
 
-      // Returns the new state to switch to, either RunningState if all is well
-      // and a new AGS lookup is needed or else IdleState (possibly with an
-      // updated hash value) otherwise.
-      def idleAction = tup.fold(BagsManager.clearAction(obs)) { _ => ioUnit }
-      runningTransition | ((IdleState(obs, newHash), idleAction))
+        // Returns the new state to switch to, either RunningState if all is well
+        // and a new AGS lookup is needed or else IdleState (possibly with an
+        // updated hash value) otherwise.
+        def idleAction = tup.fold(BagsManager.clearAction(k)) { _ => ioUnit }
+        runningTransition | ((IdleState(k, newHash), idleAction))
+      }
+
+
+      fetchObs(k).fold((ErrorState: BagsState, ioUnit)) { wakeUp }
     }
   }
 
@@ -126,31 +148,31 @@ object BagsState {
     * since the search began since we will transition to RunningEditedState
     * if something is edited in the meantime.
     */
-  case class RunningState(obs: ISPObservation, hash: AgsHashVal) extends BagsState {
+  case class RunningState(k: ObsKey, hash: AgsHashVal) extends BagsState {
     // When edited while running, we continue running but remember we were
     // edited by moving to RunningEditedState.  When the results eventually
     // come back from the AGS lookup when in RunningEditedState, we store them
     // but move to PendingState to run again.
     private[ags] override val edit: StateTransition =
-      (RunningEditedState(obs), ioUnit)
+      (RunningEditedState(k), ioUnit)
 
     // Successful AGS lookup while running (and not edited).  Apply the update
     // and move to IdleState.
     private[ags] override def succeed(results: Option[AgsStrategy.Selection]): StateTransition =
-      (IdleState(obs, Some(hash)), BagsManager.applyAction(obs, results))
+      (IdleState(k, Some(hash)), BagsManager.applyAction(k, results))
 
     // Failed AGS lookup.  Move to FailedState for a while and ask the timer to
     // wake us up in a bit.  When the timer eventually goes off we will switch
     // to PendingState (see FailedState.wakeUp).
     private[ags] override def fail(why: String, delayMs: Long): StateTransition =
-      (FailureState(obs, why), BagsManager.wakeUpAction(obs, delayMs))
+      (FailureState(k, why), BagsManager.wakeUpAction(k, delayMs))
   }
 
   /** RunningEdited. This state corresponds to a running AGS search for an
     * observation that was subsequently edited.  Since it has been edited, the
     * results we're expecting may no longer be valid when they arrive.
     */
-  case class RunningEditedState(obs: ISPObservation) extends BagsState {
+  case class RunningEditedState(k: ObsKey) extends BagsState {
     // If we're edited again while running, just loop back.  Once the results of
     // the previous edit that got us into RunningState in the first place
     // finish, we'll switch to Pending and go again.
@@ -163,20 +185,20 @@ object BagsState {
     // and as this was causing issues for BAGS overwriting PA edits, we only allow
     // BAGS to apply to unedited observations.
     private[ags] override def succeed(results: Option[AgsStrategy.Selection]): StateTransition =
-      (PendingState(obs, None), BagsManager.wakeUpAction(obs, 0))
+      (PendingState(k, None), BagsManager.wakeUpAction(k, 0))
 
     // Failed AGS but we've been edited in the meantime anyway.  Go back to
     // PendingState so we can run again.  Here we pass in no AgsHash value to
     // ensure that pending will count this as an AGS-worthy edit.
     private[ags] override def fail(why: String, delayMs: Long): StateTransition =
-      (PendingState(obs, None), BagsManager.wakeUpAction(obs, delayMs))
+      (PendingState(k, None), BagsManager.wakeUpAction(k, delayMs))
   }
 
   /** Failure. This state is used to mark an AGS lookup failure.  It is a
     * transient state since a timer is expected to eventually go off and move
     * us back to pending to retry the search.
     */
-  case class FailureState(obs: ISPObservation, why: String) extends BagsState {
+  case class FailureState(k: ObsKey, why: String) extends BagsState {
     // If edited while in failed, we just loop back.  When the timer eventually
     // goes off we'll move to pending and redo the AGS lookup anyway.
     private[ags] override val edit: StateTransition =
@@ -185,12 +207,7 @@ object BagsState {
     // When the timer goes off we can go back to pending (with no AgsHash value
     // since we want to ensure that the AGS search runs again).
     private[ags] override val wakeUp: StateTransition =
-      (PendingState(obs, None), BagsManager.wakeUpAction(obs, 0))
-  }
-
-  def hashObs(ctx: ObsContext): AgsHashVal = {
-    val when = ctx.getSchedulingBlockStart.asScalaOpt | Instant.now.toEpochMilli
-    AgsHash.hash(ctx, when)
+      (PendingState(k, None), BagsManager.wakeUpAction(k, 0))
   }
 
   // Performs checks to rule out disabled guide groups, instruments without
@@ -209,26 +226,28 @@ object BagsState {
 }
 
 // Wraps SPNodeKey in a new type to help avoid confusion with observation SPNodeKey.
-final case class ProgKey(k: SPNodeKey)
+final case class ProgKey(key: SPNodeKey, pid: Option[SPProgramID])
+
 object ProgKey {
   def apply(o: ISPObservation): ProgKey =
-    ProgKey(o.getProgramKey)
+    ProgKey(o.getProgram)
 
   def apply(p: ISPProgram): ProgKey =
-    ProgKey(p.getProgramKey)
+    ProgKey(p.getProgramKey, Option(p.getProgramID))
 
   implicit val OrderProgKey: Order[ProgKey] =
-    Order.order((k0,k1) => Ordering.fromInt(k0.k.compareTo(k1.k)))
+    Order.orderBy(pk => (pk.key, pk.pid.map(_.toString)))
 }
 
 // Wraps SPNodeKey in a new type to help avoid confusion with program SPNodeKey.
-final case class ObsKey(k: SPNodeKey)
+final case class ObsKey(prog: ProgKey, key: SPNodeKey, oid: Option[SPObservationID])
+
 object ObsKey {
   def apply(o: ISPObservation): ObsKey =
-    ObsKey(o.getNodeKey)
+    ObsKey(ProgKey(o), o.getNodeKey, Option(o.getObservationID))
 
   implicit val OrderObsKey: Order[ObsKey] =
-    Order.order((k0,k1) => Ordering.fromInt(k0.k.compareTo(k1.k)))
+    Order.orderBy(ok => (ok.prog, ok.key, ok.oid.map(_.toString)))
 }
 
 
@@ -282,71 +301,49 @@ object BagsManager {
   private def fireBagsStateChanged(k: SPNodeKey, oldState: BagsState, newState: BagsState): Unit =
     listeners.foreach(_.bagsStateChanged(k, oldState, newState))
 
-  def stateLookup(p: SPNodeKey, o: SPNodeKey): Option[BagsState] =
+  def stateLookup(k: ObsKey): Option[BagsState] =
     assertingSwingEDT("BagsStates can only be queried on the Swing EDT.") {
       for {
-        obsMap <- stateMap.lookup(ProgKey(p))
-        s <- obsMap.lookup(ObsKey(o))
+        obsMap <- stateMap.lookup(k.prog)
+        s      <- obsMap.lookup(k)
       } yield s
     }
 
   // Handle a state machine transition.  Note we switch to the Swing thread
   // here so that the calling thread continues immediately.  All updates are
   // done from the Swing thread.
-  private def transition(obs: ISPObservation, label: String, update: BagsState => StateTransition): Unit = Swing.onEDT {
-
-    def logTransition(from: BagsState, to: BagsState): IO[Unit] = IO {
-      def stateString(s: BagsState): String = s match {
-        case BagsState.ErrorState            => "Error"
-        case BagsState.IdleState(_, hash)    => s"Idle($hash)"
-        case BagsState.PendingState(_, hash) => s"Pending($hash)"
-        case BagsState.RunningState(_, hash) => s"Running($hash)"
-        case BagsState.RunningEditedState(_) => s"RunningEdited"
-        case BagsState.FailureState(_, why)  => s"Failure($why)"
-      }
-
-      val obsId = Option(obs.getObservationID).getOrElse(obs.getNodeKey)
-
-      Log.info(f"BAGS transition for obs $obsId: ${stateString(from)}%-30s - $label%-8s -> ${stateString(to)}")
-    }
-
-    val progKey = ProgKey(obs)
-    val obsKey  = ObsKey(obs)
-
-    val stateTuple = for {
-      obsMap <- stateMap.lookup(progKey)
+  private def transition(obsKey: ObsKey, update: BagsState => StateTransition): Unit = Swing.onEDT {
+    for {
+      obsMap <- stateMap.lookup(obsKey.prog)
       state  <- obsMap.lookup(obsKey)
-    } yield (obsMap, state)
-
-    stateTuple.foreach { case (obsMap, state) =>
+    } {
       val (newState, sideEffect) = update(state)
-      val newStatemap            = stateMap.insert(progKey, obsMap.insert(obsKey, newState))
+      val newStatemap            = stateMap.insert(obsKey.prog, obsMap.insert(obsKey, newState))
 
       // Some actions will produce further state transitions when executed and
       // those transitions assume the newState has been reached.  Therefore we
       // make sure to update the state map before running the associated actions.
       val action = for {
         _ <- IO { stateMap = newStatemap }
-        _ <- logTransition(state, newState)
         _ <- sideEffect
+        _ <- IO { fireBagsStateChanged(obsKey.key, state, newState) }
       } yield ()
-      action.unsafePerformIO()
 
-      fireBagsStateChanged(obs.getNodeKey, state, newState)
+      action.unsafePerformIO()
     }
   }
 
-  private def edited(obs: ISPObservation): Unit =
-    transition(obs, "edit", _.edit)
+  private def edited(o: ObsKey): Unit =
+    transition(o, _.edit)
 
-  private def wakeUp(obs: ISPObservation): Unit =
-    transition(obs, "wakeUp", _.wakeUp)
+  private def wakeUp(o: ObsKey): Unit =
+    transition(o, _.wakeUp)
 
-  private def success(obs: ISPObservation, results: Option[AgsStrategy.Selection]): Unit =
-    transition(obs, "succeed", _.succeed(results))
+  private def success(o: ObsKey, results: Option[AgsStrategy.Selection]): Unit =
+    transition(o, _.succeed(results))
 
-  private def fail(obs: ISPObservation, why: String, delay: Long): Unit =
-    transition(obs, "fail", _.fail(why, delay))
+  private def fail(o: ObsKey, why: String, delay: Long): Unit =
+    transition(o, _.fail(why, delay))
 
   /** Add a program to our watch list and attach listeners. Enqueue modified
     * observations for consideration for a BAGS lookup.
@@ -368,18 +365,24 @@ object BagsManager {
       obsKeys(k)
     }
 
-    // Scan the list of observations updating the BagsState to use the new
-    // observation reference.  If currently running, treat this as an edit in
-    // order to force the calculation to be redone.
+    // Scan the list of observations creating or updating the BagsState as
+    // necessary:
+    //
+    // 1. If an observation is missing in the map, create a new Idle state with
+    //    no hash value.
+    // 2. Most observations previously in the map will be Idle with a given hash
+    //    value.  If the hash value is the same in the updated program there is
+    //    no need to redo the lookup.  If the hash value differs, set it to None
+    //    so the search will happen again.
+    // 3. If currently in the middle of a search, check the hash value. If it
+    //    differs the eventual results will no longer apply so mark it as
+    //    RunningEdited.
     val obsMap  = (obsMap0/:obsList) { (m,o) =>
       val k = ObsKey(o)
-      val s = m.lookup(k).fold(IdleState(o, None): BagsState) {
-        case IdleState(_, Some(hash)) => IdleState(o, ObsContext.create(o).asScalaOpt.map(hashObs).filter(_ == hash))
-        case PendingState(_, h)       => PendingState(o, h)
-        case RunningState(_, _)       => RunningEditedState(o) // yes, switch to edited
-        case RunningEditedState(_)    => RunningEditedState(o)
-        case FailureState(_, w)       => FailureState(o, w)
-        case _                        => IdleState(o, None)
+      val s = m.lookup(k).fold(IdleState(k, None): BagsState) {
+        case IdleState(_, Some(hash)) => IdleState(k, hashObs(o).filter(_ === hash))
+        case RunningState(_, h)       => if (hashObs(o).contains(h)) RunningState(k, h) else RunningEditedState(k)
+        case other                    => other
       }
       m + (k -> s)
     }
@@ -419,15 +422,16 @@ object BagsManager {
         case node: ISPNode => Option(node.getContextObservation).foreach { o => Swing.onEDT {
           // Update the state map to add a new IdleState if it is missing the
           // observation that was changed.
-          val obsMap  = stateMap.lookup(ProgKey(o)).getOrElse(==>>.empty[ObsKey, BagsState])
-          val obsMap2 = obsMap.alter(ObsKey(o), {
-            case None => Some(IdleState(o, None))
+          val k       = ObsKey(o)
+          val obsMap  = stateMap.lookup(k.prog).getOrElse(==>>.empty[ObsKey, BagsState])
+          val obsMap2 = obsMap.alter(k, {
+            case None => Some(IdleState(k, None))
             case x    => x
           })
           stateMap = stateMap + (ProgKey(o) -> obsMap2)
 
           // Now mark it edited.
-          BagsManager.edited(o)
+          BagsManager.edited(ObsKey(o))
         }}
         case _             => // Ignore, not in an observation.
       }
@@ -438,18 +442,21 @@ object BagsManager {
     override def propertyChange(evt: PropertyChangeEvent): Unit =
       evt.getSource match {
         case oc: ISPObservationContainer => Swing.onEDT {
-          val progKey     = ProgKey(oc.getProgramKey)
+          val progKey     = ProgKey(oc.getProgram)
           val existingMap = stateMap.lookup(progKey).getOrElse(==>>.empty[ObsKey, BagsState])
 
           // Go through all the observations in this container adding any that
           // are missing.
           val allObs      = oc.getAllObservations.asScala.toList
           val missing     = allObs.filter { o => existingMap.lookup(ObsKey(o)).isEmpty }
-          val missingMap  = ==>>.fromList(missing.map { o => ObsKey(o) -> (IdleState(o, None): BagsState) })
+          val missingMap  = ==>>.fromList(missing.map { o =>
+            val k = ObsKey(o)
+            k -> (IdleState(k, None): BagsState)
+          })
           stateMap = stateMap + (progKey -> existingMap.union(missingMap))
 
           // Mark any missing observations edited to do the AGS lookup.
-          missing.foreach(BagsManager.edited)
+          missing.foreach(o => BagsManager.edited(ObsKey(o)))
         }
         case _                           => // ignore, not an observation container
       }
@@ -459,33 +466,33 @@ object BagsManager {
   // Side effects that accompany the state transitions.
   // -------------------------------------------------------------------------
 
-  private[ags] def wakeUpAction(obs: ISPObservation, delayMs: Long): IO[Unit] = IO {
+  private[ags] def wakeUpAction(k: ObsKey, delayMs: Long): IO[Unit] = IO {
     worker.schedule(new Runnable() {
-      def run(): Unit = BagsManager.wakeUp(obs)
+      def run(): Unit = BagsManager.wakeUp(k)
     }, delayMs, TimeUnit.MILLISECONDS)
   }
 
-  private[ags] def triggerAgsAction(obs: ISPObservation, ctx: ObsContext, ags: AgsStrategy): IO[Unit] = IO {
+  private[ags] def triggerAgsAction(k: ObsKey, ctx: ObsContext, ags: AgsStrategy): IO[Unit] = IO {
     ags.select(ctx, OT.getMagnitudeTable)(blockingExecutionContext).onComplete {
       case Success(opt) =>
-        Log.info(s"Successful BAGS lookup for observation=${obs.getObservationID}; applying on ${Thread.currentThread}")
-        BagsManager.success(obs, opt)
+        Log.info(s"Successful BAGS lookup for observation=${k.oid.getOrElse("?")}; applying on ${Thread.currentThread}")
+        BagsManager.success(k, opt)
 
       case Failure(CatalogException((e: GenericError) :: _)) =>
-        BagsManager.fail(obs, "Catalog lookup failed.", 5000)
+        BagsManager.fail(k, "Catalog lookup failed.", 5000)
 
       case Failure(ex: TimeoutException) =>
-        BagsManager.fail(obs, "Catalog timed out.", 0)
+        BagsManager.fail(k, "Catalog timed out.", 0)
 
       case Failure(ex) =>
-        BagsManager.fail(obs, s"Unexpected error ${Option(ex.getMessage).getOrElse("")}", 5000)
+        BagsManager.fail(k, s"Unexpected error ${Option(ex.getMessage).getOrElse("")}", 5000)
     }
   }
 
-  private[ags] def clearAction(obs: ISPObservation): IO[Unit] =
-    applyAction(obs, None)
+  private[ags] def clearAction(k: ObsKey): IO[Unit] =
+    applyAction(k, None)
 
-  private[ags] def applyAction(obs: ISPObservation, selOpt: Option[AgsStrategy.Selection]): IO[Unit] = IO {
+  private[ags] def applyAction(k: ObsKey, selOpt: Option[AgsStrategy.Selection]): IO[Unit] = IO {
     def applySelection(ctx: TpeContext): Unit = {
       val oldEnv = ctx.targets.envOrDefault
 
@@ -520,25 +527,29 @@ object BagsManager {
       }
     }
 
-    obs.getProgram.removeStructureChangeListener(StructureListener)
-    obs.getProgram.removeCompositeChangeListener(ChangeListener)
-    applySelection(TpeContext(obs))
+    def doApply(obs: ISPObservation): Unit = {
+      obs.getProgram.removeStructureChangeListener(StructureListener)
+      obs.getProgram.removeCompositeChangeListener(ChangeListener)
+      applySelection(TpeContext(obs))
 
-    // Update the TPE if it is visible
-    selOpt.foreach { sel =>
-      Option(TpeManager.get()).filter(_.isVisible).foreach { tpe =>
-        sel.assignments.foreach { ass =>
-          val clazz = ass.guideProbe.getType match {
-            case GuideProbe.Type.AOWFS => classOf[Altair_WFS_Feature]
-            case GuideProbe.Type.OIWFS => classOf[OIWFS_Feature]
-            case GuideProbe.Type.PWFS  => classOf[TpePWFSFeature]
+      // Update the TPE if it is visible
+      selOpt.foreach { sel =>
+        Option(TpeManager.get()).filter(_.isVisible).foreach { tpe =>
+          sel.assignments.foreach { ass =>
+            val clazz = ass.guideProbe.getType match {
+              case GuideProbe.Type.AOWFS => classOf[Altair_WFS_Feature]
+              case GuideProbe.Type.OIWFS => classOf[OIWFS_Feature]
+              case GuideProbe.Type.PWFS  => classOf[TpePWFSFeature]
+            }
+            Option(tpe.getFeature(clazz)).foreach(tpe.selectFeature)
           }
-          Option(tpe.getFeature(clazz)).foreach(tpe.selectFeature)
         }
       }
+
+      obs.getProgram.addCompositeChangeListener(ChangeListener)
+      obs.getProgram.addStructureChangeListener(StructureListener)
     }
 
-    obs.getProgram.addCompositeChangeListener(ChangeListener)
-    obs.getProgram.addStructureChangeListener(StructureListener)
+    fetchObs(k).foreach(doApply)
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
@@ -8,7 +8,7 @@ import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.SPTarget
 import jsky.app.ot.OT
-import jsky.app.ot.ags.BagsManager
+import jsky.app.ot.ags.{ObsKey, BagsManager}
 import jsky.app.ot.gemini.editor.targetComponent.TargetFeedback.Row
 
 import scala.swing.GridBagPanel.Fill
@@ -31,9 +31,7 @@ class TargetFeedbackEditor extends TelescopePosEditor {
       val bagsRow = for {
         n <- Option(node)
         o <- Option(n.getContextObservation)
-        pk <- Option(o.getProgram).map(_.getProgramKey)
-        ok <- Option(o.getNodeKey)
-        s <- BagsManager.stateLookup(pk, ok)
+        s <- BagsManager.stateLookup(ObsKey(o))
         row <- BagsFeedback.toRow(s, ctxOpt.asScalaOpt)
       } yield row
 


### PR DESCRIPTION
This PR addresses a bug with BAGS and sync.  There are two related changes:

1. The major issue is in the `BagsManager.watch` method.  `watch` is called whenever a new program is opened, or when a sync that has to incorporate remote changes is executed.  When there are incoming changes the current program is replaced wholesale by an updated copy. The `watch` method wasn't taking this into account and would skip these updates.  Future change events would be ignored since `BagsManager` would continue watching the previous/unchanged version of the program.

2. The `BagState`s all kept a reference to the corresponding `ISPObservation`.  This is problematic for sync because the entire program is copied and the copy is updated.  Much of the refactoring work went into avoiding the need to hold on to `ISPObservation` references and instead fetch them from keys when needed.
