### PR TITLE
REL-2988: GlassLabel NPE issues

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/submit/SubmitView.scala
@@ -133,11 +133,11 @@ class SubmitView(ph: ProblemRobot, newShellHandler: (Model,Option[File]) => Unit
         case ButtonClicked(_) =>
           for (m <- panel.model) {
             if (saveHandler()) {
-              GlassLabel.show(panel.peer.getRootPane, "Submitting Proposal...")
+              val glass = GlassLabel.show(panel.peer, "Submitting Proposal...")
               submitClient.submit(m.proposal) { psr =>
                 SwingUtilities.invokeLater(new Runnable {
                   def run() {
-                    GlassLabel.hide(panel.peer.getRootPane)
+                    glass.foreach(_.hide())
 
                     val anySuccess = psr.results.exists(_.result.isSuccess)
                     val errors = psr.results.map(_.result).filter(!_.isSuccess)

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -798,17 +798,17 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
   private def catalogSearch(query: CatalogQuery, backend: VoTableBackend, message: String, onSuccess: (QueryResult) => Unit): Unit = {
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    GlassLabel.show(peer.getRootPane, message)
+    val glass = GlassLabel.show(peer, message)
     VoTableClient.catalog(query, backend)(global).onComplete {
       case scala.util.Failure(f)                           =>
-        GlassLabel.hide(peer.getRootPane)
+        glass.foreach(_.hide())
         errorLabel.show(s"Exception: ${f.getMessage}")
       case scala.util.Success(x) if x.result.containsError =>
-        GlassLabel.hide(peer.getRootPane)
+        glass.foreach(_.hide())
         errorLabel.show(s"Error: ${x.result.problems.head.displayValue}")
       case scala.util.Success(x)                           =>
         Swing.onEDT {
-          GlassLabel.hide(peer.getRootPane)
+          glass.foreach(_.hide())
           onSuccess(x)
         }
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
@@ -36,17 +36,18 @@ object EphemerisUpdater {
    */
   final class UI private (c: () => Component) {
 
-    private def rootPane: Option[JRootPane] =
-      Option(SwingUtilities.getRootPane(c()))
+    private var glass: Option[GlassLabel] = None
 
     def onEDT(f: => Unit): HS2[Unit] =
       HS2.delay(Swing.onEDT(f))
 
-    def show(msg: String): HS2[Unit] =
-      onEDT(rootPane.foreach(GlassLabel.show(_, msg)))
+    def show(msg: String): HS2[Unit] = onEDT {
+      glass = GlassLabel.show(c(), msg)
+    }
 
-    val hide: HS2[Unit] =
-      onEDT(rootPane.foreach(GlassLabel.hide))
+    val hide: HS2[Unit] = onEDT {
+      glass.foreach(_.hide())
+    }
 
   }
   object UI {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/SiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/SiderealNameEditor.scala
@@ -1,7 +1,5 @@
 package jsky.app.ot.gemini.editor.targetComponent.details2
 
-import javax.swing.SwingUtilities
-
 import edu.gemini.catalog.api.CatalogQuery
 import edu.gemini.catalog.votable.{SimbadNameBackend, VoTableClient}
 import edu.gemini.pot.sp.ISPNode
@@ -25,15 +23,15 @@ final class SiderealNameEditor(mags: MagnitudeEditor2) extends TelescopePosEdito
 
   private def forkSearch(): Unit = {
     val searchItem = name.getValue
-    GlassLabel.show(SwingUtilities.getRootPane(name), "Searching...") // We are on the EDT
-    VoTableClient.catalog(CatalogQuery(searchItem), SimbadNameBackend)(implicitly).onComplete { case t =>
+    val glass      = GlassLabel.show(name, "Searching ...") // We are on the EDT
+    VoTableClient.catalog(CatalogQuery(searchItem), SimbadNameBackend)(implicitly).onComplete { case tqr =>
       Swing.onEDT {
-        GlassLabel.hide(SwingUtilities.getRootPane(name))
-        t.map(r => (r.result.problems, r.result.targets.rows.headOption)) match {
-          case Failure(f) => errmsg(f.getMessage)
-          case Success((Nil, None)) => errmsg(s"Target '$searchItem' not found ")
+        glass.foreach(_.hide())
+        tqr.map(r => (r.result.problems, r.result.targets.rows.headOption)) match {
+          case Failure(f)              => errmsg(f.getMessage)
+          case Success((Nil, None))    => errmsg(s"Target '$searchItem' not found ")
           case Success((Nil, Some(t))) => spt.setTarget(Target.name.set(t, name.getValue)) // REL-2717
-          case Success((ps, _)) => errmsg(ps.map(_.displayValue).mkString(", "))
+          case Success((ps, _))        => errmsg(ps.map(_.displayValue).mkString(", "))
         }
       }
     }


### PR DESCRIPTION
This is a somewhat sketchy update to a very sketchy `GlassLabel` utility class.  The underlying issue is that the glass label is intended to be shown on top of all other widgets, yet allows input to pass through regardless.  The user can kick off a sidereal target name search for instance and then quickly click away to another component.  By the time the result comes back, the call to lookup the root pane associated with the target name widget returns `null` because the target name is not visible.  An easy fix is to save the root component and use it for the subsequent hide but this PR goes a step or two further:

1. You now call the static `GlassLabel.show` method to display the label and get a reference to a `GlassLabel` instance.  Using the instance you call `glass.hide()` to dismiss the label.  The `GlassLabel` keeps up with the root pane reference.

2. `GlassLabel` now blocks UI events so that they don't go through to the underlying widgets.