### PR TITLE
REL-2859: Automatically download and cache images

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalogClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalogClient.scala
@@ -228,6 +228,7 @@ object ImageCatalogClient {
     }
 
     for {
+      _           <- ImageCacheOnDisk.mkCacheDir(cacheDir)
       tempFile    <- createTmpFile
       desc        <- openConnection
       _           <- writeToTempFile(tempFile)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/StoredImagesCache.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/StoredImagesCache.scala
@@ -106,6 +106,11 @@ object StoredImagesCache {
   * Useful methods to update the cached files
   */
 object ImageCacheOnDisk {
+  def mkCacheDir(cacheDir: Path): Task[Unit] =
+    Task.delay {
+      val f = cacheDir.toFile
+      if (f.exists()) f.isDirectory else f.mkdirs()
+    }.ifM(Task.now(()), Task.fail(new RuntimeException(s"Cannot create cache dir ${cacheDir.toAbsolutePath}")))
 
   /**
     * Method to prune the cache, limiting the space used

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/BackgroundImageLoader.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/BackgroundImageLoader.scala
@@ -13,6 +13,7 @@ import edu.gemini.shared.util.immutable.ScalaConverters._
 import scala.collection.JavaConverters._
 import edu.gemini.pot.sp._
 import edu.gemini.spModel.core.{Angle, Coordinates, Wavelength}
+import edu.gemini.spModel.obs.ObservationStatus
 import jsky.app.ot.tpe.{ImageCatalogPanel, TpeContext, TpeImageWidget, TpeManager}
 import jsky.image.gui.ImageLoadingException
 
@@ -76,12 +77,22 @@ object BackgroundImageLoader {
 
   /** Called when a program is created to download its images */
   def watch(prog: ISPProgram): Unit = {
+    // At startup only load images for active programs
+    def needsImage(ctx: TpeContext): Boolean = {
+      ctx.obsShell.exists(ObservationStatus.computeFor(_) match {
+        case ObservationStatus.INACTIVE | ObservationStatus.OBSERVED => false
+        case _                                                       => true
+      })
+    }
+
     // Listen for future changes
     prog.addCompositeChangeListener(ChangeListener)
     val targets = for {
-        p   <- prog.getAllObservations.asScala.toList
-        obs <- p.getObsComponents.asScala
-        i   <- requestedImage(TpeContext(obs))
+        p      <- prog.getAllObservations.asScala.toList
+        obs    <- p.getObsComponents.asScala
+        tpeCtx  = TpeContext(obs)
+        if needsImage(tpeCtx)
+        i      <- requestedImage(tpeCtx)
       } yield i
 
     // remove duplicates and request images

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObservationCatalogOverrides.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObservationCatalogOverrides.scala
@@ -102,9 +102,9 @@ object ObservationCatalogOverrides {
     // Updates the overrides file, removing the existing entries if needed
     def newOverrides(overrides: Overrides): Overrides =
       if (ImageCatalog.catalogForWavelength(wv.some) =/= c) {
-          overrides.copy(overrides = CatalogOverride(key, c) :: overrides.overrides.filter(_.key != key))
+        overrides.copy(overrides = CatalogOverride(key, c) :: overrides.overrides.filter(_.key != key))
       } else {
-          overrides.copy(overrides =overrides.overrides.filter(_.key != key))
+        overrides.copy(overrides = overrides.overrides.filter(_.key != key))
       }
 
     for {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObservationCatalogOverrides.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObservationCatalogOverrides.scala
@@ -12,6 +12,7 @@ import edu.gemini.spModel.core.Wavelength
 import jsky.util.Preferences
 
 import scalaz._
+import Scalaz._
 import scalaz.concurrent.Task
 
 /**
@@ -89,7 +90,7 @@ object ObservationCatalogOverrides {
   /**
     * Store the overridden catalog for a given node
     */
-  def storeOverride(key: SPNodeKey, c: ImageCatalog): Task[Unit] = {
+  def storeOverride(key: SPNodeKey, c: ImageCatalog, wv: Wavelength): Task[Unit] = {
     def writeOverrides(overridesFile: Path, overrides: Overrides) = Task.delay {
       this.synchronized {
         \/.fromTryCatchNonFatal {
@@ -98,11 +99,18 @@ object ObservationCatalogOverrides {
       }
     }
 
+    // Updates the overrides file, removing the existing entries if needed
+    def newOverrides(overrides: Overrides): Overrides =
+      if (ImageCatalog.catalogForWavelength(wv.some) =/= c) {
+          overrides.copy(overrides = CatalogOverride(key, c) :: overrides.overrides.filter(_.key != key))
+      } else {
+          overrides.copy(overrides =overrides.overrides.filter(_.key != key))
+      }
+
     for {
       overridesFile <- overridesFile
       old           <- Task.delay(readOverrides(overridesFile))
-      newOverrides  = old.copy(overrides = CatalogOverride(key, c) :: old.overrides.filter(_.key != key))
-      _             <- writeOverrides(overridesFile, newOverrides)
+      _             <- writeOverrides(overridesFile, newOverrides(old))
     } yield ()
   }
 }


### PR DESCRIPTION
This PR contains some small bug fixes and improvements requested by users:

* It will create the cache dir if not present (Useful if the user deletes the cache file while the OT is open)
* At program load it will not load images for inactive or observed observations (They will load if the observation is loaded on the TPE)
* Catalog overrides were stored even if it matched the calculated one, polluting the overrides file