### PR TITLE
REL-2998: check for context observation before updating

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -105,9 +105,10 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         _agsPub.subscribe((obs, oldOptions, newOptions) -> updateGuiding());
 
         BagsManager.addBagsStateListener((key, oldStatus, newStatus) -> {
-            if (key.equals(getContextObservation().getNodeKey()))
+            if (Optional.ofNullable(getContextObservation()).map(co -> key.equals(co.getNodeKey())).orElse(false)) {
                 updateTargetFeedback();
-        });
+            }
+       });
     }
 
     @Override protected void updateEnabledState(final boolean enabled) {


### PR DESCRIPTION
A tiny update to make sure that the context observation is still available when BAGS feedback arrives.