### PR TITLE
REL-2855: Do not allow the BAGS feedback to override the feedback for the currently selected target.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -499,7 +499,8 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     private void updateTargetFeedback(final TargetEnvironment env) {
         final Option<ObsContext> ctx = getObsContext(env);
         final ISPObsComponent node   = getContextTargetObsComp();
-        TargetSelection.getTargetForNode(env, node).foreach(target -> _w.detailEditor.targetFeedbackEditor().edit(ctx, target, node));
+        final SPTarget target        = TargetSelection.getTargetForNode(env, node).getOrElse(env.getBase());
+        _w.detailEditor.targetFeedbackEditor().edit(ctx, target, node);
     }
 
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
@@ -11,8 +11,8 @@ import jsky.app.ot.OT
 import jsky.app.ot.ags.{ObsKey, BagsManager}
 import jsky.app.ot.gemini.editor.targetComponent.TargetFeedback.Row
 
+import scala.swing.GridBagPanel
 import scala.swing.GridBagPanel.Fill
-import scala.swing.{GridBagPanel, Swing}
 
 
 class TargetFeedbackEditor extends TelescopePosEditor {
@@ -21,13 +21,14 @@ class TargetFeedbackEditor extends TelescopePosEditor {
   def getComponent: Component = tab.peer
 
   override def edit(ctxOpt: GOption[ObsContext], target: SPTarget, node: ISPNode): Unit = {
-    val analysis = {
-      val mt = OT.getMagnitudeTable
-      ctxOpt.asScalaOpt.map(TargetGuidingFeedback.targetAnalysis(_, mt, target)).getOrElse(Nil)
-    }
-
     // Construct the rows for the table. Optionally a BAGS row, and then a list of AGS analysis rows.
     val rows = {
+      val analysisRows = for {
+        c <- ctxOpt.asScalaOpt.toList
+        a <- TargetGuidingFeedback.targetAnalysis(c, OT.getMagnitudeTable, target)
+        if !target.isTooTarget
+      } yield a
+
       val bagsRow = for {
         n <- Option(node)
         o <- Option(n.getContextObservation)
@@ -37,7 +38,8 @@ class TargetFeedbackEditor extends TelescopePosEditor {
 
       // If the BAGS row is defined, then use it. If not, create the rows corresponding to the analysis.
       // NOTE that is target.isTooTarget, we don't want an analysis.
-      bagsRow.fold(if (target.isTooTarget) Nil else analysis)(List(_))
+
+      analysisRows ++ bagsRow
     }
 
     if (rows.isEmpty)
@@ -53,7 +55,7 @@ object TargetFeedbackEditor {
 
     def showRow(row: Row): Unit = showRows(List(row))
 
-    def showRows(rows: List[Row]): Unit = {
+    def showRows(rows: Iterable[Row]): Unit = {
       layout.clear()
 
       rows.zipWithIndex.foreach { case (row, rowIndex) =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
@@ -14,6 +14,8 @@ import jsky.app.ot.gemini.editor.targetComponent.TargetFeedback.Row
 import scala.swing.GridBagPanel
 import scala.swing.GridBagPanel.Fill
 
+import scalaz._
+import Scalaz._
 
 class TargetFeedbackEditor extends TelescopePosEditor {
   private val tab: TargetFeedbackEditor.Table = new TargetFeedbackEditor.Table
@@ -23,11 +25,7 @@ class TargetFeedbackEditor extends TelescopePosEditor {
   override def edit(ctxOpt: GOption[ObsContext], target: SPTarget, node: ISPNode): Unit = {
     // Construct the rows for the table. Optionally a BAGS row, and then a list of AGS analysis rows.
     val rows = {
-      val analysisRows = for {
-        c <- ctxOpt.asScalaOpt.toList
-        a <- TargetGuidingFeedback.targetAnalysis(c, OT.getMagnitudeTable, target)
-        if !target.isTooTarget
-      } yield a
+      val analysisRows = target.isTooTarget fold (Nil, ctxOpt.asScalaOpt.toList.flatMap(TargetGuidingFeedback.targetAnalysis(_, OT.getMagnitudeTable, target)))
 
       val bagsRow = for {
         n <- Option(node)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/TargetDetailPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/TargetDetailPanel.scala
@@ -74,10 +74,10 @@ final class TargetDetailPanel extends JPanel with TelescopePosEditor with Reentr
     }
 
     // Forward the `edit` call.
-    tpw.                  edit(obsContext, spTarget, node)
-    tde.                  edit(obsContext, spTarget, node)
+    tpw.                 edit(obsContext, spTarget, node)
+    tde.                 edit(obsContext, spTarget, node)
     targetFeedbackEditor.edit(obsContext, spTarget, node)
-    source.               edit(obsContext, spTarget, node)
+    source.              edit(obsContext, spTarget, node)
 
   }
 


### PR DESCRIPTION
In the previous implementation, if a target in the target environment was selected, pending BAGS feedback would clobber the feedback and only the BAGS feedback was shown.

This small modification ensures that both the feedback for the selected target and any BAGS feedback are both shown in the target editor.

I'd like to get this merged in the next 40 mins if possible to have it included in today's test release.