### PR TITLE
REL-2966: NPE when manually adding a guidestar on the TPE

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -210,7 +210,7 @@ public class GeneralRule implements IRule {
                 final Set<String> errorSet = new TreeSet<>();
                 for (final SPTarget target : guideTargets) {
                     //Check for empty name
-                    if (target.getName() == null || "".equals(target.getName().trim())) {
+                    if (target.getName() == null || target.getName().trim().isEmpty()) {
                         errorSet.add(String.format(WFS_EMPTY_NAME_TEMPLATE, guider.getKey()));
                     }
 

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -210,7 +210,7 @@ public class GeneralRule implements IRule {
                 final Set<String> errorSet = new TreeSet<>();
                 for (final SPTarget target : guideTargets) {
                     //Check for empty name
-                    if ("".equals(target.getName().trim())) {
+                    if (target.getName() == null || "".equals(target.getName().trim())) {
                         errorSet.add(String.format(WFS_EMPTY_NAME_TEMPLATE, guider.getKey()));
                     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -500,20 +500,21 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
             final Point2D.Double p = new Point2D.Double(mp.x, mp.y);
             getCoordinateConverter().screenToUserCoords(p, false);
             final double[] d = screenCoordsToOffset(mp.x, mp.y);
+            final Option<TpeImageWidget> source = new Some<>(this);
 
             if (evt.getID() == MouseEvent.MOUSE_CLICKED) {
                 final Option<SiderealTarget> skyObject = getCatalogPosition(mp);
                 final Option<String> name = skyObject.map(SiderealTarget::name);
                 if (!skyObject.isDefined()) {
                     Coordinates pos = CoordinatesUtilities.userToWorldCoords(getCoordinateConverter(), p.x, p.y);
-                    return new TpeMouseEvent(evt, evt.getID(), this, pos, name, (int) Math.round(mp.x), (int) Math.round(mp.y), skyObject, d[0], d[1]);
+                    return new TpeMouseEvent(evt, evt.getID(), source, pos, name, (int) Math.round(mp.x), (int) Math.round(mp.y), skyObject, d[0], d[1]);
                 } else {
                     Coordinates pos = skyObject.map(SiderealTarget::coordinates).getOrElse(Coordinates.zero());
-                    return new TpeMouseEvent(evt, evt.getID(), this, pos, name, (int) Math.round(mp.x), (int) Math.round(mp.y), skyObject, d[0], d[1]);
+                    return new TpeMouseEvent(evt, evt.getID(), source, pos, name, (int) Math.round(mp.x), (int) Math.round(mp.y), skyObject, d[0], d[1]);
                 }
             } else {
                 Coordinates pos = CoordinatesUtilities.userToWorldCoords(getCoordinateConverter(), p.x, p.y);
-                return new TpeMouseEvent(evt, evt.getID(), this, pos, None.instance(), (int) Math.round(mp.x), (int) Math.round(mp.y), None.instance(), d[0], d[1]);
+                return new TpeMouseEvent(evt, evt.getID(), source, pos, None.instance(), (int) Math.round(mp.x), (int) Math.round(mp.y), None.instance(), d[0], d[1]);
             }
         } else {
             return new TpeMouseEvent(evt);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -503,7 +503,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
 
             if (evt.getID() == MouseEvent.MOUSE_CLICKED) {
                 final Option<SiderealTarget> skyObject = getCatalogPosition(mp);
-                final String name = skyObject.map(SiderealTarget::name).getOrNull();
+                final Option<String> name = skyObject.map(SiderealTarget::name);
                 if (!skyObject.isDefined()) {
                     Coordinates pos = CoordinatesUtilities.userToWorldCoords(getCoordinateConverter(), p.x, p.y);
                     return new TpeMouseEvent(evt, evt.getID(), this, pos, name, (int) Math.round(mp.x), (int) Math.round(mp.y), skyObject, d[0], d[1]);
@@ -513,7 +513,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
                 }
             } else {
                 Coordinates pos = CoordinatesUtilities.userToWorldCoords(getCoordinateConverter(), p.x, p.y);
-                return new TpeMouseEvent(evt, evt.getID(), this, pos, "", (int) Math.round(mp.x), (int) Math.round(mp.y), None.instance(), d[0], d[1]);
+                return new TpeMouseEvent(evt, evt.getID(), this, pos, None.instance(), (int) Math.round(mp.x), (int) Math.round(mp.y), None.instance(), d[0], d[1]);
             }
         } else {
             return new TpeMouseEvent(evt);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMouseEvent.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMouseEvent.java
@@ -1,5 +1,6 @@
 package jsky.app.ot.tpe;
 
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
@@ -64,12 +65,12 @@ public class TpeMouseEvent {
     }
 
     /** Default Constructor: initialize all fields to null. */
-    public TpeMouseEvent(MouseEvent e, int id, TpeImageWidget source, Coordinates pos, String name, int xWidget, int yWidget, Option<SiderealTarget> skyObject, double xOffset, double yOffset) {
+    public TpeMouseEvent(MouseEvent e, int id, TpeImageWidget source, Coordinates pos, Option<String> name, int xWidget, int yWidget, Option<SiderealTarget> skyObject, double xOffset, double yOffset) {
         mouseEvent = e;
         this.id = id;
-        this.source = new Some<>(source);
+        this.source = ImOption.apply(source);
         this.pos = pos;
-        this.name = new Some<>(name);
+        this.name = name;
         this.xWidget = xWidget;
         this.yWidget = yWidget;
         this.skyObject = skyObject;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMouseEvent.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMouseEvent.java
@@ -65,10 +65,10 @@ public class TpeMouseEvent {
     }
 
     /** Default Constructor: initialize all fields to null. */
-    public TpeMouseEvent(MouseEvent e, int id, TpeImageWidget source, Coordinates pos, Option<String> name, int xWidget, int yWidget, Option<SiderealTarget> skyObject, double xOffset, double yOffset) {
+    public TpeMouseEvent(MouseEvent e, int id, Option<TpeImageWidget> source, Coordinates pos, Option<String> name, int xWidget, int yWidget, Option<SiderealTarget> skyObject, double xOffset, double yOffset) {
         mouseEvent = e;
         this.id = id;
-        this.source = ImOption.apply(source);
+        this.source = source;
         this.pos = pos;
         this.name = name;
         this.xWidget = xWidget;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -129,9 +129,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
             final double dec = tme.pos.dec().toDegrees();
 
             pos = new SPTarget(ra, dec);
-            if (tme.name != null) {
-                pos.setName(tme.name.getOrNull());
-            }
+            pos.setName(tme.name.getOrElse(""));
         }
 
         return pos;


### PR DESCRIPTION
An NPE has been observed when adding manually a target. It is traced to a `null` target name wrongly set on the TPE
This PR fixes this and adds an extra verification on the Phase2 check that creates the NPE