### PR TITLE
REL-2956: Reserve space for BAGS feedback message.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedback.scala
@@ -198,7 +198,7 @@ object BagsFeedback {
   case object PendingStateRow extends BagsStateRow(BANANA.some, "Waiting for automatic guide star lookup to run...", spinnerIcon)
   case object RunningStateRow extends BagsStateRow(BANANA.some, "Automatic guide star lookup is running...", spinnerIcon)
   case class  FailureStateRow(why: String) extends BagsStateRow(LIGHT_SALMON.some, s"Automatic guide star lookup failed: $why", errorIcon)
-  case object EmptyRow        extends BagsStateRow(None, " ", None) // Nonempy string to make label have required height.
+  case object EmptyRow        extends BagsStateRow(None, " ", None) // Nonempty string to make label have required height.
 
   import BagsState._
   def toRow(state: BagsState, ctx: Option[ObsContext]): Row = state match {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedbackEditor.scala
@@ -31,8 +31,7 @@ class TargetFeedbackEditor extends TelescopePosEditor {
         n <- Option(node)
         o <- Option(n.getContextObservation)
         s <- BagsManager.stateLookup(ObsKey(o))
-        row <- BagsFeedback.toRow(s, ctxOpt.asScalaOpt)
-      } yield row
+      } yield BagsFeedback.toRow(s, ctxOpt.asScalaOpt)
 
       // If the BAGS row is defined, then use it. If not, create the rows corresponding to the analysis.
       // NOTE that is target.isTooTarget, we don't want an analysis.


### PR DESCRIPTION
The remaining issue in REL-2956 was a UI issue where the BAGS feedback message would appear and disappear, thus making the other components in the target editor "bounce" up and down to accommodate its UI space requirements.

This simple PR reserves the appropriate amount of room for BAGS feedback so that this is no longer an issue. Nothing is displayed if BAGS is not running.

Right now, the BAGS feedback appears at the bottom of the window, and the guide star feedback above as per the attached picture. (Note the small empty space under the Guide Speed: FAST message.) I think this looks nicer than the alternative and makes sure that it is clear than having empty space between the target editor and the feedback, but that is a matter of personal tastes. If anyone has an argument to reverse these, this can easily be done.

<img width="1261" alt="screen shot 2016-12-02 at 9 34 31 am" src="https://cloud.githubusercontent.com/assets/8795653/20834215/dc949fae-b872-11e6-8b9b-0ccc05e5a28f.png">
