### PR TITLE
REL-2985: PIT calculation of observing and calibration overheads

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -1179,7 +1179,13 @@
                                    border-bottom-style="solid"
                                    border-bottom-width="0.25pt">
                         <fo:block font-weight="bold">
-                            Obs. Time
+                            Total
+                        </fo:block>
+                        <fo:block font-weight="bold">
+                            Program
+                        </fo:block>
+                        <fo:block font-weight="bold">
+                            Partner
                         </fo:block>
                     </fo:table-cell>
                 </fo:table-row>
@@ -1218,7 +1224,13 @@
                         </fo:table-cell>
                         <fo:table-cell>
                             <fo:block>
-                                <xsl:value-of select="format-number(time, '0.0')"/>&#160;<xsl:value-of select="time/@units"/>
+                                <xsl:value-of select="format-number(totalTime, '0.0')"/>&#160;<xsl:value-of select="totalTime/@units"/>
+                            </fo:block>
+                            <fo:block>
+                                <xsl:value-of select="format-number(progTime, '0.0')"/>&#160;<xsl:value-of select="progTime/@units"/>
+                            </fo:block>
+                            <fo:block>
+                                <xsl:value-of select="format-number(partTime, '0.0')"/>&#160;<xsl:value-of select="partTime/@units"/>
                             </fo:block>
                         </fo:table-cell>
                     </fo:table-row>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -1297,10 +1297,13 @@
                     </fo:table-cell>
                     <fo:table-cell border="0.5pt solid black">
                         <fo:block font-weight="bold">
-                            Total Time
+                            Total
                         </fo:block>
-                        <fo:block font-style="italic">
-                            (including overheads)
+                        <fo:block font-weight="bold">
+                            Program
+                        </fo:block>
+                        <fo:block font-weight="bold">
+                            Partner
                         </fo:block>
                     </fo:table-cell>
                 </fo:table-row>
@@ -1339,7 +1342,13 @@
                         </fo:table-cell>
                         <fo:table-cell border="0.5pt solid black">
                             <fo:block text-align="center">
-                                <xsl:value-of select="format-number(time, '0.0')"/>&#160;<xsl:value-of select="time/@units"/>
+                                <xsl:value-of select="format-number(totalTime, '0.0')"/>&#160;<xsl:value-of select="totalTime/@units"/>
+                            </fo:block>
+                            <fo:block text-align="center">
+                                <xsl:value-of select="format-number(progTime, '0.0')"/>&#160;<xsl:value-of select="progTime/@units"/>
+                            </fo:block>
+                            <fo:block text-align="center">
+                                <xsl:value-of select="format-number(partTime, '0.0')"/>&#160;<xsl:value-of select="partTime/@units"/>
                             </fo:block>
                         </fo:table-cell>
                     </fo:table-row>

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -34,9 +34,11 @@ object Observation {
   val empty = new Observation(None, None, None, None, M.Band.BAND_1_2)
 
   // Convenience method to extract the IntOrProgTime from the mutable observation.
-  def mTimeDisjunction(m: M.Observation): Option[Observation.IntOrProgTime] =
-    Option(m.getIntTime).map(TimeAmount(_).left[TimeAmount]).orElse(Option(m.getProgTime).map(TimeAmount(_).right[TimeAmount]))
-
+  def mTimeDisjunction(m: M.Observation): Option[Observation.IntOrProgTime] = {
+    def toTimeDisj(t: M.TimeAmount, f: TimeAmount => Observation.IntOrProgTime) =
+      Option(t).map(x => f(TimeAmount(x)))
+    toTimeDisj(m.getIntTime, _.left[TimeAmount]).orElse(toTimeDisj(m.getProgTime, _.right[TimeAmount]))
+  }
 }
 
 // REL-2985: It is unfortunate that we have to pass progTime here, but it is necessary for the migration to 2017B,

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -1,36 +1,43 @@
 package edu.gemini.model.p1.immutable
 
+import edu.gemini.model.p1.overheads.Overheads
 import edu.gemini.model.p1.{mutable => M}
+
 import scalaz._
 import Scalaz._
 
 object Observation {
 
-  // Some lenses
+  // Some lenses.
   val blueprint:Lens[Observation, Option[BlueprintBase]] = Lens.lensu((a, b) => a.copy(blueprint = b), _.blueprint)
   val condition:Lens[Observation, Option[Condition]] = Lens.lensu((a, b) => a.copy(condition = b), _.condition)
   val target:Lens[Observation, Option[Target]] = Lens.lensu((a, b) => a.copy(target = b), _.target)
   val meta:Lens[Observation, Option[ObservationMeta]] = Lens.lensu((a, b) => a.copy(meta = b), _.meta)
-  val time:Lens[Observation, Option[TimeAmount]] = Lens.lensu((a, b) => a.copy(time = b), _.time)
+  val intTime:Lens[Observation, Option[TimeAmount]] = Lens.lensu((a, b) => a.copy(intTime = b), _.intTime)
 
   def apply(blueprint:Option[BlueprintBase],
             condition:Option[Condition],
             target:Option[Target],
             band:Band,
-            time:Option[TimeAmount]) = new Observation(blueprint, condition, target, time, band)
+            intTime:Option[TimeAmount],
+            progTime:Option[TimeAmount] = None) = new Observation(blueprint, condition, target, intTime, progTime, band)
 
   def apply(m:M.Observation) = new Observation(m)
 
-  def unapply(o:Observation) = Some((o.blueprint, o.condition, o.target, o.time, o.band))
+  def unapply(o:Observation) = Some((o.blueprint, o.condition, o.target, o.intTime, o.calculatedTimes, o.band))
 
-  val empty = new Observation(None, None, None, None, M.Band.BAND_1_2)
+  val empty = new Observation(None, None, None, None, None, M.Band.BAND_1_2)
 
 }
 
+// REL-2985: It is unfortunate that we have to pass progTime here, but it is necessary for the migration to 2017B,
+// since the old "time" user-specified parameter is now progTime, and we have changed to have progTime now calculated
+// as a function of parameter intTime: thus, if progTime is defined, we must calculate intTime from it.
 class Observation private (val blueprint:Option[BlueprintBase],
                            val condition:Option[Condition],
                            val realTarget:Option[Target],
-                           val time:Option[TimeAmount],
+                           private val intTimeParam:Option[TimeAmount],
+                           private val progTimeParam:Option[TimeAmount],
                            val band:Band,
                            val meta:Option[ObservationMeta] = None,
                            val enabled:Boolean = true) {
@@ -45,23 +52,49 @@ class Observation private (val blueprint:Option[BlueprintBase],
     case None => realTarget
   }
 
+  // REL-2985 requires special handling of the times.
+  // 2017A and earlier: intTimeParam will be None, and calculatedTimesParam will be defined with progTime.
+  // If a blueprint exists - which it should - we can calculate the intTime from the progTime and then the rest
+  // of the observation times from the intTime.
+  val intTime: Option[TimeAmount] = {
+    if (intTimeParam.nonEmpty) intTimeParam
+    else for {
+      b <- blueprint
+      c <- Overheads(b)
+      p <- progTimeParam
+    } yield c.intTimeFromProgTime(p)
+  }
+
+  // 2017B and later: if the blueprint and the intTime are defined, recalculate the calculatedTimes.
+  val calculatedTimes: Option[ObservationTimes] =  for {
+    b <- blueprint
+    c <- Overheads(b)
+    t <- intTime
+  } yield c.calculate(t)
+
+  def progTime:  Option[TimeAmount] = calculatedTimes.map(_.progTime)
+  def partTime:  Option[TimeAmount] = calculatedTimes.map(_.partTime)
+  def totalTime: Option[TimeAmount] = calculatedTimes.map(_.totalTime)
+
   def copy(blueprint:Option[BlueprintBase] = blueprint,
            condition:Option[Condition] = condition,
            target:Option[Target] = target,
-           time:Option[TimeAmount] = time,
+           intTime:Option[TimeAmount] = intTime,
+           calculatedTimes:Option[ObservationTimes] = calculatedTimes,
            band:Band = band,
            meta:Option[ObservationMeta] = None, // metadata resets to None on copy, by default
            enabled:Boolean = enabled) =
-    new Observation(blueprint, condition, target, time, band, meta, enabled)
+    new Observation(blueprint, condition, target, intTime, calculatedTimes.map(_.progTime), band, meta, enabled)
 
   def this(m:M.Observation) = this (
-    Option(m.getBlueprint).map(BlueprintBase(_)),
-    Option(m.getCondition).map(Condition(_)),
-    Option(m.getTarget).map(Target(_)),
-    Option(m.getTime).map(TimeAmount(_)),
-    Option(m.getBand).getOrElse(M.Band.BAND_1_2),
-    Option(m.getMeta).map(ObservationMeta(_)),
-    m.isEnabled
+      Option(m.getBlueprint).map(BlueprintBase(_)),
+      Option(m.getCondition).map(Condition(_)),
+      Option(m.getTarget).map(Target(_)),
+      Option(m.getIntTime).map(TimeAmount(_)),
+      Option(m.getProgTime).map(TimeAmount(_)),
+      Option(m.getBand).getOrElse(M.Band.BAND_1_2),
+      Option(m.getMeta).map(ObservationMeta(_)),
+      m.isEnabled
   )
 
   def mutable(n:Namer) = {
@@ -69,36 +102,39 @@ class Observation private (val blueprint:Option[BlueprintBase],
     m.setBlueprint(blueprint.map(_.mutable(n)).orNull)
     m.setCondition(condition.map(_.mutable(n)).orNull)
     m.setTarget(target.map(_.mutable(n)).orNull)
-    m.setTime(time.map(_.mutable).orNull)
+    m.setIntTime(intTime.map(_.mutable).orNull)
+    m.setProgTime(progTime.map(_.mutable).orNull)
+    m.setPartTime(partTime.map(_.mutable).orNull)
+    m.setTotalTime(totalTime.map(_.mutable).orNull)
     m.setBand(band)
     m.setMeta(meta.map(_.mutable).orNull)
     m.setEnabled(enabled)
     m
   }
 
-  def isEmpty = blueprint.isEmpty && condition.isEmpty && target.isEmpty && time.isEmpty
+  def isEmpty = blueprint.isEmpty && condition.isEmpty && target.isEmpty && intTime.isEmpty
 
   override def equals(a:Any) = a match {
     case o:Observation => kernel == o.kernel
     case _             => false
   }
 
-  private lazy val kernel = (blueprint, condition, target, time, band, meta)
+  private lazy val kernel = (blueprint, condition, target, intTime, band, meta)
 
   override lazy val hashCode = kernel.hashCode()
 
   def isPartialObservationOf(o:Observation) =
-    (time.isEmpty)  && // If I have time defined, I might be incomplete but I'm not partial
+    intTime.isEmpty  && // If I have time defined, I might be incomplete but I'm not partial
     (band == o.band) && // must be the same band
-    (blueprint.isEmpty || target.isEmpty || condition.isEmpty || time.isEmpty) && // Must have *some* empty component
+    (blueprint.isEmpty || target.isEmpty || condition.isEmpty || intTime.isEmpty) && // Must have *some* empty component
     isPartial(blueprint, o.blueprint) &&
     isPartial(target, o.target) &&
     isPartial(condition, o.condition) &&
-    isPartial(time, o.time)
+    isPartial(intTime, o.intTime)
 
   private def isPartial[A](a:Option[A], b:Option[A]) = a.isEmpty || a == b
 
   override def toString =
-    "Observation(%s, %s, %s, %s, %s)".format(blueprint, condition, target, time, band)
+    "Observation(%s, %s, %s, %s, %s)".format(blueprint, condition, target, intTime, band)
 
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -6,6 +6,11 @@ import edu.gemini.model.p1.{mutable => M}
 import scalaz._
 import Scalaz._
 
+// TODO: Broken test scripts to fix
+// TODO: ProposalSpec
+// TODO: ItacSpec
+// TODO: TemplateSpec
+// TODO: REL_2232_Test
 object Observation {
   type IntOrProgTime = TimeAmount \/ TimeAmount
 
@@ -82,11 +87,16 @@ class Observation private (val blueprint:Option[BlueprintBase],
            enabled:Boolean = enabled) =
     new Observation(blueprint, condition, target, intTime.map(_.left), band, meta, enabled)
 
+
+  // Convenience method to extract the IntOrProgTime from the mutable observation.
+  private def mTimeDisjunction(m: M.Observation): Option[Observation.IntOrProgTime] =
+    Option(m.getIntTime).map(TimeAmount(_).left[TimeAmount]).orElse(Option(m.getProgTime).map(TimeAmount(_).right[TimeAmount]))
+
   def this(m:M.Observation) = this (
       Option(m.getBlueprint).map(BlueprintBase(_)),
       Option(m.getCondition).map(Condition(_)),
       Option(m.getTarget).map(Target(_)),
-      Option(m.getIntTime).map(TimeAmount(_).left[TimeAmount]).orElse(Option(m.getProgTime).map(TimeAmount(_).right[TimeAmount])),
+      mTimeDisjunction(m),
       Option(m.getBand).getOrElse(M.Band.BAND_1_2),
       Option(m.getMeta).map(ObservationMeta(_)),
       m.isEnabled

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -110,7 +110,7 @@ class Observation private (val blueprint:Option[BlueprintBase],
     m.setIntTime(intTime.map(_.mutable).orNull)
     m.setProgTime(progTime.map(_.mutable).orNull)
     m.setPartTime(partTime.map(_.mutable).orNull)
-    m.setTotalTime(totalTime.map(_.mutable).orNull)
+    m.setTime(totalTime.map(_.mutable).orNull)
     m.setBand(band)
     m.setMeta(meta.map(_.mutable).orNull)
     m.setEnabled(enabled)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ObservationTimes.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ObservationTimes.scala
@@ -1,4 +1,6 @@
 package edu.gemini.model.p1.immutable
 
 // All time amounts are in hours, so convert as necessary to nights.
-case class ObservationTimes(progTime: TimeAmount, partTime: TimeAmount, totalTime: TimeAmount)
+case class ObservationTimes(progTime: TimeAmount, partTime: TimeAmount) {
+  val totalTime = progTime |+| partTime
+}

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ObservationTimes.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ObservationTimes.scala
@@ -1,6 +1,7 @@
 package edu.gemini.model.p1.immutable
 
 // All time amounts are in hours, so convert as necessary to nights.
+// Note that partTime here refers to the Night Basecal Time and is not "partner time" in the traditional sense.
 case class ObservationTimes(progTime: TimeAmount, partTime: TimeAmount) {
   val totalTime = progTime |+| partTime
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ObservationTimes.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ObservationTimes.scala
@@ -1,0 +1,4 @@
+package edu.gemini.model.p1.immutable
+
+// All time amounts are in hours, so convert as necessary to nights.
+case class ObservationTimes(progTime: TimeAmount, partTime: TimeAmount, totalTime: TimeAmount)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Submissions.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Submissions.scala
@@ -27,7 +27,7 @@ sealed trait Submission {
 }
 
 object Submission {
-  def sumTimes(subs: Traversable[Submission], f: Submission=>TimeAmount): TimeAmount =
+  def sumTimes(subs: Traversable[Submission], f: Submission => TimeAmount): TimeAmount =
     TimeAmount.sum(subs.map(f))
 }
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TimeAmount.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TimeAmount.scala
@@ -1,6 +1,9 @@
 package edu.gemini.model.p1.immutable
 
-import edu.gemini.model.p1.{ mutable => M }
+import edu.gemini.model.p1.{mutable => M}
+
+import scalaz._
+import Scalaz._
 
 object TimeAmount {
 
@@ -13,7 +16,9 @@ object TimeAmount {
   // with the difference that we try to keep the time unit from changing if they
   // are all the same.
   def sum(times: Traversable[TimeAmount]): TimeAmount =
-    if (times.isEmpty) empty else (times.head/:times.tail)(_ + _)
+    if (times.isEmpty) empty else (times.head/:times.tail)(_ |+| _)
+
+  implicit val monoid = Monoid.instance[TimeAmount](_ |+| _, empty)
 }
 
 case class TimeAmount(value: Double, units: TimeUnit) {
@@ -42,7 +47,7 @@ case class TimeAmount(value: Double, units: TimeUnit) {
   def toHours  = if (units == TimeUnit.HR) this else TimeAmount(hours, TimeUnit.HR)
   def toNights = if (units == TimeUnit.NIGHT) this else TimeAmount(nights, TimeUnit.HR)
 
-  def +(that: TimeAmount): TimeAmount =
+  def |+|(that: TimeAmount): TimeAmount =
     if (units == that.units)
       TimeAmount(value + that.value, units)
     else

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TimeAmount.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TimeAmount.scala
@@ -16,7 +16,7 @@ object TimeAmount {
   // with the difference that we try to keep the time unit from changing if they
   // are all the same.
   def sum(times: Traversable[TimeAmount]): TimeAmount =
-    if (times.isEmpty) empty else (times.head/:times.tail)(_ |+| _)
+    times.foldLeft(empty)(_ |+| _)
 
   implicit val monoid = Monoid.instance[TimeAmount](_ |+| _, empty)
 }
@@ -49,14 +49,14 @@ case class TimeAmount(value: Double, units: TimeUnit) {
 
   // Time sum.
   def |+|(that: TimeAmount): TimeAmount = {
-    val (sum, unit) = (units == that.units) ? (value + that.value, units) | (hours + that.hours, TimeUnit.HR)
+    val (sum, unit) = if (units == that.units) (value + that.value, units) else (hours + that.hours, TimeUnit.HR)
     TimeAmount(sum, unit)
   }
 
   // Time difference: can never be less than zero.
   def |-|(that: TimeAmount): TimeAmount = {
-    val (diff, unit) = (units == that.units) ? (value - that.value, units) | (hours - that.hours, TimeUnit.HR)
-    TimeAmount((diff > 0) ? diff | 0, unit)
+    val (diff, unit) = if (units == that.units) (value - that.value, units) else (hours - that.hours, TimeUnit.HR)
+    TimeAmount(math.max(diff, 0), unit)
   }
 
   /**

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TimeAmount.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/TimeAmount.scala
@@ -47,11 +47,17 @@ case class TimeAmount(value: Double, units: TimeUnit) {
   def toHours  = if (units == TimeUnit.HR) this else TimeAmount(hours, TimeUnit.HR)
   def toNights = if (units == TimeUnit.NIGHT) this else TimeAmount(nights, TimeUnit.HR)
 
-  def |+|(that: TimeAmount): TimeAmount =
-    if (units == that.units)
-      TimeAmount(value + that.value, units)
-    else
-      TimeAmount(hours + that.hours, TimeUnit.HR)
+  // Time sum.
+  def |+|(that: TimeAmount): TimeAmount = {
+    val (sum, unit) = (units == that.units) ? (value + that.value, units) | (hours + that.hours, TimeUnit.HR)
+    TimeAmount(sum, unit)
+  }
+
+  // Time difference: can never be less than zero.
+  def |-|(that: TimeAmount): TimeAmount = {
+    val (diff, unit) = (units == that.units) ? (value - that.value, units) | (hours - that.hours, TimeUnit.HR)
+    TimeAmount((diff > 0) ? diff | 0, unit)
+  }
 
   /**
    * Formats a time amount to the given precision (which is treated as 0 if

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -131,9 +131,19 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
  * This converter will upgrade to 2017B
  */
 case object SemesterConverter2017ATo2017B extends SemesterConverter {
-  val timeToProgTime:TransformFunction = {
-    case t @ <time>{ns @ _*}</time> =>
-      StepResult("Former observation time parameter mapped to program time", <progTime>{ns}</progTime>).successNel
+  val timeToProgTime: TransformFunction = {
+    case o @ <observation>{ns @ _*}</observation> if (o \\ "time").nonEmpty =>
+
+      object TimeToProgTime extends BasicTransformer {
+        override def transform(n: xml.Node): xml.NodeSeq = n match {
+          case t @ <time>{ts @ _*}</time> => <progTime units={t.attribute("units")}>{ts}</progTime>
+          case elem: xml.Elem             => elem.copy(child=elem.child.flatMap(transform))
+          case _                          => n
+        }
+      }
+      StepResult("Former observation time parameter mapped to program time",
+        // Too many attributes.
+        <observation band={o.attribute("band")} enabled={o.attribute("enabled")} target={o.attribute("target")} condition={o.attribute("condition")} blueprint={o.attribute("blueprint")}>{TimeToProgTime.transform(ns)}</observation>).successNel
   }
   override val transformers = List(timeToProgTime)
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -134,6 +134,8 @@ case object SemesterConverter2017ATo2017B extends SemesterConverter {
   val timeToProgTime: TransformFunction = {
     case o @ <observation>{ns @ _*}</observation> if (o \\ "time").nonEmpty =>
 
+      // The time field from previous versions is being instead used to represent program time, and the time field
+      // will now be modified to represent total time, i.e. progTime + partTime (partmer ca;ibraation time).
       object TimeToProgTime extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
           case t @ <time>{ts @ _*}</time> => <progTime units={t.attribute("units")}>{ts}</progTime>

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -131,7 +131,11 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
  * This converter will upgrade to 2017B
  */
 case object SemesterConverter2017ATo2017B extends SemesterConverter {
-  override val transformers = Nil
+  val timeToProgTime:TransformFunction = {
+    case t @ <time>{ns @ _*}</time> =>
+      StepResult("Former observation time parameter mapped to program time", <progTime>{ns}</progTime>).successNel
+  }
+  override val transformers = List(timeToProgTime)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
@@ -1,15 +1,12 @@
-package edu.gemini.pit.overheads
+package edu.gemini.model.p1.overheads
 
 import java.time.Duration
 
 import edu.gemini.model.p1.immutable._
 
-import scalaz._
-import Scalaz._
+import scalaz.Scalaz._
 
-// We probably want to add the actual calculations for times here, which will take integration time
-// and return the other times. That way, this is accessible to both the Observation and the ObservationEditor,
-// which will need to update its fields when the integration time is updated.
+// This is not the ideal package for this to live in, but to avoid circular bundle references, we put it here.
 sealed trait Overheads {
   def partnerOverheadFraction: Double
   def acquisitionOverhead: Duration
@@ -52,9 +49,6 @@ sealed trait Overheads {
     TimeAmount(intTimeHrs, TimeUnit.HR)
   }
 }
-
-// All time amounts are in hours, so convert as necessary to nights.
-case class ObservationTimes(progTime: TimeAmount, partTime: TimeAmount, totalTime: TimeAmount)
 
 // Due to the large number of possible blueprint bases and how each one requires different configuration params
 // to determine the overheads, it seems infeasible to read this information from a file, so for now it is hard-coded

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
@@ -31,12 +31,8 @@ sealed trait Overheads {
       numAcqs * acqOverheadHrs + overheadTimeHrs
     }
     val partTimeHrs  = progTimeHrs * partnerOverheadFraction
-    val totalTimeHrs = progTimeHrs + partTimeHrs
 
-    ObservationTimes(
-      TimeAmount(progTimeHrs,  TimeUnit.HR),
-      TimeAmount(partTimeHrs,  TimeUnit.HR),
-      TimeAmount(totalTimeHrs, TimeUnit.HR))
+    ObservationTimes(TimeAmount(progTimeHrs, TimeUnit.HR), TimeAmount(partTimeHrs, TimeUnit.HR))
   }
 
   // This is needed for 2017A to 2017B migration, as time in former proposals will be migrated to progTime, and

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Observation.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Observation.xsd
@@ -17,12 +17,15 @@
     <xsd:complexType name="Observation">
 
         <xsd:sequence>
-            <xsd:element name="intTime"   type="TimeAmount"/>
-            <xsd:element name="progTime"  type="TimeAmount"/>
-            <xsd:element name="partTime"  type="TimeAmount"/>
-            <xsd:element name="totalTime" type="TimeAmount"/>
-            <xsd:element name="guide"     type="GuideGroup"          minOccurs="0"/>
-            <xsd:element name="meta"      type="ObservationMetaData" minOccurs="0"/>
+            <xsd:element name="intTime"  type="TimeAmount"/>
+            <xsd:element name="progTime" type="TimeAmount"/>
+            <xsd:element name="partTime" type="TimeAmount"/>
+
+            <!-- This "time" represents the total time required by an observation, including overheads. -->
+            <!-- In previous semesters, it was analagous to progTime. -->
+            <xsd:element name="time"     type="TimeAmount"/>
+            <xsd:element name="guide"    type="GuideGroup"          minOccurs="0"/>
+            <xsd:element name="meta"     type="ObservationMetaData" minOccurs="0"/>
         </xsd:sequence>
 
         <xsd:attribute name="band"      type="Band"/>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Observation.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Observation.xsd
@@ -17,9 +17,12 @@
     <xsd:complexType name="Observation">
 
         <xsd:sequence>
-            <xsd:element name="time"  type="TimeAmount"/>
-            <xsd:element name="guide" type="GuideGroup"          minOccurs="0"/>
-            <xsd:element name="meta"  type="ObservationMetaData" minOccurs="0"/>
+            <xsd:element name="intTime"   type="TimeAmount"/>
+            <xsd:element name="progTime"  type="TimeAmount"/>
+            <xsd:element name="partTime"  type="TimeAmount"/>
+            <xsd:element name="totalTime" type="TimeAmount"/>
+            <xsd:element name="guide"     type="GuideGroup"          minOccurs="0"/>
+            <xsd:element name="meta"      type="ObservationMetaData" minOccurs="0"/>
         </xsd:sequence>
 
         <xsd:attribute name="band"      type="Band"/>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_itac_no_ngoauthority.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_itac_no_ngoauthority.xml
@@ -121,7 +121,7 @@ Prov. de Buenos Aires</address>
     </blueprints>
     <observations>
         <observation blueprint="blueprint-0" condition="condition-0" target="target-0" band="Band 1/2">
-            <time units="hr">3.6</time>
+            <progTime units="hr">3.6</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>69</percentage>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_itac_with_ngoauthority.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_itac_with_ngoauthority.xml
@@ -121,7 +121,7 @@ Prov. de Buenos Aires</address>
     </blueprints>
     <observations>
         <observation blueprint="blueprint-0" condition="condition-0" target="target-0" band="Band 1/2">
-            <time units="hr">3.6</time>
+            <progTime units="hr">3.6</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>69</percentage>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_ver_1.0.0.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_ver_1.0.0.xml
@@ -121,7 +121,7 @@ Prov. de Buenos Aires</address>
     </blueprints>
     <observations>
         <observation blueprint="blueprint-0" condition="condition-0" target="target-0" band="Band 1/2">
-            <time units="hr">3.6</time>
+            <progTime units="hr">3.6</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>69</percentage>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_ver_1.0.0_with_uk.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_ver_1.0.0_with_uk.xml
@@ -121,7 +121,7 @@ Prov. de Buenos Aires</address>
     </blueprints>
     <observations>
         <observation blueprint="blueprint-0" condition="condition-0" target="target-0" band="Band 1/2">
-            <time units="hr">3.6</time>
+            <progTime units="hr">3.6</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>69</percentage>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_invalid_character.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_invalid_character.xml
@@ -162,7 +162,7 @@ Miyagi 980-0845, Japan</address>
     </blueprints>
     <observations>
         <observation blueprint="blueprint-0" condition="condition-0" target="target-0" enabled="true" band="Band 1/2">
-            <time units="hr">8.0</time>
+            <progTime units="hr">8.0</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>100</percentage>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_latin1_encoding.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_latin1_encoding.xml
@@ -146,7 +146,7 @@ Campus do Vale
     </blueprints>
     <observations>
         <observation band="Band 1/2" enabled="true" target="target-1" condition="condition-0" blueprint="blueprint-0">
-            <time units="hr">2.5</time>
+            <progTime units="hr">2.5</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>42</percentage>
@@ -157,7 +157,7 @@ Campus do Vale
             </meta>
         </observation>
         <observation band="Band 1/2" enabled="true" target="target-2" condition="condition-0" blueprint="blueprint-0">
-            <time units="hr">2.5</time>
+            <progTime units="hr">2.5</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>42</percentage>
@@ -168,7 +168,7 @@ Campus do Vale
             </meta>
         </observation>
         <observation band="Band 3" enabled="true" target="target-0" condition="condition-1" blueprint="blueprint-1">
-            <time units="hr">5.0</time>
+            <progTime units="hr">5.0</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>36</percentage>
@@ -179,7 +179,7 @@ Campus do Vale
             </meta>
         </observation>
         <observation band="Band 3" enabled="true" target="target-3" condition="condition-1" blueprint="blueprint-1">
-            <time units="hr">5.0</time>
+            <progTime units="hr">5.0</progTime>
             <meta ck="">
                 <guiding>
                     <percentage>28</percentage>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_observation_time.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_observation_time.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal tacCategory="Extragalactic" schemaVersion="1.0.0">
+    <meta>
+        <attachment>ar_2012B_007.pdf</attachment>
+    </meta>
+    <semester half="B" year="2012"/>
+    <title>Understanding the complex gas kinematics of compact, rapidly growing galaxies in the local Universe</title>
+    <abstract>Studying the mechanisms governing enhanced star formation in dwarf galaxies is essential to understand how they assemble and evolve. A rare subset of local starbursting dwarfs that look clumpy and highly turbulent can provide new insights on how disks are assembled in the modern Universe. As in early galaxies, gas accretion - induced by mergers or gravitational instabilities - and strong SNe feedback, have been suggested as common drivers as well. However, essential pieces of information are missing. Here we propose to obtain unbiased, 2D high quality spectroscopic observations with GMOS-IFU. These deep, high S/N data tracing both star formation and gas kinematics, are intended to spatially resolve - at kpc scales - the main kinematic components identified in Halpha, including narrow and broad emission. </abstract>
+    <keywords>
+        <keyword>Evolution</keyword>
+        <keyword>Interacting galaxies</keyword>
+        <keyword>Starburst galaxies</keyword>
+        <keyword>Emission lines</keyword>
+        <keyword>Star clusters</keyword>
+        <keyword>H II regions</keyword>
+    </keywords>
+    <investigators>
+        <pi id="investigator-1">
+            <firstName>Guillermo</firstName>
+            <lastName>Hagele</lastName>
+            <status>PhD</status>
+            <email>ghagele@fcaglp.unlp.edu.ar</email>
+            <phone></phone>
+            <address>
+                <institution>Observatorio Astronomico de La Plata</institution>
+                <address>Paseo del Bosque
+1900 La Plata
+Prov. de Buenos Aires</address>
+                <country>Argentina</country>
+            </address>
+        </pi>
+        <coi id="investigator-2">
+            <firstName>Guilllermo</firstName>
+            <lastName>Bosch</lastName>
+            <status>PhD</status>
+            <email>guille@fcaglp.unlp.edu.ar</email>
+            <phone></phone>
+            <institution>Observatorio Astronomico de La Plata</institution>
+        </coi>
+        <coi id="investigator-3">
+            <firstName>Monica</firstName>
+            <lastName>Cardaci</lastName>
+            <status>PhD</status>
+            <email>mcardaci@fcaglp.unlp.edu.ar</email>
+            <phone></phone>
+            <institution>Observatorio Astronomico de La Plata</institution>
+        </coi>
+        <coi id="investigator-4">
+            <firstName>Veronica</firstName>
+            <lastName>Firpo</lastName>
+            <status>PhD</status>
+            <email>vfirpo@fcaglp.unlp.edu.ar</email>
+            <phone></phone>
+            <institution>Observatorio Astronomico de La Plata</institution>
+        </coi>
+        <coi id="investigator-5">
+            <firstName>Enrique</firstName>
+            <lastName>Perez-Montero</lastName>
+            <status>PhD</status>
+            <email>epm@iaa.es</email>
+            <phone></phone>
+            <institution>IAA - Granada</institution>
+        </coi>
+        <coi id="investigator-6">
+            <firstName>Jose Maria</firstName>
+            <lastName>Vilchez</lastName>
+            <status>PhD</status>
+            <email>jvm@iaa.es</email>
+            <phone></phone>
+            <institution>IAA - Granada</institution>
+        </coi>
+        <coi id="investigator-7">
+            <firstName>Ana</firstName>
+            <lastName>Monreal-Ibero</lastName>
+            <status>PhD</status>
+            <email>ami@iaa.es</email>
+            <phone></phone>
+            <institution>IAA - Granada</institution>
+        </coi>
+        <coi id="investigator-8">
+            <firstName>Ricardo</firstName>
+            <lastName>Amorin</lastName>
+            <status>PhD</status>
+            <email>amorin@iaa.es</email>
+            <phone></phone>
+            <institution>IAA - Granada</institution>
+        </coi>
+    </investigators>
+    <targets>
+        <sidereal epoch="J2000" id="target-0">
+            <name>SDSS J0839</name>
+            <degDeg>
+                <ra>129.68166666030884925930877216160297393798828125</ra>
+                <dec>38.89722222222221859055935055948793888092041015625</dec>
+            </degDeg>
+        </sidereal>
+    </targets>
+    <conditions>
+        <condition id="condition-0">
+            <name>CC 50%/Clear, IQ 20%/Best, SB 50%/Dark, WV Any, AM ≤ 1.40</name>
+            <maxAirmass>1.4</maxAirmass>
+            <cc>70%/Cirrus</cc>
+            <iq>20%/Best</iq>
+            <sb>80%/Grey</sb>
+            <wv>Any</wv>
+        </condition>
+    </conditions>
+    <blueprints>
+        <gmosN>
+            <regime>optical</regime>
+            <ifu id="blueprint-0">
+                <name>GMOS-N IFU R831 OG515 (&gt; 520 nm) IFU 1 slit</name>
+                <altair>
+                    <none></none>
+                </altair>
+                <filter>OG515 (&gt; 520 nm)</filter>
+                <disperser>R831</disperser>
+                <fpu>IFU 1 slit</fpu>
+            </ifu>
+        </gmosN>
+    </blueprints>
+    <observations>
+        <observation blueprint="blueprint-0" condition="condition-0" target="target-0" band="Band 1/2">
+            <time units="hr">3.6</time>
+            <meta ck="">
+                <guiding>
+                    <percentage>69</percentage>
+                    <evaluation>Caution</evaluation>
+                </guiding>
+                <visibility>Good</visibility>
+                <gsa>0</gsa>
+            </meta>
+        </observation>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None" key="604c87d8-9bf8-96a8-0642-f70604c87d89">
+            <itac>
+                <accept>
+                    <programId>GN-2012B-Q-20</programId>
+                    <contact>anitta@gemini.edu, rschiavon@gemini.edu</contact>
+                    <email>No partner lead email assigned.</email>
+                    <band>1</band>
+                    <award units="hr">3.600000000000000088817841970012523233890533447265625</award>
+                    <rollover>false</rollover>
+                </accept>
+                <comment>ITAC Comment
+
+Gemini Comment
+This program is in band 1, however it is not accepted for rollover into future semesters if not completed in 12B.</comment>
+            </itac>
+            <ngo partnerLead="investigator-1">
+                <request>
+                    <time units="hr">3.6</time>
+                    <minTime units="hr">3.6</minTime>
+                </request>
+                <response>
+                    <receipt>
+                        <timestamp>2012-03-30T07:57:27.000-10:00</timestamp>
+                        <id>AR-2012B-007</id>
+                    </receipt>
+                    <accept>
+                        <email>asmith@fcaglp.unlp.edu.ar,ferrero.gabriel@gmail.com</email>
+                        <ranking>3.0</ranking>
+                        <recommend units="hr">3.6</recommend>
+                        <minRecommend units="hr">3.6</minRecommend>
+                        <poorWeather>false</poorWeather>
+                    </accept>
+                </response>
+                <partner>ar</partner>
+            </ngo>
+        </queue>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -243,13 +243,14 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
           changes must contain("Band3 Option is missing, set as false")
           changes must contain("Affiliate override flag is missing")
           changes must contain("NGO acceptance from the United Kingdom has been removed")
+          changes must contain("Former observation time parameter mapped to program time")
 
           // Sanity check
           ProposalIo.read(result.toString())
@@ -267,13 +268,14 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
           changes must contain("Band3 Option is missing, set as false")
           changes must contain("Affiliate override flag is missing")
           changes must contain("NGO acceptance from the United Kingdom has been removed")
+          changes must contain("Former observation time parameter mapped to program time")
 
           // Sanity check
           ProposalIo.read(result.toString())
@@ -292,7 +294,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -300,6 +302,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           changes must contain("Affiliate override flag is missing")
           changes must contain("NGO acceptance from the United Kingdom has been removed")
           changes must contain("The United Kingdom was marked as ITAC NGO authority and has been removed")
+          changes must contain("Former observation time parameter mapped to program time")
 
           // Sanity check
           ProposalIo.read(result.toString())
@@ -663,11 +666,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2014B to view the unmodified proposal")
           changes must contain("Gemini Staff is no longer a valid partner and this time request has been removed")
+          changes must contain("Former observation time parameter mapped to program time")
 
           // Sanity check
           ProposalIo.read(result.toString())
@@ -715,6 +719,26 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           changes must have length 5
           result \\ "gpi" must \\("observingMode") \>~ "H.direct"
           result \\ "gpi" must \\("name") \> "GPI H direct Prism"
+      }
+    }
+    "proposal with observation time attribute should be transformed to progTime attribute, REL-2985" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_observation_time.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          result \\ "observation" must \\("progTime")
+          result \\ "observation" must not \\ "time"
+      }
+    }
+    "proposal with request time attribute must be maintained as time attribute, REL-2985" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_observation_time.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          result \\ "request" must \\("time")
+          result \\ "request" must not \\ "progTime"
       }
     }
   }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
@@ -1,0 +1,113 @@
+package edu.gemini.model.p1.overheads
+
+import edu.gemini.model.p1.immutable._
+import org.specs2.mutable.Specification
+
+import scala.collection.immutable.HashMap
+
+class OverheadsSpec extends Specification {
+  "Overheads" should {
+    "calculate all times properly in both directions" in {
+      forall(OverheadsSpec.instMap) { case ((_, _), (blueprint, expected)) =>
+        val overheads = Overheads(blueprint())
+        val results = for (o <- Overheads(blueprint())) yield {
+          val calculated = o.calculate(OverheadsSpec.intTime)
+          val intTime    = o.intTimeFromProgTime(calculated.progTime)
+          (calculated, intTime)
+        }
+        results shouldNotEqual None and(OverheadsSpec.almostEqual(results.get._1, expected) shouldEqual true) and(OverheadsSpec.almostEqual(results.get._2, OverheadsSpec.intTime) shouldEqual true)
+      }
+    }
+  }
+}
+
+object OverheadsSpec {
+  private val precision = 0.01
+  def almostEqual(t1: TimeAmount, t2: TimeAmount): Boolean =
+    (t1.toHours.value - t2.toHours.value).abs < precision
+  def almostEqual(times1: ObservationTimes, times2: ObservationTimes): Boolean =
+    almostEqual(times1.progTime, times2.progTime) && almostEqual(times1.partTime, times2.partTime)
+
+  // Integration time in hours used in the tests.
+  val intTime = TimeAmount(1.70, TimeUnit.HR)
+
+  // Convenience function to create ObservationTimes in hours.
+  private def obsTimes(progTime: Double, partTime: Double): ObservationTimes = {
+    def hrs(t: Double): TimeAmount =
+      TimeAmount(t, TimeUnit.HR)
+    ObservationTimes(hrs(progTime), hrs(partTime))
+  }
+
+  // Mapping of all instrument modes to blueprint and results.
+  // These are taken from the python script in REL-2985.
+  // Values in blueprints don't generally matter with exception of GMOS and NIRI.
+  // We just need blueprints for the lookups.
+  val instMap = HashMap[(String,String), (() => BlueprintBase, ObservationTimes)](
+    ("gmos", "ifu") -> (
+      () => GmosSBlueprintIfu(GmosSDisperser.B600, GmosSFilter.None, GmosSFpuIfu.values.apply(0)),
+      obsTimes(2.44, 0.24)),
+    ("gmos", "longns") -> (
+      () => GmosSBlueprintLongslitNs(GmosSDisperser.B600, GmosSFilter.None, GmosSFpuNs.values.apply(0)),
+      obsTimes(2.69, 0.27)),
+    ("gmos", "mos") -> (
+      () => GmosSBlueprintMos(GmosSDisperser.B600, GmosSFilter.None, GmosSMOSFpu.values.apply(0), false, false),
+      obsTimes(2.35, 0.23)),
+    ("gmos", "long") -> (
+      () => GmosSBlueprintLongslit(GmosSDisperser.B600, GmosSFilter.None, GmosSFpu.values.apply(0)),
+      obsTimes(2.29, 0.23)),
+    ("gmos", "ifuns") -> (
+      () => GmosSBlueprintIfuNs(GmosSDisperser.B600, GmosSFilter.None, GmosSFpuIfuNs.values.apply(0)),
+      obsTimes(2.83, 0.28)),
+    ("gmos", "imaging") -> (
+      () => GmosSBlueprintImaging(Nil),
+      obsTimes(2.13, 0.00)),
+    ("gmos", "mosns") -> (
+      () => GmosSBlueprintMos(GmosSDisperser.B600, GmosSFilter.None, GmosSMOSFpu.values.apply(0), true, false),
+      obsTimes(2.76, 0.28)),
+    ("phoenix", "long") -> (
+      () => PhoenixBlueprint(Site.GS, PhoenixFocalPlaneUnit.values.apply(0), PhoenixFilter.values.apply(0)),
+      obsTimes(2.40, 0.60)),
+    ("visitor", "any") -> (
+      () => VisitorBlueprint(Site.GS, ""),
+      obsTimes(2.20, 0.00)),
+    ("f2", "mos") -> (
+      () => Flamingos2BlueprintMos(Flamingos2Disperser.R1200JH, Nil, false),
+      obsTimes(3.18, 0.80)),
+    ("f2", "imaging") -> (
+      () => Flamingos2BlueprintImaging(Nil),
+      obsTimes(2.99, 0.30)),
+    ("f2", "long") -> (
+      () => Flamingos2BlueprintLongslit(Flamingos2Disperser.R1200JH, Nil, Flamingos2Fpu.values.apply(0)),
+      obsTimes(2.85, 0.71)),
+    ("gsaoi", "imaging") -> (
+      () => GsaoiBlueprint(Nil),
+      obsTimes(4.62, 0.00)),
+    ("nifs", "ifu") -> (
+      () => NifsBlueprint(NifsDisperser.Z),
+      obsTimes(2.36, 0.59)),
+    ("texes", "long") -> (
+      () => TexesBlueprint(Site.GS, TexesDisperser.values.apply(0)),
+      obsTimes(2.40, 0.00)),
+    ("gpi", "ifu") -> (
+      () => GpiBlueprint(GpiObservingMode.HDirect, GpiDisperser.values.apply(0)),
+      obsTimes(2.60, 0.13)),
+    ("dssi", "ifu") -> (
+      () => DssiBlueprint(Site.GS),
+      obsTimes(1.88, 0.00)),
+    ("gnirs", "imaging") -> (
+      () => GnirsBlueprintImaging(AltairNone, GnirsPixelScale.PS_005, GnirsFilter.values.apply(0)),
+      obsTimes(2.34, 0.23)),
+    ("gnirs", "long") -> (
+      () => GnirsBlueprintSpectroscopy(AltairNone, GnirsPixelScale.PS_005, GnirsDisperser.D_10, GnirsCrossDisperser.LXD, GnirsFpu.values.apply(0), GnirsCentralWavelength.values.apply(0)),
+      obsTimes(2.34, 0.58)),
+    ("niri", "imagingao") -> (
+      () => NiriBlueprint(AltairNGS(false), NiriCamera.F6, Nil),
+      obsTimes(2.34, 0.23)),
+    ("niri", "imaging") -> (
+      () => NiriBlueprint(AltairNone, NiriCamera.F6, Nil),
+      obsTimes(2.21, 0.22)),
+    ("graces", "spec") -> (
+      () => GracesBlueprint(GracesFiberMode.values.apply(0), GracesReadMode.values.apply(0)),
+      obsTimes(1.93, 0.00))
+  )
+}

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
@@ -42,72 +42,94 @@ object OverheadsSpec {
   // These are taken from the python script in REL-2985.
   // Values in blueprints don't generally matter with exception of GMOS and NIRI.
   // We just need blueprints for the lookups.
-  val instMap = HashMap[(String,String), (() => BlueprintBase, ObservationTimes)](
-    ("gmos", "ifu") -> (
+  val instMap = HashMap(
+    (("gmos", "ifu"), (
       () => GmosSBlueprintIfu(GmosSDisperser.B600, GmosSFilter.None, GmosSFpuIfu.values.apply(0)),
-      obsTimes(2.44, 0.24)),
-    ("gmos", "longns") -> (
+      obsTimes(2.44, 0.24))
+      ),
+    (("gmos", "longns"), (
       () => GmosSBlueprintLongslitNs(GmosSDisperser.B600, GmosSFilter.None, GmosSFpuNs.values.apply(0)),
-      obsTimes(2.69, 0.27)),
-    ("gmos", "mos") -> (
+      obsTimes(2.69, 0.27))
+      ),
+    (("gmos", "mos"), (
       () => GmosSBlueprintMos(GmosSDisperser.B600, GmosSFilter.None, GmosSMOSFpu.values.apply(0), false, false),
-      obsTimes(2.35, 0.23)),
-    ("gmos", "long") -> (
+      obsTimes(2.35, 0.23))
+      ),
+    (("gmos", "long"), (
       () => GmosSBlueprintLongslit(GmosSDisperser.B600, GmosSFilter.None, GmosSFpu.values.apply(0)),
-      obsTimes(2.29, 0.23)),
-    ("gmos", "ifuns") -> (
+      obsTimes(2.29, 0.23))
+      ),
+    (("gmos", "ifuns"), (
       () => GmosSBlueprintIfuNs(GmosSDisperser.B600, GmosSFilter.None, GmosSFpuIfuNs.values.apply(0)),
-      obsTimes(2.83, 0.28)),
-    ("gmos", "imaging") -> (
+      obsTimes(2.83, 0.28))
+      ),
+    (("gmos", "imaging"), (
       () => GmosSBlueprintImaging(Nil),
-      obsTimes(2.13, 0.00)),
-    ("gmos", "mosns") -> (
+      obsTimes(2.13, 0.00))
+      ),
+    (("gmos", "mosns"), (
       () => GmosSBlueprintMos(GmosSDisperser.B600, GmosSFilter.None, GmosSMOSFpu.values.apply(0), true, false),
-      obsTimes(2.76, 0.28)),
-    ("phoenix", "long") -> (
+      obsTimes(2.76, 0.28))
+      ),
+    (("phoenix", "long"), (
       () => PhoenixBlueprint(Site.GS, PhoenixFocalPlaneUnit.values.apply(0), PhoenixFilter.values.apply(0)),
-      obsTimes(2.40, 0.60)),
-    ("visitor", "any") -> (
+      obsTimes(2.40, 0.60))
+      ),
+    (("visitor", "any"), (
       () => VisitorBlueprint(Site.GS, ""),
-      obsTimes(2.20, 0.00)),
-    ("f2", "mos") -> (
+      obsTimes(2.20, 0.00))
+      ),
+    (("f2", "mos"), (
       () => Flamingos2BlueprintMos(Flamingos2Disperser.R1200JH, Nil, false),
-      obsTimes(3.18, 0.80)),
-    ("f2", "imaging") -> (
+      obsTimes(3.18, 0.80))
+      ),
+    (("f2", "imaging"), (
       () => Flamingos2BlueprintImaging(Nil),
-      obsTimes(2.99, 0.30)),
-    ("f2", "long") -> (
+      obsTimes(2.99, 0.30))
+      ),
+    (("f2", "long"), (
       () => Flamingos2BlueprintLongslit(Flamingos2Disperser.R1200JH, Nil, Flamingos2Fpu.values.apply(0)),
-      obsTimes(2.85, 0.71)),
-    ("gsaoi", "imaging") -> (
+      obsTimes(2.85, 0.71))
+      ),
+    (("gsaoi", "imaging"), (
       () => GsaoiBlueprint(Nil),
-      obsTimes(4.62, 0.00)),
-    ("nifs", "ifu") -> (
+      obsTimes(4.62, 0.00))
+      ),
+    (("nifs", "ifu"), (
       () => NifsBlueprint(NifsDisperser.Z),
-      obsTimes(2.36, 0.59)),
-    ("texes", "long") -> (
+      obsTimes(2.36, 0.59))
+      ),
+    (("texes", "long"), (
       () => TexesBlueprint(Site.GS, TexesDisperser.values.apply(0)),
-      obsTimes(2.40, 0.00)),
-    ("gpi", "ifu") -> (
+      obsTimes(2.40, 0.00))
+      ),
+    (("gpi", "ifu"), (
       () => GpiBlueprint(GpiObservingMode.HDirect, GpiDisperser.values.apply(0)),
-      obsTimes(2.60, 0.13)),
-    ("dssi", "ifu") -> (
+      obsTimes(2.60, 0.13))
+      ),
+    (("dssi", "ifu"), (
       () => DssiBlueprint(Site.GS),
-      obsTimes(1.88, 0.00)),
-    ("gnirs", "imaging") -> (
+      obsTimes(1.88, 0.00))
+      ),
+    (("gnirs", "imaging"), (
       () => GnirsBlueprintImaging(AltairNone, GnirsPixelScale.PS_005, GnirsFilter.values.apply(0)),
-      obsTimes(2.34, 0.23)),
-    ("gnirs", "long") -> (
+      obsTimes(2.34, 0.23))
+      ),
+    (("gnirs", "long"), (
       () => GnirsBlueprintSpectroscopy(AltairNone, GnirsPixelScale.PS_005, GnirsDisperser.D_10, GnirsCrossDisperser.LXD, GnirsFpu.values.apply(0), GnirsCentralWavelength.values.apply(0)),
-      obsTimes(2.34, 0.58)),
-    ("niri", "imagingao") -> (
+      obsTimes(2.34, 0.58))
+      ),
+    (("niri", "imagingao"), (
       () => NiriBlueprint(AltairNGS(false), NiriCamera.F6, Nil),
-      obsTimes(2.34, 0.23)),
-    ("niri", "imaging") -> (
+      obsTimes(2.34, 0.23))
+      ),
+    (("niri", "imaging"), (
       () => NiriBlueprint(AltairNone, NiriCamera.F6, Nil),
-      obsTimes(2.21, 0.22)),
-    ("graces", "spec") -> (
+      obsTimes(2.21, 0.22))
+      ),
+    (("graces", "spec"), (
       () => GracesBlueprint(GracesFiberMode.values.apply(0), GracesReadMode.values.apply(0)),
       obsTimes(1.93, 0.00))
+      )
   )
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -34,7 +34,7 @@ object Phase1FolderFactory {
         blueprintE  <- extractBlueprintEntry(o).right
         target      <- extractTarget(site, o, time).right
         siteQuality <- extractSiteQuality(o).right
-        timeValue   <- extractObsTime(o).right
+        timeValue   <- extractIntTime(o).right
       } yield Folder(site, namer,
                 bMap + blueprintE,
                 ObsQuad(blueprintE._1, target, siteQuality, timeValue) :: oList)
@@ -58,9 +58,9 @@ object Phase1FolderFactory {
         s2 <- SpSiteQualityFactory.create(s1).right
       } yield s2
 
-    private def extractObsTime(o: Observation): Either[String, TimeValue] =
+    private def extractIntTime(o: Observation): Either[String, TimeValue] =
       for {
-        time <- o.time.toRight("Observation missing time").right
+        time <- o.intTime.toRight("Observation missing integration time").right
       } yield new TimeValue(time.toHours.hours, TimeValue.Units.hours)
 
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/REL_2232_Test.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/REL_2232_Test.scala
@@ -237,7 +237,7 @@ object REL_2232_Test extends TemplateSpec("NIFS_BP.xml") with SpecificationLike 
       </blueprints>
       <observations>
         <observation band="Band 1/2" enabled="true" target="target-1" condition="condition-0" blueprint="blueprint-0">
-          <time units="hr">1.0</time>
+          <progTime units="hr">1.0</progTime>
           <meta ck="">
             <guiding>
               <percentage>100</percentage>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
@@ -17,7 +17,7 @@ import edu.gemini.spModel.template.TemplateParameters
 import org.specs2.mutable.SpecificationLike
 import scala.collection.JavaConverters._
 import scalaz._, Scalaz._
-import Observation.{blueprint, target, condition, time}
+import Observation.{blueprint, target, condition, intTime}
 import Proposal.{ targets, observations }
 
 /**
@@ -141,7 +141,7 @@ abstract class TemplateSpec(xmlName: String) { this: SpecificationLike =>
         _ <- blueprint := Some(bp)
         _ <- target    := Some(st)
         _ <- condition := Some(Condition.empty)
-        _ <- time      := Some(TimeAmount.empty)
+        _ <- intTime   := Some(TimeAmount.empty)
       } yield ()
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/overheads/Overheads.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/overheads/Overheads.scala
@@ -7,6 +7,9 @@ import edu.gemini.model.p1.immutable._
 import scalaz._
 import Scalaz._
 
+// We probably want to add the actual calculations for times here, which will take integration time
+// and return the other times. That way, this is accessible to both the Observation and the ObservationEditor,
+// which will need to update its fields when the integration time is updated.
 sealed trait Overheads {
   def partnerOverheadFraction: Double
   def acquisitionOverhead: Duration

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/overheads/Overheads.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/overheads/Overheads.scala
@@ -1,0 +1,89 @@
+package edu.gemini.pit.overheads
+
+import java.time.Duration
+
+import edu.gemini.model.p1.immutable._
+
+import scalaz._
+import Scalaz._
+
+sealed trait Overheads {
+  def partnerOverheadFraction: Double
+  def acquisitionOverhead: Duration
+  def typicalExpTime: Option[Duration]
+  def otherOverheadFraction: Double
+}
+
+// Due to the large number of possible blueprint bases and how each one requires different configuration params
+// to determine the overheads, it seems infeasible to read this information from a file, so for now it is hard-coded
+// and will require changing here if these values change.
+object Overheads extends (BlueprintBase => Option[Overheads]) {
+  private class SimpleOverheads(override val partnerOverheadFraction: Double,
+                                override val acquisitionOverhead: Duration,
+                                override val typicalExpTime: Option[Duration],
+                                override val otherOverheadFraction: Double) extends Overheads
+
+  // Simplified way to create SimpleOverheads with standard fields.
+  // Times must be given in minutes.
+  private object SimpleOverheads {
+    def apply(partnerOverheadFraction: Double,
+              acquisitionOverhead: Long,
+              typicalExpTime: Long,
+              otherOverheadFraction: Double) =
+      new SimpleOverheads(
+        partnerOverheadFraction,
+        Duration.ofMinutes(acquisitionOverhead),
+        Duration.ofMinutes(typicalExpTime).some,
+        otherOverheadFraction)
+  }
+
+  // GMOS overheads are the same between sites.
+  private lazy val GmosImagingOverheads    = SimpleOverheads(0.00,  6,  300, 0.137).some
+  private lazy val GmosLongslitOverheads   = SimpleOverheads(0.10, 16, 1200, 0.034).some
+  private lazy val GmosLongslitNsOverheads = SimpleOverheads(0.10, 16,  960, 0.271).some
+  private lazy val GmosMosOverheads        = SimpleOverheads(0.10, 18, 1200, 0.028).some
+  private lazy val GmosMosNsOverheads      = SimpleOverheads(0.10, 18,  960, 0.271).some
+  private lazy val GmosIfuOverheads        = SimpleOverheads(0.10, 18, 1200, 0.083).some
+  private lazy val GmosIfuNsOverheads      = SimpleOverheads(0.10, 18,  960, 0.311).some
+
+  def apply(b: BlueprintBase): Option[Overheads] = b match {
+    case _: Flamingos2BlueprintImaging  => SimpleOverheads(0.10, 15,   60, 0.467).some
+    case _: Flamingos2BlueprintLongslit => SimpleOverheads(0.25, 20,  120, 0.283).some
+    case _: Flamingos2BlueprintMos      => SimpleOverheads(0.25, 30,  120, 0.283).some
+
+    case _: GnirsBlueprintImaging       => SimpleOverheads(0.10, 10,   60, 0.183).some
+    case _: GnirsBlueprintSpectroscopy  => SimpleOverheads(0.25, 15,  300, 0.080).some
+
+    case _: NifsBlueprint               => SimpleOverheads(0.25, 11,  600, 0.175).some
+    case _: GsaoiBlueprint              => SimpleOverheads(0.00, 30,   60, 0.833).some
+    case _: GracesBlueprint             => SimpleOverheads(0.00, 10, 1200, 0.036).some
+    case _: GpiBlueprint                => SimpleOverheads(0.05, 10,   60, 0.333).some
+    case _: PhoenixBlueprint            => SimpleOverheads(0.25, 20, 1200, 0.021).some
+    case _: TexesBlueprint              => SimpleOverheads(0.00, 20,  900, 0.022).some
+
+    case _: DssiBlueprint               => new SimpleOverheads(0.00, Duration.ofMinutes(10), None, 0.010).some
+    case _: VisitorBlueprint            => new SimpleOverheads(0.00, Duration.ofMinutes(10), None, 0.100).some
+
+
+    // NIRI relies on whether or not AO is being used.
+    case nbp: NiriBlueprint             => SimpleOverheads(0.10, nbp.altair.ao.toBoolean ? 10 | 6, 60, 0.183).some
+
+
+    // GMOS is independent of site unless N&S is being used.
+    case _: GmosNBlueprintImaging    | _: GmosSBlueprintImaging    => GmosImagingOverheads
+    case _: GmosNBlueprintLongslit   | _: GmosSBlueprintLongslit   => GmosLongslitOverheads
+    case _: GmosNBlueprintLongslitNs | _: GmosSBlueprintLongslitNs => GmosLongslitNsOverheads
+    case _: GmosNBlueprintIfu        | _: GmosSBlueprintIfu        => GmosIfuOverheads
+
+    // Only GMOS-S offers IFU N&S.
+    case _: GmosSBlueprintIfuNs                                    => GmosIfuNsOverheads
+
+    // For MOS, N&S setting is a represented as a boolean flag.
+    case gmosbp: GmosNBlueprintMos => gmosbp.nodAndShuffle ? GmosMosNsOverheads | GmosMosOverheads
+    case gmosbp: GmosSBlueprintMos => gmosbp.nodAndShuffle ? GmosMosNsOverheads | GmosMosOverheads
+
+
+    // Any other configuration is unsupported.
+    case _ => None
+  }
+}

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
@@ -110,9 +110,9 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
   def updateTimeLabels(): Unit = {
     val intTime = TimeAmount(\/.fromTryCatchNonFatal(IntegrationTime.text.toDouble).getOrElse(0.0), Units.selection.item)
     val obsTimes = calculator.map(_.calculate(intTime))
-    ProgramTime.update(obsTimes.map(_.progTime).getOrElse(TimeAmount.empty))
-    PartTime.update(obsTimes.map(_.partTime).getOrElse(TimeAmount.empty))
-    TotalTime.update(obsTimes.map(_.totalTime).getOrElse(TimeAmount.empty))
+    ProgramTime.update(obsTimes.foldMap(_.progTime))
+    PartTime.update(obsTimes.foldMap(_.partTime))
+    TotalTime.update(obsTimes.foldMap(_.totalTime))
   }
   IntegrationTime.reactions += {
     case ValueChanged(_) => updateTimeLabels()

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
@@ -21,7 +21,6 @@ object ObservationEditor {
 
   def open(c:Option[Observation], editable:Boolean, parent:UIElement) =
     new ObservationEditor(c.getOrElse(Observation.empty.copy(intTime = Some(TimeAmount.empty))), editable).open(parent)
-
 }
 
 /**
@@ -73,7 +72,7 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
   // Time calculator
   val calculator = obs.blueprint.flatMap(Overheads)
 
-  object IntegrationTime extends NumberField(obs.intTime.map(_.value).orElse(Some(1.0)), allowEmpty = false) {
+  object IntegrationTime extends NumberField(obs.intTime.map(_.value).orElse(Some(1.0)), allowEmpty = false, format = NumberField.TimeFormatter) {
     enabled = canEdit
     override def valid(d:Double) = d > 0
   }
@@ -88,7 +87,7 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
       text = t
   }
 
-  class CalculatedTimeAmountField extends NumberField(None, allowEmpty = false) {
+  class CalculatedTimeAmountField extends NumberField(None, allowEmpty = false, format = NumberField.TimeFormatter) {
     enabled = false
 
     def update(t: TimeAmount): Unit =

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
@@ -7,7 +7,7 @@ import edu.gemini.pit.ui.util._
 import java.awt.Color
 import javax.swing.Icon
 
-import edu.gemini.pit.overheads.Overheads
+import edu.gemini.model.p1.overheads.Overheads
 import edu.gemini.shared.gui.textComponent.NumberField
 
 import scala.swing._
@@ -20,7 +20,7 @@ import Scalaz._
 object ObservationEditor {
 
   def open(c:Option[Observation], editable:Boolean, parent:UIElement) =
-    new ObservationEditor(c.getOrElse(Observation.empty.copy(time = Some(TimeAmount.empty))), editable).open(parent)
+    new ObservationEditor(c.getOrElse(Observation.empty.copy(intTime = Some(TimeAmount.empty))), editable).open(parent)
 
 }
 
@@ -73,14 +73,14 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
   // Time calculator
   val calculator = obs.blueprint.flatMap(Overheads)
 
-  object IntegrationTime extends NumberField(obs.time.map(_.value).orElse(Some(1.0)), allowEmpty = false) {
+  object IntegrationTime extends NumberField(obs.intTime.map(_.value).orElse(Some(1.0)), allowEmpty = false) {
     enabled = canEdit
     override def valid(d:Double) = d > 0
   }
 
   object Units extends ComboBox(TimeUnit.values.toList) with ValueRenderer[TimeUnit] {
     enabled = canEdit
-    selection.item = obs.time.getOrElse(TimeAmount.empty).units
+    selection.item = obs.intTime.getOrElse(TimeAmount.empty).units
   }
 
   class UnitsLabel extends Label {
@@ -140,6 +140,6 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
 
   // Construct a new value
   def value = obs.copy(
-    time = Some(TimeAmount(IntegrationTime.text.toDouble, Units.selection.item)),
+    intTime = Some(TimeAmount(IntegrationTime.text.toDouble, Units.selection.item)),
     meta = None)
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/ObservationEditor.scala
@@ -2,18 +2,18 @@ package edu.gemini.pit.ui.editor
 
 
 import edu.gemini.model.p1.immutable._
-
 import edu.gemini.pit.ui.util.SharedIcons._
 import edu.gemini.pit.ui.util._
-
 import java.awt.Color
 import javax.swing.Icon
 
 import edu.gemini.shared.gui.textComponent.NumberField
 
 import scala.swing._
-import event.ValueChanged
+import event.{SelectionChanged, ValueChanged}
 import scala.swing.Swing._
+import scalaz._
+import Scalaz._
 
 object ObservationEditor {
 
@@ -29,32 +29,36 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
 
   // Editor component
   object Editor extends GridBagPanel with Rows {
-    addRow(new Label("Conditions"), new OptionLabel(obs.condition, ICON_CONDS))
-    addRow(new Label("Resources"), new OptionLabel(obs.blueprint, ICON_DEVICE))
+    addRow(new Label("Conditions"), new OptionLabel(obs.condition, ICON_CONDS), gw=2)
+    addRow(new Label("Resources"), new OptionLabel(obs.blueprint, ICON_DEVICE), gw=2)
     addRow(new Label("Target"), new OptionLabel(obs.target, obs.target match {
       case Some(_:NonSiderealTarget) => ICON_NONSIDEREAL
       case _                         => ICON_SIDEREAL
-    }))
+    }), gw=2)
     addSpacer()
-    addRow(new Label("Time"), new BorderPanel {
-      border = null
-      add(Time, BorderPanel.Position.Center)
-      add(Units, BorderPanel.Position.East)
-    })
-    preferredSize = (400, preferredSize.height) // force width
+    addLabeledRow(new RightLabel("Integration Time"), IntegrationTime, Units)
+    addLabeledRow(new RightLabel("Program Time"), ProgramTime, ProgramTimeUnits)
+    addLabeledRow(new RightLabel("Night Basecal Time"), PartTime, PartTimeUnits)
+    addLabeledRow(new RightLabel("Total Time"), TotalTime, TotalTimeUnits)
+    preferredSize = (500, preferredSize.height) // force width
+  }
+
+
+  class RightLabel(t: String) extends Label(t) {
+    horizontalAlignment = Alignment.Right
   }
 
   // Editable
   Contents.Footer.OkButton.enabled = canEdit
 
   // Validation
-  override def editorValid = Time.valid
-  Time.reactions += {
+  override def editorValid = IntegrationTime.valid
+  IntegrationTime.reactions += {
     case ValueChanged(_) => validateEditor()
   }
 
   type Named = {
-    def name:String
+    def name: String
   }
 
   class OptionLabel(a:Option[Named], icon0:Icon) extends Label() {
@@ -65,7 +69,7 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
       foreground = Color.GRAY
   }
 
-  object Time extends NumberField(obs.time.map(_.value).orElse(Some(1.0)), allowEmpty = false) {
+  object IntegrationTime extends NumberField(obs.time.map(_.value).orElse(Some(1.0)), allowEmpty = false) {
     enabled = canEdit
     override def valid(d:Double) = d > 0
   }
@@ -75,13 +79,59 @@ class ObservationEditor private (obs:Observation, canEdit:Boolean) extends StdMo
     selection.item = obs.time.getOrElse(TimeAmount.empty).units
   }
 
+  class UnitsLabel extends Label {
+    def update(t: String): Unit =
+      text = t
+  }
+
+  object ProgramTime extends NumberField(None, allowEmpty = false) {
+    enabled = false
+    def update(t: Double): Unit =
+      text = t.toString
+  }
+  object ProgramTimeUnits extends UnitsLabel
+
+  object PartTime extends NumberField(None, allowEmpty = false) {
+    enabled = false
+    def update(t: Double): Unit =
+      text = t.toString
+  }
+  object PartTimeUnits extends UnitsLabel
+
+  object TotalTime extends NumberField(None, allowEmpty = false) {
+    enabled = false
+    def update(t: Double): Unit =
+      text = t.toString
+  }
+  object TotalTimeUnits extends UnitsLabel
+
+  def updateTimeLabels(): Unit = {
+    val t = \/.fromTryCatchNonFatal(IntegrationTime.text.toDouble).getOrElse(0.0)
+    ProgramTime.update(t)
+    PartTime.update(t)
+    TotalTime.update(t)
+  }
+  IntegrationTime.reactions += {
+    case ValueChanged(_) => updateTimeLabels()
+  }
+  updateTimeLabels()
+
+  def updateUnitsLabels(): Unit = {
+    val t = Units.selection.item.value()
+    ProgramTimeUnits.update(t)
+    PartTimeUnits.update(t)
+    TotalTimeUnits.update(t)
+  }
+  Units.selection.reactions += {
+    case SelectionChanged(_) => updateUnitsLabels()
+  }
+  updateUnitsLabels()
+
   // Construct our editor
   def editor = Editor
 
   // Construct a new value
   def value = obs.copy(
-    time = Some(TimeAmount(Time.text.toDouble, Units.selection.item)),
+    time = Some(TimeAmount(IntegrationTime.text.toDouble, Units.selection.item)),
     meta = None)
-
 }
-

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SubmissionRequestEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SubmissionRequestEditor.scala
@@ -21,7 +21,7 @@ object SubmissionRequestEditor {
     add(Time, BorderPanel.Position.Center)
     add(Units, BorderPanel.Position.East)
 
-    object Time extends NumberField(tu.map(_.value), allowEmpty = false) {
+    object Time extends NumberField(tu.map(_.value), allowEmpty = false, format = NumberField.TimeFormatter) {
       override def valid(d:Double) = d >= 0
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -644,8 +644,9 @@ import TimeProblems._
 
 object TimeProblems {
   // Are two time amounts close enough to be considered the same?
+  // Times are all rounded to two decimal places.
   def sameTime(t1: TimeAmount, t2: TimeAmount): Boolean =
-    (t1.hours - t2.hours).abs < 0.001
+    (t1.hours - t2.hours).abs < 0.01
 
   // The goal here is to not show too much precision and yet not say two
   // times are different and print out two amounts that look the same.
@@ -682,7 +683,7 @@ case class TimeProblems(p: Proposal, s: ShellAdvisor) {
   lazy val requested = p.proposalClass.requestedTime
   def obsTimeSum(b: Band) = TimeAmount.sum(for {
     o <- p.observations if o.band == b
-    t <- o.progTime
+    t <- o.totalTime
   } yield t)
   lazy val obs = obsTimeSum(Band.BAND_1_2)
   lazy val obsB3 = obsTimeSum(Band.BAND_3)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -457,7 +457,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     }
 
     private lazy val missingObsDetailsCheck =
-      p.observations.filter(_.time.isEmpty) match {
+      p.observations.filter(_.intTime.isEmpty) match {
         case Nil => None
         case h :: Nil => Some(new Problem(Severity.Error, "One observation has no observation time.", "Observations", indicateObservation(h)))
         case h :: tail => Some(new Problem(Severity.Error, s"${1 + tail.length} observations have no observation times.", "Observations", indicateObservation(h)))
@@ -498,8 +498,8 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       )
 
     private lazy val badVisibility = for {
-      o @ Observation(Some(_), Some(_), Some(t), Some(_), _) <- p.observations
-      v                                                      <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
+      o @ Observation(Some(_), Some(_), Some(t), Some(_), _, _) <- p.observations
+      v                                                         <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
       if v == TargetVisibility.Bad
     } yield new Problem(Severity.Error,
         visibilityMessage("Target is inaccessible at %s during %s. Consider an alternative.", p.semester, o),
@@ -507,8 +507,8 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
         indicateObservation(o))
 
     private lazy val iffyVisibility = for {
-      o @ Observation(Some(_), Some(_), Some(_), Some(_), _) <- p.observations
-      v                                                      <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
+      o @ Observation(Some(_), Some(_), Some(_), Some(_), _, _) <- p.observations
+      v                                                         <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
       if v == TargetVisibility.Limited
     } yield new Problem(Severity.Warning,
         visibilityMessage("Target has limited visibility at %s during %s.", p.semester, o),
@@ -682,7 +682,7 @@ case class TimeProblems(p: Proposal, s: ShellAdvisor) {
   lazy val requested = p.proposalClass.requestedTime
   def obsTimeSum(b: Band) = TimeAmount.sum(for {
     o <- p.observations if o.band == b
-    t <- o.time
+    t <- o.progTime
   } yield t)
   lazy val obs = obsTimeSum(Band.BAND_1_2)
   lazy val obsB3 = obsTimeSum(Band.BAND_3)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/Rows.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/Rows.scala
@@ -1,21 +1,30 @@
 package edu.gemini.pit.ui.util
 
 import com.jgoodies.forms.factories.Borders.DLU4_BORDER
-import swing.{Separator, GridBagPanel, Component, Label}
+
+import swing.{Component, GridBagPanel, Insets, Label, Separator}
 
 trait Rows { this: GridBagPanel =>
 
   border = DLU4_BORDER
   private var row = 0
-  def addRow(a: Component, b: Component, f:GridBagPanel.Fill.Value = GridBagPanel.Fill.Horizontal, wy:Int = 0 ) {
+  def addRow(a: Component, b: Component, f:GridBagPanel.Fill.Value = GridBagPanel.Fill.Horizontal, wy: Int = 0, gw: Int = 1) {
     add(a, new Constraints { gridx = 0; gridy = row; ipadx = 10; ipady = 4; anchor = GridBagPanel.Anchor.NorthEast })
-    add(b, new Constraints { gridx = 1; gridy = row; fill = f; weightx = 1; weighty = wy })
+    add(b, new Constraints { gridx = 1; gridy = row; fill = f; weightx = 1; weighty = wy; gridwidth = gw })
     row = row + 1
   }
   def addRow(a: Component, b: Component, c: Component) {
     add(a, new Constraints { gridx = 0; gridy = row; ipadx = 10; ipady = 4; anchor = GridBagPanel.Anchor.West })
     add(b, new Constraints { gridx = 1; gridy = row; fill = GridBagPanel.Fill.Horizontal; weightx = 2 })
     add(c, new Constraints { gridx = 2; gridy = row; weightx = 1 })
+    row = row + 1
+  }
+
+  // Add a row with a pre- and post-label, with a supposedly editable component in the middle.
+  def addLabeledRow(a: Component, b: Component, c: Component) {
+    add(a, new Constraints { gridx = 0; gridy = row; ipadx = 10; ipady = 4; anchor = GridBagPanel.Anchor.NorthEast })
+    add(b, new Constraints { gridx = 1; gridy = row; insets = new Insets(0, 10, 0, 10); fill = GridBagPanel.Fill.Horizontal })
+    add(c, new Constraints { gridx = 2; gridy = row; anchor = GridBagPanel.Anchor.NorthWest })
     row = row + 1
   }
   def addRow(a: Component) {
@@ -31,7 +40,7 @@ trait Rows { this: GridBagPanel =>
     row = row + 1
   }
   def addSpacer() {
-    addRow(new Label(""), new Label("")) // :-/
+    addRow(new Label(" "), new Label("")) // :-/
   }
   def addSeparator() {
     add(new Separator(), new Constraints { gridx = 0; gridwidth = 3; gridy = row; ipadx = 10; ipady = 4; fill = GridBagPanel.Fill.Horizontal ; weightx = 1.0})

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/Rows.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/util/Rows.scala
@@ -40,6 +40,8 @@ trait Rows { this: GridBagPanel =>
     row = row + 1
   }
   def addSpacer() {
+    // Empty labels are given a preferred size of 0x0, so unfortunately, we have to make one label non-empty to actually
+    // have space added to the UI.
     addRow(new Label(" "), new Label("")) // :-/
   }
   def addSeparator() {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
@@ -47,7 +47,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
   def -(e:ObsListElem) = {
 
     def update(o:Observation) = e match {
-      case _:ObsElem        => o.copy(intTime = None, calculatedTimes = None)
+      case _:ObsElem        => o.copy(intTime = None)
       case _:ConditionGroup => o.copy(condition = None)
       case _:TargetGroup    => o.copy(target = None)
       case _:BlueprintGroup => o.copy(blueprint = None)
@@ -130,7 +130,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
       // To stamp and clear we fold over the associated groups. When stamping we also want to be sure to switch the
       // band to whatever this model's primary band is. This lets us paste stuff between BAND_1_2 and BAND_3.
       def stamp(o:Observation) = (o /: toStamp)((o, g) => g.stamp(target, o).copy(band = band))
-      def clear(o:Observation) = (o.copy(intTime = None, calculatedTimes = None) /: toClear)((o, g) => g.clear(o))
+      def clear(o:Observation) = (o.copy(intTime = None) /: toClear)((o, g) => g.clear(o))
 
       // Our list of dropped Observations,
       val os = source._1.selected(source._2)
@@ -186,7 +186,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
   def cut(elem:ObsListElem):ObsListModel = elem match {
     case target:ObsGroup[_] =>
       val (_, toClear) = Seq(gs._1, gs._2, gs._3).splitAt(depth(target))
-      def clear(o:Observation) = (o.copy(intTime = None, calculatedTimes = None) /: toClear)((o, g) => g.clear(o))
+      def clear(o:Observation) = (o.copy(intTime = None) /: toClear)((o, g) => g.clear(o))
       val os = selected(target)
       (this /: os.zip(os.map(clear)))(_.replacePair(_))
     case o:ObsElem          => this - o

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
@@ -47,7 +47,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
   def -(e:ObsListElem) = {
 
     def update(o:Observation) = e match {
-      case _:ObsElem        => o.copy(time = None)
+      case _:ObsElem        => o.copy(intTime = None, calculatedTimes = None)
       case _:ConditionGroup => o.copy(condition = None)
       case _:TargetGroup    => o.copy(target = None)
       case _:BlueprintGroup => o.copy(blueprint = None)
@@ -130,7 +130,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
       // To stamp and clear we fold over the associated groups. When stamping we also want to be sure to switch the
       // band to whatever this model's primary band is. This lets us paste stuff between BAND_1_2 and BAND_3.
       def stamp(o:Observation) = (o /: toStamp)((o, g) => g.stamp(target, o).copy(band = band))
-      def clear(o:Observation) = (o.copy(time = None) /: toClear)((o, g) => g.clear(o))
+      def clear(o:Observation) = (o.copy(intTime = None, calculatedTimes = None) /: toClear)((o, g) => g.clear(o))
 
       // Our list of dropped Observations,
       val os = source._1.selected(source._2)
@@ -186,7 +186,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
   def cut(elem:ObsListElem):ObsListModel = elem match {
     case target:ObsGroup[_] =>
       val (_, toClear) = Seq(gs._1, gs._2, gs._3).splitAt(depth(target))
-      def clear(o:Observation) = (o.copy(time = None) /: toClear)((o, g) => g.clear(o))
+      def clear(o:Observation) = (o.copy(intTime = None, calculatedTimes = None) /: toClear)((o, g) => g.clear(o))
       val os = selected(target)
       (this /: os.zip(os.map(clear)))(_.replacePair(_))
     case o:ObsElem          => this - o
@@ -220,7 +220,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
         val innerGroups:List[ObsListElem] = osByA.groupBy(gb).toList.sortBy(_._1.toString).map {
           case (b, osByAB) =>
             val innerInnerGroups:List[ObsListElem] = osByAB.groupBy(gc).toList.sortBy(_._1.toString).map {
-              case (c, osByABC) => (a |> b |> c, osByABC.filterNot(_.o.time.isEmpty))
+              case (c, osByABC) => (a |> b |> c, osByABC.filterNot(_.o.intTime.isEmpty))
             }.filterNot(p => p._1.isEmpty && p._2.isEmpty).flatMap(cons).toList
             (a |> b, innerInnerGroups)
         }.filterNot(p => p._1.isEmpty && p._2.isEmpty).flatMap(cons).toList

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -475,8 +475,8 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
         case _                              => null
       }
       case Time    => e match {
-        case ObsElem(o) if o.progTime.isDefined => "%3.2f %s".format(o.progTime.get.value, o.progTime.get.units)
-        case _                                  => null
+        case ObsElem(o) if o.totalTime.isDefined => "%3.2f %s".format(o.totalTime.get.value, o.totalTime.get.units)
+        case _                                   => null
       }
       case Guiding => presentation(e, guiding, _.text)
     }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -158,10 +158,10 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
         BorderFactory.createEmptyBorder(2, 4, 2, 4))
       override def refresh(m:Option[List[Observation]]) {
         text = ~panel.model.map {p =>
-          val b1 = p.observations.filter(_.band == Band.BAND_1_2).flatMap(_.time).map(_.hours).sum
+          val b1 = p.observations.filter(_.band == Band.BAND_1_2).flatMap(_.progTime).map(_.hours).sum
           p.proposalClass match {
             case q:QueueProposalClass if q.band3request.isDefined =>
-              val b3 = p.observations.filter(_.band == Band.BAND_3).flatMap(_.time).map(_.hours).sum
+              val b3 = p.observations.filter(_.band == Band.BAND_3).flatMap(_.progTime).map(_.hours).sum
               "Sum observation times: %3.2f hr | Sum Band 3 times: %3.2f hr".format(b1, b3)
             case _ =>
               "Sum observation times: %3.2f hr".format(b1)
@@ -236,7 +236,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
       viewer.onSelectionChanged {s =>
         enabled = canEdit && ~(for (m <- model) yield {
             ~s.map {
-              case ObsElem(o)    => o.time.isDefined
+              case ObsElem(o)    => o.intTime.isDefined
               case g:ObsGroup[_] => m.childrenOf(g).nonEmpty
             }
           })
@@ -403,7 +403,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
 
     override def foreground(e:ObsListElem) = {
       case Item => e match {
-        case ObsElem(o) if o.time.isEmpty    => Color.LIGHT_GRAY
+        case ObsElem(o) if o.intTime.isEmpty => Color.LIGHT_GRAY
         case g:ObsGroup[_] if g.isEmpty      => Color.LIGHT_GRAY
         case _                               => Color.BLACK
       }
@@ -425,7 +425,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
         b <- o.blueprint if !b.site.isExchange
         t <- o.target
         _ <- t.coords(s.midPoint)
-        _ <- o.time
+        _ <- o.intTime
       } yield true)
 
     override def alignment(e:ObsListElem) = {
@@ -455,7 +455,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
     def icon(e:ObsListElem) = {
       case Item    => e match {
         case g:ObsGroup[_] => g.icon
-        case ObsElem(o)    => if (o.time.isEmpty) obsDisIcon else ICON_CLOCK
+        case ObsElem(o)    => if (o.intTime.isEmpty) obsDisIcon else ICON_CLOCK
       }
       case Guiding => presentation(e, guiding, _.icon)
       case Vis     => semPresentation(e, visibility, _.icon)
@@ -464,9 +464,9 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
 
     def text(e:ObsListElem) = {
       case Item    => e match {
-        case ObsElem(o) if o.time.isDefined => "Observation"
-        case ObsElem(o)                     => empty("observation time")
-        case e:ObsGroup[_] if e.isEmpty     => e.grouping match {
+        case ObsElem(o) if o.intTime.isDefined => "Observation"
+        case ObsElem(o)                        => empty("observation time")
+        case e:ObsGroup[_] if e.isEmpty        => e.grouping match {
           case ObsListGrouping.Target    => empty("target")
           case ObsListGrouping.Blueprint => empty("resource configuration")
           case ObsListGrouping.Condition => empty("observing conditions")
@@ -475,8 +475,8 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
         case _                              => null
       }
       case Time    => e match {
-        case ObsElem(o) if o.time.isDefined => "%3.2f %s".format(o.time.get.value, o.time.get.units)
-        case _                              => null
+        case ObsElem(o) if o.progTime.isDefined => "%3.2f %s".format(o.progTime.get.value, o.progTime.get.units)
+        case _                                  => null
       }
       case Guiding => presentation(e, guiding, _.text)
     }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -158,10 +158,10 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
         BorderFactory.createEmptyBorder(2, 4, 2, 4))
       override def refresh(m:Option[List[Observation]]) {
         text = ~panel.model.map {p =>
-          val b1 = p.observations.filter(_.band == Band.BAND_1_2).flatMap(_.progTime).map(_.hours).sum
+          val b1 = p.observations.filter(_.band == Band.BAND_1_2).flatMap(_.totalTime).map(_.hours).sum
           p.proposalClass match {
             case q:QueueProposalClass if q.band3request.isDefined =>
-              val b3 = p.observations.filter(_.band == Band.BAND_3).flatMap(_.progTime).map(_.hours).sum
+              val b3 = p.observations.filter(_.band == Band.BAND_3).flatMap(_.totalTime).map(_.hours).sum
               "Sum observation times: %3.2f hr | Sum Band 3 times: %3.2f hr".format(b1, b3)
             case _ =>
               "Sum observation times: %3.2f hr".format(b1)

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/Phase1Folder.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/Phase1Folder.java
@@ -8,6 +8,7 @@ import edu.gemini.spModel.pio.PioFactory;
 import java.io.Serializable;
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * The original Phase 1 blueprints with their grouped observations.
@@ -23,8 +24,8 @@ public final class Phase1Folder implements Serializable {
     public final List<Phase1Group> groups;
 
     public Phase1Folder(Map<String, SpBlueprint> blueprintMap, List<Phase1Group> groups) {
-        this.blueprintMap = Collections.unmodifiableMap(new HashMap<String, SpBlueprint>(blueprintMap));
-        this.groups       = Collections.unmodifiableList(new ArrayList<Phase1Group>(groups));
+        this.blueprintMap = Collections.unmodifiableMap(new HashMap<>(blueprintMap));
+        this.groups       = Collections.unmodifiableList(new ArrayList<>(groups));
     }
 
     @Override
@@ -57,15 +58,13 @@ public final class Phase1Folder implements Serializable {
         }
 
         // Add all pigs
-        for (Phase1Group pig : groups) {
-            ps.addParamSet(pig.getParamSet(factory));
-        }
+        groups.forEach(pig -> ps.addParamSet(pig.getParamSet(factory)));
 
         return ps;
     }
 
     public static Phase1Folder fromParamSet(ParamSet paramSet) {
-        final Map<String, SpBlueprint> blueprintMap = new HashMap<String, SpBlueprint>();
+        final Map<String, SpBlueprint> blueprintMap = new HashMap<>();
 
         final List<ParamSet> bpEntries = paramSet.getParamSets(BLUEPRINT_ENTRY_PARAM_SET);
         for (ParamSet bpEntry : bpEntries) {
@@ -85,11 +84,10 @@ public final class Phase1Folder implements Serializable {
             blueprintMap.put(id, SpBlueprintFactory.fromParamSet(psList.get(0)));
         }
 
-        final List<Phase1Group> pigs = new ArrayList<Phase1Group>();
-        for (ParamSet pigPs : paramSet.getParamSets(Phase1Group.PARAM_SET_NAME)) {
-            pigs.add(Phase1Group.fromParamSet(pigPs));
-        }
-
+        final List<Phase1Group> pigs = paramSet.getParamSets(Phase1Group.PARAM_SET_NAME)
+                .stream()
+                .map(Phase1Group::fromParamSet)
+                .collect(Collectors.toList());
         return new Phase1Folder(blueprintMap, pigs);
     }
 

--- a/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
+++ b/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
@@ -15,6 +15,13 @@ object NumberField {
     df.setGroupingUsed(false)
     df
   }
+
+  object TimeFormatter extends DecimalFormat {
+    setMaximumFractionDigits(2)
+    setMinimumFractionDigits(2)
+    setMinimumIntegerDigits(1)
+    setGroupingUsed(false)
+  }
 }
 
 class NumberField(d: Option[Double], allowEmpty: Boolean, format: java.text.Format = NumberField.df) extends FormattedTextField(format) with SelectOnFocus {

--- a/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
+++ b/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
@@ -19,8 +19,7 @@ object NumberField {
 
 class NumberField(d: Option[Double], allowEmpty: Boolean, format: java.text.Format = NumberField.df) extends FormattedTextField(format) with SelectOnFocus {
   d.orElse(Some(0)).foreach { d =>
-    import NumberField.df
-    text = df.format(d)
+    text = format.format(d)
     commitEdit()
   }
 

--- a/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
+++ b/bundle/edu.gemini.shared.gui/src/main/scala/edu/gemini/shared/gui/textComponent/NumberField.scala
@@ -31,6 +31,9 @@ class NumberField(d: Option[Double], allowEmpty: Boolean, format: java.text.Form
 
   def valid(d:Double):Boolean = true
 
+  def value: Option[Double] = Option(peer.getValue).map(_.asInstanceOf[Double])
+  def value_=(v: Double): Unit = peer.setValue(v)
+
   override def enabled_=(b:Boolean) {
     super.enabled = b
     background = if (b && !valid) pink else white


### PR DESCRIPTION
This is a substantial change, as described in parent task REL-2925:
http://jira.gemini.edu:8080/browse/REL-2925

Previously, the user would calculate the program time and enter it into the PIT, and this was included for each observation:
`<observation...><time unit="hrs">1.0</time>...</observation>`
for example.

REL-2985 requires the following:

1. Instead of accepting calculated program time, the PIT must now accept integration time, look up overheads from a table (see the `Overheads` class) based on the instrument configuration, and manually perform the calculations to obtain program time, partner time, and total time.

2. When importing old proposals, the existing time must be assumed to be program time, and the calculations reversed as per the instructions on REL-2985 to calculate integration time, as this is the parameter that determines the other time values along with the instrument configuration.

The instrument configuration parameters can be found here:
http://jira.gemini.edu:8080/secure/attachment/13761/nightpartnercal_overheads.xlsx

This PR includes the majority of the functionality from the PIT side of things (conversion from older proposals, all calculations, schema changes, and PDF generation changes), but probably still needs some work, including tests for the overheads calculations.

Additionally, I am hoping to use this PR as an opportunity to:

1. Begin a discussion with @swalker2m and @cquiroz regarding what need to be done for ITAC and Phase 2 (REL-2927 and REL-2928 respectively), which are currently unassigned, as this will be necessary for the 2017B release, and may require additional handling from the PIT.

2. Get feedback on the current changes.