### PR TITLE
REL-2997: Fix PA issue with BAGS

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedback.scala
@@ -203,7 +203,7 @@ object BagsFeedback {
   def toRow(state: BagsState, ctx: Option[ObsContext]): Option[Row] = state match {
     case ErrorState            => ErrorStateRow.some
     case PendingState(_,_)     => PendingStateRow.some
-    case RunningState(_,_)     => RunningStateRow.some
+    case RunningState(_,_,_)   => RunningStateRow.some
     case RunningEditedState(_) => RunningStateRow.some
     case FailureState(_,why)   => FailureStateRow(why).some
     case IdleState(_,_) if ctx.exists(_.getTargets.getGuideEnvironment.guideEnv.auto === AutomaticGroup.Initial) => NoStarsRow.some


### PR DESCRIPTION
There was a PA issue with BAGS for OI guide probes where if:

1. the PA was set to `x` and a 180 flip mode was available;
2. BAGS found the best guide star at the flip; and
3. The user then reset, either via dragging in the TPE or pasting in the instrument editor, the PA to `x`;

then BAGS would not rerun for the PA of `x`, and thus the guide star at the 180 flip of `x` was maintained but registered as inaccessible to the patrol field.

This is because BAGS maintained, for the observation, the old `AgsHash` value that it previously used to do the lookup, and noted that it had already last performed the lookup for this PA and determined that it did not need to run.

This modification passes around the `ObsContext` to check if the position angle has changed, and if it has, then the hash is recalculated.