### PR TITLE
REL-2924: Add explicit parallactic override mode

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
@@ -78,7 +78,7 @@ object AgsHash {
 
     // Position Angle
     Option(ctx.getPositionAngle).foreach { a =>
-      a.degrees.## +=: buf
+      a.toDegrees.## +=: buf
     }
 
     // Position Angle Constraint

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -112,7 +112,7 @@ object AgsStrategy {
       // the position angle as well if the automatic group is primary.
       applyTo(ctx.getTargets) |> ctx.withTargets |> { ctx0 =>
         val auto = ctx0.getTargets.getGuideEnvironment.guideEnv.primaryGroup.isAutomatic
-        auto ? ctx0.withPositionAngle(posAngle.toOldModel) | ctx0
+        auto ? ctx0.withPositionAngle(posAngle) | ctx0
       }
     }
   }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -257,7 +257,7 @@ object GemsResultsAnalyzer {
 
   // Returns true if the given target is valid for the given group
   private def isTargetValidInGroup(obsContext: ObsContext, target: SiderealTarget, group: GemsGuideProbeGroup, posAngle: Angle): Boolean = {
-    val ctx = obsContext.withPositionAngle(posAngle.toOldModel)
+    val ctx = obsContext.withPositionAngle(posAngle)
     val st = toSPTarget(target)
     group.getMembers.asScala.exists(_.validate(st, ctx) == GuideStarValidation.VALID)
   }
@@ -270,7 +270,7 @@ object GemsResultsAnalyzer {
   // If reverseOrder is true, reverse the order in which guide probes are tried (to make sure to get all
   // combinations of cwfs1 and cwfs2, since cwfs3 is otherwise fixed)
   private def guideProbe(obsContext: ObsContext, target: SiderealTarget, group: GemsGuideProbeGroup, posAngle: Angle, tiptiltGroup: GemsGuideProbeGroup, otherTargets: List[GuideProbeTargets], tiptiltTargetList: List[SiderealTarget], assignCwfs3ToBrightest: Boolean, reverseOrder: Boolean): Option[ValidatableGuideProbe] = {
-    val ctx = obsContext.withPositionAngle(posAngle.toOldModel)
+    val ctx = obsContext.withPositionAngle(posAngle)
     val isFlexure = tiptiltGroup != group
     val isTiptilt = !isFlexure
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -132,7 +132,7 @@ trait GemsStrategy extends AgsStrategy {
 
     // why do we need multiple position angles?  catalog results are given in
     // a ring (limited by radius limits) around a base position ... confusion
-    val posAngles   = (ctx.getPositionAngle.toNewModel :: (0 until 360 by 90).map(Angle.fromDegrees(_)).toList).toSet
+    val posAngles   = (ctx.getPositionAngle :: (0 until 360 by 90).map(Angle.fromDegrees(_)).toList).toSet
     search(GemsTipTiltMode.canopus, ctx, posAngles, None)(ec).map(simplifiedResult)
   }
 
@@ -189,11 +189,11 @@ trait GemsStrategy extends AgsStrategy {
   override def select(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[Option[Selection]] = {
     val posAngles = ctx.getInstrument.getType match {
       case SPComponentType.INSTRUMENT_GSAOI if ctx.getInstrument.asInstanceOf[Gsaoi].getPosAngleConstraint == PosAngleConstraint.FIXED =>
-        Set(ctx.getPositionAngle.toNewModel)
+        Set(ctx.getPositionAngle)
       case SPComponentType.INSTRUMENT_FLAMINGOS2 if ctx.getInstrument.asInstanceOf[Flamingos2].getPosAngleConstraint == PosAngleConstraint.FIXED =>
-        Set(ctx.getPositionAngle.toNewModel)
+        Set(ctx.getPositionAngle)
       case _ =>
-        Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+        Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
     }
 
     val results = search(GemsTipTiltMode.canopus, ctx, posAngles, None)(ec)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -31,7 +31,7 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
   override def select(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] = {
     // The science target is the guide star, but must be converted from SPTarget to SkyObject.
     val siderealTarget = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
-    val posAngle       = ctx.getPositionAngle.toNewModel
+    val posAngle       = ctx.getPositionAngle
     val assignment     = AgsStrategy.Assignment(guideProbe, siderealTarget)
     val selection      = AgsStrategy.Selection(posAngle, List(assignment))
     Future.successful(Some(selection))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -164,9 +164,9 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
         case vprobe: VProbe =>
           // Filter for brightness constraints and reachability.
           val results = ctx.getPosAngleConstraint match {
-            case FIXED                         => filterBounded(List(ctx), mt, candidates)
-            case FIXED_180 | PARALLACTIC_ANGLE => filterBounded(List(ctx, ctx180(ctx)), mt, candidates)
-            case UNBOUNDED                     => filterUnbounded(ctx, mt, candidates)
+            case FIXED                                                => filterBounded(List(ctx), mt, candidates)
+            case FIXED_180 | PARALLACTIC_ANGLE | PARALLACTIC_OVERRIDE => filterBounded(List(ctx, ctx180(ctx)), mt, candidates)
+            case UNBOUNDED                                            => filterUnbounded(ctx, mt, candidates)
           }
 
           // Select the highest quality target that vignettes the least.
@@ -175,9 +175,9 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
         // Otherwise proceed as normal.
         case _ =>
           val results = ctx.getPosAngleConstraint match {
-            case FIXED                         => selectBounded(List(ctx), mt, candidates)
-            case FIXED_180 | PARALLACTIC_ANGLE => selectBounded(List(ctx, ctx180(ctx)), mt, candidates)
-            case UNBOUNDED                     => selectUnbounded(ctx, mt, candidates)
+            case FIXED                                                => selectBounded(List(ctx), mt, candidates)
+            case FIXED_180 | PARALLACTIC_ANGLE | PARALLACTIC_OVERRIDE => selectBounded(List(ctx, ctx180(ctx)), mt, candidates)
+            case UNBOUNDED                                            => selectUnbounded(ctx, mt, candidates)
           }
           params.brightest(results)(_._2).map {
             case (angle, st) => AgsStrategy.Selection(angle, List(AgsStrategy.Assignment(params.guideProbe, st)))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -68,8 +68,8 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
     // If we are unbounded and there are any candidates, we are guaranteed success.
     val pac   = ctx.getPosAngleConstraint(UNBOUNDED)
     val cv    = CandidateValidator(params, mt, candidates)
-    val steps = pac.steps(ctx.getPositionAngle, params.stepSize.toOldModel).toList.asScala
-    val anglesWithResults  = steps.filter { angle => cv.exists(ctx.withPositionAngle(angle)) }
+    val steps = pac.steps(ctx.getPositionAngle.toNewModel, params.stepSize).toList.asScala
+    val anglesWithResults  = steps.filter { angle => cv.exists(ctx.withPositionAngle(angle.toOldModel)) }
     val successProbability = anglesWithResults.size.toDouble / steps.size.toDouble
     AgsStrategy.Estimate.toEstimate(successProbability)
   }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
@@ -101,10 +101,10 @@ class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.
 
     "differ if the position angle changes significantly" in
       forAll { (ctx0: ObsContext, pa: Angle) =>
-        val ctx1 = ctx0.withPositionAngle(pa.toOldModel)
+        val ctx1 = ctx0.withPositionAngle(pa)
 
-        val pa0  = ctx0.getPositionAngle.toDegrees.getMagnitude
-        val pa1  = ctx1.getPositionAngle.toDegrees.getMagnitude
+        val pa0  = ctx0.getPositionAngle.toDegrees
+        val pa1  = ctx1.getPositionAngle.toDegrees
 
         (pa0 == pa1) == hashSame(ctx0, ctx1)
       }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/UCAC3Regression.scala
@@ -41,7 +41,7 @@ trait UCAC3Regression {
     val env = TargetEnvironment.create(baseTarget)
     val offsets = new java.util.HashSet[edu.gemini.skycalc.Offset]
 
-    val obsContext = ObsContext.create(env, new Gsaoi, new JSome(Site.GS), conditions, offsets, new Gems, JNone.instance()).withPositionAngle(Angle.zero.toOldModel)
+    val obsContext = ObsContext.create(env, new Gsaoi, new JSome(Site.GS), conditions, offsets, new Gems, JNone.instance()).withPositionAngle(Angle.zero)
     val gemsResults = GemsResultsAnalyzer.analyze(obsContext, posAngles.asJava, results.asJava, None)
     areGuideStarListsEqual(expectedGuideStars, gemsResults.asScala.toList)
   }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/AgsTest.scala
@@ -101,7 +101,7 @@ case class AgsTest(ctx: ObsContext, guideProbe: GuideProbe, usable: List[(Sidere
     copy(usable = AgsTest.usableSiderealTarget(so: _*))
 
   def rotated(deg: Double): AgsTest =
-    copy(ctx.withPositionAngle(Angle.fromDegrees(deg).toOldModel))
+    copy(ctx.withPositionAngle(Angle.fromDegrees(deg)))
 
   def withConditions(c: Conditions): AgsTest =
     copy(ctx.withConditions(c))
@@ -313,7 +313,7 @@ case class AgsTest(ctx: ObsContext, guideProbe: GuideProbe, usable: List[(Sidere
 
   // Convenience function to calculate the proper rotation.
   private def rotation: AffineTransform =
-    AffineTransform.getRotateInstance(-ctx.getPositionAngle.toRadians.getMagnitude)
+    AffineTransform.getRotateInstance(-ctx.getPositionAngle.toRadians)
 
   def testBase(): Unit =
     allConditions().foreach(_.testXform())
@@ -428,7 +428,7 @@ case class AgsTest(ctx: ObsContext, guideProbe: GuideProbe, usable: List[(Sidere
         res match {
           case None                                       => // ok
           case Some(AgsStrategy.Selection(posAngle, Nil)) =>
-            equalPosAngles(ctx.getPositionAngle.toNewModel, posAngle)
+            equalPosAngles(ctx.getPositionAngle, posAngle)
           case Some(AgsStrategy.Selection(_,        asn)) =>
               fail("Expected nothing but got: " + asn.map { a =>
                 s"(${a.guideStar.toString}, ${a.guideProbe})"
@@ -440,14 +440,14 @@ case class AgsTest(ctx: ObsContext, guideProbe: GuideProbe, usable: List[(Sidere
           case None      =>
             fail(s"Expected: ($expStar, $expSpeed), but nothing selected")
           case Some(AgsStrategy.Selection(posAngle, asn)) =>
-            equalPosAngles(ctx.getPositionAngle.toNewModel, posAngle)
+            equalPosAngles(ctx.getPositionAngle, posAngle)
             asn match {
               case List(AgsStrategy.Assignment(actProbe, actStar)) =>
                 assertEquals(guideProbe, actProbe)
                 assertEqualTarget(expStar, actStar)
                 strategy.params.referenceMagnitude(actStar).foreach { mag =>
                   val actSpeed = AgsMagnitude.fastestGuideSpeed(mc, mag, ctx.getConditions)
-                  assertTrue(s"Expected: $expSpeed , actual: $actSpeed", actSpeed.exists(_ == expSpeed))
+                  assertTrue(s"Expected: $expSpeed , actual: $actSpeed", actSpeed.contains(expSpeed))
                 }
               case Nil => fail(s"Expected: ($expStar, $expSpeed), but nothing selected")
               case _   => fail(s"Multiple guide probe assignments: $asn")

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -83,7 +83,7 @@ class GemsStrategySpec extends Specification {
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
-      val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+      val posAngles = Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
 
       testSearchOnNominal("/gems_pal1.xml", ctx, tipTiltMode, posAngles, 2, 2)
 
@@ -151,7 +151,7 @@ class GemsStrategySpec extends Specification {
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
-      val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+      val posAngles = Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
 
       testSearchOnStandardConditions("/gems_sn1987A.xml", ctx, tipTiltMode, posAngles, 9, 9)
 
@@ -229,7 +229,7 @@ class GemsStrategySpec extends Specification {
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
-      val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+      val posAngles = Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
 
       testSearchOnBestConditions("/gems_sn1987A.xml", ctx, tipTiltMode, posAngles, 12, 9)
 
@@ -294,7 +294,7 @@ class GemsStrategySpec extends Specification {
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
-      val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+      val posAngles = Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
 
       testSearchOnStandardConditions("/gems_TYC_8345_1155_1.xml", ctx, tipTiltMode, posAngles, 25, 28)
 
@@ -369,7 +369,7 @@ class GemsStrategySpec extends Specification {
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
-      val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+      val posAngles = Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
 
       testSearchOnStandardConditions("/gems_m6.xml", ctx, tipTiltMode, posAngles, 5, 7)
 
@@ -445,7 +445,7 @@ class GemsStrategySpec extends Specification {
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
-      val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+      val posAngles = Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
 
       testSearchOnStandardConditions("/gems_bpm_37093.xml", ctx, tipTiltMode, posAngles, 4, 5)
 
@@ -509,7 +509,7 @@ class GemsStrategySpec extends Specification {
       val ctx = ObsContext.create(env, inst, new JSome(Site.GS), conditions, null, new Gems, JNone.instance())
       val tipTiltMode = GemsTipTiltMode.canopus
 
-      val posAngles = Set(ctx.getPositionAngle.toNewModel, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
+      val posAngles = Set(ctx.getPositionAngle, Angle.zero, Angle.fromDegrees(90), Angle.fromDegrees(180), Angle.fromDegrees(270))
 
       testSearchOnBestConditions("/gems_bpm_37093.xml", ctx, tipTiltMode, posAngles, 5, 5)
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/SingleProbeVignettingTest.scala
@@ -86,7 +86,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
     }
 
   def ctx180(ctx: ObsContext): ObsContext =
-    ctx.withPositionAngle(ctx.getPositionAngle.add(180, edu.gemini.skycalc.Angle.Unit.DEGREES))
+    ctx.withPositionAngle(ctx.getPositionAngle.flip)
 
   def contexts(ctx: ObsContext): List[ObsContext] =
     ctx.getInstrument match {
@@ -140,7 +140,7 @@ object SingleProbeVignettingTest extends Specification with ScalaCheck with Vign
 
             val res = selection.exists { sel =>
               winners.exists { case (gs, c, _, _, _) =>
-                almostEqual(sel.posAngle.toDegrees, c.getPositionAngle.toNewModel.toDegrees) &&
+                almostEqual(sel.posAngle.toDegrees, c.getPositionAngle.toDegrees) &&
                   sel.assignments.exists { _.guideStar == gs }
               }
             }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/altair/AltairAowfsGuider.java
@@ -112,7 +112,7 @@ public enum AltairAowfsGuider implements OffsetValidatingGuideProbe, Validatable
 
             // check positions against corrected patrol field
             return getCorrectedPatrolField(ctx).map(pf ->
-                    patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions)
+                    pf.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions)
             ).getOrElse(BoundaryPosition.outside);
         });
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -1382,16 +1382,12 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
     }
 
     @Override
-    public String getPosAngleConstraintDescriptorKey() {
-        return POS_ANGLE_CONSTRAINT_PROP.getName();
-    }
-
-    @Override
     public ImList<PosAngleConstraint> getSupportedPosAngleConstraints() {
         return DefaultImList.create(PosAngleConstraint.FIXED,
                                     PosAngleConstraint.FIXED_180,
                                     PosAngleConstraint.UNBOUNDED,
-                                    PosAngleConstraint.PARALLACTIC_ANGLE);
+                                    PosAngleConstraint.PARALLACTIC_ANGLE,
+                                    PosAngleConstraint.PARALLACTIC_OVERRIDE);
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -1,5 +1,6 @@
 package edu.gemini.spModel.gemini.gmos;
 
+import edu.gemini.shared.util.immutable.MapOp;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Coordinates;
@@ -77,7 +78,7 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
             // check positions against corrected patrol field
             return getCorrectedPatrolField(ctx).map(pf ->
-                    patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions)
+                    pf.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions)
             ).getOrElse(BoundaryPosition.outside);
         });
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbe.java
@@ -1,10 +1,5 @@
-//
-// $
-//
-
 package edu.gemini.spModel.gemini.gmos;
 
-import edu.gemini.shared.util.immutable.MapOp;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Coordinates;
@@ -13,7 +8,6 @@ import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.guide.VignettingCalculator;
 import edu.gemini.spModel.guide.*;
-import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.telescope.IssPort;
@@ -78,16 +72,13 @@ public enum GmosOiwfsGuideProbe implements ValidatableGuideProbe, OffsetValidati
 
     public Option<BoundaryPosition> checkBoundaries(final Coordinates coords, final ObsContext ctx) {
         return ctx.getBaseCoordinates().map(baseCoordinates -> {
-            final Angle positionAngle = ctx.getPositionAngle();
+            final Angle positionAngle = ctx.getPositionAngleJava();
             final Set<Offset> sciencePositions = ctx.getSciencePositions();
 
             // check positions against corrected patrol field
-            return getCorrectedPatrolField(ctx).map(new MapOp<PatrolField, BoundaryPosition>() {
-                @Override
-                public BoundaryPosition apply(PatrolField patrolField) {
-                    return patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
-                }
-            }).getOrElse(BoundaryPosition.outside);
+            return getCorrectedPatrolField(ctx).map(pf ->
+                    patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions)
+            ).getOrElse(BoundaryPosition.outside);
         });
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -1859,16 +1859,12 @@ public abstract class InstGmosCommon<
     }
 
     @Override
-    public String getPosAngleConstraintDescriptorKey() {
-        return POS_ANGLE_CONSTRAINT_PROP.getName();
-    }
-
-    @Override
     public ImList<PosAngleConstraint> getSupportedPosAngleConstraints() {
         return DefaultImList.create(PosAngleConstraint.FIXED,
                                     PosAngleConstraint.FIXED_180,
                                     PosAngleConstraint.UNBOUNDED,
-                                    PosAngleConstraint.PARALLACTIC_ANGLE);
+                                    PosAngleConstraint.PARALLACTIC_ANGLE,
+                                    PosAngleConstraint.PARALLACTIC_OVERRIDE);
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -1031,14 +1031,10 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     }
 
     @Override
-    public String getPosAngleConstraintDescriptorKey() {
-        return POS_ANGLE_CONSTRAINT_PROP.getName();
-    }
-
-    @Override
     public ImList<PosAngleConstraint> getSupportedPosAngleConstraints() {
         return DefaultImList.create(PosAngleConstraint.FIXED,
-                                    PosAngleConstraint.PARALLACTIC_ANGLE);
+                                    PosAngleConstraint.PARALLACTIC_ANGLE,
+                                    PosAngleConstraint.PARALLACTIC_OVERRIDE);
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
@@ -850,11 +850,6 @@ public final class Gsaoi extends SPInstObsComp
     }
 
     @Override
-    public String getPosAngleConstraintDescriptorKey() {
-        return POS_ANGLE_CONSTRAINT_PROP.getName();
-    }
-
-    @Override
     public ImList<PosAngleConstraint> getSupportedPosAngleConstraints() {
         return DefaultImList.create(PosAngleConstraint.FIXED,
                                     PosAngleConstraint.UNBOUNDED);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArray.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArray.java
@@ -222,9 +222,9 @@ public enum GsaoiDetectorArray {
 
 
     private List<Tuple2<Quadrant, Shape>> defaultQuadrantShapes() {
-        List<Tuple2<Quadrant, Shape>> res = new ArrayList<Tuple2<Quadrant, Shape>>();
+        List<Tuple2<Quadrant, Shape>> res = new ArrayList<>();
         for (Quadrant q : Quadrant.values()) {
-            res.add(new Pair<Quadrant, Shape>(q, q.shape()));
+            res.add(new Pair<>(q, q.shape()));
         }
         return res;
     }
@@ -241,8 +241,8 @@ public enum GsaoiDetectorArray {
             return defaultQuadrantShapes();
         }
 
-        Map<Quadrant, Area> map = new HashMap<Quadrant, Area>();
-        for (Offset off : offsets) {
+        final Map<Quadrant, Area> map = new HashMap<>();
+        for (final Offset off : offsets) {
             double x = -off.p().toArcsecs().getMagnitude();
             double y = -off.q().toArcsecs().getMagnitude();
             AffineTransform xform = AffineTransform.getTranslateInstance(x, y);
@@ -260,9 +260,9 @@ public enum GsaoiDetectorArray {
             }
         }
 
-        List<Tuple2<Quadrant, Shape>> res = new ArrayList<Tuple2<Quadrant, Shape>>();
+        List<Tuple2<Quadrant, Shape>> res = new ArrayList<>();
         for (Quadrant q : Quadrant.values()) {
-            res.add(new Pair<Quadrant, Shape>(q, map.get(q)));
+            res.add(new Pair<>(q, map.get(q)));
         }
         return res;
     }
@@ -297,7 +297,7 @@ public enum GsaoiDetectorArray {
 
             // Get a rotation to transform the shape to the position angle.
             AffineTransform xform = new AffineTransform();
-            xform.rotate(-ctx.getPositionAngle().toRadians().getMagnitude());
+            xform.rotate(-ctx.getPositionAngle().toRadians());
 
             // Check each quadrant to see if it contains the point, returning
             // a new Some if so.
@@ -305,7 +305,7 @@ public enum GsaoiDetectorArray {
             for (Tuple2<Quadrant, Shape> t : quadrantIntersection(offsets)) {
                 Area a = new Area(t._2());
                 a.transform(xform);
-                if (a.contains(p, q)) return new Some<Id>(t._1().id(ctx.getIssPort()));
+                if (a.contains(p, q)) return new Some<>(t._1().id(ctx.getIssPort()));
             }
 
             // Not on the detector for all offset positions.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/GuideProbeUtil.java
@@ -7,10 +7,8 @@ import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.CoordinateDiff;
 import edu.gemini.skycalc.Coordinates;
 import edu.gemini.skycalc.Offset;
-import edu.gemini.shared.skyobject.coords.HmsDegCoordinates;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.data.ISPDataObject;
-import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.SPTarget;
@@ -108,7 +106,7 @@ public enum GuideProbeUtil {
     }
 
     public GuideStarValidation validate(final Coordinates coords, final GuideProbe guideProbe, final ObsContext ctx) {
-        final Angle positionAngle = ctx.getPositionAngle();
+        final Angle positionAngle = ctx.getPositionAngleJava();
         final Set<Offset> sciencePositions = ctx.getSciencePositions();
         return ctx.getBaseCoordinates().map(bcs ->
             guideProbe.getCorrectedPatrolField(ctx).exists(patrolField -> {
@@ -138,7 +136,7 @@ public enum GuideProbeUtil {
             final double yOffset = -offset.q().toArcsecs().getMagnitude();
             final PatrolField offsetPatrolField = patrolField.getTransformed(AffineTransform.getTranslateInstance(xOffset, yOffset));
             // and we must rotate the patrol field according to position angle
-            final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians().getMagnitude()));
+            final PatrolField rotatedPatrolField = offsetPatrolField.getTransformed(AffineTransform.getRotateInstance(-ctx.getPositionAngle().toRadians()));
             // find distance of base position to the guide star
             return
                 guideStar.getSkycalcCoordinates(ctx.getSchedulingBlockStart()).flatMap(gcs ->

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/guide/PatrolField.java
@@ -254,7 +254,7 @@ public class PatrolField {
     public Area usableArea(ObsContext ctx) {
         Area a = offsetIntersection(ctx.getSciencePositions());
         AffineTransform xform = new AffineTransform();
-        xform.rotate(-ctx.getPositionAngle().toRadians().getMagnitude());
+        xform.rotate(-ctx.getPositionAngle().toRadians());
         a.transform(xform);
         return a;
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
@@ -1,10 +1,3 @@
-// Copyright 1997-2000
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: SPInstObsComp.java 39389 2011-11-25 18:00:51Z swalker $
-//
 package edu.gemini.spModel.obscomp;
 
 import edu.gemini.pot.sp.ISPObservation;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -1,10 +1,5 @@
-//
-// $
-//
-
 package edu.gemini.spModel.target.obsComp;
 
-import edu.gemini.shared.util.immutable.MapOp;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.skycalc.Coordinates;
@@ -14,7 +9,6 @@ import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.gemini.gmos.GmosCommonType;
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon;
 import edu.gemini.spModel.guide.*;
-import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.SPTarget;
@@ -303,31 +297,27 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
      *
      * @param coords the coordinates
      * @param ctx the context
-     * @return
      */
     public Option<BoundaryPosition> checkBoundaries(final Coordinates coords, final ObsContext ctx) {
         return ctx.getBaseCoordinates().map(baseCoordinates -> {
-            final Angle positionAngle = ctx.getPositionAngle();
+            final Angle positionAngle = ctx.getPositionAngleJava();
             final Set<Offset> sciencePositions = ctx.getSciencePositions();
 
             // check positions against corrected outer patrol field bounds
-            return getCorrectedPatrolField(ctx).map(new MapOp<PatrolField, BoundaryPosition>() {
-                @Override
-                public BoundaryPosition apply(PatrolField patrolField) {
-                    final BoundaryPosition bp = patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
-                    if (bp != BoundaryPosition.inside) {
-                        return BoundaryPosition.outside;
-                    }
-
-                    // Check if any of the guide stars are inside the inner bounds (opposite logic needed, union instead of intersection)
-                    final double minLimit = getVignettingClearance(ctx).toArcsecs().getMagnitude();
-                    final Ellipse2D e = new Ellipse2D.Double(-minLimit, -minLimit, minLimit * 2.0, minLimit * 2.0);
-                    final PatrolField p = getCorrectedPatrolField(new PatrolField(e, e, e), ctx);
-                    if (p.anyInside(coords, baseCoordinates, positionAngle, sciencePositions)) {
-                        return BoundaryPosition.inside;
-                    }
-                    return BoundaryPosition.innerBoundary;
+            return getCorrectedPatrolField(ctx).map(pf -> {
+                final BoundaryPosition bp = patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
+                if (bp != BoundaryPosition.inside) {
+                    return BoundaryPosition.outside;
                 }
+
+                // Check if any of the guide stars are inside the inner bounds (opposite logic needed, union instead of intersection)
+                final double minLimit = getVignettingClearance(ctx).toArcsecs().getMagnitude();
+                final Ellipse2D e = new Ellipse2D.Double(-minLimit, -minLimit, minLimit * 2.0, minLimit * 2.0);
+                final PatrolField p = getCorrectedPatrolField(new PatrolField(e, e, e), ctx);
+                if (p.anyInside(coords, baseCoordinates, positionAngle, sciencePositions)) {
+                    return BoundaryPosition.inside;
+                }
+                return BoundaryPosition.innerBoundary;
             }).getOrElse(BoundaryPosition.outside);
         });
     }
@@ -341,7 +331,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
 
     @Override
     public Option<PatrolField> getCorrectedPatrolField(ObsContext ctx) {
-        return GuideProbeUtil.instance.isAvailable(ctx, this) ? new Some<>(getCorrectedPatrolField(getPatrolField(), ctx)) : None.<PatrolField>instance();
+        return GuideProbeUtil.instance.isAvailable(ctx, this) ? new Some<>(getCorrectedPatrolField(getPatrolField(), ctx)) : None.instance();
     }
 
     public PatrolField getCorrectedPatrolField(PatrolField patrolField, ObsContext ctx) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -305,7 +305,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
 
             // check positions against corrected outer patrol field bounds
             return getCorrectedPatrolField(ctx).map(pf -> {
-                final BoundaryPosition bp = patrolField.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
+                final BoundaryPosition bp = pf.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
                 if (bp != BoundaryPosition.inside) {
                     return BoundaryPosition.outside;
                 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraint.java
@@ -55,12 +55,22 @@ public enum PosAngleConstraint {
         public String description() {
             return "Best position angle";
         }
+
+        @Override
+        public boolean isCalculated() {
+            return true;
+        }
     },
 
     /** Parallactic angle allows provided pos angle, or pos angle plus 180 deg. */
     PARALLACTIC_ANGLE() {
         @Override
         public String description() { return "Average parallactic"; }
+
+        @Override
+        public boolean isCalculated() {
+            return true;
+        }
     },
 
     /** Parallactic angle is displayed, but overridden by a FIXED_180 value specified by user. */
@@ -85,6 +95,13 @@ public enum PosAngleConstraint {
      * Description of the constraint for use in creating GUI combo boxes.
      */
     public abstract String description();
+
+    /**
+     * Is this value automatically calculated?
+     */
+    public boolean isCalculated() {
+        return false;
+    }
 
     @Override
     public String toString() { return description(); }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraint.java
@@ -1,12 +1,13 @@
 package edu.gemini.spModel.telescope;
 
-import edu.gemini.skycalc.Angle;
 import edu.gemini.shared.util.immutable.DefaultImList;
 import edu.gemini.shared.util.immutable.ImCollections;
 import edu.gemini.shared.util.immutable.ImList;
+import edu.gemini.spModel.core.Angle;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Constraint options on automatic position angle adjustments.
@@ -28,11 +29,6 @@ public enum PosAngleConstraint {
     /** The provided pos angle, or the pos angle plus 180 deg. */
     FIXED_180() {
         @Override
-        public ImList<Angle> steps(Angle start, Angle stepSize) {
-            return DefaultImList.create(start, start.add(Angle.ANGLE_PI));
-        }
-
-        @Override
         public String description() {
             return "Allow 180\u00ba flip";
         }
@@ -42,22 +38,35 @@ public enum PosAngleConstraint {
      * by the guide probe.
      */
     UNBOUNDED() {
+        /**
+         * Steps through position angles from the start angle through 360 degrees
+         * by step size.
+         */
+        @Override
+        public ImList<Angle> steps(Angle start, Angle stepSize) {
+            final int stepSizeDegrees = (int) stepSize.toDegrees();
+            final int numSteps = (stepSizeDegrees == 0) ? 1 : 360 / stepSizeDegrees;
+
+            final List<Angle> angles = IntStream.range(0, numSteps).mapToObj(i -> start.$plus(stepSize.$times(i))).collect(Collectors.toList());
+            return DefaultImList.create(angles);
+        }
+
         @Override
         public String description() {
-            //return "Allow guide star search to set position angle";
-            return "Find best";
+            return "Best position angle";
         }
     },
 
     /** Parallactic angle allows provided pos angle, or pos angle plus 180 deg. */
     PARALLACTIC_ANGLE() {
         @Override
-        public ImList<Angle> steps(Angle start, Angle stepSize) {
-            return DefaultImList.create(start, start.add(Angle.ANGLE_PI));
-        }
-
-        @Override
         public String description() { return "Average parallactic"; }
+    },
+
+    /** Parallactic angle is displayed, but overridden by a FIXED_180 value specified by user. */
+    PARALLACTIC_OVERRIDE() {
+        @Override
+        public String description() { return "Parallactic override"; }
     }
     ;
 
@@ -66,20 +75,10 @@ public enum PosAngleConstraint {
      * by step size, but obeying the position angle constraint.  For example,
      * the FIXED constraint would provide just a single angle, the start
      * angle.  An UNKNOWN or UNBOUNDED constraint will step through the entire range.
-     * As the entire range is used by multiple enum values, it is the default.
+     * As the range for multiple types is fixed / fixed + 180, that is by default used.
      */
-    public ImList<Angle> steps(Angle start, Angle stepSize) {
-        int deg = (int) Math.round(stepSize.toPositive().toDegrees().getMagnitude());
-        int stepCount = (deg == 0) ? 1 : 360 / deg;
-
-        Angle cur = start;
-        List<Angle> res = new ArrayList<Angle>(stepCount);
-        for (int i=0; i<stepCount; ++i) {
-            res.add(cur);
-            cur = cur.add(stepSize);
-        }
-
-        return DefaultImList.create(res);
+    public ImList<Angle> steps(Angle start, Angle requestedStepSize) {
+        return DefaultImList.create(start, start.flip());
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraintAware.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraintAware.java
@@ -11,12 +11,6 @@ public interface PosAngleConstraintAware {
     void setPosAngleConstraint(PosAngleConstraint pac);
 
     /**
-     * Used to configure property change listeners.
-     * @return the descriptor corresponding to the position angle constraint.
-     */
-    String getPosAngleConstraintDescriptorKey();
-
-    /**
      * The list of valid position angle constraints for this instrument.
      * @return a list of the supported position angle constraints.
      */

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2OiwfsProbeArm.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/flamingos2/F2OiwfsProbeArm.scala
@@ -88,7 +88,7 @@ object F2OiwfsProbeArm extends ProbeArmGeometry {
 
     val flamingos2  = ctx.getInstrument.asInstanceOf[Flamingos2]
     val flip        = flamingos2.getFlipConfig(gemsFlag)
-    val posAngle    = ctx.getPositionAngle.toNewModel
+    val posAngle    = ctx.getPositionAngle
     val fovRotation = flamingos2.getRotationConfig(gemsFlag).toNewModel
     guideStarOffset(ctx, guideStar).map { gsOffset =>
       val angle = armAngle(posAngle, fovRotation, gsOffset, offset, flip, flamingos2.getLyotWheel.getPlateScale)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/GmosOiwfsProbeArm.scala
@@ -80,7 +80,7 @@ object GmosOiwfsProbeArm extends ProbeArmGeometry {
     } yield {
       val ifuOffset = Offset(ifu.arcsecs[OffsetP], OffsetQ.Zero)
       val flip = ctx.getIssPort == IssPort.SIDE_LOOKING
-      val posAngle = ctx.getPositionAngle.toNewModel
+      val posAngle = ctx.getPositionAngle
       val angle = armAngle(posAngle, gsOffset, offset, ifuOffset, flip)
       ArmAdjustment(angle, gsOffset)
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ScienceAreaGeometry.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/inst/ScienceAreaGeometry.scala
@@ -18,7 +18,7 @@ trait ScienceAreaGeometry {
   /** Adjusted science area shapes in context, ready to be used in further
     * calculations or transformed to a screen plot. */
   def geometry(ctx: ObsContext, offset: Offset): Option[Shape] =
-    offsetTransform(ctx.getPositionAngle.toNewModel, offset) |> { trans =>
+    offsetTransform(ctx.getPositionAngle, offset) |> { trans =>
       unadjustedGeometry(ctx).map { trans.createTransformedShape }
     }
 

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gmos/GmosOiwfsGuideProbeTest.java
@@ -13,19 +13,12 @@ import junit.framework.TestCase;
 import org.junit.Test;
 
 import edu.gemini.shared.util.immutable.None;
-import edu.gemini.spModel.core.Site;
 
 import java.awt.geom.Rectangle2D;
 
 import static edu.gemini.skycalc.Angle.Unit.ARCSECS;
 import static edu.gemini.skycalc.Angle.Unit.DEGREES;
 
-/**
- * Test class for GmosOiwfsGuideProbe
- *
- * @author Nicolas A. Barriga
- * Date: Aug 25, 2010
- */
 public class GmosOiwfsGuideProbeTest extends TestCase {
 
     // test offsetIntersection
@@ -48,7 +41,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.UP_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        baseContext = ObsContext.create(env, inst, None.instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
     }
 
     /**
@@ -111,13 +104,13 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
                         baseContext) == GuideStarValidation.VALID);
 
-        ObsContext ctx = baseContext.withPositionAngle(new Angle(90, DEGREES));
+        ObsContext ctx = baseContext.withPositionAngleJava(new Angle(90, DEGREES));
         assertFalse("Mid point of fov, after 90 degree rotation of fov.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
                         ctx) == GuideStarValidation.VALID);
 
-        ctx = baseContext.withPositionAngle(new Angle(45, DEGREES));
+        ctx = baseContext.withPositionAngleJava(new Angle(45, DEGREES));
         assertTrue("Mid point of fov, after 45 degree rotation of fov.",
                 GmosOiwfsGuideProbe.instance.validate(
                         new SPTarget(coords.getRaDeg(), coords.getDecDeg()),
@@ -148,7 +141,7 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
 
         InstGmosNorth ign = (InstGmosNorth) baseContext.getInstrument();
         ign.setFPUnit(GmosNorthType.FPUnitNorth.IFU_2);
-        ObsContext    ctx = ObsContext.create(env, ign, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        ObsContext    ctx = ObsContext.create(env, ign, None.instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
 
         assertFalse("Point outside of fov, after IFU selected.",
                 GmosOiwfsGuideProbe.instance.validate(
@@ -164,7 +157,6 @@ public class GmosOiwfsGuideProbeTest extends TestCase {
      *
      * @param rect where to get the corners from
      * @param shift distance to be moved. >0 means move to the outside
-     * @return
      */
     private Coordinates[] getCorners(Rectangle2D rect, Double shift){
            return new Coordinates[]{

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArrayTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArrayTest.java
@@ -43,7 +43,7 @@ public class GsaoiDetectorArrayTest extends TestCase {
         inst.setPosAngle(0);
         inst.setIssPort(IssPort.SIDE_LOOKING);
 
-        baseContext = ObsContext.create(env, inst, None.<Site>instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
+        baseContext = ObsContext.create(env, inst, None.instance(), SPSiteQuality.Conditions.BEST, null, null, None.instance());
     }
 
     private void assertEmpty(Coordinates[] coordsArray) {
@@ -121,7 +121,7 @@ public class GsaoiDetectorArrayTest extends TestCase {
                 new Coordinates(new Angle( midDetector, ARCSECS), new Angle( midDetector, ARCSECS)), // 3
                 new Coordinates(new Angle( midDetector, ARCSECS), new Angle(-midDetector, ARCSECS)), // 4
         };
-        assertOrdered(coordsArray, baseContext.withPositionAngle(new Angle(90, DEGREES)));
+        assertOrdered(coordsArray, baseContext.withPositionAngleJava(new Angle(90, DEGREES)));
 
         // These fall in the gaps when the pos angle is 0, but should be in the
         // detector when rotated 45 degrees.
@@ -131,7 +131,7 @@ public class GsaoiDetectorArrayTest extends TestCase {
                 new Coordinates(new Angle(0, ARCSECS),            new Angle( midDetector, ARCSECS)), // 3
                 new Coordinates(new Angle( midDetector, ARCSECS), new Angle(0, ARCSECS)),            // 4
         };
-        assertOrdered(coordsArray, baseContext.withPositionAngle(new Angle(45, DEGREES)));
+        assertOrdered(coordsArray, baseContext.withPositionAngleJava(new Angle(45, DEGREES)));
     }
 
     @Test

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/inst/VignettingArbitraries.scala
@@ -23,7 +23,7 @@ trait VignettingArbitraries extends edu.gemini.spModel.test.SpModelArbitraries {
   def genCandidates(ctx: ObsContext): Gen[List[Coordinates]] =
     ctx.getInstrument match {
       case paca: PosAngleConstraintAware if paca.getPosAngleConstraint == FIXED_180 =>
-        val ctx180 = ctx.withPositionAngle(ctx.getPositionAngle.add(180, edu.gemini.skycalc.Angle.Unit.DEGREES))
+        val ctx180 = ctx.withPositionAngle(ctx.getPositionAngle.flip)
         for {
           a0 <- genFixedPosAngleCandidates(ctx)
           a1 <- genFixedPosAngleCandidates(ctx180)
@@ -50,7 +50,7 @@ trait VignettingArbitraries extends edu.gemini.spModel.test.SpModelArbitraries {
         // Rotate the offset in p and q by the position angle. To get the
         // p delta and q delta (which are negated because screen coords
         // are flipped)
-        val rot      = AffineTransform.getRotateInstance(-ctx.getPositionAngle.toRadians.getMagnitude)
+        val rot      = AffineTransform.getRotateInstance(-ctx.getPositionAngle.toRadians)
         val offsetPt = rot.transform(new Point2D.Double(p, q), new Point2D.Double())
         val pd       = -offsetPt.getX // arcsecs
         val qd       = -offsetPt.getY // arcsecs

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -454,7 +454,7 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
             final Option<ObsContext> adjCtxOpt;
             final GuideGrp grp = group.grp();
             if (grp instanceof AutomaticGroup.Active) {
-                adjCtxOpt = ctxOpt.map(ctx -> ctx.withPositionAngle(edu.gemini.skycalc.Angle.degrees(((AutomaticGroup.Active) grp).posAngle().toDegrees())));
+                adjCtxOpt = ctxOpt.map(ctx -> ctx.withPositionAngle(((AutomaticGroup.Active) grp).posAngle()));
             } else {
                 adjCtxOpt = ctxOpt;
             }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/GemsGuideStarWorker.java
@@ -213,7 +213,7 @@ public class GemsGuideStarWorker extends SwingWorker implements MascotProgress {
     private static Set<edu.gemini.spModel.core.Angle> getPosAngles(ObsContext obsContext) {
         final Set<edu.gemini.spModel.core.Angle> posAngles = new TreeSet<>(Comparator.comparingDouble(edu.gemini.spModel.core.Angle::toDegrees));
 
-        posAngles.add(ModelConverters.toNewAngle(obsContext.getPositionAngle()));
+        posAngles.add(obsContext.getPositionAngle());
         posAngles.add(ModelConverters.toNewAngle(new Angle(0., Angle.Unit.DEGREES)));
         posAngles.add(ModelConverters.toNewAngle(new Angle(90., Angle.Unit.DEGREES)));
         posAngles.add(ModelConverters.toNewAngle(new Angle(180., Angle.Unit.DEGREES)));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchController.java
@@ -76,7 +76,7 @@ class GemsGuideStarSearchController {
 
     private Set<edu.gemini.spModel.core.Angle> getPosAngles(final ObsContext obsContext) {
         final Set<edu.gemini.spModel.core.Angle> posAngles = new HashSet<>();
-        posAngles.add(ModelConverters.toNewAngle(obsContext.getPositionAngle()));
+        posAngles.add(obsContext.getPositionAngle());
         if (_model.isAllowPosAngleAdjustments()) {
             posAngles.add(ModelConverters.toNewAngle(new Angle(0., Angle.Unit.DEGREES)));
             posAngles.add(ModelConverters.toNewAngle(new Angle(90., Angle.Unit.DEGREES)));

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -662,7 +662,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           iqBox.selection.item = c.iq
         }
         List(sbBox, ccBox, iqBox).foreach(i => i.listenTo(i.selection))
-        i.ctx.map(_.getPositionAngle).foreach(a => pa = a.toNewModel)
+        i.ctx.map(_.getPositionAngle).foreach(a => pa = a)
         i.ctx.map(_.getSciencePositions).foreach(o => offsets = o.asScala.map(_.toNewModel).toSet)
         updateGuideSpeedText()
       }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -154,7 +154,8 @@ object ObservationInfo {
     case Some(i: InstAltair) => AltairParams.Mode.values().toList.map(m => obsCtx.withAOComponent(new InstAltair() <| {_.setMode(m)})) :+ obsCtx.withoutAOComponent()
     case _                   => List(obsCtx)
   }
-  
+
+  val PosAngleConstraints = Set(PosAngleConstraint.FIXED_180, PosAngleConstraint.PARALLACTIC_OVERRIDE)
 
   def apply(ctx: ObsContext, mt: MagnitudeTable):ObservationInfo = ObservationInfo(
     ctx.some,
@@ -165,7 +166,7 @@ object ObservationInfo {
     expandAltairModes(ctx).flatMap(c => AgsRegistrar.validStrategies(c).map(toSupportedStrategy(c, _, mt))).sorted,
     ctx.getConditions.some,
     ctx.getPositionAngle,
-    Option(ctx.getInstrument).collect{case p: PosAngleConstraintAware => p.getPosAngleConstraint == PosAngleConstraint.FIXED_180}.getOrElse(false),
+    Option(ctx.getInstrument).collect{case p: PosAngleConstraintAware => PosAngleConstraints.contains(p.getPosAngleConstraint)}.getOrElse(false),
     ctx.getSciencePositions.asScala.map(_.toNewModel).toSet,
     UCAC4,
     mt)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -28,11 +28,11 @@ import scala.swing.event.{ButtonClicked, Event}
 import scalaz._, Scalaz._, scalaz.effect.IO
 
 /**
- * This class encompasses all of the logic required to manage the average parallactic angle information associated
- * with an instrument configuration.
- *
- * @param isPaUi should be true for PA controls, false for Scheduling Block controls
- */
+  * This class encompasses all of the logic required to manage the average parallactic angle information associated
+  * with an instrument configuration.
+  *
+  * @param isPaUi should be true for PA controls, false for Scheduling Block controls
+  */
 class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publisher {
   import ParallacticAngleControls._
 
@@ -149,9 +149,9 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
 
 
   /**
-   * Initialize the UI and set the instrument editor to allow for the parallactic angle updates.
-   * The `Runnable` is a callback that will be invoked on the EDT after the target is updated.
-   */
+    * Initialize the UI and set the instrument editor to allow for the parallactic angle updates.
+    * The `Runnable` is a callback that will be invoked on the EDT after the target is updated.
+    */
   def init(e: OtItemEditor[_, _], s: Option[Site], f: Format, c: Runnable): Unit = Swing.onEDT {
     editor    = Some(e)
     site      = s
@@ -241,9 +241,9 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
 
 
   /**
-   * Triggered when the date time button is clicked. Shows the ParallacticAngleDialog to allow the user to
-   * explicitly set a date and duration for the parallactic angle calculation.
-   */
+    * Triggered when the date time button is clicked. Shows the ParallacticAngleDialog to allow the user to
+    * explicitly set a date and duration for the parallactic angle calculation.
+    */
   private def displayParallacticAngleDialog(): Unit = Swing.onEDT {
     for {
       e <- editor
@@ -263,10 +263,10 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
 
 
   /**
-   * This should be called whenever the position angle changes to compare it to the parallactic angle.
-   * A warning icon is displayed if the two are different. This is a consequence of allowing the user to
-   * set the PA to something other than the parallactic angle, even when it is selected.
-   */
+    * This should be called whenever the position angle changes to compare it to the parallactic angle.
+    * A warning icon is displayed if the two are different. This is a consequence of allowing the user to
+    * set the PA to something other than the parallactic angle, even when it is selected.
+    */
   def positionAngleChanged(positionAngleText: String): Unit = Swing.onEDT {
     // We only do this if the parallactic angle can be calculated, and is different from the PA.
     for {
@@ -282,8 +282,8 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
 
 
   /**
-   * This should be called whenever the parallactic angle components need to be reinitialized, and at initialization.
-   */
+    * This should be called whenever the parallactic angle components need to be reinitialized, and at initialization.
+    */
   def resetComponents(): Unit = Swing.onEDT {
     ui.parallacticAngleFeedback.text = ""
     for {
@@ -331,8 +331,8 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
     }
 
   /**
-   * The parallactic angle calculation, if it can be calculated
-   */
+    * The parallactic angle calculation, if it can be calculated
+    */
   def parallacticAngle: Option[Angle] =
     for {
       e <- editor

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -280,10 +280,8 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       // Set up the UI.
       updatePATextFieldEditableState(posAngleConstraint)
       ui.controlsPanel.updatePanel()
-      ui.positionAngleConstraintComboBox.selection.item match {
-        case PosAngleConstraint.PARALLACTIC_ANGLE => p.resetComponents()
-        case _                                    =>
-      }
+      if (ParallacticAnglePosConstraints.contains(posAngleConstraint))
+        p.resetComponents()
     }
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -20,7 +20,7 @@ import jsky.app.ot.util.OtColor
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
 import scala.swing.event._
-import scala.util.Try
+
 import scalaz._
 import Scalaz._
 
@@ -60,7 +60,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       // disallow any alphabetic characters.
       def angle: Option[Double] = for {
         t <- "^-?\\d*\\.?\\d*$".r.findFirstMatchIn(text.trim)
-        d <- Try { t.group(0).toDouble }.toOption
+        d <- \/.fromTryCatchNonFatal{ t.group(0).toDouble }.toOption
       } yield d
 
       override def validate(): Unit = Swing.onEDT {


### PR DESCRIPTION
This PR solves the issue of BAGS clashing with the parallactic angle controls and restores the functionality of allowing users to override the parallactic angle.

Prior to BAGS, we allowed users to override the parallactic angle simply by typing in the position angle text field. This was problematic with BAGS because BAGS lookups would trigger reinitialization of GUI components, which would recalculate the parallactic angle, which would repopulate the position angle text field, thus clobbering user input.

It was determined that being able to override parallactic angle is a requirement, as there are cases where the user wishes to have the parallactic angle calculation available and specify a different angle to be used.

The solution we decided to implement for the Dec 2016 release is to change the behavior of the "Parallactic angle" position angle constraint, so when it is selected, the parallactic angle must be used as the position angle: the position angle text field is rendered uneditable as can be seen here:
![screen shot 2016-11-04 at 3 47 10 pm](https://cloud.githubusercontent.com/assets/8795653/20018556/ea229608-a2a6-11e6-8fbe-ad9bac6ce07e.png)

To allow the override to be made, the user must now select a new position angle constraint from the combo box, namely "Parallactic override", which behaves precisely like the "Allow 180 flip" constraint, but displays the parallactic angle calculation:
![screen shot 2016-11-04 at 3 45 55 pm](https://cloud.githubusercontent.com/assets/8795653/20018586/105c647a-a2a7-11e6-97fc-e056dadfa2c8.png)

This required some minor changes to AGS to accommodate the new mode.

I also took advantage of this to migrate from the old `edu.gemini.skycalc.Angle` to the new `edu.gemini.spModel.core.Angle` class in a number of places, and switched from explicit single-method mappings and expressions to Java 8 lambda expressions.