### PR TITLE
REL-1939: Instrument/Sequence Sync Update

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/InstrumentSequenceSync.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/InstrumentSequenceSync.java
@@ -43,9 +43,7 @@ public enum InstrumentSequenceSync implements ISPEventMonitor {
         final ISPObservation obs = change.getModifiedNode().getContextObservation();
         if (obs == null) return;
 
-        if (addedFirstInstrumentIterator(change)) {
-            syncFromInstrument(obs);
-        } else if (addedInstrumentOrEngineeringComponent(change)) {
+        if (addedFirstInstrumentIterator(change) || addedInstrumentOrEngineeringComponent(change)) {
             syncFromIterator(obs);
         }
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/InstrumentSequenceSync.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/InstrumentSequenceSync.java
@@ -68,9 +68,9 @@ public enum InstrumentSequenceSync implements ISPEventMonitor {
             return false;
 
         // What did we add (if anything)
-        final Set<ISPObsComponent> oldSet = new HashSet<ISPObsComponent>((Collection<ISPObsComponent>) change.getOldValue());
-        final Set<ISPObsComponent> newSet = new HashSet<ISPObsComponent>((Collection<ISPObsComponent>) change.getNewValue());
-        final Set<ISPObsComponent> addedSet = new HashSet<ISPObsComponent>(newSet);
+        final Set<ISPObsComponent> oldSet = new HashSet<>((Collection<ISPObsComponent>) change.getOldValue());
+        final Set<ISPObsComponent> newSet = new HashSet<>((Collection<ISPObsComponent>) change.getNewValue());
+        final Set<ISPObsComponent> addedSet = new HashSet<>(newSet);
         addedSet.removeAll(oldSet);
 
         // Did we add an instrument or eng component?
@@ -289,8 +289,8 @@ public enum InstrumentSequenceSync implements ISPEventMonitor {
     private static Tuple2<Collection<IParameter>, Collection<IParameter>> separateVolatileParameters(
             ISysConfig sysConfig,
             Map<String, PropertyDescriptor> props) {
-        final List<IParameter> vParams = new ArrayList<IParameter>();
-        final List<IParameter> nvParams = new ArrayList<IParameter>();
+        final List<IParameter> vParams = new ArrayList<>();
+        final List<IParameter> nvParams = new ArrayList<>();
 
         for (IParameter p : sysConfig.getParameters()) {
             final PropertyDescriptor pd = props.get(p.getName());
@@ -298,7 +298,7 @@ public enum InstrumentSequenceSync implements ISPEventMonitor {
             (PropertySupport.isVolatile(pd) ? vParams : nvParams).add(p);
         }
 
-        return new Pair<Collection<IParameter>, Collection<IParameter>>(vParams, nvParams);
+        return new Pair<>(vParams, nvParams);
     }
 
     // Applies the first row values to the instrument static component.
@@ -383,13 +383,10 @@ public enum InstrumentSequenceSync implements ISPEventMonitor {
 
         boolean updated = false;
         for (IParameter param : sysConfig.getParameters()) {
+            // Get a mutable value list.
             //noinspection unchecked
-            // SR: The List<Object> valueList as defined below does not support the set(int, Object) method called
-            //     below, resulting in an UnsupportedOperationException being thrown. We can fix this by making sure
-            //     that the list is mutable and supports set(int, Object).
-            //final List<Object> valueList = (List<Object>) param.getValue();
-            final List<Object> valueList = new ArrayList<Object>((List<Object>) param.getValue());
-            if ((valueList == null) || (valueList.size() == 0)) continue;
+            final List<Object> valueList = new ArrayList<>((List<Object>) param.getValue());
+            if (valueList.size() == 0) continue;
 
             final String propertyName = param.getName();
             final PropertyDescriptor pd = props.get(propertyName);
@@ -403,10 +400,6 @@ public enum InstrumentSequenceSync implements ISPEventMonitor {
             }
 
             valueList.set(0, val);
-
-            // SR: Now this may cause problems, as valueList is now a java.util.ArrayList<Object> as opposed to a
-            //     java.util.List<Object>, but it seems like it should be okay, since a java.util.ArrayList is an
-            //     implementation of a java.util.List.
             param.setValue(valueList);
         }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/seqcomp/InstrumentSequenceSyncTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/seqcomp/InstrumentSequenceSyncTest.scala
@@ -58,6 +58,10 @@ class InstrumentSequenceSyncTest extends InstrumentSequenceTestBase[InstGmosSout
 
   @Test
   def testRearrangeIterators(): Unit = {
+    // REL-1939: Top level configuration overwrites instrument iterators
+    // Changed behavior to reverse the sync direction when a new or different
+    // iterator becomes the first iterator.  Was inst => iterator,
+    // now iterator => inst.
 
     val cmp1 = getInstSeqComp
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/seqcomp/InstrumentSequenceSyncTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/seqcomp/InstrumentSequenceSyncTest.scala
@@ -1,0 +1,93 @@
+package edu.gemini.spModel.seqcomp
+
+import edu.gemini.pot.sp.{ISPSeqComponent, ISPNode, SPComponentType}
+import edu.gemini.spModel.gemini.gmos.{GmosSouthType, SeqConfigGmosSouth, InstGmosSouth}
+import edu.gemini.spModel.gemini.gmos.GmosSouthType.FilterSouth.{r_G0326, g_G0325}
+import edu.gemini.spModel.test.InstrumentSequenceTestBase
+import edu.gemini.spModel.test.InstrumentSequenceTestBase._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.collection.JavaConverters._
+
+class InstrumentSequenceSyncTest extends InstrumentSequenceTestBase[InstGmosSouth, SeqConfigGmosSouth] {
+  override protected val getObsCompSpType: SPComponentType = SPComponentType.INSTRUMENT_GMOSSOUTH
+  override protected val getSeqCompSpType: SPComponentType = SPComponentType.ITERATOR_GMOSSOUTH
+
+  private val FilterProp = InstGmosSouth.FILTER_PROP.getName
+
+  private def expectStaticFilter(f: GmosSouthType.FilterSouth): Unit =
+    assertEquals(f, getInstObsComp.getDataObject.asInstanceOf[InstGmosSouth].getFilter)
+
+
+  private def expectSequenceFilters(sc: ISPSeqComponent, fs: GmosSouthType.FilterSouth*): Unit =
+    assertEquals(fs.asJava, sc.getDataObject.asInstanceOf[SeqConfigGmosSouth].getSysConfig.getParameterValue(FilterProp))
+
+  private def expectSequenceFilters(fs: GmosSouthType.FilterSouth*): Unit =
+    expectSequenceFilters(getInstSeqComp, fs: _*)
+
+  @Test
+  def testIteratorUpdatePropagates(): Unit = {
+    assertNotEquals(r_G0326, getInstDataObj.getFilter)
+
+    // Add a step that sets the "r" filter.
+    val sc = createSysConfig()
+    sc.putParameter(getParam(FilterProp, r_G0326))
+    setSysConfig(sc)
+
+    // Should be reflected in the static component.
+    expectStaticFilter(r_G0326)
+  }
+
+  @Test
+  def testStaticUpdatePropagates(): Unit = {
+
+    // Add a step that sets the "r" filter.
+    val sc = createSysConfig()
+    sc.putParameter(getParam(FilterProp, r_G0326))
+    setSysConfig(sc)
+
+    // Set the filter in the static component.
+    getInstDataObj.setFilter(g_G0325)
+    storeStaticUpdates()
+
+    // Should be reflected in the iterator.
+    expectSequenceFilters(g_G0325)
+  }
+
+  @Test
+  def testRearrangeIterators(): Unit = {
+
+    val cmp1 = getInstSeqComp
+
+    // Add a step that sets the "r" filter.
+    val sc1 = createSysConfig()
+    sc1.putParameter(getParam(FilterProp, r_G0326))
+    setSysConfig(sc1)
+
+    // Create a second sequence iterator.
+    val cmp2 = addSeqComponent(getObs.getSeqComponent, getSeqCompSpType)
+    val dbj2 = cmp2.getDataObject.asInstanceOf[SeqConfigGmosSouth]
+    val sc2  = createSysConfig()
+    sc2.putParameter(getParam(FilterProp, g_G0325))
+    dbj2.setSysConfig(sc2)
+    cmp2.setDataObject(dbj2)
+
+    // Static component should still show r
+    expectStaticFilter(r_G0326)
+
+    // Rearrange the iterators.
+    val root = getObs.getSeqComponent
+    root.setChildren(List(cmp2: ISPNode, cmp1).asJava)
+
+    // Static component switches to g.
+    expectStaticFilter(g_G0325)
+
+    // First iterator (which was originally the second) stays at g
+    expectSequenceFilters(cmp2, g_G0325)
+
+    // Second iterator (which was originally the first) stays at r
+    expectSequenceFilters(cmp1, r_G0326)
+  }
+}


### PR DESCRIPTION
The static instrument component and the first instrument iterator in the sequence (if any) are kept in sync by an `ISPEventMonitor` called `InstrumentSequenceSync`.  When it is informed of a structure change or a property change it performs a synchronization, updating either the static instrument component or the sequence component (or both even) as necessary.  For example, setting the filter  in a GMOS instrument component will automatically update the first row in the GMOS iterator to match if it includes a filter item.

The problem being addressed by this pull request is that rearranging iterators was incorrectly causing the new first instrument iterator to be updated from the static instrument component instead of the other way around.  This results in edits to the iterators just from rearranging their position in the sequence.  The fix is to reverse the direction of the synchronization.