### PR TITLE
REL-2655: Fixing ODB Browser remaining time

### DIFF
--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryParam.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryParam.scala
@@ -12,7 +12,7 @@ import edu.gemini.spModel.gemini.altair.{AltairParams, InstAltair}
 import edu.gemini.spModel.gemini.obscomp.{SPProgram, SPSiteQuality}
 import edu.gemini.spModel.gemini.obscomp.SPProgram.Active
 import edu.gemini.spModel.gemini.phase1.GsaPhase1Data
-import edu.gemini.spModel.obs.{ObsClassService, ObsTargetCalculatorService, ObservationStatus, SPObservation}
+import edu.gemini.spModel.obs.{ObsClassService, ObsTimesService, ObservationStatus, SPObservation}
 import edu.gemini.spModel.obsclass.ObsClass
 import edu.gemini.spModel.obscomp.SPInstObsComp
 import edu.gemini.spModel.obslog.ObsLog
@@ -168,7 +168,7 @@ object LchQueryParam {
 
     // Remaining time in ms.
     def remainingTime: Long =
-      prog.getAllObservations.asScala.map(ObsTargetCalculatorService.calculateRemainingTime).sum
+      ObsTimesService.getRemainingProgramTime(prog)
   }
 
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
@@ -107,8 +107,8 @@ public final class ObsTimesService {
     }
 
     /**
-     * Gets the remaining time for the program, which is the awarded time - the program time, i.e. the corrected time
-     * across the observations.
+     * Gets the remaining time in ms for the program, which is the awarded time minus the program time,
+     * i.e. the corrected time across the observations.
      */
     public static long getRemainingProgramTime(final ISPProgram prog) {
         final long awarded = ImOption.apply(prog.getDataObject()).

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
@@ -1,9 +1,14 @@
 package edu.gemini.spModel.obs;
 
+import edu.gemini.pot.sp.ISPProgram;
+import edu.gemini.shared.util.TimeValue;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.ISPObservationContainer;
 import edu.gemini.spModel.obslog.ObsLog;
+import edu.gemini.spModel.time.ChargeClass;
 import edu.gemini.spModel.time.ObsTimeCharges;
 import edu.gemini.spModel.time.ObsTimes;
 
@@ -99,5 +104,18 @@ public final class ObsTimesService {
         }
 
         return new ObsTimes(elapsedTime, charges);
+    }
+
+    /**
+     * Gets the remaining time for the program, which is the awarded time - the program time, i.e. the corrected time
+     * across the observations.
+     */
+    public static long getRemainingProgramTime(final ISPProgram prog) {
+        final long awarded = ImOption.apply(prog.getDataObject()).
+                map(dataObj -> ((SPProgram)dataObj).getAwardedTime()).
+                getOrElse(TimeValue.ZERO_HOURS).
+                getMilliseconds();
+        final long progTime = getCorrectedObsTimes(prog).getTimeCharges().getTime(ChargeClass.PROGRAM);
+        return awarded - progTime;
     }
 }

--- a/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TextBoxWidgetWatcher.java
+++ b/bundle/jsky.util.gui/src/main/java/jsky/util/gui/TextBoxWidgetWatcher.java
@@ -1,9 +1,3 @@
-// Copyright 1997 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-// See the file LICENSE for complete details.
-//
-// $Id: TextBoxWidgetWatcher.java 6719 2005-11-08 19:35:36Z brighton $
-//
 package jsky.util.gui;
 
 public interface TextBoxWidgetWatcher {


### PR DESCRIPTION
During testing, Andy noticed that the remaining time was not as he expected, and I discovered that I was not calculating it correctly.

This PR fixes the issue by rectifying the calculation.

Since this calculation is also used in `EdProgram`, I moved the calculation into `ObsTimesService` as per Shane's recommendation.

Since the `EdProgram` code was rather muddled and messy, I cleaned up this class considerably as well. I did, however, leave the `try - catch` blocks in place, even though I don't think some of them are ever invoked (unless possibly with a `NullPointerException`) because I didn't want to risk fundamentally altering the behaviour of this class, especially so close to the December release.