### PR TITLE
REL-2996: Parallactic angle + position angle warning fix

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -145,22 +145,24 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
         */
       def warningState(): Unit =
         for {
-          e     <- editor
-          fmt   <- formatter
-          inst  <- Option(e.getContextInstrumentDataObject).collect { case s: SPInstObsComp => s }
+          e    <- editor
+          fmt  <- formatter
+          inst <- Option(e.getContextInstrumentDataObject).collect { case s: SPInstObsComp => s }
         } warningStateFromPAString(inst.getPosAngleDegrees.toString)
 
-      def warningStateFromPAString(paStr: String): Unit =
+      /**
+        * Compares the parallactic angle to the supplied position angle.
+        */
+      def warningStateFromPAString(paStr: String): Unit = Swing.onEDT {
         for {
-          e     <- editor
-          fmt   <- formatter
-          inst  <- Option(e.getContextInstrumentDataObject).collect { case s: SPInstObsComp => s }
+          e   <- editor
+          fmt <- formatter
         } {
           // We warn only if the parallactic angle exists and has been explicitly set.
           val warningFlag = parallacticAngle.exists { angle =>
-              val fa = fmt.format(angle.toDegrees)
-              val faFlip = fmt.format(angle.flip.toDegrees)
-              !fa.equals(paStr) && !faFlip.equals(paStr)
+            val fa = fmt.format(angle.toDegrees)
+            val faFlip = fmt.format(angle.flip.toDegrees)
+            !fa.equals(paStr) && !faFlip.equals(paStr)
           }
 
           if (warningFlag) {
@@ -171,6 +173,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
             tooltip = ""
           }
         }
+      }
 
       // This is kind of horrible, but we want to recalculate the warning state whenever the text of the label
       // changes, so this is the most robust way to ensure that this will happen no matter where the label changes.

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -173,8 +173,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
         }
 
       // This is kind of horrible, but we want to recalculate the warning state whenever the text of the label
-      // changes, which can happen via a number of methods (BAGS, user, switching observations), so this is the most
-      // robust way to manually ensure that this will happen no matter where the label changes.
+      // changes, so this is the most robust way to ensure that this will happen no matter where the label changes.
       peer.addPropertyChangeListener("text", new PropertyChangeListener {
         override def propertyChange(evt: PropertyChangeEvent): Unit = {
           warningState()


### PR DESCRIPTION
When a parallactic angle mode is selected and the PA text field has a value that does not equal the calculated parallactic angle or its 180 flip, a warning icon is displayed in the parallactic angle information label, and a tooltip set.

Andy found an issue where switching between observations caused this to break sometimes, where the warning would be improperly set. The need for displaying the warning needs to be re-evaluated whenever the parallactic angle information label changes or the PA text field contents change.

When the PA contents change, an event is fired that is handled, so this case is fine. However, there were instances where the parallactic angle info label contents would change and the warning display code would not be called, thus resulting possibly in a lack of warning or a warning in improper circumstances.

I now ensure that whenever the parallactic info label text changes, the warning generation / clearing method is called via a `PropertyChangeListener` on the `text` of the label. This is kind of horrible in that it is so Javaesque, but there doesn't appear to be any published events from the Scala `Label` class, so I think it is the only way to make sure this is handled.

This should be preferable to having to call the warning text from anywhere else, as it will void the need to do so should the code change.

Also, there was an issue where if the parallactic angle could not be calculated, the warning would stay the same due to the use of the `for` construct. I have fixed this as well to clear the warning if the parallactic angle cannot be calculated.