### PR TITLE
REL-2659: ITC support for summing GMOS IFU elements

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -18,7 +18,7 @@
 
 	<!-- Spatial profile and brightness definitions follow-->
 	<p>
-	<span style="color: #ff0000"><b>Astronomical source definition</b></span> 
+	<span style="color: #ff0000"><b>Astronomical source definition</b></span>
 	</p>
 	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="101" width="100%">
 		<tbody>
@@ -585,11 +585,11 @@
 				<input name="ifuMaxOffset" size="5" value="3.0" type="text" /> arcsec </td>
 
 			</tr>
-			<tr>
+			<!--tr>
 				<td><input value="sumIFU" name="analysisMethod" type="radio" /></td>
 				<td>Sum all IFU elements within <input name="ifuNum" size="5" value="2" type="text" /> arcsec of the center
 				</td>
-			</tr>
+			</tr-->
 			<tr>
 				<td colspan="3" height="50" valign="bottom"><b>Output:</b> </td>
 			</tr>


### PR DESCRIPTION
Tiny PR hiding an option on the ITC page for GMOS that is not ready to be made public in the next release