### PR TITLE
REL-3039: Unhide the F2 MOS option.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
@@ -34,7 +34,7 @@ object Flamingos2 {
   class ModeNode extends SingleSelectNode[Unit, F2Mode, Unit](()) {
     val title       = "Select Instrument Mode"
     val description = "Flamingos2 can be used for both imaging and spectroscopy."
-    def choices     = F2Mode.values.filter(_ != F2Mode.Mos).toList // Hide temporarily the MOS option REL-1355
+    def choices     = F2Mode.values.toList
 
     def apply(m: F2Mode) = m match {
       case Imaging   => Left(new ImagingFilterNode)


### PR DESCRIPTION
Previously, the F2 MOS option was always filtered out since it was unavailable.

It is hoping to be made available in 2017B, so this simply undoes the code that filtered out this option from appearing in the resource configuration for F2.