### PR TITLE
REL-2990: QPT and parallactic override mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2017A", true, 1, 4, 1)
 
 pitVersion in ThisBuild := OcsVersion("2017A", true, 1, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2017A", true, 1, 4, 1)
+ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2017A", true, 1, 1, 0)
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/telescope/PosAngleConstraint.java
@@ -71,12 +71,18 @@ public enum PosAngleConstraint {
         public boolean isCalculated() {
             return true;
         }
+
+        @Override
+        public boolean isParallactic() { return true; }
     },
 
     /** Parallactic angle is displayed, but overridden by a FIXED_180 value specified by user. */
     PARALLACTIC_OVERRIDE() {
         @Override
         public String description() { return "Parallactic override"; }
+
+        @Override
+        public boolean isParallactic() { return true; }
     }
     ;
 
@@ -105,4 +111,6 @@ public enum PosAngleConstraint {
 
     @Override
     public String toString() { return description(); }
+
+    public boolean isParallactic() { return false; }
 }

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
@@ -659,13 +659,11 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
      * @return true if the observation uses the average parallactic angle
      * @throws RemoteException
      */
-    private boolean usesAverageParallacticAngle(ISPObservation obsShell) throws RemoteException {
-        for (ISPObsComponent comp : obsShell.getObsComponents()) {
+    private boolean usesAverageParallacticAngle(final ISPObservation obsShell) throws RemoteException {
+        return obsShell.getObsComponents().stream().anyMatch(comp -> {
             final ISPDataObject dObj = comp.getDataObject();
-            if (dObj instanceof PosAngleConstraintAware)
-                return ((PosAngleConstraintAware) dObj).getPosAngleConstraint() == PosAngleConstraint.PARALLACTIC_ANGLE;
-        }
-        return false;
+            return (dObj instanceof PosAngleConstraintAware) && ((PosAngleConstraintAware) dObj).getPosAngleConstraint().isParallactic();
+        });
     }
 
     private void applySysConfigs(ISPObservation obsShell, ApplyOp<ISysConfig> op) {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -164,7 +164,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       def updatePanel(): Unit = Swing.onEDT {
         editor.foreach { e =>
           val pac = e.getDataObject.getPosAngleConstraint
-          if (ParallacticAnglePosConstraints.contains(pac))
+          if (pac.isParallactic)
             showParallacticAngleControls()
           else
             showPositionAngleFeedback()
@@ -280,7 +280,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       // Set up the UI.
       updatePATextFieldEditableState(posAngleConstraint)
       ui.controlsPanel.updatePanel()
-      if (ParallacticAnglePosConstraints.contains(posAngleConstraint))
+      if (posAngleConstraint.isParallactic)
         p.resetComponents()
     }
   }
@@ -316,10 +316,10 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
       val isParInstAndOk = i.isInstanceOf[ParallacticAngleSupport] &&
                            i.asInstanceOf[ParallacticAngleSupport].isCompatibleWithMeanParallacticAngleMode
       val canUseAvgPar = isParInstAndOk && !ObsClassService.lookupObsClass(o).equals(ObsClass.DAY_CAL)
-      ParallacticAnglePosConstraints.foreach(c => setOptionEnabled(c, canUseAvgPar))
+      PosAngleConstraint.values().toSeq.filter(_.isParallactic).foreach(c => setOptionEnabled(c, canUseAvgPar))
 
       // Now the parallactic angle is in use if it can be used and is selected.
-      if (canUseAvgPar && ParallacticAnglePosConstraints.contains(i.getPosAngleConstraint)) {
+      if (canUseAvgPar && i.getPosAngleConstraint.isParallactic) {
         p.ui.relativeTimeMenu.rebuild()
       }
     }
@@ -345,6 +345,4 @@ object PositionAnglePanel {
   def apply[I <: SPInstObsComp with PosAngleConstraintAware with ParallacticAngleSupport,
             E <: OtItemEditor[ISPObsComponent, I]](instType: SPComponentType): PositionAnglePanel[I,E] =
     new PositionAnglePanel[I,E](instType)
-
-  val ParallacticAnglePosConstraints = Set(PosAngleConstraint.PARALLACTIC_ANGLE, PosAngleConstraint.PARALLACTIC_OVERRIDE)
 }


### PR DESCRIPTION
The QPT displays a warning when a parallactic angle mode observation is scheduled.
This was not properly accounted for when the `PARALLACTIC_OVERRIDE` mode was added.

This code cleans up the `PosAngleConstraint`s corresponding to parallactic modes by making a common method that ascertains whether a position angle constraint is parallactic, as this check must be done in multiple places, thus eliminating the need to ensure both modes are checked for.

The QPT now properly displays a warning whether an observation's position angle constraint is `PARALLACTIC_ANGLE` or `PARALLACTIC_OVERRIDE`.