### PR TITLE
REL-2881 WIP

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/spdb/osgi/Activator.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/spdb/osgi/Activator.java
@@ -76,7 +76,7 @@ public class Activator implements BundleActivator {
         private State state;
         private IDBDatabaseService db;
         private ServiceRegistration<IDBDatabaseService> dbReg;
-        private ServiceRegistration<IDBQueryRunner>     qrReg;
+        private ServiceRegistration<SecureServiceFactory<IDBQueryRunner>> qrReg;
 
         DatabaseLoader(BundleContext ctx, File dir) {
             this.ctx   = ctx;
@@ -102,12 +102,14 @@ public class Activator implements BundleActivator {
             final Dictionary<String, Object> properties2 = new Hashtable<String, Object>();
             properties2.put("trpc", ""); // publish just the QueryRunner as TRPC service
             // A factory to make a new query runner for each TRPC user
-            final ServiceFactory<IDBQueryRunner> factory = new SecureServiceFactory<IDBQueryRunner>() {
-                public IDBQueryRunner getService(Bundle b, ServiceRegistration<IDBQueryRunner> reg, Set<Principal> ps) {
+            final SecureServiceFactoryForJava<IDBQueryRunner> factory = new SecureServiceFactoryForJava<IDBQueryRunner>() {
+                public IDBQueryRunner getService(Set<Principal> ps) {
                     return DatabaseLoader.this.db.getQueryRunner(ps);
                 }
             };
-            qrReg = (ServiceRegistration<IDBQueryRunner>) ctx.registerService(IDBQueryRunner.class.getName(), (Object) factory, properties2);
+            qrReg = SecureServiceFactory$.MODULE$.<IDBQueryRunner>registerSecureServiceForJava(
+                ctx, factory, IDBQueryRunner.class, properties2
+            );
 
         }
 

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Activator.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/osgi/Activator.scala
@@ -8,6 +8,7 @@ import edu.gemini.sp.vcs2.{Vcs, VcsServer, VcsService}
 import edu.gemini.sp.vcs.log.VcsLog
 import edu.gemini.sp.vcs.reg.VcsRegistrar
 import edu.gemini.util.osgi.SecureServiceFactory
+import edu.gemini.util.osgi.SecureServiceFactory._
 import edu.gemini.util.security.auth.keychain.KeyChain
 import org.osgi.framework.{Bundle, ServiceRegistration, BundleContext, BundleActivator}
 
@@ -35,18 +36,16 @@ class Activator extends BundleActivator{
         val vcsServer = new VcsServer(odb)
 
         // The public service.
-        val props = new util.Hashtable[String, Object]()
-        props.put(PUBLISH_TRPC, "true")
         val factory = new SecureServiceFactory[VcsService] {
-          def getService(b: Bundle, reg: ServiceRegistration[VcsService], ps: java.util.Set[Principal]): VcsService =
-            new vcsServer.SecureVcsService(ps.asScala.toSet, log)
+          def getService(ps: Set[Principal]): VcsService =
+            new vcsServer.SecureVcsService(ps, log)
         }
 
         // Register the Vcs client and a secure service factory for making the
         // VcsService implementation.
         List(
           ctx.registerService(classOf[Vcs], Vcs(auth, vcsServer), null),
-          ctx.registerService(classOf[VcsService].getName, factory, props)
+          ctx.registerSecureService(factory, Map(PUBLISH_TRPC -> ""))
         )
       } { _.foreach(_.unregister()) },
 

--- a/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/osgi/Activator.scala
+++ b/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/osgi/Activator.scala
@@ -10,8 +10,10 @@ import org.osgi.framework.{ServiceRegistration, Bundle, BundleActivator, BundleC
 import org.osgi.util.tracker.ServiceTracker
 import edu.gemini.spModel.core.osgi.SiteProperty
 import edu.gemini.util.osgi.SecureServiceFactory
+import edu.gemini.util.osgi.SecureServiceFactory._
 import java.security.Principal
 
+import scala.collection.JavaConverters._
 
 class Activator extends BundleActivator {
   private var tracker: Option[ServiceTracker[_,_]] = None
@@ -35,12 +37,10 @@ class Activator extends BundleActivator {
 
           // Our TooServiceApi, for TRPC clients
           val factory = new SecureServiceFactory[TooServiceApi] {
-            def getService(b: Bundle, reg: ServiceRegistration[TooServiceApi], ps: java.util.Set[Principal]): TooServiceApi =
-              service.serviceApi(ps)
+            def getService(ps: Set[Principal]): TooServiceApi =
+              service.serviceApi(ps.asJava)
           }
-          val props2 = new java.util.Hashtable[String,String]
-          props2.put("trpc", "") // publish to trpc
-          val reg2 = ctx.registerService(classOf[TooServiceApi].getName, factory, props2)
+          val reg2 = ctx.registerSecureService(factory, Map("trpc" -> ""))
 
           // Cleanup
           () => {

--- a/bundle/edu.gemini.util.osgi/build.sbt
+++ b/bundle/edu.gemini.util.osgi/build.sbt
@@ -16,6 +16,9 @@ unmanagedJars in Test ++= Seq(
   new File(baseDirectory.value, "../../bundle/edu.gemini.osgi.main/lib/org.apache.felix-4.2.1.jar")
 )
 
+libraryDependencies ++= Seq(
+  "org.scalaz" %% "scalaz-core" % ScalaZVersion)
+
 osgiSettings
 
 ocsBundleSettings
@@ -24,8 +27,7 @@ OsgiKeys.bundleActivator := None
 
 OsgiKeys.bundleSymbolicName := name.value
 
-OsgiKeys.dynamicImportPackage := Seq("")
+OsgiKeys.dynamicImportPackage := Seq("*")
 
 OsgiKeys.exportPackage := Seq(
   "edu.gemini.util.osgi")
-

--- a/bundle/edu.gemini.util.osgi/src/main/scala/edu/gemini/util/osgi/SecureServiceFactory.scala
+++ b/bundle/edu.gemini.util.osgi/src/main/scala/edu/gemini/util/osgi/SecureServiceFactory.scala
@@ -1,52 +1,144 @@
 package edu.gemini.util.osgi
 
 import org.osgi.framework._
+import org.osgi.framework.FrameworkUtil.createFilter
 import java.security.Principal
+import java.util.{ Set => JSet, Hashtable => JHashtable, Dictionary => JDictionary }
 import scala.util.DynamicVariable
 import collection.JavaConverters._
+import scalaz._, Scalaz._
+import scala.reflect.ClassTag
+
+
+trait SecureServiceFactory[A] {
+
+  def getService(ps: Set[Principal]): A
+
+}
+
+abstract class SecureServiceFactoryForJava[A] extends SecureServiceFactory[A] {
+
+  final def getService(ps: Set[Principal]): A =
+    getService(ps.asJava)
+
+  def getService(ps: JSet[Principal]): A
+
+}
 
 object SecureServiceFactory {
 
-  private val principals: DynamicVariable[Set[Principal]] = 
-    new DynamicVariable(Set())
+  /**
+   * When we register a `SecureService[A]` with the container, the registration will have
+   * `ServiceProp` bound to the runtime classname of `A`, which is what we use for lookups.
+   */
+  val ServiceProp = "service"
 
-  /**  Equivalent to getServiceReferences followed by getService. */
-  def getSecureServices(context: BundleContext, clazz: String, filter: String, ps: Set[Principal]): List[(ServiceReference[_], Any)] = 
-    principals.withValue(ps) {
-      Option(context.getServiceReferences(clazz, filter)).map(_.toList.map { ref => 
-        (ref, context.getService(ref))
-      }).getOrElse(Nil)
+  /** Filter is a semigroup under conjunction. */
+  implicit val SemigroupFilter: Semigroup[Filter] =
+    Semigroup.instance((a, b) => createFilter(s"(&$a$b)"))
+
+  /** Construct an equality filter. */
+  def filter(key: String, value: String = "*"): Filter =
+    createFilter(s"($key=$value)")
+
+  /** Construct an filter binding `ServiceProp` to the name of the given class. */
+  def serviceFilter[A](clazz: Class[A]): Filter =
+    filter(ServiceProp, clazz.getName)
+
+  /**
+   * Look up a service factory for the given clazz with any additional filter conditions, create an
+   * instance with the given set of principals, evaluate the given function and return the result,
+   * releasing references as needed; or return `None` if the requested service is unavailable.
+   */
+  def withSecureService[A, B](
+    context: BundleContext,
+    clazz:   Class[A],
+    ps:      Set[Principal],
+    ofilter: Option[Filter]
+  )(f: A => B): Option[B] = {
+    val fcName = classOf[SecureServiceFactory[A]].getName
+    val filter = ofilter.foldLeft(serviceFilter(clazz))(_ |+| _).toString
+    val orefs  = Option(context.getServiceReferences(fcName,filter))
+    val oref   = orefs.flatMap(_.headOption)
+    oref.map { ref =>
+      val svc = context.getService(ref).asInstanceOf[SecureServiceFactory[A]]
+      try f(svc.getService(ps)) finally context.ungetService(ref)
     }
+  }
 
-  /**  Equivalent to getServiceReference followed by getService. */
-  def getSecureService(context: BundleContext, clazz: String, filter: String, ps: Set[Principal]): Option[(ServiceReference[_], Any)] = 
-    principals.withValue(ps) {
-      Option(context.getServiceReferences(clazz, filter)).flatMap(_.headOption).map { ref => 
-        (ref, context.getService(ref))
+
+  def withSecureServiceByName[B](
+    context: BundleContext,
+    clazz:   String,
+    ps:      Set[Principal],
+    ofilter: Option[Filter]
+  )(f: Any => B): Option[B] =
+    withSecureService(context, Class.forName(clazz), ps, ofilter)(f)
+
+  /**
+   * Register the given `SecureServiceFactory` with the container, using any additional provided
+   * service properties, such that instances of `A` can be constructed via `withSecureService`
+   * above.
+   */
+  def registerSecureService[A](
+    context: BundleContext,
+    factory: SecureServiceFactory[A],
+    clazz:   Class[A],
+    props:   Map[String, String]
+  ): ServiceRegistration[SecureServiceFactory[A]] = {
+    val propsʹ = new JHashtable[String, Object]
+    props.foreach { case (k, v) => propsʹ.put(k, v) }
+    propsʹ.put(ServiceProp, clazz.getName)
+    context.registerService(classOf[SecureServiceFactory[A]], factory, propsʹ)
+  }
+
+  /**
+   * Register the given `SecureServiceFactory` with the container, using any additional provided
+   * service properties, such that instances of `A` can be constructed via `withSecureService`
+   * above.
+   */
+  def registerSecureServiceForJava[A](
+    context: BundleContext,
+    factory: SecureServiceFactory[A],
+    clazz:   Class[A],
+    props:   JDictionary[String, Object]
+  ): ServiceRegistration[SecureServiceFactory[A]] = {
+    props.put(ServiceProp, clazz.getName)
+    context.registerService(classOf[SecureServiceFactory[A]], factory, props)
+  }
+
+  // Some convenience syntax for the methods above.
+  implicit class BundleContextOps(val bc: BundleContext) {
+
+    // Partial application of polymorphic method `withSecureService` below.
+    // See http://tpolecat.github.io/2015/07/30/infer.html
+    class WithSecureServicePartiallyApplied[A](ps: Set[Principal], filter: Option[Filter]) {
+      def apply[B](f: A => B)(implicit ev: ClassTag[A]): Option[B] = {
+        val clazz = ev.runtimeClass.asInstanceOf[Class[A]]
+        SecureServiceFactory.withSecureService(bc, clazz, ps, filter)(f)
       }
     }
 
-  implicit class BundleContextOps(val bc: BundleContext) extends AnyVal {
+    def withSecureService[A](ps: Set[Principal]): WithSecureServicePartiallyApplied[A] =
+      new WithSecureServicePartiallyApplied(ps, None)
 
-    def getSecureServices(clazz: String, filter: String, ps: Set[Principal]): List[(ServiceReference[_], Any)] = 
-      SecureServiceFactory.getSecureServices(bc, clazz, filter, ps)
+    def withSecureService[A](ps: Set[Principal], filter: Filter): WithSecureServicePartiallyApplied[A] =
+      new WithSecureServicePartiallyApplied(ps, Some(filter))
 
-    def getSecureService(clazz: String, filter: String, ps: Set[Principal]): Option[(ServiceReference[_], Any)] = 
-      SecureServiceFactory.getSecureService(bc, clazz, filter, ps)
+    def withSecureServiceByName[B](clazz: String, ps: Set[Principal])(f: Any => B): Option[B] =
+      SecureServiceFactory.withSecureServiceByName(bc, clazz, ps, None)(f)
+
+    def withSecureServiceByName[B](clazz: String, ps: Set[Principal], filter: Filter)(f: Any => B): Option[B] =
+      SecureServiceFactory.withSecureServiceByName(bc, clazz, ps, Some(filter))(f)
+
+    def registerSecureService[A](
+      factory: SecureServiceFactory[A],
+      props:   Map[String, String] = Map()
+    )(implicit ev: ClassTag[A]): ServiceRegistration[SecureServiceFactory[A]] = {
+      val clazz = ev.runtimeClass.asInstanceOf[Class[A]]
+      SecureServiceFactory.registerSecureService(bc, factory, clazz, props)
+    }
 
   }
 
 }
-
-abstract class SecureServiceFactory[A <: AnyRef] extends ServiceFactory[A] {
-
-  final def getService(b: Bundle, reg: ServiceRegistration[A]): A = 
-    getService(b, reg, SecureServiceFactory.principals.value.asJava)
-
-  def getService(b: Bundle, reg: ServiceRegistration[A], ps: java.util.Set[Principal]): A
-
-  def ungetService(b: Bundle, reg: ServiceRegistration[A], a: A): Unit =
-    ()
-
-}
-

--- a/bundle/edu.gemini.util.trpc/src/main/scala/edu/gemini/util/trpc/osgi/package.scala
+++ b/bundle/edu.gemini.util.trpc/src/main/scala/edu/gemini/util/trpc/osgi/package.scala
@@ -8,7 +8,7 @@ import edu.gemini.util.osgi.SecureServiceFactory
 package object osgi {
 
   val Attr = "trpc"
-  val Filter = "(%s=*)".format(Attr)
+  val Filter = SecureServiceFactory.filter(Attr)
   val Alias = "/%s".format(Attr)
   val Log = Logger.getLogger("edu.gemini.util.trpc.osgi") // hack hack
 

--- a/bundle/jsky.app.ot.testlauncher/src/main/scala/jsky/app/ot/testlauncher/ServiceChecker.scala
+++ b/bundle/jsky.app.ot.testlauncher/src/main/scala/jsky/app/ot/testlauncher/ServiceChecker.scala
@@ -1,0 +1,42 @@
+package jsky.app.ot.testlauncher
+
+import edu.gemini.sp.vcs2.VcsService
+
+import scalaz._
+import Scalaz._
+import edu.gemini.util.trpc.auth.TrpcKeyChain
+import edu.gemini.util.security.auth.keychain.Action._
+import java.io.File
+
+import edu.gemini.auxfile.server.AuxFileServer
+import edu.gemini.itc.shared.ItcService
+import edu.gemini.pot.spdb.IDBQueryRunner
+import edu.gemini.services.client.TelescopeScheduleService
+import edu.gemini.spModel.core.{Peer, Site}
+import edu.gemini.too.event.api.TooService
+import edu.gemini.util.security.auth.keychain.KeyService
+import edu.gemini.util.trpc.client.TrpcClient
+
+object ServiceChecker extends App {
+
+  // Store everything in /tmp; clean it up by hand as needed.
+  val gs    = new Peer("localhost", 8443, Site.GS)
+  val dir   = new File("/tmp/ot-servicechecker") <| (_.mkdirs)
+  val peers = List(gs)
+  val keys  = TrpcKeyChain(new File(dir, "keys.ser"), peers).unsafeRunAndThrow
+
+  // As a sanity check ensure that all TRPC services are answering
+  def check[A](implicit ev: Manifest[A]): Unit =
+  TrpcClient(gs).withKeyChain(keys)(_[A].toString) match {
+    case -\/(e) => Console.err.println(s">> TRPC check failed for ${ev.runtimeClass.getName}"); e.printStackTrace()
+    case \/-(s) => Console.out.println(s">> TRPC check ok     for ${ev.runtimeClass.getName} - $s")
+  }
+
+  check[VcsService]
+  check[IDBQueryRunner]
+  check[TooService]
+  check[AuxFileServer]
+  check[ItcService]
+  check[KeyService]
+
+}


### PR DESCRIPTION
WIP fixing the sync/permissions issue. There's a race condition that will cause the same service instance to be re-used for simultaneous requests which has the effect of running all of them with the same set of permissions.

```
[info] Secure Service Factory getSecureService (singular) should
[info]   + work fine with normal service registrations
[info]   + pass principals correctly via getSecureServices
[info]   + ignore principals when called normally
[error]   x return a new service instance each time requested
[error]    '(foo,Set(PImpl(Bob), PImpl(Steve)))' is not equal to '(foo,Set(PImpl(Sam), PImpl(Harry)))' (SecureServiceFactorySpec.scala:100)
[error] Actual:   ...Impl([Bob]),...l([Steve])))
[error] Expected: ...Impl([Sam]),...l([Harry])))
```

Not clear how to fix it yet but at least it seems to be isolated.