### PR TITLE
REL-2638: Add individual CWFS stars using the TPE

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
@@ -65,9 +65,8 @@ case class CatalogSearchCriterion(name: String, radiusConstraint: RadiusConstrai
      * @param obj the SiderealTarget to match
      * @return true if the object matches the magnitude and radius limits
      */
-    def matches(obj: SiderealTarget): Boolean = {
+    def matches(obj: SiderealTarget): Boolean =
       matches(obj.magnitudes) && matches(obj.coordinates)
-    }
 
     private def matches(coords: Coordinates): Boolean = {
       val distance = Coordinates.difference(adjBase, coords).distance

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
@@ -107,7 +107,7 @@ case class GemsCatalogSearchResults(criterion: GemsCatalogSearchCriterion, resul
 
   def resultsAsJava: java.util.List[SiderealTarget] = new java.util.ArrayList[SiderealTarget](results.asJava)
 
-  def targetAt(i: Int): GOption[SiderealTarget] = \/.fromTryCatchNonFatal(results(i)).toOption.asGeminiOpt
+  def targetAt(i: Int): GOption[SiderealTarget] = results.lift(i).asGeminiOpt
 }
 
 /**

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/CatalogSearchCriterion.scala
@@ -1,11 +1,11 @@
 package edu.gemini.ags.gems
 
 import edu.gemini.catalog.api.{MagnitudeConstraints, RadiusConstraint}
-import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.core.AngleSyntax._
-import edu.gemini.shared.skyobject
 import edu.gemini.spModel.gems.{GemsGuideProbeGroup, GemsGuideStarType}
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.shared.util.immutable.{Option => GOption}
 import scala.collection.JavaConverters._
 
 import scalaz._
@@ -107,6 +107,8 @@ case class GemsCatalogSearchResults(criterion: GemsCatalogSearchCriterion, resul
   def this(results: java.util.List[SiderealTarget], criterion: GemsCatalogSearchCriterion) = this(criterion, results.asScala.toList)
 
   def resultsAsJava: java.util.List[SiderealTarget] = new java.util.ArrayList[SiderealTarget](results.asJava)
+
+  def targetAt(i: Int): GOption[SiderealTarget] = \/.fromTryCatchNonFatal(results(i)).toOption.asGeminiOpt
 }
 
 /**

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsUtils4Java.scala
@@ -1,12 +1,10 @@
 package edu.gemini.ags.gems
 
-import edu.gemini.pot.ModelConverters._
 import edu.gemini.shared.util.immutable.ImList
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core.{Magnitude, MagnitudeBand, SingleBand, RBandsList, SiderealTarget}
 import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.guide.GuideProbe
-import edu.gemini.shared.skyobject
 import scala.collection.JavaConverters._
 
 import scalaz._
@@ -16,13 +14,15 @@ import Scalaz._
  * Utility methods for Java classes to access scala classes/methods
  */
 object GemsUtils4Java {
+  private val equalByName = Equal.equal[SiderealTarget](_.name === _.name)
 
   /**
    * Returns a list of unique targets in the given search results.
    */
   def uniqueTargets(list: java.util.List[GemsCatalogSearchResults]): java.util.List[SiderealTarget] = {
-    import collection.breakOut
-    new java.util.ArrayList(list.asScala.flatMap(_.results).groupBy(_.name).map(_._2.head)(breakOut).asJava)
+    // Find distinct targets by name as there may be duplicates on the search results
+    val k = list.asScala.toList.flatMap(_.results).distinctE(equalByName)
+    k.toList.asJava
   }
 
   /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -63,17 +63,6 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
     }
 
     /**
-     * Create an instance for one time use.
-     */
-    public GemsGuideStarWorker(scala.concurrent.ExecutionContext ec) {
-        ProgressPanel progressPanel = ProgressPanel.makeProgressPanel("GeMS Strehl Calculations",
-                TpeManager.create().getImageWidget());
-        progressPanel.addActionListener(e -> interrupted = true);
-        init(progressPanel);
-        this.ec = ec;
-    }
-
-    /**
      * Called by constructors
      */
     public void init(StatusLogger statusLogger) {
@@ -222,7 +211,7 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
      * @param obsContext used to getthe current pos angle
      */
     private static Set<edu.gemini.spModel.core.Angle> getPosAngles(ObsContext obsContext) {
-        final Set<edu.gemini.spModel.core.Angle> posAngles = new TreeSet<>((a1, a2) -> Double.compare(a1.toDegrees(), a2.toDegrees()));
+        final Set<edu.gemini.spModel.core.Angle> posAngles = new TreeSet<>(Comparator.comparingDouble(edu.gemini.spModel.core.Angle::toDegrees));
 
         posAngles.add(ModelConverters.toNewAngle(obsContext.getPositionAngle()));
         posAngles.add(ModelConverters.toNewAngle(new Angle(0., Angle.Unit.DEGREES)));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMouseEvent.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeMouseEvent.java
@@ -1,12 +1,9 @@
 package jsky.app.ot.tpe;
 
-import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.core.Coordinates;
 import edu.gemini.spModel.core.SiderealTarget;
-import jsky.coords.WorldCoords;
 
 import java.awt.event.MouseEvent;
 
@@ -42,7 +39,7 @@ public class TpeMouseEvent {
     public final Option<String> name;
 
     // Optional details of the object.
-    public final Option<SiderealTarget> skyObject;
+    public final Option<SiderealTarget> target;
 
     /** The X offset of the event from the base position in arcsec. */
     public final double xOffset;
@@ -57,7 +54,7 @@ public class TpeMouseEvent {
         this.source = None.instance();
         this.pos = Coordinates.zero();
         this.name = None.instance();
-        this.skyObject = None.instance();
+        this.target = None.instance();
         this.xWidget = 0;
         this.yWidget = 0;
         this.xOffset = 0;
@@ -65,7 +62,7 @@ public class TpeMouseEvent {
     }
 
     /** Default Constructor: initialize all fields to null. */
-    public TpeMouseEvent(MouseEvent e, int id, Option<TpeImageWidget> source, Coordinates pos, Option<String> name, int xWidget, int yWidget, Option<SiderealTarget> skyObject, double xOffset, double yOffset) {
+    public TpeMouseEvent(MouseEvent e, int id, Option<TpeImageWidget> source, Coordinates pos, Option<String> name, int xWidget, int yWidget, Option<SiderealTarget> target, double xOffset, double yOffset) {
         mouseEvent = e;
         this.id = id;
         this.source = source;
@@ -73,7 +70,7 @@ public class TpeMouseEvent {
         this.name = name;
         this.xWidget = xWidget;
         this.yWidget = yWidget;
-        this.skyObject = skyObject;
+        this.target = target;
         this.xOffset = xOffset;
         this.yOffset = yOffset;
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -114,8 +114,8 @@ public class TpeGuidePosFeature extends TpePositionFeature
     }
 
     private SPTarget createNewTarget(final TpeMouseEvent tme) {
-        final Option<SiderealTarget> skyObjectOpt = tme.skyObject;
-        return skyObjectOpt.map(SPTarget::new).getOrElse(() -> {
+        final Option<SiderealTarget> targetOpt = tme.target;
+        return targetOpt.map(SPTarget::new).getOrElse(() -> {
             final double ra  = tme.pos.ra().toDegrees();
             final double dec = tme.pos.dec().toDegrees();
             // No SkyObject info is present so we use the old way of creating

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -270,7 +270,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
         groups.forEach(group -> res.add(new GuiderGroupCreatableItem(group)));
 
         // Sort the list by label.
-        Collections.sort(res, (item1, item2) -> item1.getLabel().compareTo(item2.getLabel()));
+        res.sort(Comparator.comparing(TpeCreatableItem::getLabel));
 
         return res;
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -114,25 +114,16 @@ public class TpeGuidePosFeature extends TpePositionFeature
     }
 
     private SPTarget createNewTarget(final TpeMouseEvent tme) {
-        final SPTarget pos;
-
         final Option<SiderealTarget> skyObjectOpt = tme.skyObject;
-        if (!skyObjectOpt.isEmpty()) {
-
-            final SiderealTarget st = skyObjectOpt.getValue();
-
-            pos = new SPTarget(st);
-        } else {
-            // No SkyObject info is present so we use the old way of creating
-            // a target from a mouse event.
+        return skyObjectOpt.map(SPTarget::new).getOrElse(() -> {
             final double ra  = tme.pos.ra().toDegrees();
             final double dec = tme.pos.dec().toDegrees();
-
-            pos = new SPTarget(ra, dec);
-            pos.setName(tme.name.getOrElse(""));
-        }
-
-        return pos;
+            // No SkyObject info is present so we use the old way of creating
+            // a target from a mouse event using only the coordinates.
+            SPTarget target = new SPTarget(ra, dec);
+            target.setName(tme.name.getOrElse(""));
+            return target;
+        });
     }
 
     // Creatable item for a particular guider.  There will be one for each

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeTargetPosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeTargetPosFeature.java
@@ -103,8 +103,8 @@ public class TpeTargetPosFeature extends TpePositionFeature
                 final TargetObsComp obsComp = getTargetObsComp();
                 if (obsComp == null) return;
 
-                final Option<SiderealTarget> skyObjectOpt = tme.skyObject;
-                SPTarget userPos = skyObjectOpt.map(SPTarget::new).getOrElse(() -> {
+                final Option<SiderealTarget> targetOpt = tme.target;
+                SPTarget userPos = targetOpt.map(SPTarget::new).getOrElse(() -> {
                     final double ra  = tme.pos.ra().toDegrees();
                     final double dec = tme.pos.dec().toDegrees();
                     // No SkyObject info is present so we use the old way of creating

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateAsterismsTreeTableModel.java
@@ -66,7 +66,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         ;
 
         private final String displayName;
-        Col(String displayName) { this.displayName = displayName; }
+        Col(final String displayName) { this.displayName = displayName; }
         public String displayName() { return displayName; }
         public abstract Object getValue(Row row);
     }
@@ -100,7 +100,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         // A row corresponding to a GemsGuideStars object
         // (top level node, displays the Strehl info and checkbox)
-        Row(GemsGuideStars gemsGuideStars, List<Row> children, Option<Long> when) {
+        Row(final GemsGuideStars gemsGuideStars, final List<Row> children, final Option<Long> when) {
             _gemsGuideStars = gemsGuideStars;
             _guideProbeTargets = null;
             _band = null;
@@ -115,7 +115,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         }
 
         // A row corresponding to a GuideProbeTargets object (child node)
-        Row(GemsGuideStars gemsGuideStars, GuideProbeTargets guideProbeTargets, MagnitudeBand band, Option<Long> when) {
+        Row(final GemsGuideStars gemsGuideStars, final GuideProbeTargets guideProbeTargets, final MagnitudeBand band, final Option<Long> when) {
             _gemsGuideStars = gemsGuideStars;
             _guideProbeTargets = guideProbeTargets;
             _band = band;
@@ -138,7 +138,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
         Boolean getCheck() {
             if (_gemsGuideStars != null) {
-                GemsStrehl strehl = _gemsGuideStars.strehl();
+                final GemsStrehl strehl = _gemsGuideStars.strehl();
                 if (strehl != null) {
                     return _checkBoxSelected;
                 }
@@ -154,7 +154,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
             return null;
         }
 
-        void setPrimary(Boolean b) {
+        void setPrimary(final Boolean b) {
             _primary = b;
         }
 
@@ -168,7 +168,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
                     return _guideProbeTargets.getPrimary().getValue().getName();
                 }
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
-                GemsStrehl strehl = _gemsGuideStars.strehl();
+                final GemsStrehl strehl = _gemsGuideStars.strehl();
                 if (strehl != null) {
                     return String.format("%.1f rms", _gemsGuideStars.strehl().rms() * 100);
                 }
@@ -179,11 +179,11 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         String getMag() {
             if (_guideProbeTargets != null) {
                 if (!_guideProbeTargets.getPrimary().isEmpty()) {
-                    GuideProbe guideProbe = _guideProbeTargets.getGuider();
+                    final GuideProbe guideProbe = _guideProbeTargets.getGuider();
                     return GemsUtils4Java.probeMagnitudeInUse(guideProbe, _band, _guideProbeTargets.getPrimary().getValue().getMagnitudesJava());
                 }
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
-                GemsStrehl strehl = _gemsGuideStars.strehl();
+                final GemsStrehl strehl = _gemsGuideStars.strehl();
                 if (strehl != null) {
                     return String.format("%.1f min", _gemsGuideStars.strehl().min() * 100);
                 }
@@ -202,7 +202,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
             if (_guideProbeTargets != null) {
                 return getTarget().getRaString(_when).getOrNull();
             } else if (_gemsGuideStars != null) { // top level displays Strehl values
-                GemsStrehl strehl = _gemsGuideStars.strehl();
+                final GemsStrehl strehl = _gemsGuideStars.strehl();
                 if (strehl != null) {
                     return String.format("%.1f max", _gemsGuideStars.strehl().max() * 100);
                 }
@@ -221,11 +221,11 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
             return _band;
         }
 
-        public boolean isCheckBoxSelected() {
+        boolean isCheckBoxSelected() {
             return _checkBoxSelected != null && _checkBoxSelected;
         }
 
-        public boolean isTopLevel() {
+        boolean isTopLevel() {
             return _isTopLevel;
         }
 
@@ -236,7 +236,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
     private final ImList<String> _columnHeaders;
 
-    CandidateAsterismsTreeTableModel(List<GemsGuideStars> gemsGuideStarsList, MagnitudeBand band, Option<Long> when) {
+    CandidateAsterismsTreeTableModel(final List<GemsGuideStars> gemsGuideStarsList, final MagnitudeBand band, final Option<Long> when) {
         super(new ArrayList<Row>());
         _columnHeaders = computeColumnHeaders();
 
@@ -251,14 +251,14 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         }
 
         if (tmp.size() > 0) {
-            Row row = tmp.get(0);
+            final Row row = tmp.get(0);
             row._checkBoxSelected = true; // select first item by default
             row._primary = true;          // and make it for the primary group
         }
     }
 
     private static ImList<String> computeColumnHeaders() {
-        List<String> hdr = new ArrayList<>();
+        final List<String> hdr = new ArrayList<>();
         for (Col c : Col.values()) hdr.add(c.displayName());
         return DefaultImList.create(hdr);
     }
@@ -269,22 +269,22 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     }
 
     @Override
-    public String getColumnName(int index) {
+    public String getColumnName(final int index) {
         return _columnHeaders.get(index);
     }
 
     @Override
-    public Object getValueAt(Object node, int columnIndex) {
+    public Object getValueAt(final Object node, final int columnIndex) {
         if (node instanceof Row) {
-            Row row = (Row) node;
-            Col[] cols = Col.values();
+            final Row row = (Row) node;
+            final Col[] cols = Col.values();
             return cols[columnIndex].getValue(row);
         }
         return null;
     }
 
     @Override
-    public void setValueAt(Object value, Object node, int column) {
+    public void setValueAt(final Object value, final Object node, final int column) {
         if (column == Col.CHECK.ordinal() && node instanceof Row && value instanceof Boolean) {
             ((Row)node)._checkBoxSelected = (Boolean)value;
             // If a checkbox is selected, set primary to false, otherwise null, in which case a new
@@ -293,7 +293,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
                 ((Row)node)._primary = (getPrimaryIndex(-1) == -1); // true if no others are marked primary
             } else {
                 ((Row)node)._primary = null;
-                List<Row> rowList = getRows();
+                final List<Row> rowList = getRows();
                 for (Row row : rowList) {
                     if (row.isCheckBoxSelected()) {
                         row.setPrimary(true);
@@ -308,14 +308,14 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Object getChild(Object parent, int index) {
+    public Object getChild(final Object parent, final int index) {
         if (parent instanceof List) {
-            List<Row> rowList = (List<Row>)parent;
-            if(rowList.size() > index) {
+            final List<Row> rowList = (List<Row>)parent;
+            if (rowList.size() > index) {
                 return rowList.get(index);
             }
         } else if (parent instanceof Row) {
-            Row row = (Row)parent;
+            final Row row = (Row)parent;
             List<Row> rowList = row.getChildren();
             if (rowList != null && rowList.size() > index) {
                 return rowList.get(index);
@@ -326,12 +326,12 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
     @Override
     @SuppressWarnings("unchecked")
-    public int getChildCount(Object parent) {
+    public int getChildCount(final Object parent) {
         if (parent instanceof List) {
-            List<Row> rowList = (List<Row>)parent;
+            final List<Row> rowList = (List<Row>)parent;
             return rowList.size();
         } else if (parent instanceof Row) {
-            Row row = (Row)parent;
+            final Row row = (Row)parent;
             List<Row> rowList = row.getChildren();
             if (rowList != null) {
                 return rowList.size();
@@ -342,7 +342,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
 
     @Override
     @SuppressWarnings("unchecked")
-    public int getIndexOfChild(Object parent, Object child) {
+    public int getIndexOfChild(final Object parent, final Object child) {
         List<Row> rowList = null;
         if (parent instanceof List) {
             rowList = (List<Row>)parent;
@@ -361,12 +361,12 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     }
 
     @Override
-    public boolean isCellEditable(Object node, int column) {
+    public boolean isCellEditable(final Object node, final int column) {
         return column == Col.CHECK.ordinal();
     }
 
     @Override
-    public boolean isLeaf(Object node) {
+    public boolean isLeaf(final Object node) {
         return node instanceof Row && !((Row)node).isTopLevel();
     }
 
@@ -378,10 +378,10 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     /**
      * Returns a list of GemsGuideStars for the checked asterisms
      */
-    public List<GemsGuideStars> getCheckedAsterisms() {
-        List<GemsGuideStars> result = new ArrayList<>();
+    List<GemsGuideStars> getCheckedAsterisms() {
+        final List<GemsGuideStars> result = new ArrayList<>();
         if (getRoot() != null) {
-            List<Row> rowList = getRows();
+            final List<Row> rowList = getRows();
             for (Row row : rowList) {
                 if (row.isCheckBoxSelected()) {
                     result.add(row.getGemsGuideStars());
@@ -394,15 +394,14 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
     /**
      * Returns the index of the row marked to be the primary guide group, or defaultIndex if none are marked
      */
-    public int getPrimaryIndex(int defaultIndex) {
+    int getPrimaryIndex(final int defaultIndex) {
         if (getRoot() != null) {
             int i = 0;
-            List<Row> rowList = getRows();
+            final List<Row> rowList = getRows();
             for (Row row : rowList) {
                 if (row.isCheckBoxSelected()) {
                     if (row.getPrimary() != null && row.getPrimary()) {
                         return i;
-
                     }
                     i++;
                 }
@@ -411,9 +410,9 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         return defaultIndex;
     }
 
-    void clearPrimary() {
+    private void clearPrimary() {
         if (getRoot() != null) {
-            List<Row> rowList = getRows();
+            final List<Row> rowList = getRows();
             for (Row row : rowList) {
                 if (row.getPrimary() != null && row.getPrimary()) {
                     row.setPrimary(false);
@@ -427,7 +426,7 @@ class CandidateAsterismsTreeTableModel extends AbstractTreeTableModel {
         return (List<Row>) getRoot();
     }
 
-    void setPrimary(Row row) {
+    void setPrimary(final Row row) {
         clearPrimary();
         row.setPrimary(true);
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTable.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTable.java
@@ -23,7 +23,7 @@ class CandidateGuideStarsTable extends TableDisplay {
     // Used to select a table row when the symbol is selected
     private SymbolSelectionListener symbolListener = new SymbolSelectionListener() {
 
-        public void symbolSelected(SymbolSelectionEvent e) {
+        public void symbolSelected(final SymbolSelectionEvent e) {
             if (!_ignoreSelection && e.getTable() == getTableQueryResult()) {
                 _ignoreSelection = true;
                 try {
@@ -35,7 +35,7 @@ class CandidateGuideStarsTable extends TableDisplay {
             }
         }
 
-        public void symbolDeselected(SymbolSelectionEvent e) {
+        public void symbolDeselected(final SymbolSelectionEvent e) {
             if (!_ignoreSelection && e.getTable() == getTableQueryResult()) {
                 _ignoreSelection = true;
                 try {
@@ -54,12 +54,12 @@ class CandidateGuideStarsTable extends TableDisplay {
         public void valueChanged(ListSelectionEvent e) {
             if (e.getValueIsAdjusting() || _ignoreSelection)
                 return;
-            ListSelectionModel model = getTable().getSelectionModel();
-            int first = e.getFirstIndex();
-            int last = e.getLastIndex();
+            final ListSelectionModel model = getTable().getSelectionModel();
+            final int first = e.getFirstIndex();
+            final int last = e.getLastIndex();
             if (first != -1 && last != -1) {
                 for (int i = first; i <= last; i++) {
-                    int index = getTable().getSortedRowIndex(i);
+                    final int index = getTable().getSortedRowIndex(i);
                     if (model.isSelectedIndex(i)) {
                         _plotter.selectSymbol(getTableQueryResult(), index);
                     } else {
@@ -71,13 +71,13 @@ class CandidateGuideStarsTable extends TableDisplay {
     };
 
 
-    public CandidateGuideStarsTable(TablePlotter plotter) {
+    CandidateGuideStarsTable(final TablePlotter plotter) {
         super();
         _plotter = plotter;
         getTable().setSortingAllowed(false); // REL-560: Sorting code doesn't seem to handle editable columns correctly
     }
 
-    public void setTableModel(CandidateGuideStarsTableModel tableModel) {
+    public void setTableModel(final CandidateGuideStarsTableModel tableModel) {
         unplot();
         _tableModel = tableModel;
         setModel(_tableModel.getTableQueryResult());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTable.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTable.java
@@ -72,6 +72,7 @@ class CandidateGuideStarsTable extends TableDisplay {
 
 
     public CandidateGuideStarsTable(TablePlotter plotter) {
+        super();
         _plotter = plotter;
         getTable().setSortingAllowed(false); // REL-560: Sorting code doesn't seem to handle editable columns correctly
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -1,6 +1,7 @@
 package jsky.app.ot.tpe.gems;
 
 import edu.gemini.ags.gems.GemsUtils4Java;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.catalog.api.UCAC4$;
 import jsky.catalog.FieldDesc;
@@ -44,7 +45,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     // SkyObjects corresponding to the table rows
     private List<SiderealTarget> _siderealTargets;
 
-    public CandidateGuideStarsTableModel(GemsGuideStarSearchModel model) {
+    CandidateGuideStarsTableModel(GemsGuideStarSearchModel model) {
         _model = model;
         _nirBand = _model.getBand().name();
         _unusedBands = getOtherNirBands(_nirBand);
@@ -99,7 +100,6 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
         return rows;
     }
 
-
     @Override
     public boolean isCellEditable(int row, int column) {
         return column == 0;
@@ -137,7 +137,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     }
 
     @SuppressWarnings("unchecked")
-    public TableQueryResult getTableQueryResult() {
+    TableQueryResult getTableQueryResult() {
         String raPosition = String.valueOf(_columnNames.indexOf(RA_TITLE));
         String decPosition = String.valueOf(_columnNames.indexOf(DEC_TITLE));
         Properties props = new Properties();
@@ -147,6 +147,11 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
         props.setProperty(SkycatConfigFile.LONG_NAME, "ucac4");
         SkycatConfigEntry entry = new SkycatConfigEntry(props);
         SkycatTable skycatTable = new SkycatTable(entry, getDataVector(), getFields()) {
+            @Override
+            public Option<SiderealTarget> getSiderealTarget(int i) {
+                return _model.targetAt(i);
+            }
+
             @Override
             public boolean isCellEditable(int rowIndex, int columnIndex) {
                 return columnIndex == Cols.CHECK.ordinal();
@@ -165,12 +170,12 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
      * Returns a list of SkyObjects corresponding to the checked (or unchecked) rows in the table
      * @param checked if true, return the checked rows (candidates), otherwise the unchecked (non-candidates)
      */
-    public List<SiderealTarget> getCandidates(boolean checked) {
+    List<SiderealTarget> getCandidates() {
         List<SiderealTarget> result = new ArrayList<>();
         int numRows = getRowCount();
         int col = Cols.CHECK.ordinal();
         for(int row = 0; row < numRows; row++) {
-            if ((Boolean)getValueAt(row, col) == checked) {
+            if (!((Boolean) getValueAt(row, col))) {
                 result.add(_siderealTargets.get(row));
             }
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -7,7 +7,6 @@ import edu.gemini.catalog.api.UCAC4$;
 import jsky.catalog.FieldDesc;
 import jsky.catalog.FieldDescAdapter;
 import jsky.catalog.TableQueryResult;
-import jsky.catalog.skycat.SkycatCatalog;
 import jsky.catalog.skycat.SkycatConfigEntry;
 import jsky.catalog.skycat.SkycatConfigFile;
 import jsky.catalog.skycat.SkycatTable;
@@ -25,6 +24,11 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     private enum Cols {
         CHECK, ID, _r, R, UC, NIR_BAND, RA, DEC, UNUSED_BAND1, UNUSED_BAND2
     }
+
+    private static final String RA_COL = "ra_col";
+    private static final String DEC_COL = "dec_col";
+    private static final String SERV_TYPE = "serv_type";
+    private static final String LONG_NAME = "long_name";
 
     private final String RA_TITLE = "RA";
     private final String DEC_TITLE = "Dec";
@@ -141,12 +145,12 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
         String raPosition = String.valueOf(_columnNames.indexOf(RA_TITLE));
         String decPosition = String.valueOf(_columnNames.indexOf(DEC_TITLE));
         Properties props = new Properties();
-        props.setProperty(SkycatConfigFile.RA_COL, raPosition);
-        props.setProperty(SkycatConfigFile.DEC_COL, decPosition);
-        props.setProperty(SkycatConfigFile.SERV_TYPE, "catalog");
-        props.setProperty(SkycatConfigFile.LONG_NAME, "ucac4");
+        props.setProperty(RA_COL, raPosition);
+        props.setProperty(DEC_COL, decPosition);
+        props.setProperty(SERV_TYPE, "catalog");
+        props.setProperty(LONG_NAME, "ucac4");
         SkycatConfigEntry entry = new SkycatConfigEntry(props);
-        SkycatTable skycatTable = new SkycatTable(entry, getDataVector(), getFields()) {
+        return new SkycatTable(entry, CandidateGuideStarsTableModel.this.getDataVector(), getFields()) {
             @Override
             public Option<SiderealTarget> getSiderealTarget(int i) {
                 return _model.targetAt(i);
@@ -162,13 +166,10 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
                 return "GEMS"; // see entry in ot.skycat.cfg - needed for GemsSkyObjectFactory
             }
         };
-        skycatTable.setCatalog(new SkycatCatalog(entry));
-        return skycatTable;
     }
 
     /**
-     * Returns a list of SkyObjects corresponding to the checked (or unchecked) rows in the table
-     * @param checked if true, return the checked rows (candidates), otherwise the unchecked (non-candidates)
+     * Returns a list of SideralTargets corresponding to the checked (or unchecked) rows in the table
      */
     List<SiderealTarget> getCandidates() {
         List<SiderealTarget> result = new ArrayList<>();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -168,7 +168,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     }
 
     /**
-     * Returns a list of SideralTargets corresponding to the checked (or unchecked) rows in the table
+     * Returns a list of SiderealTargets corresponding to the checked rows in the table
      */
     List<SiderealTarget> getCandidates() {
         final List<SiderealTarget> result = new ArrayList<>();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -8,7 +8,6 @@ import jsky.catalog.FieldDesc;
 import jsky.catalog.FieldDescAdapter;
 import jsky.catalog.TableQueryResult;
 import jsky.catalog.skycat.SkycatConfigEntry;
-import jsky.catalog.skycat.SkycatConfigFile;
 import jsky.catalog.skycat.SkycatTable;
 
 import javax.swing.table.DefaultTableModel;
@@ -34,22 +33,22 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     private final String DEC_TITLE = "Dec";
 
     // User interface model
-    private GemsGuideStarSearchModel _model;
+    private final GemsGuideStarSearchModel _model;
     private final boolean _isUCAC4;
 
     // The selected NIR band
-    private String _nirBand;
+    private final String _nirBand;
 
     // The unselected bands (displayed at end)
-    private String[] _unusedBands;
+    private final String[] _unusedBands;
 
     // Table column names
-    private Vector<String> _columnNames;
+    private final Vector<String> _columnNames;
 
-    // SkyObjects corresponding to the table rows
+    // SideralTargets corresponding to the table rows
     private List<SiderealTarget> _siderealTargets;
 
-    CandidateGuideStarsTableModel(GemsGuideStarSearchModel model) {
+    CandidateGuideStarsTableModel(final GemsGuideStarSearchModel model) {
         _model = model;
         _nirBand = _model.getBand().name();
         _unusedBands = getOtherNirBands(_nirBand);
@@ -59,7 +58,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     }
 
     private Vector<String> makeColumnNames() {
-        Vector<String> columnNames = new Vector<>();
+        final Vector<String> columnNames = new Vector<>();
         columnNames.add(""); // checkbox column
         columnNames.add("Id");
         if (_isUCAC4) {
@@ -77,7 +76,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     }
 
     private String[] getOtherNirBands(String band) {
-        String[] bands = new String[2];
+        final String[] bands = new String[2];
         if ("J".equals(band)) {
             bands[0] = "H";
             bands[1] = "K";
@@ -93,7 +92,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
 
     private Vector<Vector<Object>> makeDataVector() {
         _siderealTargets = GemsUtils4Java.uniqueTargets(_model.getGemsCatalogSearchResults());
-        Vector<Vector<Object>> rows = new Vector<>();
+        final Vector<Vector<Object>> rows = new Vector<>();
         for (SiderealTarget siderealTarget : _siderealTargets) {
             if (_isUCAC4) {
                 rows.add(CatalogUtils4Java.makeUCAC4Row(siderealTarget, _nirBand, _unusedBands));
@@ -105,12 +104,12 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     }
 
     @Override
-    public boolean isCellEditable(int row, int column) {
-        return column == 0;
+    public boolean isCellEditable(final int row, final int column) {
+        return column == Cols.CHECK.ordinal();
     }
 
     @Override
-    public Class<?> getColumnClass(int columnIndex) {
+    public Class<?> getColumnClass(final int columnIndex) {
         if (columnIndex == Cols.CHECK.ordinal())
             return Boolean.class;
         if (columnIndex == Cols.ID.ordinal())
@@ -122,7 +121,7 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
     }
 
     public FieldDesc[] getFields() {
-        List<FieldDescAdapter> fields = new ArrayList<>();
+        final List<FieldDescAdapter> fields = new ArrayList<>();
         for(String columnName: _columnNames) {
             FieldDescAdapter desc = new FieldDescAdapter(columnName);
             if (columnName.equals(RA_TITLE)) {
@@ -142,14 +141,14 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
 
     @SuppressWarnings("unchecked")
     TableQueryResult getTableQueryResult() {
-        String raPosition = String.valueOf(_columnNames.indexOf(RA_TITLE));
-        String decPosition = String.valueOf(_columnNames.indexOf(DEC_TITLE));
-        Properties props = new Properties();
+        final String raPosition = String.valueOf(_columnNames.indexOf(RA_TITLE));
+        final String decPosition = String.valueOf(_columnNames.indexOf(DEC_TITLE));
+        final Properties props = new Properties();
         props.setProperty(RA_COL, raPosition);
         props.setProperty(DEC_COL, decPosition);
         props.setProperty(SERV_TYPE, "catalog");
         props.setProperty(LONG_NAME, "ucac4");
-        SkycatConfigEntry entry = new SkycatConfigEntry(props);
+        final SkycatConfigEntry entry = new SkycatConfigEntry(props);
         return new SkycatTable(entry, CandidateGuideStarsTableModel.this.getDataVector(), getFields()) {
             @Override
             public Option<SiderealTarget> getSiderealTarget(int i) {
@@ -172,9 +171,9 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
      * Returns a list of SideralTargets corresponding to the checked (or unchecked) rows in the table
      */
     List<SiderealTarget> getCandidates() {
-        List<SiderealTarget> result = new ArrayList<>();
-        int numRows = getRowCount();
-        int col = Cols.CHECK.ordinal();
+        final List<SiderealTarget> result = new ArrayList<>();
+        final int numRows = getRowCount();
+        final int col = Cols.CHECK.ordinal();
         for(int row = 0; row < numRows; row++) {
             if (!((Boolean) getValueAt(row, col))) {
                 result.add(_siderealTargets.get(row));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
@@ -37,8 +37,8 @@ class GemsGuideStarSearchController {
      * @param dialog the main dialog
      * @param imageDisplay the Tpe reference
      */
-    public GemsGuideStarSearchController(GemsGuideStarSearchModel model, GemsGuideStarWorker worker,
-                                         GemsGuideStarSearchDialog dialog, CatalogImageDisplay imageDisplay) {
+    GemsGuideStarSearchController(GemsGuideStarSearchModel model, GemsGuideStarWorker worker,
+                                  GemsGuideStarSearchDialog dialog, CatalogImageDisplay imageDisplay) {
         _model = model;
         _worker = worker;
         _dialog = dialog;
@@ -91,7 +91,7 @@ class GemsGuideStarSearchController {
      * @param excludeCandidates list of SkyObjects to exclude
      */
     // Called from the TPE
-    public void analyze(List<SiderealTarget> excludeCandidates) throws Exception {
+    void analyze(List<SiderealTarget> excludeCandidates) throws Exception {
         TpeImageWidget tpe = TpeManager.create().getImageWidget();
         WorldCoords basePos = tpe.getBasePos();
         ObsContext obsContext = _worker.getObsContext(basePos.getRaDeg(), basePos.getDecDeg());
@@ -100,7 +100,7 @@ class GemsGuideStarSearchController {
                 filter(excludeCandidates, _model.getGemsCatalogSearchResults())));
     }
 
-    // Returns a list of the given gemsCatalogSearchResults, with any SkyObjects removed that are not
+    // Returns a list of the given gemsCatalogSearchResults, with any SiderealTargets removed that are not
     // in the candidates list.
     private List<GemsCatalogSearchResults> filter(List<SiderealTarget> excludeCandidates,
                                                   List<GemsCatalogSearchResults> gemsCatalogSearchResults) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
@@ -37,8 +37,8 @@ class GemsGuideStarSearchController {
      * @param dialog the main dialog
      * @param imageDisplay the Tpe reference
      */
-    GemsGuideStarSearchController(GemsGuideStarSearchModel model, GemsGuideStarWorker worker,
-                                  GemsGuideStarSearchDialog dialog, CatalogImageDisplay imageDisplay) {
+    GemsGuideStarSearchController(final GemsGuideStarSearchModel model, final GemsGuideStarWorker worker,
+                                  final GemsGuideStarSearchDialog dialog, final CatalogImageDisplay imageDisplay) {
         _model = model;
         _worker = worker;
         _dialog = dialog;
@@ -48,14 +48,14 @@ class GemsGuideStarSearchController {
     /**
      * Searches for guide star candidates and saves the results in the model
      */
-    public void query(scala.concurrent.ExecutionContext ec) throws Exception {
-        WorldCoords basePos = _tpe.getBasePos();
-        ObsContext obsContext = _worker.getObsContext(basePos.getRaDeg(), basePos.getDecDeg());
-        Set<edu.gemini.spModel.core.Angle> posAngles = getPosAngles(obsContext);
+    public void query(final scala.concurrent.ExecutionContext ec) throws Exception {
+        final WorldCoords basePos = _tpe.getBasePos();
+        final ObsContext obsContext = _worker.getObsContext(basePos.getRaDeg(), basePos.getDecDeg());
+        final Set<edu.gemini.spModel.core.Angle> posAngles = getPosAngles(obsContext);
 
-        MagnitudeBand nirBand = _model.getBand().getBand();
+        final MagnitudeBand nirBand = _model.getBand().getBand();
 
-        GemsTipTiltMode tipTiltMode = _model.getAnalyseChoice().getGemsTipTiltMode();
+        final GemsTipTiltMode tipTiltMode = _model.getAnalyseChoice().getGemsTipTiltMode();
         List<GemsCatalogSearchResults> results;
         try {
             results = _worker.search(_model.getCatalog(), tipTiltMode, obsContext, posAngles,
@@ -74,8 +74,8 @@ class GemsGuideStarSearchController {
         }
     }
 
-    private Set<edu.gemini.spModel.core.Angle> getPosAngles(ObsContext obsContext) {
-        Set<edu.gemini.spModel.core.Angle> posAngles = new HashSet<>();
+    private Set<edu.gemini.spModel.core.Angle> getPosAngles(final ObsContext obsContext) {
+        final Set<edu.gemini.spModel.core.Angle> posAngles = new HashSet<>();
         posAngles.add(ModelConverters.toNewAngle(obsContext.getPositionAngle()));
         if (_model.isAllowPosAngleAdjustments()) {
             posAngles.add(ModelConverters.toNewAngle(new Angle(0., Angle.Unit.DEGREES)));
@@ -91,26 +91,26 @@ class GemsGuideStarSearchController {
      * @param excludeCandidates list of SkyObjects to exclude
      */
     // Called from the TPE
-    void analyze(List<SiderealTarget> excludeCandidates) throws Exception {
-        TpeImageWidget tpe = TpeManager.create().getImageWidget();
-        WorldCoords basePos = tpe.getBasePos();
-        ObsContext obsContext = _worker.getObsContext(basePos.getRaDeg(), basePos.getDecDeg());
-        Set<edu.gemini.spModel.core.Angle> posAngles = getPosAngles(obsContext);
+    void analyze(final List<SiderealTarget> excludeCandidates) throws Exception {
+        final TpeImageWidget tpe = TpeManager.create().getImageWidget();
+        final WorldCoords basePos = tpe.getBasePos();
+        final ObsContext obsContext = _worker.getObsContext(basePos.getRaDeg(), basePos.getDecDeg());
+        final Set<edu.gemini.spModel.core.Angle> posAngles = getPosAngles(obsContext);
         _model.setGemsGuideStars(_worker.findAllGuideStars(obsContext, posAngles,
                 filter(excludeCandidates, _model.getGemsCatalogSearchResults())));
     }
 
     // Returns a list of the given gemsCatalogSearchResults, with any SiderealTargets removed that are not
     // in the candidates list.
-    private List<GemsCatalogSearchResults> filter(List<SiderealTarget> excludeCandidates,
-                                                  List<GemsCatalogSearchResults> gemsCatalogSearchResults) {
-        List<GemsCatalogSearchResults> results = new ArrayList<>();
+    private List<GemsCatalogSearchResults> filter(final List<SiderealTarget> excludeCandidates,
+                                                  final List<GemsCatalogSearchResults> gemsCatalogSearchResults) {
+        final List<GemsCatalogSearchResults> results = new ArrayList<>();
         for (GemsCatalogSearchResults in : gemsCatalogSearchResults) {
-            List<SiderealTarget> siderealTargets = new ArrayList<>(in.results().size());
+            List<SiderealTarget> siderealTargets =new ArrayList<>(in.results().size());
             siderealTargets.addAll(in.resultsAsJava());
             siderealTargets = removeAll(siderealTargets, excludeCandidates);
             if (!siderealTargets.isEmpty()) {
-                GemsCatalogSearchResults out = new GemsCatalogSearchResults(siderealTargets, in.criterion());
+                final GemsCatalogSearchResults out = new GemsCatalogSearchResults(siderealTargets, in.criterion());
                 results.add(out);
             }
         }
@@ -118,13 +118,13 @@ class GemsGuideStarSearchController {
     }
 
     // Removes all the objects in the targets list that are also in the excludeCandidates list by comparing names
-    private List<SiderealTarget> removeAll(List<SiderealTarget> targets, List<SiderealTarget> excludeCandidates) {
+    private List<SiderealTarget> removeAll(final List<SiderealTarget> targets, final List<SiderealTarget> excludeCandidates) {
         return targets.stream().filter(siderealTarget -> !contains(excludeCandidates, siderealTarget)).collect(Collectors.toList());
     }
 
     // Returns true if a SkyObject with the same name is in the list
-    private boolean contains(List<SiderealTarget> targets, SiderealTarget target) {
-        String name = target.name();
+    private boolean contains(final List<SiderealTarget> targets, final SiderealTarget target) {
+        final String name = target.name();
         if (name != null) {
             for (SiderealTarget s : targets) {
                 if (name.equals(s.name())) return true;
@@ -138,7 +138,7 @@ class GemsGuideStarSearchController {
      * @param selectedAsterisms information used to create the guide groups
      * @param primaryIndex if more than one item in list, the index of the primary guide group
      */
-    public void add(List<GemsGuideStars> selectedAsterisms, int primaryIndex) {
+    public void add(final List<GemsGuideStars> selectedAsterisms, final int primaryIndex) {
         _worker.applyResults(selectedAsterisms, primaryIndex);
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -525,8 +525,8 @@ public class GemsGuideStarSearchDialog extends JFrame {
         _model.setAnalyseChoice((AnalyseChoice) _analyseComboBox.getSelectedItem());
         _model.setReviewCandidatesBeforeSearch(_reviewCandidatesCheckBox.isSelected());
         _model.setAllowPosAngleAdjustments(_allowPosAngleChangesCheckBox.isSelected());
-        _model.setGemsCatalogSearchResults(null);
-        _model.setGemsGuideStars(null);
+        _model.setGemsCatalogSearchResults(new ArrayList<>());
+        _model.setGemsGuideStars(new ArrayList<>());
 
         new SwingWorker() {
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -21,21 +21,8 @@ import jsky.util.gui.SwingWorker;
 import jsky.util.gui.DialogUtil;
 import jsky.util.gui.StatusPanel;
 
-import javax.swing.AbstractAction;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTabbedPane;
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.NumberFormat;
@@ -145,6 +132,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
 
     // Context dependent message (title)
     private final JLabel _actionLabel = new JLabel();
+    private final JLabel _manualSelectionLabel = new JLabel("<html><body><p style='font-style:italic'>To manually add a target to a manual guide group, select one of the +CWFS1/2/3 options in the Position Editor and then click on a guide star.</p></body></html>");
 
     private final JComboBox<CatalogChoice> _catalogComboBox = new JComboBox<>(CatalogChoice.values());
     private final JComboBox<NirBandChoice> _nirBandComboBox = new JComboBox<>(NirBandChoice.values());
@@ -235,9 +223,18 @@ public class GemsGuideStarSearchDialog extends JFrame {
             insets = labelInsets;
         }});
 
-        panel.add(new JLabel("Catalog"), new GridBagConstraints() {{
+        panel.add(_manualSelectionLabel, new GridBagConstraints() {{
             gridx = 0;
             gridy = 1;
+            gridwidth = 4;
+            anchor = WEST;
+            fill = HORIZONTAL;
+            insets = labelInsets;
+        }});
+
+        panel.add(new JLabel("Catalog"), new GridBagConstraints() {{
+            gridx = 0;
+            gridy = 2;
             insets = labelInsets;
             anchor = EAST;
         }});
@@ -246,28 +243,28 @@ public class GemsGuideStarSearchDialog extends JFrame {
         catalogPanel.add(_catalogComboBox);
         panel.add(catalogPanel, new GridBagConstraints() {{
             gridx = 1;
-            gridy = 1;
+            gridy = 2;
             insets = valueInsets;
             anchor = WEST;
         }});
 
         panel.add(new JLabel("NIR"), new GridBagConstraints() {{
             gridx = 2;
-            gridy = 1;
+            gridy = 2;
             insets = labelInsets;
             anchor = EAST;
         }});
 
         panel.add(_nirBandComboBox, new GridBagConstraints() {{
             gridx = 3;
-            gridy = 1;
+            gridy = 2;
             anchor = WEST;
             insets = valueInsets;
         }});
 
         panel.add(_reviewCandidatesCheckBox, new GridBagConstraints() {{
             gridx = 1;
-            gridy = 2;
+            gridy = 3;
             gridwidth = 3;
             anchor = WEST;
             insets = valueInsets;
@@ -275,21 +272,21 @@ public class GemsGuideStarSearchDialog extends JFrame {
 
         panel.add(new JLabel("Asterism"), new GridBagConstraints() {{
             gridx = 0;
-            gridy = 4;
+            gridy = 5;
             insets = labelInsets;
             anchor = EAST;
         }});
 
         panel.add(_analyseComboBox, new GridBagConstraints() {{
             gridx = 1;
-            gridy = 4;
+            gridy = 5;
             insets = valueInsets;
             anchor = WEST;
         }});
 
         panel.add(_allowPosAngleChangesCheckBox, new GridBagConstraints() {{
             gridx = 1;
-            gridy = 5;
+            gridy = 6;
             gridwidth = 3;
             anchor = WEST;
             insets = valueInsets;
@@ -300,7 +297,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         _tabbedPane.add(makeCandidateAsterismsPanel());
         panel.add(_tabbedPane, new GridBagConstraints() {{
             gridx = 0;
-            gridy = 6;
+            gridy = 7;
             gridwidth = 4;
             weightx = 1;
             weighty = 1;
@@ -467,7 +464,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
     private void makeCandidateGuideStarsPanel() {
         _candidateGuideStarsPanel.setName("Candidate Guide Stars");
         _candidateGuideStarsPanel.add(_candidateGuideStarsTable, BorderLayout.CENTER);
-        _candidateGuideStarsPanel.add(new JLabel("Select to view in position editor. Uncheck to exclude from asterism search."),
+        _candidateGuideStarsPanel.add(new JLabel("Select to highlight in the Position Editor. Uncheck to exclude from the automatic asterism search."),
                 BorderLayout.SOUTH);
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -2,9 +2,7 @@ package jsky.app.ot.tpe.gems;
 
 import edu.gemini.ags.gems.GemsGuideStarSearchOptions.*;
 import edu.gemini.ags.gems.GemsGuideStars;
-import edu.gemini.pot.sp.ISPProgram;
 import edu.gemini.pot.sp.SPComponentType;
-import edu.gemini.pot.sp.SPUtil;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SiderealTarget;
@@ -589,7 +587,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         _model.setAnalyseChoice((AnalyseChoice) _analyseComboBox.getSelectedItem());
         _model.setAllowPosAngleAdjustments(_allowPosAngleChangesCheckBox.isSelected());
 
-        final List<SiderealTarget> excludeCandidates = _candidateGuideStarsTable.getTableModel().getCandidates(false);
+        final List<SiderealTarget> excludeCandidates = _candidateGuideStarsTable.getTableModel().getCandidates();
 
         new SwingWorker() {
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchModel.java
@@ -15,7 +15,6 @@ import java.util.List;
 class GemsGuideStarSearchModel {
 
     private CatalogChoice _catalog;
-
     private NirBandChoice _band;
     private AnalyseChoice _analyseChoice;
     private boolean _reviewCandidatesBeforeSearch;
@@ -27,7 +26,7 @@ class GemsGuideStarSearchModel {
         return _catalog;
     }
 
-    public void setCatalog(CatalogChoice catalog) {
+    public void setCatalog(final CatalogChoice catalog) {
         _catalog = catalog;
     }
 
@@ -35,7 +34,7 @@ class GemsGuideStarSearchModel {
         return _band;
     }
 
-    public void setBand(NirBandChoice band) {
+    public void setBand(final NirBandChoice band) {
         _band = band;
     }
 
@@ -43,11 +42,11 @@ class GemsGuideStarSearchModel {
         return _analyseChoice;
     }
 
-    void setAnalyseChoice(AnalyseChoice analyseChoice) {
+    void setAnalyseChoice(final AnalyseChoice analyseChoice) {
         _analyseChoice = analyseChoice;
     }
 
-    void setReviewCandidatesBeforeSearch(boolean reviewCanditatesBeforeSearch) {
+    void setReviewCandidatesBeforeSearch(final boolean reviewCanditatesBeforeSearch) {
         _reviewCandidatesBeforeSearch = reviewCanditatesBeforeSearch;
     }
 
@@ -55,7 +54,7 @@ class GemsGuideStarSearchModel {
         return _reviewCandidatesBeforeSearch;
     }
 
-    void setAllowPosAngleAdjustments(boolean allowPosAngleAdjustments) {
+    void setAllowPosAngleAdjustments(final boolean allowPosAngleAdjustments) {
         _allowPosAngleAdjustments = allowPosAngleAdjustments;
     }
 
@@ -67,7 +66,7 @@ class GemsGuideStarSearchModel {
         return _gemsCatalogSearchResults;
     }
 
-    void setGemsCatalogSearchResults(List<GemsCatalogSearchResults> gemsCatalogSearchResults) {
+    void setGemsCatalogSearchResults(final List<GemsCatalogSearchResults> gemsCatalogSearchResults) {
         _gemsCatalogSearchResults = gemsCatalogSearchResults;
     }
 
@@ -75,11 +74,11 @@ class GemsGuideStarSearchModel {
         return _gemsGuideStars;
     }
 
-    void setGemsGuideStars(List<GemsGuideStars> gemsGuideStars) {
+    void setGemsGuideStars(final List<GemsGuideStars> gemsGuideStars) {
         _gemsGuideStars = gemsGuideStars;
     }
 
-    Option<SiderealTarget> targetAt(int i) {
+    Option<SiderealTarget> targetAt(final int i) {
         return ImOption.apply(_gemsCatalogSearchResults.get(0)).flatMap(c -> c.targetAt(i));
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchModel.java
@@ -3,6 +3,9 @@ package jsky.app.ot.tpe.gems;
 import edu.gemini.ags.gems.GemsGuideStarSearchOptions.*;
 import edu.gemini.ags.gems.GemsCatalogSearchResults;
 import edu.gemini.ags.gems.GemsGuideStars;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.spModel.core.SiderealTarget;
 
 import java.util.List;
 
@@ -74,5 +77,9 @@ class GemsGuideStarSearchModel {
 
     void setGemsGuideStars(List<GemsGuideStars> gemsGuideStars) {
         _gemsGuideStars = gemsGuideStars;
+    }
+
+    Option<SiderealTarget> targetAt(int i) {
+        return ImOption.apply(_gemsCatalogSearchResults.get(0)).flatMap(c -> c.targetAt(i));
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TableDisplay.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/TableDisplay.java
@@ -121,7 +121,7 @@ public class TableDisplay extends JPanel
      * Initialize an empty table. Call setModel() to set the data to display,
      * and setQueryResultDisplay to set the display class to use when following links.
      */
-    public TableDisplay() {
+    protected TableDisplay() {
         this(null, null);
     }
 

--- a/bundle/jsky.util.gui/src/main/java/jsky/util/gui/ConnectionUtil.java
+++ b/bundle/jsky.util.gui/src/main/java/jsky/util/gui/ConnectionUtil.java
@@ -1,10 +1,3 @@
-/*
- * Copyright 2000 Association for Universities for Research in Astronomy, Inc.,
- * Observatory Control System, Gemini Telescopes Project.
- *
- * $Id: ConnectionUtil.java 4414 2004-02-03 16:21:36Z brighton $
- */
-
 package jsky.util.gui;
 
 import java.io.IOException;
@@ -49,7 +42,6 @@ public class ConnectionUtil {
      * Background thread making the connection.
      */
     private SwingWorker worker;
-
 
     /**
      * Initialize with the given URL


### PR DESCRIPTION
This PR adds support for adding CWFS guide stars on the TPE once the GEMS Manual Guide Star box has been opened. To make it work you need to get the GEMS Dialog box and using the TPE click on the `+CMFS1/2/3` button and hit on of the hilighted targets

There were at least 2 other alternatives to this problem:
* Integrate GEMS to the Catalog Query Tool
* Add explicit add buttons to GEMS Guide Star Dialog

These were discarded due to the amount of time available