### PR TITLE
REL-2646: GNIRS observing wavelength in acquisitions

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsImaging.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsImaging.scala
@@ -31,12 +31,13 @@ case class GnirsImaging(blueprint:SpGnirsBlueprintImaging) extends GnirsBase[SpG
   //                 H2 (2.122um) => H2: 2.12um
   //                 PAH (3.295) => PAH: 3.3um
   //             IF FILTER == PAH SET Well Depth = Deep
-  //             SET Central Wavelength according to FILTER in all GNIRS iterators
+  //             REL-2646 removes the following line:
+  //             X - SET Central Wavelength according to FILTER in all GNIRS iterators
 
   val filter = oldFilter match {
     case Filter.ORDER_5 => Filter.J // J (1.25um) => J-MK: 1.25um
     case Filter.ORDER_3 => Filter.K // K (2.20um) => K-MK: 2.20um
-    case _ => oldFilter
+    case _              => oldFilter
   }
 
   include(16, 17, 18, 19, 20, 21) in TargetGroup
@@ -58,11 +59,5 @@ case class GnirsImaging(blueprint:SpGnirsBlueprintImaging) extends GnirsBase[SpG
     mutateSeq(
       iterate(PARAM_FILTER, List(filter))),
     ifTrue(filter == PAH)(
-      setWellDepth(DEEP)),
-    ifTrue(filter.wavelength() != null)(
-      mutateSeq(
-        iterate(PARAM_WAVELENGTH, List(new Wavelength(f"${filter.wavelength().doubleValue()}%.2f"))))
-    ))
-
-
+      setWellDepth(DEEP)))
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSConstants.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSConstants.java
@@ -29,7 +29,9 @@ public final class GNIRSConstants extends InstConstants {
     public static final ItemKey CENTRAL_WAVELENGTH_KEY = key(CENTRAL_WAVELENGTH_PROP);
     public static final String CENTRAL_WAVELENGTH_ORDER_N_PROP = "centralWavelengthOrderN";
     public static final String FILTER_PROP = "filter";
+    public static final ItemKey FILTER_KEY = key(FILTER_PROP);
     public static final String ACQUISITION_MIRROR_PROP = "acquisitionMirror";
+    public static final ItemKey ACQUISITION_MIRROR_KEY = key(ACQUISITION_MIRROR_PROP);
 
     public static final double DEF_EXPOSURE_TIME = 17.0; // sec (by default settings)
     public static final double DEF_CENTRAL_WAVELENGTH = 2.2; // um (band=K)

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
@@ -739,13 +739,13 @@ public class GNIRSParams {
         ORDER_5("order 5 (J)", "J", 1.25),
         ORDER_4("order 4 (H-MK: 1.65um)", "H", "order 4 (H)", 1.65),
         ORDER_3("order 3 (K)", "K", 2.20),
-        ORDER_2("order 2 (L)", "L"),
-        ORDER_1("order 1 (M)", "M"),
+        ORDER_2("order 2 (L)", "L", 3.50),
+        ORDER_1("order 1 (M)", "M", 4.80),
         // Added for OT-349
-        H2("H2: 2.12um", "H2", 2.122),
-        H_plus_ND100X("H + ND100X","H+ND100X"),
-        H2_plus_ND100X("H2 + ND100X","H2+ND100X"),
-        PAH("PAH: 3.3um", "PAH", 3.295),
+        H2("H2: 2.12um", "H2", 2.12),
+        H_plus_ND100X("H + ND100X","H+ND100X",    1.65),
+        H2_plus_ND100X("H2 + ND100X","H2+ND100X", 2.12),
+        PAH("PAH: 3.3um", "PAH", 3.30),
 
         // Added for REL-444
         Y("Y-MK: 1.03um", "Y", "Y: 1.03um", 1.03),

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
@@ -890,7 +890,7 @@ public class GNIRSParams {
                 case PS_005: return (blue) ? LONG_BLUE  : LONG_RED;
                 case PS_015: return (blue) ? SHORT_BLUE : SHORT_RED;
             }
-            throw new RuntimeException("Unexecpted pixel scale: " + ps);
+            throw new RuntimeException("Unexpected pixel scale: " + ps);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
@@ -734,23 +734,23 @@ public class GNIRSParams {
      */
     public enum Filter implements DisplayableSpType, SequenceableSpType, LoggableSpType {
 
-        X_DISPERSED("x-dispersed", "XD"),
-        ORDER_6("order 6 (X)", "X", 1.10),
-        ORDER_5("order 5 (J)", "J", 1.25),
-        ORDER_4("order 4 (H-MK: 1.65um)", "H", "order 4 (H)", 1.65),
-        ORDER_3("order 3 (K)", "K", 2.20),
-        ORDER_2("order 2 (L)", "L", 3.50),
-        ORDER_1("order 1 (M)", "M", 4.80),
+        X_DISPERSED   ("x-dispersed",            "XD"                    ),
+        ORDER_6       ("order 6 (X)",            "X",                1.10),
+        ORDER_5       ("order 5 (J)",            "J",                1.25),
+        ORDER_4       ("order 4 (H-MK: 1.65um)", "H", "order 4 (H)", 1.65),
+        ORDER_3       ("order 3 (K)",            "K",                2.20),
+        ORDER_2       ("order 2 (L)",            "L",                3.50),
+        ORDER_1       ("order 1 (M)",            "M",                4.80),
         // Added for OT-349
-        H2("H2: 2.12um", "H2", 2.12),
-        H_plus_ND100X("H + ND100X","H+ND100X",    1.65),
-        H2_plus_ND100X("H2 + ND100X","H2+ND100X", 2.12),
-        PAH("PAH: 3.3um", "PAH", 3.30),
+        H2            ("H2: 2.12um",             "H2",               2.12),
+        H_plus_ND100X ("H + ND100X",             "H+ND100X",         1.65),
+        H2_plus_ND100X("H2 + ND100X",            "H2+ND100X",        2.12),
+        PAH           ("PAH: 3.3um",             "PAH",              3.30),
 
         // Added for REL-444
-        Y("Y-MK: 1.03um", "Y", "Y: 1.03um", 1.03),
-        J("J-MK: 1.25um", "J", "J: 1.25um", 1.25),
-        K("K-MK: 2.20um", "K", "K: 2.20um", 2.20),
+        Y             ("Y-MK: 1.03um",           "Y", "Y: 1.03um",   1.03),
+        J             ("J-MK: 1.25um",           "J", "J: 1.25um",   1.25),
+        K             ("K-MK: 2.20um",           "K", "K: 2.20um",   2.20),
         ;
 
         /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -889,7 +889,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
             if (am == AcquisitionMirror.IN) {
                 final Option<Filter> f  = ImOption.apply((Filter) c.getItemValue(GNIRSConstants.FILTER_KEY));
                 final Option<Double> wl = f.flatMap(f0 -> ImOption.apply(f0.wavelength()));
-                wl.foreach(d -> c.putItem(GNIRSConstants.OBSERVING_WAVELENGTH_KEY, String.format("%.3f", d)));
+                wl.foreach(d -> c.putItem(GNIRSConstants.OBSERVING_WAVELENGTH_KEY, String.format("%.2f", d)));
             }
 
             if (isCalStep(c)) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.DefaultImList;
 import edu.gemini.shared.util.immutable.ImList;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.spModel.config.ConfigPostProcessor;
@@ -883,6 +884,14 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         final Config[] configs = in.getAllSteps();
 
         for (Config c : configs) {
+            // Override the observing wavelength for acquisition steps.
+            final AcquisitionMirror am = (AcquisitionMirror) c.getItemValue(GNIRSConstants.ACQUISITION_MIRROR_KEY);
+            if (am == AcquisitionMirror.IN) {
+                final Option<Filter> f  = ImOption.apply((Filter) c.getItemValue(GNIRSConstants.FILTER_KEY));
+                final Option<Double> wl = f.flatMap(f0 -> ImOption.apply(f0.wavelength()));
+                wl.foreach(d -> c.putItem(GNIRSConstants.OBSERVING_WAVELENGTH_KEY, String.format("%.3f", d)));
+            }
+
             if (isCalStep(c)) {
                 final Double expTime = calExposureTime(c);
                 if (expTime != null) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -880,11 +880,11 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     }
 
     @Override public ConfigSequence postProcessSequence(ConfigSequence in) {
-        Config[] configs = in.getAllSteps();
+        final Config[] configs = in.getAllSteps();
 
         for (Config c : configs) {
             if (isCalStep(c)) {
-                Double expTime = calExposureTime(c);
+                final Double expTime = calExposureTime(c);
                 if (expTime != null) {
                     c.putItem(ReadMode.KEY, selectCalReadMode(expTime));
                 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRSNI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRSNI.java
@@ -6,6 +6,7 @@
 //
 package edu.gemini.spModel.gemini.gnirs;
 
+import edu.gemini.pot.sp.ISPNode;
 import edu.gemini.pot.sp.ISPObsComponent;
 
 import edu.gemini.pot.sp.SPComponentType;
@@ -26,6 +27,16 @@ public final class InstGNIRSNI extends DefaultInstNodeInitializer {
 
     @Override public SPInstObsComp createDataObject() {
         return new InstGNIRS();
+    }
+
+    @Override public void updateNode(ISPNode n) {
+        super.updateNode(n);
+
+        // REL-2646: make sure that new GNIRS components correctly set the
+        // acquisition observing wavelength.
+        final InstGNIRS gnirs = (InstGNIRS) n.getDataObject();
+        gnirs.setOverrideAcqObsWavelength(true);
+        n.setDataObject(gnirs);
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRSNI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRSNI.java
@@ -33,7 +33,12 @@ public final class InstGNIRSNI extends DefaultInstNodeInitializer {
         super.updateNode(n);
 
         // REL-2646: make sure that new GNIRS components correctly set the
-        // acquisition observing wavelength.
+        // acquisition observing wavelength.  This method is called by the
+        // factory after copying an instance so that new copies will definitely
+        // have the override flag set to true.  Otherwise, copies of old
+        // executed observations would still have the override flag set to false
+        // and would use the incorrect method of calculating observing
+        // wavelength from the grating central wavelength.
         final InstGNIRS gnirs = (InstGNIRS) n.getDataObject();
         gnirs.setOverrideAcqObsWavelength(true);
         n.setDataObject(gnirs);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -45,7 +45,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     // for serialization
     private static final long serialVersionUID = 4L;
 
-    public static final String VERSION = "2016B-2";
+    public static final String VERSION = "2017A-1";
 
     /** This property records the program queue/classical state. */
     public static final String PROGRAM_MODE_PROP = "programMode";

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/InstConstants.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/InstConstants.java
@@ -9,6 +9,7 @@ package edu.gemini.spModel.obscomp;
 
 import edu.gemini.spModel.config2.ItemKey;
 
+import static edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY;
 import static edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_KEY;
 
 /**
@@ -28,6 +29,7 @@ public class InstConstants {
     public static final ItemKey EXPOSURE_TIME_KEY = new ItemKey(OBSERVE_KEY, EXPOSURE_TIME_PROP);
 
     public static final String OBSERVING_WAVELENGTH_PROP = "observingWavelength";
+    public static final ItemKey OBSERVING_WAVELENGTH_KEY = new ItemKey(INSTRUMENT_KEY, OBSERVING_WAVELENGTH_PROP);
 
     public static final String OBSERVATIONID_PROP = "observationId";
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gnirs/ObsWavelengthTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/gnirs/ObsWavelengthTest.scala
@@ -1,0 +1,113 @@
+package edu.gemini.spModel.gemini.gnirs
+
+import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances
+import edu.gemini.spModel.config2.ConfigSequence
+import edu.gemini.spModel.data.config.{DefaultParameter, IParameter}
+import edu.gemini.spModel.obscomp.InstConstants
+import edu.gemini.spModel.test.InstrumentSequenceTestBase
+import InstrumentSequenceTestBase._
+import GNIRSParams.AcquisitionMirror.{IN, OUT}
+import GNIRSParams.Filter.{J, K, X_DISPERSED, Y}
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.collection.JavaConverters._
+
+class ObsWavelengthTest extends InstrumentSequenceTestBase[InstGNIRS, SeqConfigGNIRS] {
+
+  override def getObsCompSpType: SPComponentType = InstGNIRS.SP_TYPE
+  override def getSeqCompSpType: SPComponentType = SeqConfigGNIRS.SP_TYPE
+
+  private def configSeq: ConfigSequence =
+    ConfigBridge.extractSequence(getObs, null, ConfigValMapInstances.IDENTITY_MAP)
+
+  def param[T](n: String, vs: Seq[T]): IParameter =
+    DefaultParameter.getInstance(n, vs.toList.asJava)
+
+  private def setOverrideMode(over: Boolean): Unit = {
+    val gnirs = getInstDataObj
+    gnirs.setOverrideAcqObsWavelength(over)
+    storeStaticUpdates()
+  }
+
+  private def setCentralWavelength(d: Double): Unit = {
+    val gnirs = getInstDataObj
+    gnirs.setCentralWavelength(d)
+    storeStaticUpdates()
+  }
+
+  private def setSequence(s: (GNIRSParams.AcquisitionMirror, GNIRSParams.Filter)*): Unit = {
+    val sc = createSysConfig()
+    val (as, fs) = s.unzip
+    sc.putParameter(param(GNIRSConstants.ACQUISITION_MIRROR_PROP, as))
+    sc.putParameter(param(GNIRSConstants.FILTER_PROP,             fs))
+    setSysConfig(sc)
+  }
+
+  private def assertWavelengths(wl: String*): Unit = {
+    val actual = configSeq.getItemValueAtEachStep(InstConstants.OBSERVING_WAVELENGTH_KEY)
+    wl.zipAll(actual, "", "").foreach { case (e,a) =>
+      assertEquals(s"Expected: $e, actual: $a", e, a)
+    }
+  }
+
+  @Test def testAcqImagingWavelength(): Unit = {
+    // In general, new acquisition imaging observations should take observing
+    // wavelength from filter
+    setSequence((IN, J), (IN, K), (IN, Y))
+    assertWavelengths("1.25", "2.20", "1.03")
+  }
+
+  @Test def testOldObservation(): Unit = {
+    // Old executed observations should not override observing wavelength
+    setOverrideMode(false)
+    setCentralWavelength(4.0)
+    setSequence((IN, J), (IN, K), (IN, Y))
+    assertWavelengths("4.0", "4.0", "4.0")
+  }
+
+  @Test def testNotAcq(): Unit = {
+    // For steps without the acquisition mirror in, use grating central wavelength
+    setCentralWavelength(4.0)
+    setSequence((IN, J), (OUT, K), (IN, Y))
+    assertWavelengths("1.25", "4.0", "1.03")
+  }
+
+  @Test def testNoFilter(): Unit = {
+    // If filters aren't defined, use grating central wavelength
+    setCentralWavelength(4.0)
+    val sc = createSysConfig()
+    sc.putParameter(param(GNIRSConstants.ACQUISITION_MIRROR_PROP, List(IN, IN, IN)))
+    setSysConfig(sc)
+
+    assertWavelengths("4.0", "4.0", "4.0")
+  }
+
+  @Test def testNoFilterWavelength(): Unit = {
+    // If no wavelength associated with a filter, use grating central wl
+    setCentralWavelength(4.0)
+    setSequence((IN, J), (IN, X_DISPERSED), (IN, Y))
+    assertWavelengths("1.25", "4.0", "1.03")
+  }
+
+  @Test def testOldObservationCopy(): Unit = {
+    setOverrideMode(false)
+    setCentralWavelength(4.0)
+    setSequence((IN, J), (IN, K), (IN, Y))
+    assertWavelengths("4.0", "4.0", "4.0")
+
+    // Copying should produce a copy with a true override value
+    val obs2 = getFactory.createObservationCopy(getProgram, getObs, false)
+    val seq2 = ConfigBridge.extractSequence(obs2, null, ConfigValMapInstances.IDENTITY_MAP)
+    val act2 = seq2.getItemValueAtEachStep(InstConstants.OBSERVING_WAVELENGTH_KEY)
+    val exp2 = List("1.25", "2.20", "1.03")
+
+    exp2.zipAll(act2, "", "").foreach { case (e,a) =>
+      assertEquals(s"Expected: $e, actual: $a", e, a)
+    }
+  }
+
+}

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
@@ -20,6 +20,7 @@ import edu.gemini.spModel.io.impl.migration.to2015B.To2015B;
 import edu.gemini.spModel.io.impl.migration.to2016A.To2016A;
 import edu.gemini.spModel.io.impl.migration.to2016B.To2016B;
 import edu.gemini.spModel.io.impl.migration.to2016B.To2016B2;
+import edu.gemini.spModel.io.impl.migration.to2017A.To2017A;
 import edu.gemini.spModel.io.impl.migration.toPalote.Grillo2Palote;
 import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obscomp.SPGroup;
@@ -226,6 +227,9 @@ public final class PioSpXmlParser {
 
         // Update pre-2016B-2 programs
         To2016B2.updateProgram(doc);
+
+        // Update pre-2017A programs
+        To2017A.updateProgram(doc);
 
         // We will special case the Phase 1 container.
         Container p1Container = null;

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
@@ -67,6 +67,11 @@ trait Migration {
     d.findContainers(SPComponentType.OBSERVATION_BASIC)
      .map(_.getParamSet(ParamSetObservation))
 
+  /** Determines whether an observation should count as having been executed.
+    * @param obs observation container
+    * @return `true` if the observation has at least one dataset record;
+    *        `false` otherwise
+    */
   protected def isExecuted(obs: Container): Boolean =
     (for {
       log <- obs.findContainers(SPComponentType.OBS_EXEC_LOG)

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/PioSyntax.scala
@@ -1,6 +1,7 @@
 package edu.gemini.spModel.io.impl.migration
 
 import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.pio.{Container, ContainerParent, ParamSet}
 
 import scala.collection.JavaConverters._
@@ -31,6 +32,9 @@ object PioSyntax {
     def paramSets: List[ParamSet] =
       c.getParamSets.asInstanceOf[java.util.List[ParamSet]].asScala.toList
 
+    def dataObject: Option[ParamSet] =
+      paramSets.find(_.getKind == ISPDataObject.PARAM_SET_KIND)
+
     def allParamSets: List[ParamSet] = {
       val ps = paramSets
       ps ++ ps.flatMap(_.allParamSets)
@@ -42,6 +46,9 @@ object PioSyntax {
 
     def paramSets: List[ParamSet] =
       p.getParamSets.asScala.toList
+
+    def paramSet(n: String): Option[ParamSet] =
+      paramSets.find(_.getName == n)
 
     def allParamSets: List[ParamSet] = {
       val ps = paramSets

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2017A/To2017A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2017A/To2017A.scala
@@ -16,6 +16,15 @@ object To2017A extends Migration {
 
   val fact = new PioXmlFactory
 
+  // REL-2646: Updates executed GNIRS observations with a flag that tells the
+  // sequence generation code to use the old, incorrect, observing wavelength
+  // calculation that existed before 2017A.
+  private def updateExecutedGnirs(d: Document): Unit =
+    for {
+      o <- findObservations(d)(c => hasGnirs(c) && isExecuted(c))
+      d <- gnirs(o)
+    } Pio.addBooleanParam(fact, d, InstGNIRS.OVERRIDE_ACQ_OBS_WAVELENGTH_PROP.getName, false)
+
   private def gnirs(obs: Container): Option[ParamSet] =
     for {
       g <- obs.findContainers(SPComponentType.INSTRUMENT_GNIRS).headOption
@@ -25,9 +34,4 @@ object To2017A extends Migration {
   private def hasGnirs(obs: Container): Boolean =
     gnirs(obs).isDefined
 
-  private def updateExecutedGnirs(d: Document): Unit =
-    for {
-      o <- findObservations(d)(c => hasGnirs(c) && isExecuted(c))
-      d <- gnirs(o)
-    } Pio.addBooleanParam(fact, d, InstGNIRS.OVERRIDE_ACQ_OBS_WAVELENGTH_PROP.getName, false)
 }

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2017A/To2017A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2017A/To2017A.scala
@@ -1,0 +1,33 @@
+package edu.gemini.spModel.io.impl.migration.to2017A
+
+import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.gemini.gnirs.InstGNIRS
+import edu.gemini.spModel.io.impl.migration.Migration
+import edu.gemini.spModel.io.impl.migration.PioSyntax._
+
+import edu.gemini.spModel.pio.xml.PioXmlFactory
+import edu.gemini.spModel.pio.{ParamSet, Container, Pio, Document, Version}
+
+object To2017A extends Migration {
+
+  val version = Version.`match`("2017A-1")
+
+  val conversions: List[Document => Unit] = List(updateExecutedGnirs)
+
+  val fact = new PioXmlFactory
+
+  private def gnirs(obs: Container): Option[ParamSet] =
+    for {
+      g <- obs.findContainers(SPComponentType.INSTRUMENT_GNIRS).headOption
+      d <- g.dataObject
+    } yield d
+
+  private def hasGnirs(obs: Container): Boolean =
+    gnirs(obs).isDefined
+
+  private def updateExecutedGnirs(d: Document): Unit =
+    for {
+      o <- findObservations(d)(c => hasGnirs(c) && isExecuted(c))
+      d <- gnirs(o)
+    } Pio.addBooleanParam(fact, d, InstGNIRS.OVERRIDE_ACQ_OBS_WAVELENGTH_PROP.getName, false)
+}

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2017A/gnirs.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2017A/gnirs.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2016B-2" subtype="basic" key="d6d2997a-1f10-4927-a5d4-fd03c180738b" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="title" value="GNIRS Observing Wavelength Test"/>
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="piInfo">
+        <param name="firstName" value=""/>
+        <param name="lastName" value=""/>
+        <param name="email" value=""/>
+        <param name="phone" value=""/>
+      </paramset>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="434ec6e5-1985-48cf-9234-cb17282e71a7" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="Executed"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <paramset name="schedulingBlock">
+          <param name="start" value="1477935000000"/>
+          <paramset name="duration">
+            <param name="tag" value="unstated"/>
+          </paramset>
+        </paramset>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="2d22b9b4-d2f3-4a3b-b3c8-9b21da9b5ddd" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="3409a3d9-b46f-4606-b025-64206fe2826a" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <paramset name="target">
+                <param name="name" value="Untitled"/>
+                <paramset name="coordinates">
+                  <param name="ra" value="0.0"/>
+                  <param name="dec" value="0.0"/>
+                </paramset>
+                <param name="tag" value="sidereal"/>
+              </paramset>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="0"/>
+              <paramset name="guideGroup">
+                <param name="tag" value="AutoInitialTag"/>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2014A-1" subtype="GNIRS" key="45d603d0-4846-42a5-a8ce-337005ef35bc" name="GNIRS">
+        <paramset name="GNIRS" kind="dataObj">
+          <param name="exposureTime" value="17.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <param name="pixelScale" value="PS_015"/>
+          <param name="disperser" value="D_32"/>
+          <param name="slitWidth" value="SW_4"/>
+          <param name="crossDispersed" value="NO"/>
+          <param name="wollastonPrism" value="NO"/>
+          <param name="readMode" value="BRIGHT"/>
+          <param name="wellDepth" value="SHALLOW"/>
+          <param name="centralWavelength" value="1.25"/>
+          <param name="acquisitionMirror" value="OUT"/>
+          <param name="camera" value="SHORT_BLUE"/>
+          <param name="decker" value="ACQUISITION"/>
+          <param name="filter" value="ORDER_5"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="53296734-d315-4afb-9451-27e37b4b2819" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="ae89058d-3baf-482d-b8a4-e64c82decc7b" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets">
+              <paramset name="datasetRecord">
+                <paramset name="dataset">
+                  <param name="datasetLabel" value="GS-2012B-Q-30-128-001"/>
+                  <param name="dhsFilename" value="S20120901S0246"/>
+                  <param name="timestamp" value="1346488928367"/>
+                </paramset>
+                <paramset name="summit">
+                  <param name="req" value="PASS"/>
+                  <param name="tag" value="missing"/>
+                </paramset>
+                <paramset name="archive">
+                  <param name="qa" value="PASS"/>
+                  <param name="timestamp" value="2016-03-12T17:26:47.952033Z"/>
+                  <param name="md5" value="C3CC6253870CDEA2C907F57CCA11407A"/>
+                </paramset>
+              </paramset>
+            </paramset>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="59907f22-610a-4827-b51e-1249c1e654fc" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+        <container kind="seqComp" type="Iterator" version="2010B-2" subtype="GNIRS" key="1bdc608a-c86d-4770-95b6-a15e82f5da82" name="GNIRS Sequence">
+          <paramset name="GNIRS Sequence" kind="dataObj">
+            <param name="acquisitionMirror">
+              <value sequence="0">OUT</value>
+              <value sequence="1">IN</value>
+            </param>
+            <param name="centralWavelength">
+              <value sequence="0">1.25</value>
+              <value sequence="1">2.22</value>
+            </param>
+            <param name="filter">
+              <value sequence="0">ORDER_5</value>
+              <value sequence="1">ORDER_2</value>
+            </param>
+          </paramset>
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="53ee0b45-b553-4441-9910-51236c1f96a8" name="Observe">
+            <paramset name="Observe" kind="dataObj">
+              <param name="repeatCount" value="1"/>
+              <param name="class" value="SCIENCE"/>
+            </paramset>
+          </container>
+        </container>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="2c178282-ec64-4e98-b606-921f6bf3cc68" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="Not Executed"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <paramset name="schedulingBlock">
+          <param name="start" value="1477935000000"/>
+          <paramset name="duration">
+            <param name="tag" value="unstated"/>
+          </paramset>
+        </paramset>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="42734c2f-d2c8-428d-9189-21c53f08ee5b" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="401d9019-a271-44f8-a04c-e2d428e72227" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <paramset name="target">
+                <param name="name" value="Untitled"/>
+                <paramset name="coordinates">
+                  <param name="ra" value="0.0"/>
+                  <param name="dec" value="0.0"/>
+                </paramset>
+                <param name="tag" value="sidereal"/>
+              </paramset>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="0"/>
+              <paramset name="guideGroup">
+                <param name="tag" value="AutoInitialTag"/>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2014A-1" subtype="GNIRS" key="72478cd4-b268-4181-8d40-743d2777aeb3" name="GNIRS">
+        <paramset name="GNIRS" kind="dataObj">
+          <param name="exposureTime" value="17.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <param name="pixelScale" value="PS_015"/>
+          <param name="disperser" value="D_32"/>
+          <param name="slitWidth" value="SW_4"/>
+          <param name="crossDispersed" value="NO"/>
+          <param name="wollastonPrism" value="NO"/>
+          <param name="readMode" value="BRIGHT"/>
+          <param name="wellDepth" value="SHALLOW"/>
+          <param name="centralWavelength" value="2.2"/>
+          <param name="acquisitionMirror" value="OUT"/>
+          <param name="camera" value="SHORT_BLUE"/>
+          <param name="decker" value="ACQUISITION"/>
+          <param name="filter" value="ORDER_5"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="576ff067-b6d7-463a-8d30-574fc4981182" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="dab53b31-49b5-441f-9d4d-1299e08700d9" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c1b2b227-ca78-435b-b70c-e5a9c979b479" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="401d9019-a271-44f8-a04c-e2d428e72227"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2d22b9b4-d2f3-4a3b-b3c8-9b21da9b5ddd"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="576ff067-b6d7-463a-8d30-574fc4981182"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ae89058d-3baf-482d-b8a4-e64c82decc7b"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="3409a3d9-b46f-4606-b025-64206fe2826a"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="53296734-d315-4afb-9451-27e37b4b2819"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="434ec6e5-1985-48cf-9234-cb17282e71a7"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="1"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="9"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="2c178282-ec64-4e98-b606-921f6bf3cc68"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="13"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="45d603d0-4846-42a5-a8ce-337005ef35bc"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="3"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="53ee0b45-b553-4441-9910-51236c1f96a8"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="42734c2f-d2c8-428d-9189-21c53f08ee5b"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="72478cd4-b268-4181-8d40-743d2777aeb3"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="59907f22-610a-4827-b51e-1249c1e654fc"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1bdc608a-c86d-4770-95b6-a15e82f5da82"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="17"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d6d2997a-1f10-4927-a5d4-fd03c180738b"/>
+      <param name="cbbc9b73-91d1-4d3b-8adb-da25cf937fec" value="29"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="dab53b31-49b5-441f-9d4d-1299e08700d9"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c1b2b227-ca78-435b-b70c-e5a9c979b479"/>
+      <param name="a8718157-6802-4a83-9944-12738c1ec0bc" value="1"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2017A/GnirsObsWavelengthTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2017A/GnirsObsWavelengthTest.scala
@@ -1,0 +1,26 @@
+package edu.gemini.spModel.io.impl.migration.to2017A
+
+import edu.gemini.pot.sp.{ISPProgram, SPComponentType}
+import edu.gemini.spModel.gemini.gnirs.InstGNIRS
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import org.specs2.matcher.MatchResult
+import org.specs2.mutable.Specification
+import edu.gemini.spModel.rich.pot.sp._
+
+class GnirsObsWavelengthTest extends Specification with MigrationTest {
+
+  def check(p: ISPProgram, obsNum: Int, expected: Boolean): MatchResult[Any] =
+    p.getObservations.get(obsNum).findObsComponentByType(SPComponentType.INSTRUMENT_GNIRS).map { oc =>
+      oc.getDataObject.asInstanceOf[InstGNIRS].isOverrideAcqObsWavelength
+    } must_== Some(expected)
+
+  "2017A Gnirs Migration" should {
+    "Set override acq observing wavelength to false for executed observations" in withTestProgram2("gnirs.xml") { p =>
+      check(p, 0, expected = false)
+    }
+
+    "Leave unexecuted observations alone" in withTestProgram2("gnirs.xml") { p =>
+      check(p, 1, expected = true)
+    }
+  }
+}


### PR DESCRIPTION
## Disclaimer

I must apologize in advance for this PR.  It's a fairly ugly hack.  I didn't see another way of doing this because it deals with a value that is computed during sequence construction.  The computation must work one way for old executed observations and a different way for new observations.  In the new tabular sequence model, this will no longer be an issue.  At least I feel like I've documented it adequately in the code itself.

- [x] Test cases pending; PR update to come

## PR Description

The observing wavelength for GNIRS acquisition observations should be computed based on the imaging filter.  Unfortunately in the past this was not done and instead the observing wavelength was always taken from the grating central wavelength during sequence construction.  Old observations therefore used the wrong observing wavelength and we must continue to compute the value that was actually used for them so that the display matches the value that was used.  To avoid correcting the observing wavelength during sequence construction for old observed observations, we have to check a property that is set during migration.

If "override acquisition observing wavelength" is `true` (which it will be by default for new observations), then the new method of setting the observing wavelength from the filter will be used.  If not, the old method of using the grating central wavelength will be used.