### PR TITLE
REL-3026: PIT PDF cosmestic changes for CoInvestigator information

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -451,17 +451,19 @@
                                         </fo:table-cell>
                                     </xsl:if>
                                     <fo:table-cell>
-                                        <fo:block>
-                                            <xsl:value-of select="firstName"/>
-                                            <xsl:text>&#160;</xsl:text>
-                                            <xsl:value-of select="lastName"/>
-
+                                        <fo:block text-indent="-1em" start-indent="1em">
+                                            <fo:inline font-weight="bold">
+                                                <xsl:value-of select="firstName"/>
+                                                <xsl:text>&#160;</xsl:text>
+                                                <xsl:value-of select="lastName"/>
+                                            </fo:inline>
                                             <xsl:if test="status = 'Grad Thesis'">
                                                 <fo:inline font-weight="bold">&#160;(thesis)</fo:inline>
                                             </xsl:if>
 
                                             <xsl:text>:&#160;</xsl:text>
                                             <xsl:value-of select="institution"/>
+
                                             <xsl:text>,&#160;</xsl:text>
                                             <xsl:value-of select="email"/>
                                         </fo:block>


### PR DESCRIPTION
It was requested that, to improve readability in the PDFs generated from the PIT for non-NOAO formats, in the list of co-investigators, the investigator names be made bolded, and hanging indents used in the co-investigator information.

Please see the attached images for what the list used to look like, and what it looks like with regards to these changes.
![old](https://cloud.githubusercontent.com/assets/8795653/22523923/e3486788-e89f-11e6-92dd-153f085af718.png)
![new](https://cloud.githubusercontent.com/assets/8795653/22523930/e9621c36-e89f-11e6-8ef4-14e58f6fb0ec.png)
