### PR TITLE
OCS3 Export Updates

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichProgram.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichProgram.scala
@@ -13,7 +13,19 @@ class RichProgram(prog:ISPProgram) {
       prog.dataObject = dataObj
     }
 
-  def allObservations:List[ISPObservation] = prog.getAllObservations.asScala.toList
+  def templateGroups: List[ISPTemplateGroup] =
+    Option(prog.getTemplateFolder).toList.flatMap(_.getTemplateGroups.asScala.toList)
+
+  private def allObs(oc: ISPObservationContainer): List[ISPObservation] =
+    oc.getAllObservations.asScala.toList
+
+  def allObservations: List[ISPObservation] =
+    allObs(prog)
+
+  def allObservationsIncludingTemplateObservations: List[ISPObservation] =
+    (List(allObs(prog))/:templateGroups) { (l, tg) =>
+      allObs(tg) :: l
+    }.flatten
 
   def obsByLibraryId(lid:String):Either[String, ISPObservation] =
     allObservations.find(_.libraryId.exists(_ == lid)).toRight(s"Observation with library id '$lid' was not found.")

--- a/bundle/edu.gemini.spModel.io/build.sbt
+++ b/bundle/edu.gemini.spModel.io/build.sbt
@@ -28,4 +28,5 @@ OsgiKeys.dynamicImportPackage := Seq("")
 OsgiKeys.exportPackage := Seq(
   "edu.gemini.spModel.io",
   "edu.gemini.spModel.io.updater",
-  "edu.gemini.spModel.io.app")
+  "edu.gemini.spModel.io.app",
+  "edu.gemini.spModel.io.ocs3")

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/ocs3/Ocs3ExportServlet.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/ocs3/Ocs3ExportServlet.scala
@@ -1,9 +1,11 @@
 package edu.gemini.spModel.io.ocs3
 
-import edu.gemini.pot.sp.{ISPNode, SPObservationID}
-import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.pot.sp.{ISPObservationContainer, ISPNode, ISPObservation, ISPProgram, ISPTemplateGroup, SPObservationID}
+import edu.gemini.pot.spdb.{IDBDatabaseService, IDBFunctor}
 
 import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.util.DBProgramListFunctor
 
 import java.util.logging.{Level, Logger}
 import java.security.Principal
@@ -11,17 +13,88 @@ import java.security.Principal
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import javax.servlet.http.HttpServletResponse.{SC_BAD_REQUEST, SC_FORBIDDEN, SC_INTERNAL_SERVER_ERROR, SC_NOT_FOUND, SC_OK}
 
+import scala.collection.JavaConverters._
+
 import scala.util.Try
 import scalaz._
 import Scalaz._
 
+import Ocs3ExportServlet._
 
 /** A program export servlet that provides program XML in a format that is
   * more easily ingested into the ocs3 model.
   */
 final class Ocs3ExportServlet(db: IDBDatabaseService) extends HttpServlet {
 
-  import Ocs3ExportServlet.Log
+  private def doCommand(cmd: Command): Result[String] =
+    cmd match {
+      case FetchXml(id) =>
+        for {
+          n  <- fetchNode(id)
+          x  <- fetchXml(n, id)
+        } yield x
+
+      case ListObs(id)  =>
+        fetchNode(id).map { n =>
+          <obsList>
+            {listObs(n).sorted.map(oid => <oid>{oid.toString}</oid>)}
+          </obsList>.mkString
+        }
+
+      case ListProgs   =>
+        listProgs.map { pids =>
+          <progList>
+            {pids.sorted.map(pid=> <pid>{pid.toString}</pid>)}
+          </progList>.mkString
+        }
+    }
+
+  // Fetch the ISPProgram or ISPObservation associated with the id, if any.
+  private def fetchNode(id: String): Result[ISPNode] = {
+    def lookup(n: => ISPNode): Option[ISPNode] =
+      \/.fromTryCatchNonFatal(Option(n)).toOption.flatten
+
+    val node = lookup(db.lookupObservationByID(new SPObservationID(id))) orElse
+                 lookup(db.lookupProgramByID(SPProgramID.toProgramID(id)))
+
+    node \/> Error.notFound(id)
+  }
+
+  // Convert the program or observation into an XML String.
+  private def fetchXml(n: ISPNode, id: String): Result[String] =
+    \/.fromTryCatchNonFatal {
+      db.getQueryRunner(java.util.Collections.emptySet[Principal]).execute(new Ocs3ExportFunctor, n)
+    }.leftMap { t => Error.exportError(id, Some(t))           }
+     .flatMap { f => f.result \/> Error.exportError(id, None) }
+
+  // List the observations contained in the given node, if any.
+  private def listObs(n: ISPNode): List[SPObservationID] =
+    n match {
+      case p: ISPProgram     =>
+        p.allObservationsIncludingTemplateObservations.map(_.getObservationID)
+      case o: ISPObservation =>
+        List(o.getObservationID)
+      case _                 =>
+        List.empty
+    }
+
+  // List the programs in the database.
+  private def listProgs: Result[List[SPProgramID]] =
+    \/.fromTryCatchNonFatal {
+      db.getQueryRunner(java.util.Collections.emptySet[Principal]).queryPrograms(new DBProgramListFunctor)
+    }.leftMap { t => Error.listProgsError(Some(t))                                                           }
+     .flatMap { f => Option(f.getList).map(_.asScala.toList.map(_.programID)) \/> Error.listProgsError(None) }
+
+  override def doGet(req: HttpServletRequest, res: HttpServletResponse): Unit =
+    (for {
+      _  <- checkScheme(req)
+      c  <- parseRequest(req)
+      x  <- doCommand(c)
+    } yield x).send(res)
+}
+
+object Ocs3ExportServlet {
+  val Log = Logger.getLogger(this.getClass.getName)
 
   case class Error(code: Int, msg: String, ex: Option[Throwable])
 
@@ -35,8 +108,14 @@ final class Ocs3ExportServlet(db: IDBDatabaseService) extends HttpServlet {
     def notFound(id: String): Error =
       Error(SC_NOT_FOUND, s"no program or observation with id '$id'", None)
 
-    def unexpected(id: String, ot: Option[Throwable]): Error =
-      Error(SC_INTERNAL_SERVER_ERROR, s"problem exporting '$id'" + ot.map(t => s": ${t.getMessage}").orZero, ot)
+    private def serverError(msg: String, ot: Option[Throwable]): Error =
+      Error(SC_INTERNAL_SERVER_ERROR, msg + ot.map(t => s": ${t.getMessage}").orZero, ot)
+
+    def listProgsError(ot: Option[Throwable]): Error =
+      serverError("problem listing programs", ot)
+
+    def exportError(id: String, ot: Option[Throwable]): Error =
+      serverError(s"problem exporting '$id'", ot)
   }
 
 
@@ -72,43 +151,19 @@ final class Ocs3ExportServlet(db: IDBDatabaseService) extends HttpServlet {
       case _      => Error.forbidden.left
     }
 
-  // Parse the request path to obtain the program or observation id string
-  private def extractId(req: HttpServletRequest): Result[String] =
+  sealed trait Command extends Product with Serializable
+
+  final case class FetchXml(id: String) extends Command
+  case object ListProgs                 extends Command
+  final case class ListObs(pid: String) extends Command
+
+  // Determines the command encoded in the request.
+  private def parseRequest(req: HttpServletRequest): Result[Command] =
     req.getRequestURI.split('/').drop(2).toList match {
-      case id :: Nil => id.right
-      case x         => Error.badRequest(x.mkString("/")).left
+      case "fetch" :: id :: Nil => FetchXml(id).right
+      case "list"  :: id :: Nil => ListObs(id).right
+      case "list"  :: Nil       => ListProgs.right
+      case x                    => Error.badRequest(x.mkString("/")).left
     }
 
-  // Fetch the ISPProgram or ISPObservation associated with the id, if any.
-  private def fetchNode(id: String): Result[ISPNode] = {
-    def lookup(n: => ISPNode): Option[ISPNode] =
-      \/.fromTryCatchNonFatal(Option(n)).toOption.flatten
-
-    val node = lookup(db.lookupObservationByID(new SPObservationID(id))) orElse
-                 lookup(db.lookupProgramByID(SPProgramID.toProgramID(id)))
-
-    node \/> Error.notFound(id)
-  }
-
-  // Convert the program or observation into an XML String.
-  private def fetchXml(n: ISPNode, id: String): Result[String] = {
-    def unsafeRunFunctor(): Ocs3ExportFunctor =
-      db.getQueryRunner(java.util.Collections.emptySet[Principal]).execute(new Ocs3ExportFunctor, n)
-
-    \/.fromTryCatchNonFatal(unsafeRunFunctor())
-      .leftMap { t => Error.unexpected(id, Some(t)) }
-      .flatMap { f => f.result \/> Error.unexpected(id, None) }
-  }
-
-  override def doGet(req: HttpServletRequest, res: HttpServletResponse): Unit =
-    (for {
-      _  <- checkScheme(req)
-      id <- extractId(req)
-      n  <- fetchNode(id)
-      x  <- fetchXml(n, id)
-    } yield x).send(res)
-}
-
-object Ocs3ExportServlet {
-  val Log = Logger.getLogger(this.getClass.getName)
 }

--- a/bundle/edu.gemini.spdb.shell/src/main/java/edu/gemini/spdb/shell/osgi/Activator.java
+++ b/bundle/edu.gemini.spdb.shell/src/main/java/edu/gemini/spdb/shell/osgi/Activator.java
@@ -33,6 +33,7 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<IDBD
                 "rmprog",
                 "importXml",
                 "exportXml",
+                "exportOcs3",
                 "du",
                 "purge",
                 "migrateAltair",

--- a/bundle/edu.gemini.spdb.shell/src/main/scala/edu/gemini/spdb/shell/misc/ExportOcs3Command.scala
+++ b/bundle/edu.gemini.spdb.shell/src/main/scala/edu/gemini/spdb/shell/misc/ExportOcs3Command.scala
@@ -1,0 +1,104 @@
+package edu.gemini.spdb.shell.misc
+
+import edu.gemini.pot.sp.ISPProgram
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.io.ocs3.Ocs3ExportFunctor
+import edu.gemini.spModel.util.{DBProgramInfo, DBProgramListFunctor}
+
+import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.io.{File, PrintWriter, StringWriter}
+import java.security.Principal
+import java.util.Set
+
+import scala.collection.JavaConverters._
+
+import scalaz.effect.IO
+import scalaz._
+import Scalaz._
+
+import ExportOcs3Command._
+
+/** Implements an OSGi shell command that writes OCS3-style program XML to
+  * files.
+  */
+final class ExportOcs3Command(db: IDBDatabaseService, dir: File, user: java.util.Set[Principal]) {
+
+  def exportOcs3(pids: java.util.List[SPProgramID]): Unit =
+    exportAll(pids.asScala.toList).unsafePerformIO
+
+  private def exportAll(pids: List[SPProgramID]): IO[Unit] = {
+    def lookupPids: IO[List[SPProgramID]] =
+      for {
+        res <- fetchPidList.run
+        ps  <- res.fold(t => IO.putStrLn(s"Could not fetch program list.\n${t.mkString}") *> IO(List.empty[SPProgramID]), IO(_))
+      } yield ps
+
+    def report(pid: SPProgramID, res: Throwable \/ File): IO[Unit] =
+      IO.putStr(s"$pid: ") *> (res match {
+        case -\/(t) => IO.putStrLn(s"Export failed:\n${t.mkString}")
+        case \/-(f) => IO.putStrLn(s"${f.getPath}")
+      })
+
+    for {
+      pids0 <- if (pids.nonEmpty) IO(pids) else lookupPids
+      res   <- pids0.traverseU(pid => export(pid).run)
+      _     <- pids0.zip(res).traverseU((report _).tupled)
+    } yield ()
+  }
+
+  private val fetchPidList: Export[List[SPProgramID]] =
+    Export(db.getQueryRunner(user).queryPrograms(new DBProgramListFunctor))
+      .map { _.getList.asScala.toList.map(_.programID) }
+
+  private def export(pid: SPProgramID): Export[File] =
+    for {
+      p <- Export { Option(db.lookupProgramByID(pid)).getOrElse(sys.error(s"ODB does not contain $pid")) }
+      f <- export(p)
+    } yield f
+
+  private def export(p: ISPProgram): Export[File] = {
+    val n = fileName(p)
+    val f = new File(dir, s"$n.xml")
+
+    for {
+      fun <- Export { db.getQueryRunner(user).execute(new Ocs3ExportFunctor, p) }
+      _   <- Option(fun.getException).fold(Export.unit) { ex => Export.error(s"missing xml for $n", Some(ex)) }
+      x   <- Export.fromOption(s"xml not returned by ODB for $n")(fun.result)
+      _   <- Export { Files.write(f.toPath, x.getBytes(UTF_8)) }
+    } yield f
+  }
+}
+
+object ExportOcs3Command {
+
+
+  type Export[A] = EitherT[IO, Throwable, A]
+
+  object Export {
+    def apply[A](a: => A): Export[A] =
+      EitherT(IO(\/.fromTryCatchNonFatal(a)))
+
+    def fromOption[A](msg: => String)(oa: Option[A]): Export[A] =
+      EitherT.fromDisjunction(oa \/> (new RuntimeException(msg): Throwable))
+
+    val unit: Export[Unit] =
+      EitherT.right(IO.ioUnit)
+
+    def error(msg: String, ex: Option[Throwable]): Export[Unit] =
+      EitherT.left(IO(new RuntimeException(msg, ex.orNull)))
+  }
+
+  private def fileName(p: ISPProgram): String =
+    Option(p.getProgramID).map(_.stringValue).getOrElse(p.getProgramKey.toString)
+
+  implicit class ThrowableOps(t: Throwable) {
+    def mkString: String = {
+      val sw = new StringWriter
+      val pw = new PrintWriter(sw)
+      t.printStackTrace(pw)
+      sw.toString
+    }
+  }
+}

--- a/bundle/edu.gemini.spdb.shell/src/main/scala/edu/gemini/spdb/shell/misc/ExportOcs3Command.scala
+++ b/bundle/edu.gemini.spdb.shell/src/main/scala/edu/gemini/spdb/shell/misc/ExportOcs3Command.scala
@@ -43,8 +43,7 @@ final class ExportOcs3Command(db: IDBDatabaseService, dir: File, user: java.util
 
     for {
       pids0 <- if (pids.nonEmpty) IO(pids) else lookupPids
-      res   <- pids0.traverseU(pid => export(pid).run)
-      _     <- pids0.zip(res).traverseU((report _).tupled)
+      _     <- pids0.sorted.traverseU(pid => export(pid).run >>= (report(pid, _)))
     } yield ()
   }
 


### PR DESCRIPTION
This PR builds upon #1148:

* Adds an `exportOcs3` OSGi shell command that works just like `exportXML` except that it uses the OCS3 XML format.  This will make it possible to import from files instead of always having to have an ODB running.

* Adds a program listing option to the export servlet.  Since the servlet exports one program at a time, this allows a client to discover the available programs and request them one by one.

* Fixes a few issues with the OCS3 XML generation.