### PR TITLE
REL-2992: GMOS Hamamatsu CCD ITC overestimates the peak signal + background 

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -44,6 +44,11 @@ sealed trait ItcResult extends Serializable {
 
   def ccd(i: Int = 0): ItcCcd            = ccds(i % ccds.length)
   def peakPixelFlux(ccdIx: Int = 0): Int = ccd(ccdIx).peakPixelFlux.toInt
+  def maxPeakPixelFlux: Int              = ccds.map(_.peakPixelFlux).max.toInt
+  def maxAdu: Int                        = ccds.map(_.adu).max
+  def maxPercentFullWell: Double         = ccds.map(_.percentFullWell).max
+  def maxSingleSNRatio: Double           = ccds.map(_.singleSNRatio).max
+  def maxTotalSNRatio: Double            = ccds.map(_.totalSNRatio).max
 
   val warnings: List[ItcWarning] = {
     def concatWarnings =

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -35,20 +35,20 @@ final case class ItcCcd(
     ampGain:                Double,     // the amplifier gain for this CCD (used to calculate ADU)
     warnings: List[ItcWarning]          // the warnings provided by ITC for this CCD
 ) {
-  val percentFullWell = peakPixelFlux / wellDepth * 100.0   // the max percentage of the well saturation for peak pixel
-  val adu             = (peakPixelFlux / ampGain).toInt     // the ADU value
+  val percentFullWell: Double = peakPixelFlux / wellDepth * 100.0   // the max percentage of the well saturation for peak pixel
+  val adu: Int                = (peakPixelFlux / ampGain).toInt     // the ADU value
 }
 
 sealed trait ItcResult extends Serializable {
   def ccds:                         List[ItcCcd]
 
-  def ccd(i: Int = 0)               = ccds(i % ccds.length)
-  def peakPixelFlux(ccdIx: Int = 0) = ccd(ccdIx).peakPixelFlux.toInt
+  def ccd(i: Int = 0): ItcCcd            = ccds(i % ccds.length)
+  def peakPixelFlux(ccdIx: Int = 0): Int = ccd(ccdIx).peakPixelFlux.toInt
 
   val warnings: List[ItcWarning] = {
     def concatWarnings =
       ccds.zipWithIndex.flatMap { case (c, i) =>
-        c.warnings.map(w => new ItcWarning(s"CCD $i: ${w.msg}"))
+        c.warnings.map(w => ItcWarning(s"CCD $i: ${w.msg}"))
       }
 
     if (ccds.length > 1) concatWarnings
@@ -67,18 +67,18 @@ final case class ItcImagingResult(ccds: List[ItcCcd]) extends ItcResult
 
 // There are two different types of charts
 sealed trait SpcChartType
-case object SignalChart       extends SpcChartType { val instance = this } // signal and background over wavelength [nm]
-case object S2NChart          extends SpcChartType { val instance = this } // single and final S2N over wavelength [nm]
-case object SignalPixelChart  extends SpcChartType { val instance = this } // single and final S2N over wavelength [nm]
+case object SignalChart       extends SpcChartType { val instance: SpcChartType = this } // signal and background over wavelength [nm]
+case object S2NChart          extends SpcChartType { val instance: SpcChartType = this } // single and final S2N over wavelength [nm]
+case object SignalPixelChart  extends SpcChartType { val instance: SpcChartType = this } // single and final S2N over wavelength [nm]
 
 // There are four different data sets
 sealed trait SpcDataType
-case object SignalData        extends SpcDataType { val instance = this }  // signal over wavelength [nm]
-case object BackgroundData    extends SpcDataType { val instance = this }  // background over wavelength [nm]
-case object SingleS2NData     extends SpcDataType { val instance = this }  // single S2N over wavelength [nm]
-case object FinalS2NData      extends SpcDataType { val instance = this }  // final S2N over wavelength [nm]
-case object PixSigData        extends SpcDataType { val instance = this }  // signal over pixels
-case object PixBackData       extends SpcDataType { val instance = this }  // background over pixels
+case object SignalData        extends SpcDataType { val instance: SpcDataType = this }  // signal over wavelength [nm]
+case object BackgroundData    extends SpcDataType { val instance: SpcDataType = this }  // background over wavelength [nm]
+case object SingleS2NData     extends SpcDataType { val instance: SpcDataType = this }  // single S2N over wavelength [nm]
+case object FinalS2NData      extends SpcDataType { val instance: SpcDataType = this }  // final S2N over wavelength [nm]
+case object PixSigData        extends SpcDataType { val instance: SpcDataType = this }  // signal over pixels
+case object PixBackData       extends SpcDataType { val instance: SpcDataType = this }  // background over pixels
 
 /** Series of (x,y) data points used to create charts and text data files. */
 final case class SpcSeriesData(dataType: SpcDataType, title: String, data: Array[Array[Double]], color: Option[Color] = None) {

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -21,7 +21,7 @@ final case class SourceDefinition(
                      normBand: MagnitudeBand,
                      redshift: Redshift) {
 
-  val isUniform = profile match {
+  val isUniform: Boolean = profile match {
     case UniformSource => true
     case _             => false
   }
@@ -88,7 +88,7 @@ final case class IfuSum(skyFibres: Int, num: Double, isIfu2: Boolean) extends If
 // === Observation Details
 
 final case class ObservationDetails(calculationMethod: CalculationMethod, analysisMethod: AnalysisMethod) {
-  def exposureTime   = calculationMethod.exposureTime
-  def sourceFraction = calculationMethod.sourceFraction
-  def isAutoAperture = analysisMethod.isInstanceOf[AutoAperture]
+  def exposureTime: Double    = calculationMethod.exposureTime
+  def sourceFraction: Double  = calculationMethod.sourceFraction
+  def isAutoAperture: Boolean = analysisMethod.isInstanceOf[AutoAperture]
 }

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
@@ -68,8 +68,10 @@ public final class GmosPrinter extends PrinterBase {
                 printCcdTitle(instrument);
             }
             final int ccdIndex = instrument.getDetectorCcdIndex();
-            _printPeakPixelInfo(s.ccd(ccdIndex));
-            _printWarnings(s.ccd(ccdIndex).warnings());
+            if (s.ccd(ccdIndex).isDefined()) {
+                _printPeakPixelInfo(s.ccd(ccdIndex));
+                _printWarnings(s.ccd(ccdIndex).get().warnings());
+            }
         }
 
         _print("<HR align=left SIZE=3>");
@@ -124,9 +126,10 @@ public final class GmosPrinter extends PrinterBase {
 
             final int ccdIndex = ccd.getDetectorCcdIndex();
             _println(CalculatablePrinter.getTextResult(results[ccdIndex].is2nCalc(), results[ccdIndex].observation()));
-            _printPeakPixelInfo(s.ccd(ccdIndex));
-            _printWarnings(s.ccd(ccdIndex).warnings());
-
+            if (s.ccd(ccdIndex).isDefined()) {
+                _printPeakPixelInfo(s.ccd(ccdIndex));
+                _printWarnings(s.ccd(ccdIndex).get().warnings());
+            }
         }
 
         printConfiguration(results[0].parameters(), instrument);

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/PrinterBase.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/PrinterBase.java
@@ -124,10 +124,12 @@ public abstract class PrinterBase {
                 toPlotLimits(pd) + "\"/>");
     }
 
-    protected void _printPeakPixelInfo(final ItcCcd ccd) {
-        _println(
-            String.format("The peak pixel signal + background is %.0f e- (%d ADU). This is %.0f%% of the full well depth of %.0f e-.",
-            ccd.peakPixelFlux(), ccd.adu(), ccd.percentFullWell(), ccd.wellDepth()));
+    protected void _printPeakPixelInfo(final scala.Option<ItcCcd> ccd) {
+        if (ccd.isDefined()) {
+            _println(
+                    String.format("The peak pixel signal + background is %.0f e- (%d ADU). This is %.0f%% of the full well depth of %.0f e-.",
+                            ccd.get().peakPixelFlux(), ccd.get().adu(), ccd.get().percentFullWell(), ccd.get().wellDepth()));
+        }
     }
 
     protected void _printWarnings(final scala.collection.immutable.Seq<ItcWarning> warnings) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Detector.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Detector.java
@@ -2,14 +2,14 @@ package edu.gemini.itc.base;
 
 public class Detector extends TransmissionElement {
     private int _detectorPixels;
-    private String _detectorType;
-    private String _name;
+    private final String _detectorType;
+    private final String _name;
 
-    public Detector(String directory, String prefix, String filename, String detectorType) {
+    public Detector(final String directory, final String prefix, final String filename, final String detectorType) {
         this(directory, prefix, filename, detectorType, "");
     }
 
-    public Detector(String directory, String prefix, String filename, String detectorType, String name) {
+    public Detector(final String directory, final String prefix, final String filename, final String detectorType, final String name) {
         super(directory + prefix + filename + Instrument.getSuffix());
         _detectorType = detectorType;
         _name = name;
@@ -23,7 +23,7 @@ public class Detector extends TransmissionElement {
         _detectorPixels = detectorPixels;
     }
 
-    public String toString() {
+    @Override public String toString() {
         return "Detector - " + _detectorType;
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SampledSpectrumVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SampledSpectrumVisitor.java
@@ -16,6 +16,7 @@ package edu.gemini.itc.base;
  * "recipes" of operations consisting of a list of Visitors.
  * So the operations themselves are an abstraction in this problem.
  */
+@FunctionalInterface
 public interface SampledSpectrumVisitor {
     void visit(SampledSpectrum spectrum);
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -113,7 +113,7 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
                 _IFU = new IFUComponent(getPrefix(), ifu.minOffset(), ifu.maxOffset());
             } else if (getIfuMethod().get() instanceof IfuSum) {
                 double num =  ((IfuSum) odp.analysisMethod()).num();
-                _IFU = new IFUComponent(getPrefix(), ((IfuSum) odp.analysisMethod()).num(), isIfu2());
+                _IFU = new IFUComponent(getPrefix(), num, isIfu2());
             } else {
                 throw new Error("invalid IFU type");
             }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
@@ -40,22 +40,27 @@ public final class GmosNorth extends Gmos {
         super(gp, odp, FILENAME, detectorCcdIndex);
     }
 
+    @Override
     public boolean isIfu2() {
         return getFpMask() == GmosNorthType.FPUnitNorth.IFU_1;
     }
 
+    @Override
     protected Gmos[] createCcdArray() {
         return new Gmos[]{this, new GmosNorth(gp, odp, 1), new GmosNorth(gp, odp, 2)};
     }
 
+    @Override
     protected String getPrefix() {
         return INSTR_PREFIX;
     }
 
+    @Override
     protected String[] getCcdFiles() {
         return DETECTOR_CCD_FILES;
     }
 
+    @Override
     protected String[] getCcdNames() {
         return DETECTOR_CCD_NAMES;
     }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -177,9 +177,9 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             final Slit slit = Slit$.MODULE$.apply(instrument.getSlitWidth(), slitLength, instrument.getPixelSize());
 
             // for uniform sources the result is the same regardless of the IFU offsets/position
-            // in this case we only calcualte and display the result of the first IFU element
+            // in this case we only calculate and display the result of the first IFU element
             // For the summed IFU we will also only have a single S/N value.
-            int ifusToShow = (_sdParameters.isUniform()) ? 1 : sf_list.size();
+            int ifusToShow;
             if (instrument.isIfuUsed() &&  _obsDetailParameters.analysisMethod() instanceof IfuSum) {
                 ifusToShow = 1;
             } else {
@@ -190,14 +190,14 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             // process all IFU elements
             double totalspsf = 0;
             if (instrument.isIfuUsed() &&  _obsDetailParameters.analysisMethod() instanceof IfuSum) {
-                for (int i=0; i < sf_list.size(); i++) {
-                    final double spsf = sf_list.get(i);
+                for (Double aSf_list : sf_list) {
+                    final double spsf = aSf_list;
                     totalspsf += spsf;
                 }
             }
 
             for (int i = 0; i < ifusToShow; i++) {
-                double spsf = 0;
+                double spsf;
                 if (instrument.isIfuUsed() &&  _obsDetailParameters.analysisMethod() instanceof IfuSum) {
                     spsf = totalspsf;
                 } else {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/SpecS2NSlitVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/SpecS2NSlitVisitor.java
@@ -93,6 +93,7 @@ public class SpecS2NSlitVisitor implements SampledSpectrumVisitor, SpecS2N {
     /**
      * Implements the SampledSpectrumVisitor interface
      */
+    @Override
     public void visit(final SampledSpectrum sed) {
         // step one: do some resampling and preprocessing
         resample();

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
@@ -6,6 +6,9 @@ import edu.gemini.itc.shared._
 
 import scala.collection.JavaConversions._
 
+import scalaz._
+import Scalaz._
+
 sealed trait Recipe
 
 trait ImagingRecipe extends Recipe {
@@ -44,8 +47,8 @@ object Recipe {
 
   def createSignalChart(result: SpectroscopyResult, title: String, index: Int): SpcChartData = {
     val data: java.util.List[SpcSeriesData] = new java.util.ArrayList[SpcSeriesData]()
-    data.add(new SpcSeriesData(SignalData,     "Signal",               result.specS2N(index).getSignalSpectrum.getData))
-    data.add(new SpcSeriesData(BackgroundData, "SQRT(Background)",     result.specS2N(index).getBackgroundSpectrum.getData))
+    data.add(SpcSeriesData(SignalData,     "Signal",           result.specS2N(index).getSignalSpectrum.getData))
+    data.add(SpcSeriesData(BackgroundData, "SQRT(Background)", result.specS2N(index).getBackgroundSpectrum.getData))
     new SpcChartData(SignalChart, title, ChartAxis("Wavelength (nm)"), ChartAxis("e- per exposure per spectral pixel"), data.toList)
   }
 
@@ -59,8 +62,8 @@ object Recipe {
 
   def createS2NChart(result: SpectroscopyResult, title: String, index: Int): SpcChartData = {
     val data: java.util.List[SpcSeriesData] = new util.ArrayList[SpcSeriesData]
-    data.add(new SpcSeriesData(SingleS2NData, "Single Exp S/N", result.specS2N(index).getExpS2NSpectrum.getData))
-    data.add(new SpcSeriesData(FinalS2NData,  "Final S/N  ",    result.specS2N(index).getFinalS2NSpectrum.getData))
+    data.add(SpcSeriesData(SingleS2NData, "Single Exp S/N", result.specS2N(index).getExpS2NSpectrum.getData))
+    data.add(SpcSeriesData(FinalS2NData,  "Final S/N  ",    result.specS2N(index).getFinalS2NSpectrum.getData))
     new SpcChartData(S2NChart, title, ChartAxis("Wavelength (nm)"), ChartAxis("Signal / Noise per spectral pixel"), data.toList)
   }
 
@@ -72,8 +75,10 @@ object Recipe {
   def serviceResult(r: ImagingResult): ItcImagingResult =
     ItcImagingResult(List(toCcdData(r)))
 
-  def serviceResult(r: Array[ImagingResult]): ItcImagingResult =
-    ItcImagingResult(r.map(toCcdData).toList)
+  def serviceResult(r: Array[ImagingResult]): ItcImagingResult = {
+    val ccds = r.map(toCcdData).toList
+    ItcImagingResult(ccds)
+  }
 
   // === Spectroscopy
 
@@ -101,8 +106,10 @@ object Recipe {
 
   // A set of results and a set of groups of charts, this covers GMOS (3 CCDs and potentially separate groups
   // for IFU cases, if IFU is activated).
-  def serviceGroupedResult(rs: Array[SpectroscopyResult], charts: java.util.List[java.util.List[SpcChartData]]): ItcSpectroscopyResult =
-    ItcSpectroscopyResult(rs.map(r => toCcdData(r, charts.toList.flatten)).toList, charts.toList.map(l => SpcChartGroup(l.toList)))
+  def serviceGroupedResult(rs: Array[SpectroscopyResult], charts: java.util.List[java.util.List[SpcChartData]]): ItcSpectroscopyResult = {
+    val ccds = rs.map(r => toCcdData(r, charts.toList.flatten)).toList
+    ItcSpectroscopyResult(ccds, charts.toList.map(l => SpcChartGroup(l.toList)))
+  }
 
 }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/seqcomp/InstrumentSequenceSyncTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/seqcomp/InstrumentSequenceSyncTest.scala
@@ -29,7 +29,7 @@ class InstrumentSequenceSyncTest extends InstrumentSequenceTestBase[InstGmosSout
 
   @Test
   def testIteratorUpdatePropagates(): Unit = {
-    assertNotEquals(r_G0326, getInstDataObj.getFilter)
+    assertFalse(r_G0326 == getInstDataObj.getFilter)
 
     // Add a step that sets the "r" filter.
     val sc = createSysConfig()

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -88,17 +88,23 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   protected def sourceFraction(i: ItcParameters) = f"${i.observation.sourceFraction}%.2f"
 
-  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int): Option[Int]       = serviceResult(result).map(_.peakPixelFlux(ccd))
-  protected def maxPeakPixelFlux(result: Future[ItcService.Result]): Option[Int]              = serviceResult(result).map(_.maxPeakPixelFlux)
+  private def maxR[A](result: Future[ItcService.Result], f: ItcResult => A): Option[A] =
+    serviceResult(result).map(f)
 
-  protected def imgPercentWell(result: Future[ItcService.Result], ccd: Int): Option[Double]   = serviceResult(result).map(_.ccd(ccd).percentFullWell)
-  protected def maxImgPercentWell(result: Future[ItcService.Result]): Option[Double]          = serviceResult(result).map(_.maxPercentFullWell)
-  protected def imgAdu(result: Future[ItcService.Result], ccd: Int): Option[Int]              = serviceResult(result).map(_.ccd(ccd).adu)
-  protected def maxImgAdu(result: Future[ItcService.Result]): Option[Int]                     = serviceResult(result).map(_.maxAdu)
-  protected def singleSNRatio(result: Future[ItcService.Result], ccd: Int): Option[Double]    = serviceResult(result).map(_.ccd(ccd).singleSNRatio)
-  protected def maxSingleSNRatio(result: Future[ItcService.Result]): Option[Double]           = serviceResult(result).map(_.maxSingleSNRatio)
-  protected def totalSNRatio  (result: Future[ItcService.Result], ccd: Int): Option[Double]   = serviceResult(result).map(_.ccd(ccd).totalSNRatio)
-  protected def maxTotalSNRatio(result: Future[ItcService.Result]): Option[Double]            = serviceResult(result).map(_.maxTotalSNRatio)
+  private def maxR[A](result: Future[ItcService.Result], ccd: Int, f: ItcCcd => A): Option[A] =
+    serviceResult(result).flatMap(_.ccd(ccd)).map(f)
+
+  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int): Option[Int]       = serviceResult(result).flatMap(_.peakPixelFlux(ccd))
+  protected def maxPeakPixelFlux(result: Future[ItcService.Result]): Option[Int]              = maxR(result, _.maxPeakPixelFlux)
+
+  protected def imgPercentWell(result: Future[ItcService.Result], ccd: Int): Option[Double]   = maxR(result, ccd, _.percentFullWell)
+  protected def maxImgPercentWell(result: Future[ItcService.Result]): Option[Double]          = maxR(result, _.maxPercentFullWell)
+  protected def imgAdu(result: Future[ItcService.Result], ccd: Int): Option[Int]              = maxR(result, ccd, _.adu)
+  protected def maxImgAdu(result: Future[ItcService.Result]): Option[Int]                     = maxR(result, _.maxAdu)
+  protected def singleSNRatio(result: Future[ItcService.Result], ccd: Int): Option[Double]    = maxR(result, ccd, _.singleSNRatio)
+  protected def maxSingleSNRatio(result: Future[ItcService.Result]): Option[Double]           = maxR(result, _.maxSingleSNRatio)
+  protected def totalSNRatio  (result: Future[ItcService.Result], ccd: Int): Option[Double]   = maxR(result, ccd, _.totalSNRatio)
+  protected def maxTotalSNRatio(result: Future[ItcService.Result]): Option[Double]            = maxR(result, _.maxTotalSNRatio)
 
   // ===
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -27,19 +27,19 @@ object ItcTableModel {
 sealed trait ItcTableModel extends AbstractTableModel {
 
   /// Define some generic columns. Values are rendered as strings in order to have them left aligned, similar to other sequence tables.
-  val LabelsColumn  = Column("Data\nLabels",           (c, i, r) => (resultIcon(r).orNull, c.labels))
-  val ImagesColumn  = Column("Images",                 (c, i, r) => s"${c.count}",                     tooltip = "Number of exposures used in S/N calculation")
-  val CoaddsColumn  = Column("Coadds",                 (c, i, r) => s"${c.coadds.getOrElse(1.0)}",     tooltip = "Number of coadds")
-  val ExpTimeColumn = Column("Exposure\nTime (s)",     (c, i, r) => f"${c.singleExposureTime}%.1f",    tooltip = "Exposure time of each image")
-  val TotTimeColumn = Column("Total Exp.\nTime (s)",   (c, i, r) => f"${c.totalExposureTime}%.1f",     tooltip = "Total exposure time")
-  val SrcMagColumn  = Column("Source\nMag",            (c, i, r) => i.map(sourceMag).toOption,         tooltip = "Source magnitude (mag)")
-  val SrcFracColumn = Column("Source\nFraction",       (c, i, r) => i.map(sourceFraction).toOption,    tooltip = "Fraction of images on source")
+  val LabelsColumn  = Column("Data\nLabels",           (c, _, r) => (resultIcon(r).orNull, c.labels))
+  val ImagesColumn  = Column("Images",                 (c, _, _) => s"${c.count}",                     tooltip = "Number of exposures used in S/N calculation")
+  val CoaddsColumn  = Column("Coadds",                 (c, _, _) => s"${c.coadds.getOrElse(1.0)}",     tooltip = "Number of coadds")
+  val ExpTimeColumn = Column("Exposure\nTime (s)",     (c, _, _) => f"${c.singleExposureTime}%.1f",    tooltip = "Exposure time of each image")
+  val TotTimeColumn = Column("Total Exp.\nTime (s)",   (c, _, _) => f"${c.totalExposureTime}%.1f",     tooltip = "Total exposure time")
+  val SrcMagColumn  = Column("Source\nMag",            (_, i, _) => i.map(sourceMag).toOption,         tooltip = "Source magnitude (mag)")
+  val SrcFracColumn = Column("Source\nFraction",       (_, i, _) => i.map(sourceFraction).toOption,    tooltip = "Fraction of images on source")
 
-  val PeakPixelColumn     = Column("Peak\n(e-)",       (c, i, r) => peakPixelFlux(r),                  tooltip = ItcTableModel.PeakPixelETooltip)
-  val PeakADUColumn       = Column("Peak\n(ADU)",      (c, i, r) => imgAdu(r),                         tooltip = ItcTableModel.PeakPixelAduTooltip)
-  val PeakFullWellColumn  = Column("Peak\n(%FW)",      (c, i, r) => imgPercentWell(r),                 tooltip = ItcTableModel.PeakPixelFWTooltip)
-  val SNSingleColumn      = Column("S/N Single Coadd", (c, i, r) => singleSNRatio(r),                  tooltip = "Signal / Noise for one exposure with one coadd")
-  val SNTotalColumn       = Column("S/N Total",        (c, i, r) => totalSNRatio (r),                  tooltip = "Total Signal / Noise for all exposures and coadds")
+  val PeakPixelColumn     = Column("Peak\n(e-)",       (_, _, r) => peakPixelFlux(r),                  tooltip = ItcTableModel.PeakPixelETooltip)
+  val PeakADUColumn       = Column("Peak\n(ADU)",      (_, _, r) => imgAdu(r),                         tooltip = ItcTableModel.PeakPixelAduTooltip)
+  val PeakFullWellColumn  = Column("Peak\n(%FW)",      (_, _, r) => imgPercentWell(r),                 tooltip = ItcTableModel.PeakPixelFWTooltip)
+  val SNSingleColumn      = Column("S/N Single Coadd", (_, _, r) => singleSNRatio(r),                  tooltip = "Signal / Noise for one exposure with one coadd")
+  val SNTotalColumn       = Column("S/N Total",        (_, _, r) => totalSNRatio (r),                  tooltip = "Total Signal / Noise for all exposures and coadds")
 
   // Define different sets of columns as headers
   val PeakColumns       = List(PeakPixelColumn, PeakADUColumn, PeakFullWellColumn)
@@ -76,7 +76,7 @@ sealed trait ItcTableModel extends AbstractTableModel {
     f.value.fold {
       Some(ItcPanel.SpinnerIcon).asInstanceOf[Option[Icon]]
     } {
-      case Failure(t)                       => Some(ItcPanel.ErrorIcon)
+      case Failure(_)                       => Some(ItcPanel.ErrorIcon)
       case Success(s) => s match {
         case -\/(_)                         => Some(ItcPanel.ErrorIcon)
         case \/-(r) if r.warnings.nonEmpty  => Some(ItcPanel.WarningIcon)
@@ -88,12 +88,12 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   protected def sourceFraction  (i: ItcParameters) = f"${i.observation.sourceFraction}%.2f"
 
-  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int = 0) = serviceResult(result).map(_.peakPixelFlux(ccd))
+  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int = 0): Option[Int] = serviceResult(result).map(_.peakPixelFlux(ccd))
 
-  protected def imgPercentWell  (result: Future[ItcService.Result], ccd: Int = 0) = serviceResult(result).map(_.ccd(ccd).percentFullWell)
-  protected def imgAdu          (result: Future[ItcService.Result], ccd: Int = 0) = serviceResult(result).map(_.ccd(ccd).adu)
-  protected def singleSNRatio   (result: Future[ItcService.Result], ccd: Int = 0) = serviceResult(result).map(_.ccd(ccd).singleSNRatio)
-  protected def totalSNRatio    (result: Future[ItcService.Result], ccd: Int = 0) = serviceResult(result).map(_.ccd(ccd).totalSNRatio)
+  protected def imgPercentWell  (result: Future[ItcService.Result], ccd: Int = 0): Option[Double] = serviceResult(result).map(_.ccd(ccd).percentFullWell)
+  protected def imgAdu          (result: Future[ItcService.Result], ccd: Int = 0): Option[Int] = serviceResult(result).map(_.ccd(ccd).adu)
+  protected def singleSNRatio   (result: Future[ItcService.Result], ccd: Int = 0): Option[Double] = serviceResult(result).map(_.ccd(ccd).singleSNRatio)
+  protected def totalSNRatio    (result: Future[ItcService.Result], ccd: Int = 0): Option[Double] = serviceResult(result).map(_.ccd(ccd).totalSNRatio)
 
   // ===
 
@@ -155,29 +155,29 @@ class ItcGenericImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List
 class ItcGmosImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcParameters], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = Headers
   val results = List(
-    Column("CCD1 Peak\n(e-)",           (c, i, r) => peakPixelFlux  (r, ccd=0),   tooltip = ItcTableModel.PeakPixelETooltip),
-    Column("CCD1 Peak\n(ADU)",          (c, i, r) => imgAdu         (r, ccd=0),   tooltip = ItcTableModel.PeakPixelAduTooltip),
-    Column("CCD1 Peak\n(% Full Well)",  (c, i, r) => imgPercentWell (r, ccd=0),   tooltip = ItcTableModel.PeakPixelFWTooltip),
-    Column("CCD1\nS/N Single",          (c, i, r) => singleSNRatio  (r, ccd=0)),
-    Column("CCD1\nS/N Total",           (c, i, r) => totalSNRatio   (r, ccd=0)),
+    Column("CCD1 Peak\n(e-)",          (_, _, r) => peakPixelFlux  (r, ccd = 0),   tooltip = ItcTableModel.PeakPixelETooltip),
+    Column("CCD1 Peak\n(ADU)",         (_, _, r) => imgAdu         (r, ccd = 0),   tooltip = ItcTableModel.PeakPixelAduTooltip),
+    Column("CCD1 Peak\n(% Full Well)", (_, _, r) => imgPercentWell (r, ccd = 0),   tooltip = ItcTableModel.PeakPixelFWTooltip),
+    Column("CCD1\nS/N Single",         (_, _, r) => singleSNRatio  (r, ccd = 0)),
+    Column("CCD1\nS/N Total",          (_, _, r) => totalSNRatio   (r, ccd = 0)),
 
-    Column("CCD2 Peak\n(e-)",           (c, i, r) => peakPixelFlux  (r, ccd=1),   tooltip = ItcTableModel.PeakPixelETooltip),
-    Column("CCD2 Peak\n(ADU)",          (c, i, r) => imgAdu         (r, ccd=1),   tooltip = ItcTableModel.PeakPixelAduTooltip),
-    Column("CCD2 Peak\n(% Full Well)",  (c, i, r) => imgPercentWell (r, ccd=1),   tooltip = ItcTableModel.PeakPixelFWTooltip),
-    Column("CCD2\nS/N Single",          (c, i, r) => singleSNRatio  (r, ccd=1)),
-    Column("CCD2\nS/N Total",           (c, i, r) => totalSNRatio   (r, ccd=1)),
+    Column("CCD2 Peak\n(e-)",          (_, _, r) => peakPixelFlux  (r, ccd = 1),   tooltip = ItcTableModel.PeakPixelETooltip),
+    Column("CCD2 Peak\n(ADU)",         (_, _, r) => imgAdu         (r, ccd = 1),   tooltip = ItcTableModel.PeakPixelAduTooltip),
+    Column("CCD2 Peak\n(% Full Well)", (_, _, r) => imgPercentWell (r, ccd = 1),   tooltip = ItcTableModel.PeakPixelFWTooltip),
+    Column("CCD2\nS/N Single",         (_, _, r) => singleSNRatio  (r, ccd = 1)),
+    Column("CCD2\nS/N Total",          (_, _, r) => totalSNRatio   (r, ccd = 1)),
 
-    Column("CCD3 Peak\n(e-)",           (c, i, r) => peakPixelFlux  (r, ccd=2),   tooltip = ItcTableModel.PeakPixelETooltip),
-    Column("CCD3 Peak\n(ADU)",          (c, i, r) => imgAdu         (r, ccd=2),   tooltip = ItcTableModel.PeakPixelAduTooltip),
-    Column("CCD3 Peak\n(% Full Well)",  (c, i, r) => imgPercentWell (r, ccd=2),   tooltip = ItcTableModel.PeakPixelFWTooltip),
-    Column("CCD3\nS/N Single",          (c, i, r) => singleSNRatio  (r, ccd=2)),
-    Column("CCD3\nS/N Total",           (c, i, r) => totalSNRatio   (r, ccd=2))
+    Column("CCD3 Peak\n(e-)",          (_, _, r) => peakPixelFlux  (r, ccd = 2),   tooltip = ItcTableModel.PeakPixelETooltip),
+    Column("CCD3 Peak\n(ADU)",         (_, _, r) => imgAdu         (r, ccd = 2),   tooltip = ItcTableModel.PeakPixelAduTooltip),
+    Column("CCD3 Peak\n(% Full Well)", (_, _, r) => imgPercentWell (r, ccd = 2),   tooltip = ItcTableModel.PeakPixelFWTooltip),
+    Column("CCD3\nS/N Single",         (_, _, r) => singleSNRatio  (r, ccd = 2)),
+    Column("CCD3\nS/N Total",          (_, _, r) => totalSNRatio   (r, ccd = 2))
   )
 }
 
 class ItcGsaoiImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcParameters], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = HeadersWithCoadds ++ List(
-    Column("Strehl",          (c, i, r) => gems(i),                    tooltip = "Estimated Strehl and band")
+    Column("Strehl", (_, i, _) => gems(i), tooltip = "Estimated Strehl and band")
   )
   val results = PeakColumns ++ SNColumns
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -35,11 +35,11 @@ sealed trait ItcTableModel extends AbstractTableModel {
   val SrcMagColumn  = Column("Source\nMag",            (_, i, _) => i.map(sourceMag).toOption,         tooltip = "Source magnitude (mag)")
   val SrcFracColumn = Column("Source\nFraction",       (_, i, _) => i.map(sourceFraction).toOption,    tooltip = "Fraction of images on source")
 
-  val PeakPixelColumn     = Column("Peak\n(e-)",       (_, _, r) => peakPixelFlux(r),                  tooltip = ItcTableModel.PeakPixelETooltip)
-  val PeakADUColumn       = Column("Peak\n(ADU)",      (_, _, r) => imgAdu(r),                         tooltip = ItcTableModel.PeakPixelAduTooltip)
-  val PeakFullWellColumn  = Column("Peak\n(%FW)",      (_, _, r) => imgPercentWell(r),                 tooltip = ItcTableModel.PeakPixelFWTooltip)
-  val SNSingleColumn      = Column("S/N Single Coadd", (_, _, r) => singleSNRatio(r),                  tooltip = "Signal / Noise for one exposure with one coadd")
-  val SNTotalColumn       = Column("S/N Total",        (_, _, r) => totalSNRatio (r),                  tooltip = "Total Signal / Noise for all exposures and coadds")
+  val PeakPixelColumn     = Column("Peak\n(e-)",       (_, _, r) => peakPixelFlux(r, 0),               tooltip = ItcTableModel.PeakPixelETooltip)
+  val PeakADUColumn       = Column("Peak\n(ADU)",      (_, _, r) => imgAdu(r, 0),                      tooltip = ItcTableModel.PeakPixelAduTooltip)
+  val PeakFullWellColumn  = Column("Peak\n(%FW)",      (_, _, r) => imgPercentWell(r, 0),              tooltip = ItcTableModel.PeakPixelFWTooltip)
+  val SNSingleColumn      = Column("S/N Single Coadd", (_, _, r) => singleSNRatio(r, 0),               tooltip = "Signal / Noise for one exposure with one coadd")
+  val SNTotalColumn       = Column("S/N Total",        (_, _, r) => totalSNRatio (r, 0),               tooltip = "Total Signal / Noise for all exposures and coadds")
 
   // Define different sets of columns as headers
   val PeakColumns       = List(PeakPixelColumn, PeakADUColumn, PeakFullWellColumn)
@@ -88,12 +88,12 @@ sealed trait ItcTableModel extends AbstractTableModel {
 
   protected def sourceFraction  (i: ItcParameters) = f"${i.observation.sourceFraction}%.2f"
 
-  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int = 0): Option[Int] = serviceResult(result).map(_.peakPixelFlux(ccd))
+  protected def peakPixelFlux(result: Future[ItcService.Result], ccd: Int): Option[Int] = serviceResult(result).map(_.peakPixelFlux(ccd))
 
-  protected def imgPercentWell  (result: Future[ItcService.Result], ccd: Int = 0): Option[Double] = serviceResult(result).map(_.ccd(ccd).percentFullWell)
-  protected def imgAdu          (result: Future[ItcService.Result], ccd: Int = 0): Option[Int] = serviceResult(result).map(_.ccd(ccd).adu)
-  protected def singleSNRatio   (result: Future[ItcService.Result], ccd: Int = 0): Option[Double] = serviceResult(result).map(_.ccd(ccd).singleSNRatio)
-  protected def totalSNRatio    (result: Future[ItcService.Result], ccd: Int = 0): Option[Double] = serviceResult(result).map(_.ccd(ccd).totalSNRatio)
+  protected def imgPercentWell  (result: Future[ItcService.Result], ccd: Int): Option[Double] = serviceResult(result).map(_.ccd(ccd).percentFullWell)
+  protected def imgAdu          (result: Future[ItcService.Result], ccd: Int): Option[Int] = serviceResult(result).map(_.ccd(ccd).adu)
+  protected def singleSNRatio   (result: Future[ItcService.Result], ccd: Int): Option[Double] = serviceResult(result).map(_.ccd(ccd).singleSNRatio)
+  protected def totalSNRatio    (result: Future[ItcService.Result], ccd: Int): Option[Double] = serviceResult(result).map(_.ccd(ccd).totalSNRatio)
 
   // ===
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success}
 import scalaz._
 
 /** Columns in the table are defined by their header label and a function on the unique config of the row. */
-case class Column(label: String, value: (ItcUniqueConfig, String\/ItcParameters, Future[ItcService.Result]) => AnyRef, tooltip: String = "")
+case class Column(label: String, value: (ItcUniqueConfig, String \/ ItcParameters, Future[ItcService.Result]) => AnyRef, tooltip: String = "")
 
 object ItcTableModel {
   val PeakPixelETooltip   = "Peak Signal + Background in electrons / coadd"
@@ -157,13 +157,13 @@ sealed trait ItcTableModel extends AbstractTableModel {
 /** Generic ITC imaging tables model. */
 sealed trait ItcImagingTableModel extends ItcTableModel
 
-class ItcGenericImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcParameters], val res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcImagingTableModel {
+case class ItcGenericImagingTableModel(keys: List[ItemKey], uniqueSteps: List[ItcUniqueConfig], inputs: List[String\/ItcParameters], res: List[Future[ItcService.Result]], showCoadds: Boolean = false) extends ItcImagingTableModel {
   val headers = if (showCoadds) HeadersWithCoadds else Headers
   val results = PeakColumns ++ SNColumns
 }
 
 /** GMOS specific ITC imaging table model. */
-class ItcGmosImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcParameters], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
+case class ItcGmosImagingTableModel(keys: List[ItemKey], uniqueSteps: List[ItcUniqueConfig], inputs: List[String\/ItcParameters], res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = Headers
   val results = List(
     Column("CCD1 Peak\n(e-)",          (_, _, r) => peakPixelFlux  (r, ccd = 0),   tooltip = ItcTableModel.PeakPixelETooltip),
@@ -186,7 +186,7 @@ class ItcGmosImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[It
   )
 }
 
-class ItcGsaoiImagingTableModel(val keys: List[ItemKey], val uniqueSteps: List[ItcUniqueConfig], val inputs: List[String\/ItcParameters], val res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
+case class ItcGsaoiImagingTableModel(keys: List[ItemKey], uniqueSteps: List[ItcUniqueConfig], inputs: List[String\/ItcParameters], res: List[Future[ItcService.Result]]) extends ItcImagingTableModel {
   val headers = HeadersWithCoadds ++ List(
     Column("Strehl", (_, i, _) => gems(i), tooltip = "Estimated Strehl and band")
   )


### PR DESCRIPTION
The OT ITC spectroscopy table was ignoring the fact that some instruments have multiple CCDs. This PR fixes that taking the maximum of the CCD values as requested  and improves the safety of the calculations