### PR TITLE
REL-2655: Fixed issue with ODB Browser target requests by filtering / unpacking Option.

### DIFF
--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
@@ -191,15 +191,9 @@ class LchQueryFunctor(queryType: LchQueryFunctor.QueryType,
 
                 if (queryType == LchQueryFunctor.QueryType.TargetQuery) {
                   obs.targetEnvironment.foreach { env =>
-                    Option(env.getTargets) collect {
-                      case lst if lst.nonEmpty => lst.asScalaList
-                    } foreach { tgts =>
-                      setTargetsNode(new TargetsNode() {
-                        tgts.map(tgt => makeTargetNode(tgt, env)).collect {
-                          case Some(t) => t
-                        }.foreach(getTargets.add)
-                      })
-                    }
+                    setTargetsNode(new TargetsNode() {
+                      getTargets.addAll(env.getTargets.asScalaList.flatMap(t => makeTargetNode(t, env)).asJavaCollection)
+                    })
                   }
                 }
               }

--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
@@ -12,7 +12,7 @@ import edu.gemini.pot.sp.{ISPNode, ISPObservation, ISPProgram}
 import edu.gemini.pot.spdb.{DBAbstractQueryFunctor, IDBDatabaseService}
 import edu.gemini.skycalc.{DDMMSS, HHMMSS}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
-import edu.gemini.spModel.obs.{ObsClassService, ObservationStatus}
+import edu.gemini.spModel.obs.ObservationStatus
 import edu.gemini.spModel.rich.shared.immutable._
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.TargetEnvironment
@@ -59,7 +59,7 @@ class LchQueryFunctor(queryType: LchQueryFunctor.QueryType,
 
 
   private def addProgram(prog: ISPProgram, obsList: List[ISPObservation]): Unit = {
-    import LchQueryParam.{ISPProgramExtractors, ISPObservationExtractors, ToYesNo}
+    import LchQueryParam.{ISPProgramExtractors, ISPObservationExtractors}
 
     def makeTargetNode(target: SPTarget, env: TargetEnvironment): Option[Serializable] = {
       def targetType: Option[String] = {
@@ -195,14 +195,15 @@ class LchQueryFunctor(queryType: LchQueryFunctor.QueryType,
                       case lst if lst.nonEmpty => lst.asScalaList
                     } foreach { tgts =>
                       setTargetsNode(new TargetsNode() {
-                        tgts.map(tgt => makeTargetNode(tgt, env)).foreach(getTargets.add)
+                        tgts.map(tgt => makeTargetNode(tgt, env)).collect {
+                          case Some(t) => t
+                        }.foreach(getTargets.add)
                       })
                     }
                   }
-
                 }
               }
-            } foreach getObservations.add
+            }.foreach(getObservations.add)
           })
         }
       }


### PR DESCRIPTION
So as it turns out, I was forgetting to filter / unpack a scala `Option` when working with targets in the ODB Browser. This was adding `Option[SPTarget]` to the `TargetsNode`, which blindly accepts anything `Serializable`. This caused the marshaling to fail when converting to XML.

This collects the unpacked `Some[SPTarget]` entries from the list and adds them to the `TargetsNode` instead.

I have tested with three fairly detailed programs and the query runs properly and the targets now appear in the XML output as they did previously.

(Also did some very minor cleanup.)