### PR TITLE
REL-2941: make GeMS AGS ignore flexure correction assignment

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -205,6 +205,13 @@ object GemsResultsAnalyzer {
         val gpt = assignGuideProbeTarget(obsContext, posAngle, tiptiltGroup, x, tiptiltGroup, result, tiptiltTargetList, reverseOrder)
         gpt.map(x => addTipTiltGuideProbeTargets(tail, (x :: result).reverse, obsContext.withTargets(obsContext.getTargets.putPrimaryGuideProbeTargets(x)))).getOrElse((obsContext, Nil))
     }
+
+    // TODO: REL-2941
+    // addTipTiltGuideProbeTargets(tiptiltTargetList, Nil, obsContext)._2
+    //
+    // Remove everything below replacing it with the above line.  Get rid of
+    // "tiptiltGroup" since it is always Canopus.Wfs.group.instance.  Git rid
+    // of flexureGroup, flexureStars  Propagate changes ...
     val tipTiltGuideProbeTargets = addTipTiltGuideProbeTargets(tiptiltTargetList, Nil, obsContext)
 
     // assign guide probe for flexure star

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -114,7 +114,7 @@ trait GemsStrategy extends AgsStrategy {
       }
     }
 
-    mapGroup(Canopus.Wfs.Group.instance) ++ mapGroup(GsaoiOdgw.Group.instance)
+    mapGroup(Canopus.Wfs.Group.instance) // TODO: REL-2941 ++ mapGroup(GsaoiOdgw.Group.instance)
   }
 
   override def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = {
@@ -202,7 +202,7 @@ trait GemsStrategy extends AgsStrategy {
 
       // Now we must convert from an Option[GemsGuideStars] to a Selection.
       gemsGuideStars.map { x =>
-        val assignments = x.guideGroup.getAll.asScalaList.flatMap(targets => {
+        val assignments = x.guideGroup.getAll.asScalaList.filter(_.getGuider.getGroup.contains(Canopus.Wfs.Group.instance)).flatMap(targets => {
           val guider = targets.getGuider
           targets.getTargets.asScalaList.map(target => Assignment(guider, target.toSiderealTarget(ctx.getSchedulingBlockStart)))
         })

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
@@ -35,7 +35,7 @@ public final class GemsGuideStarRule implements IRule {
     private static final String ConfigError = "Configuration not supported. Please select 3 CWFS + 1 ODGW or 1 CWFS + 3 ODGW";
     private static final String TipTilt = "Less than 3 GeMS guide stars of the same origin. Tip-tilt correction will not be optimal.";
     private static final String SlowFocus = "Missing Slow-focus Sensor star. Slow Focus correction will be not be applied.";
-    private static final String Flexure = "Missing flexure guide star. Flexure will not be compensated.";
+// TODO: REL-2941   private static final String Flexure = "Missing flexure guide star. Flexure will not be compensated.";
     private static final String NoIqAny = "GeMS cannot be used in IQAny conditions.";
     private static final String NoCloudy = "GeMS cannot be used in cloudy conditions.";
 
@@ -130,10 +130,13 @@ public final class GemsGuideStarRule implements IRule {
                 if ((odgws == 3 || odgws == 2) && cwfs == 0) {
                     problems.addWarning(PREFIX + "SlowFocus", SlowFocus, targetNode);
                 }
+
+                /* TODO: REL-2941
                 //No flexure guide star (GSAOI ODGW or Flamingos II OIWFS) when using 2 or 3 CWFS.
                 if ((cwfs == 3 || cwfs == 2) && odgws == 0) {
                     problems.addWarning(PREFIX + "Flexure", Flexure, targetNode);
                 }
+                */
             }
 
             if (Flamingos2.SP_TYPE.equals(elements.getInstrument().getType())) {
@@ -143,12 +146,14 @@ public final class GemsGuideStarRule implements IRule {
                 if (!gpt.isEmpty() && !gpt.getValue().getPrimary().isEmpty()) {
                     f2oiwfs = true;
                 }
+                /* TODO: REL-2941
                 //No flexure guide star (GSAOI ODGW or Flamingos II OIWFS) when using 2 or 3 CWFS.
                 if (!f2oiwfs && (cwfs == 3 || cwfs == 2)) {
                     if (gpt.isEmpty() || gpt.getValue().getPrimary().isEmpty()) {
                         problems.addWarning(PREFIX + "Flexure", Flexure, targetNode);
                     }
                 }
+                */
                 //When using less than 3 of either CANOPUS CWFS or ODGW when 1 of the complementary type (CWFS3 or ODGW/F2 OIWFS)
                 if ((f2oiwfs && cwfs < 3) && !isDayCal) {
                     problems.addWarning(PREFIX + "TipTilt", TipTilt, targetNode);


### PR DESCRIPTION
This PR updates GeMS AGS so that it ignores the flexure star assignment, preventing ODGW stars from being added to the auto guide group.  Correspondingly, it removes any analysis or phase 2 checks related to ODGW stars for GeMS.

This is the bare minimum required for December but there is a tremendous opportunity for simplification here that we cannot pass up.  The entirety of GeMS AGS can be stripped of flexure star selection code and no longer needs to support ODGW for tip tilt correction - tip tilt will always be Canopus.  The NIR band option can be removed as well.  Since the changes are rather large, we'll leave further work for post-December.

__Note__: there are a few comments tagged with TODO: REL-2941.  Ordinarily we should not leave commented out code but here I wanted to do so since work on 2941 will continue post-release.