### PR TITLE
REL-2989: Attempting to fix the PA text field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2017A", true, 1, 5, 1)
 
 pitVersion in ThisBuild := OcsVersion("2017A", true, 1, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2017A", true, 1, 5, 1)
+ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2017A", true, 1, 1, 0)
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -3,12 +3,12 @@ package edu.gemini.ags.impl
 import edu.gemini.ags.api._
 import edu.gemini.ags.api.AgsMagnitude._
 import edu.gemini.catalog.api.CatalogQuery
-import edu.gemini.catalog.votable.{ConeSearchBackend, VoTableBackend, CatalogException, VoTableClient}
+import edu.gemini.catalog.votable.{CatalogException, ConeSearchBackend, VoTableBackend, VoTableClient}
 import edu.gemini.pot.ModelConverters._
 import edu.gemini.spModel.ags.AgsStrategyKey
-import edu.gemini.spModel.core.{Coordinates, Angle}
+import edu.gemini.spModel.core.{Angle, Coordinates}
 import edu.gemini.spModel.core.SiderealTarget
-import edu.gemini.spModel.guide.{ValidatableGuideProbe, VignettingGuideProbe, GuideProbe}
+import edu.gemini.spModel.guide.{GuideProbe, ValidatableGuideProbe, VignettingGuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.telescope.PosAngleConstraint._
 import edu.gemini.shared.util.immutable.ScalaConverters._
@@ -16,7 +16,6 @@ import edu.gemini.shared.util.immutable.ScalaConverters._
 import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import scalaz._
 import Scalaz._
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -138,7 +138,6 @@ object BagsState {
         runningTransition | ((IdleState(k, newHash), idleAction))
       }
 
-
       fetchObs(k).fold((ErrorState: BagsState, ioUnit)) { wakeUp }
     }
   }


### PR DESCRIPTION
As per REL-2989, BAGS and the PA text field were still having issues. This only seems to manifest when:
1. The TPE is open; and
2. The user modifies the PA contents quickly, e.g. 123.

It appears that due to the use of the Swing EDT, BAGS launches on an old value such as 1 or 12, and then subtasks of tasks launched on the Swing EDT finish in an unpredictable order, and the 123 is overwritten by BAGS and the 123 is never properly registered by BAGS as requiring a new lookup.

This is a very head-desk bashing attempt to fix this by fiddling with the way things are run on the Swing EDT, which seems to fix it in all cases except very rare circumstances which still require the above two mentioned conditions. Instead of Swing EDT tasks launching new Swing EDT tasks, for example, I have consolidated so that everything is run in a single Swing EDT task. (This was a problem in the `PositionAnglePanel`, as a `Swing.onEDT` piece of code `A` would call a `Swing.onEDT` piece of code `B`, and then `A` would terminate before `B` since `Swing.onEDT` schedules and returns immediately before the task is completed.)

This is not a sure-fire permanent fix, as, as Shane noted, there will almost certainly always be issues when an automatic and manual process are fighting to update the same text field. In the June 2017 release, we will separate out the user PA text field and the PA chosen by BAGS. In the interim, unless someone has any more suggestions, I suspect this will be the closest we may get to a solution that works in almost all cases.

We should also create a JIRA task to pad my office after fighting with this for as long as I have. 😸 