### PR TITLE
REL-2999: Only update TPE image if new

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/image/gui/DivaMainImageDisplay.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/gui/DivaMainImageDisplay.java
@@ -387,8 +387,11 @@ public class DivaMainImageDisplay extends DivaGraphicsImageDisplay implements Ma
             setURL(FileUtil.makeURL(null, fileOrUrl));
             return;
         }
-        if (!checkSave())
+
+        // REL-2999: skip image updates when the file hasn't changed.
+        if (fileOrUrl.equals(_filename) || !checkSave()) {
             return;
+        }
 
         addToHistory();
         _filename = fileOrUrl;


### PR DESCRIPTION
Background image updating refreshes the TPE image on display with each edit, including trivial updates that don't impact the coordinates or wavelength.  In the majority of cases the actual image file is already being displayed.  This PR introduces a small hack to skip the image update when the TPE is already displaying the desired image.

This works well with the automatic background image updater, but an obvious flaw is that manually selecting a different image with the same file path would fail.  Given where we are in the desktop OT product lifecycle, I think we can safely ignore this issue.