### PR TITLE
REL-2033: fix split export

### DIFF
--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/TextExport/TextJorgeObslogExporter.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/TextExport/TextJorgeObslogExporter.java
@@ -129,8 +129,7 @@ public class TextJorgeObslogExporter {
             StringBuilder segsBuffer = new StringBuilder();
 
             for (IObservingLogSegment segment: mergedSegments) {
-                InstrumentTextSegmentExporter exporter  = new InstrumentTextSegmentExporter(segment, spProg.stringValue());
-                segsBuffer = exporter.export(segsBuffer);
+                segsBuffer = new InstrumentTextSegmentExporter(segment, spProg).export(segsBuffer);
             }
 
             fullView.append(infoBuffer);

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/TextExport/support/InstrumentTextSegmentExporter.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/TextExport/support/InstrumentTextSegmentExporter.java
@@ -6,6 +6,7 @@ import edu.gemini.obslog.obslog.ConfigMapUtil;
 import edu.gemini.obslog.obslog.IObservingLogSegment;
 import edu.gemini.pot.sp.SPObservationID;
 import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SPBadIDException;
 import edu.gemini.spModel.core.SPProgramID;
@@ -24,7 +25,8 @@ public class InstrumentTextSegmentExporter extends AbstractDatasetExporterSuppor
     private final Option<SPProgramID> _thisProgramOnly;
 
     public InstrumentTextSegmentExporter(IObservingLogSegment segment) {
-        this(segment, null);
+        super(segment);
+        _thisProgramOnly = None.instance();
     }
 
     public InstrumentTextSegmentExporter(IObservingLogSegment segment, SPProgramID pid) {


### PR DESCRIPTION
This PR fixes an embarrassing stringly-typed programming issue.  Namely, when exporting an observing log split by program id, we were picking up program multiple program ids based on a `String` prefix comparison.   For example, observation `GS-2016B-Q-20-1` would be considered to be a part of program `GS-2016B-Q-2` because the program id as a `String` is a prefix of the observation id as a `String`.