### PR TITLE
REL-2924: Multiple fixes for parallactic angle mode.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -12,6 +12,8 @@ import edu.gemini.spModel.target.*;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
+import edu.gemini.spModel.telescope.PosAngleConstraint;
+import edu.gemini.spModel.telescope.PosAngleConstraintAware;
 import edu.gemini.spModel.util.Angle;
 import jsky.app.ot.tpe.gems.GemsGuideStarSearchDialog;
 import jsky.app.ot.util.OtColor;
@@ -853,6 +855,11 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
         final Double d = _ctx.instrument().posAngleOrZero();
         if ((d != posAngle) && (inst != null)) {
             inst.setPosAngle(posAngle);
+            if (inst instanceof PosAngleConstraintAware) {
+                final PosAngleConstraintAware pacInst = (PosAngleConstraintAware) inst;
+                if (pacInst.getPosAngleConstraint() == PosAngleConstraint.PARALLACTIC_ANGLE)
+                    pacInst.setPosAngleConstraint(PosAngleConstraint.PARALLACTIC_OVERRIDE);
+            }
         }
 
         if (!getCoordinateConverter().isWCS()) {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -147,10 +147,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
           e     <- editor
           fmt   <- formatter
           inst  <- Option(e.getContextInstrumentDataObject).collect { case s: SPInstObsComp => s }
-        } {
-          //warningStateFromPAString(fmt.format(inst.getPosAngleDegrees))
-          warningStateFromPAString(inst.getPosAngleDegrees.toString)
-        }
+        } warningStateFromPAString(inst.getPosAngleDegrees.toString)
       }
 
       def warningStateFromPAString(paStr: String): Unit = Swing.onEDT {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -162,7 +162,6 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
         } {
           val explicitlySet = !fmt.format(angle.toDegrees).equals(paStr) &&
                               !fmt.format((angle + Angle.fromDegrees(180)).toDegrees).equals(paStr)
-          println(s"*** paStr=$paStr, parAngle=${fmt.format(angle.toDegrees)}, explicitlySet=$explicitlySet")
           if (explicitlySet) {
             icon = Resources.getIcon("eclipse/alert.gif")
             tooltip = "The PA is not at the average parallactic value."

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -15,7 +15,8 @@ import edu.gemini.spModel.obs.{ObsTargetCalculatorService, SPObservation, Schedu
 import edu.gemini.spModel.obs.SchedulingBlock.Duration
 import edu.gemini.spModel.obs.SchedulingBlock.Duration._
 import edu.gemini.spModel.rich.shared.immutable._
-import edu.gemini.shared.util.immutable.{Option => JOption, ImOption}
+import edu.gemini.shared.util.immutable.{ImOption, Option => JOption}
+import edu.gemini.spModel.obscomp.SPInstObsComp
 import jsky.app.ot.editor.OtItemEditor
 import jsky.app.ot.gemini.editor.EphemerisUpdater
 import jsky.app.ot.util.TimeZonePreference
@@ -24,8 +25,9 @@ import jsky.util.gui.DialogUtil
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
 import scala.swing.event.{ButtonClicked, Event}
-
-import scalaz._, Scalaz._, scalaz.effect.IO
+import scalaz._
+import Scalaz._
+import scalaz.effect.IO
 
 /**
   * This class encompasses all of the logic required to manage the average parallactic angle information associated
@@ -131,13 +133,47 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
     }
 
     object parallacticAngleFeedback extends Label {
-      foreground             = Color.black
-      horizontalAlignment    = Alignment.Left
-      iconTextGap            = iconTextGap - 2
+      foreground          = Color.black
+      horizontalAlignment = Alignment.Left
+      icon                = Resources.getIcon("eclipse/blank.gif")
+      iconTextGap         = iconTextGap - 2
 
-      def warningState(warn: Boolean): Unit =
-        icon = if (warn) Resources.getIcon("eclipse/alert.gif") else Resources.getIcon("eclipse/blank.gif")
+      /**
+        * This should be called whenever the position angle or parallactic angle changes.
+        * A warning icon and tooltip are displayed if the two are different.
+        */
+      def warningState(): Unit = Swing.onEDT {
+        for {
+          e     <- editor
+          fmt   <- formatter
+          inst  <- Option(e.getContextInstrumentDataObject).collect { case s: SPInstObsComp => s }
+        } {
+          //warningStateFromPAString(fmt.format(inst.getPosAngleDegrees))
+          warningStateFromPAString(inst.getPosAngleDegrees.toString)
+        }
+      }
+
+      def warningStateFromPAString(paStr: String): Unit = Swing.onEDT {
+        for {
+          e     <- editor
+          fmt   <- formatter
+          inst  <- Option(e.getContextInstrumentDataObject).collect { case s: SPInstObsComp => s }
+          angle <- parallacticAngle
+        } {
+          val explicitlySet = !fmt.format(angle.toDegrees).equals(paStr) &&
+                              !fmt.format((angle + Angle.fromDegrees(180)).toDegrees).equals(paStr)
+          println(s"*** paStr=$paStr, parAngle=${fmt.format(angle.toDegrees)}, explicitlySet=$explicitlySet")
+          if (explicitlySet) {
+            icon = Resources.getIcon("eclipse/alert.gif")
+            tooltip = "The PA is not at the average parallactic value."
+          } else {
+            icon = Resources.getIcon("eclipse/blank.gif")
+            tooltip = ""
+          }
+        }
+      }
     }
+
     layout(parallacticAngleFeedback) = new Constraints() {
       gridx   = 2
       weightx = 1.0
@@ -239,7 +275,6 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
 
     }
 
-
   /**
     * Triggered when the date time button is clicked. Shows the ParallacticAngleDialog to allow the user to
     * explicitly set a date and duration for the parallactic angle calculation.
@@ -261,23 +296,11 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
     }
   }
 
-
   /**
     * This should be called whenever the position angle changes to compare it to the parallactic angle.
-    * A warning icon is displayed if the two are different. This is a consequence of allowing the user to
-    * set the PA to something other than the parallactic angle, even when it is selected.
     */
-  def positionAngleChanged(positionAngleText: String): Unit = Swing.onEDT {
-    // We only do this if the parallactic angle can be calculated, and is different from the PA.
-    for {
-      e     <- editor
-      angle <- parallacticAngle
-      fmt   <- formatter
-    } {
-      val explicitlySet = !fmt.format(angle.toDegrees).equals(positionAngleText) &&
-                          !fmt.format((angle + Angle.fromDegrees(180)).toDegrees).equals(positionAngleText)
-      ui.parallacticAngleFeedback.warningState(explicitlySet)
-    }
+  def positionAngleChanged(positionAngleText: String): Unit = {
+    ui.parallacticAngleFeedback.warningStateFromPAString(positionAngleText)
   }
 
 
@@ -300,16 +323,17 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       // Scheduling block duration, in minutes
       val durStr = sb.duration.toOption.map(_ / 60000.0).foldMap(n => f", $n%2.1f min")
 
-      // Parallactic Angle
+      // Parallactic angle. If it can be calculated, display its value and its 180 flip value.
       val paStr = parallacticAngle
-        .map(_.toDegrees)
-        .fold(", not visible")(a => s", ${fmt.format(a)}°")
+        .map(a => List(a.toDegrees, a.flip.toDegrees).sorted.map(a0 => s"${fmt.format(a0)}°").mkString(" / "))
+        .fold(", not visible")(a => s", $a")
 
       ui.parallacticAngleFeedback.text =
         if (isPaUi) dateTimeStr + durStr + paStr
         else dateTimeStr
 
       if (didParllacticAngleChange) {
+        ui.parallacticAngleFeedback.warningState()
         publish(ParallacticAngleControls.ParallacticAngleChangedEvent)
       }
     }
@@ -326,7 +350,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
           val oldAngleDegrees = e.getContextInstrumentDataObject.getPosAngleDegrees
           Math.abs(oldAngleDegrees - newAngle.toDegrees)
         }
-        angleDiff >= Precision && Math.abs(angleDiff - 180) >= Precision
+        angleDiff >= Precision || Math.abs(angleDiff - 180) >= Precision
       }
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -350,7 +350,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
           val oldAngleDegrees = e.getContextInstrumentDataObject.getPosAngleDegrees
           Math.abs(oldAngleDegrees - newAngle.toDegrees)
         }
-        angleDiff >= Precision || Math.abs(angleDiff - 180) >= Precision
+        angleDiff >= Precision && Math.abs(angleDiff - 180) >= Precision
       }
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -83,9 +83,9 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     listenTo(positionAngleTextField.keys)
     reactions += {
       case ValueChanged(`positionAngleTextField`) =>
-        ui.parallacticAngleControlsOpt.foreach(_.positionAngleChanged(positionAngleTextField.text))
         ui.positionAngleTextField.validate()
         copyPosAngleToInstrument()
+        ui.parallacticAngleControlsOpt.foreach(_.positionAngleChanged(positionAngleTextField.text))
 
       case FocusGained(`positionAngleTextField`, _, _) | FocusLost(`positionAngleTextField`, _, _) =>
         copyPosAngleToTextField()


### PR DESCRIPTION
This PR encompasses a bunch of fixes and requested enhancements for parallactic angle mode, namely:

1. If the PA constraint is set to "parallactic mode" and the user changes the position angle in the TPE, the mode is now automatically switched to "parallactic override."

2. This fixes an issue where the position angle, when being entered by the user, was being written to the instrument in the wrong order, i.e. after the parallactic controls were updated instead of before. This was causing issues with things being overridden.

3. Now the parallactic calculation, as per Andy's request, displays, e.g. if the parallactic angle is 10, "10 / 190" so as to minimize user confusion with 180 flips.

4. A warning tool tip has been added to the parallactic angle calculation to accompany the warning symbol for when parallactic angle has been overridden and is not equal to the calculation.

5. The parallactic angle calculation field now is supplied with a default empty icon so that the spacing remains consistent whether or not the parallactic angle is overridden.