### PR TITLE
REL-2859: Automatically download and cache images

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalog.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalog.scala
@@ -152,12 +152,17 @@ object ImageCatalog {
 
   /**
     * Returns a catalog appropriate for a given wavelength
+    * TODO Re-enable catalog selection an a per-wavelength basis when handling
+    * of 2MASS catalogs has been improved
     */
-  def catalogForWavelength(w: Option[Wavelength]): ImageCatalog = w match {
+  def catalogForWavelength(w: Option[Wavelength]): ImageCatalog = DssGemini
+    /* As per user request, don't delete this code
+    w match {
       case Some(d) if d <= DssCutoff                           => DssGemini
       case Some(d) if d <= MassJCutoff                         => TwoMassJ
       case Some(d) if d <= MassHCutoff                         => TwoMassH
       case Some(_)                                             => TwoMassK
       case None                                                => DefaultImageCatalog
     }
+    */
 }


### PR DESCRIPTION
Per user request this PR removes (Or hides) the auto selection of image catalogs depending on the observation Wavelength. Instead all queries will be done by default to Gemini DSS with the option to manually override

It is requested to keep the code commented to re-enable this feature in the future