### PR TITLE
REL-3068: For NOAO PDF generation, move investigator information

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -167,134 +167,6 @@
                     </fo:block>
                     <!-- END title -->
 
-                    <!-- BEGIN partner lead scientist -->
-                    <xsl:if test="count(proposalClass/*/ngo) > 1">
-                        <fo:block space-before="12pt">
-                            <fo:inline font-weight="bold">
-                                <xsl:call-template name="get-partner-name"><xsl:with-param name="partner" select="$this-partner"/></xsl:call-template>
-                                <xsl:text>&#160;</xsl:text>Lead Scientist:<xsl:text>&#160;</xsl:text>
-                            </fo:inline>
-                            <xsl:variable name="investigatorRef" select="/proposal/proposalClass/*/ngo[partner=$this-partner]/request/@lead"/>
-                            <xsl:variable name="investigator" select="/proposal/investigators/*[@id=$investigatorRef]"/>
-                            <xsl:value-of select="$investigator/firstName"/><xsl:text>&#160;</xsl:text>
-                            <xsl:value-of select="$investigator/lastName"/>
-                        </fo:block>
-                    </xsl:if>
-                    <!-- END partner lead scientist -->
-
-                    <!-- BEGIN PI -->
-                    <fo:table table-layout="fixed" space-before="12pt"
-                              space-after="8pt">
-                        <fo:table-column column-width="6cm"/>
-                        <fo:table-column column-width="2cm"/>
-                        <fo:table-column column-width="8cm"/>
-                        <fo:table-body>
-                            <fo:table-row>
-                                <fo:table-cell>
-                                    <fo:block>
-                                        <fo:inline font-weight="bold">PI:</fo:inline>
-                                        <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
-                                        <xsl:value-of select="investigators/pi/firstName"/>
-                                        <xsl:text>&#160;</xsl:text>
-                                        <xsl:value-of select="investigators/pi/lastName"/>
-                                    </fo:block>
-                                </fo:table-cell>
-                                <fo:table-cell>
-                                    <fo:block>
-                                        <fo:inline font-weight="bold">Status:</fo:inline>
-                                        <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
-                                        <xsl:variable name="status" select="investigators/pi/status"/>
-                                        <xsl:if test="$status = 'Grad Thesis'">T</xsl:if>
-                                        <xsl:if test="$status = 'PhD'">P</xsl:if>
-                                        <xsl:if test="$status = 'Grad No Thesis'">G</xsl:if>
-                                        <xsl:if test="$status = 'Other'">O</xsl:if>
-                                    </fo:block>
-                                </fo:table-cell>
-                                <fo:table-cell>
-                                    <fo:block>
-                                        <fo:inline font-weight="bold">Affil:</fo:inline>
-                                        <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
-                                        <xsl:value-of select="investigators/pi/address/institution"/>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </fo:table-row>
-                            <fo:table-row>
-                                <fo:table-cell number-columns-spanned="3">
-                                    <fo:block>
-                                        <xsl:value-of select="investigators/pi/address/address"/>&#160;
-                                        <xsl:value-of select="investigators/pi/address/country"/>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </fo:table-row>
-                            <fo:table-row>
-                                <fo:table-cell number-columns-spanned="2">
-                                    <fo:block>
-                                        Email:<xsl:text>&#160;</xsl:text>
-                                        <xsl:value-of select="investigators/pi/email"/>
-                                    </fo:block>
-                                </fo:table-cell>
-                                <fo:table-cell>
-                                    <fo:block>
-                                        Phone:<xsl:text>&#160;</xsl:text>
-                                        <xsl:value-of select="investigators/pi/phone"/>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </fo:table-row>
-                        </fo:table-body>
-                    </fo:table>
-                    <!-- END PI -->
-
-                    <!-- This is how you create a horizontal rule. -->
-                    <fo:block text-align="center" space-after="8pt">
-                        <fo:leader leader-length="11.5cm"
-                                   leader-pattern="rule"
-                                   alignment-baseline="middle"
-                                   rule-thickness="0.5pt" color="black"/>
-                    </fo:block>
-
-                    <!-- BEGIN CIs -->
-                    <xsl:if test="count(investigators/coi) > 0">
-                        <fo:table table-layout="fixed" space-after="10pt">
-                            <fo:table-column column-width="6cm"/>
-                            <fo:table-column column-width="2cm"/>
-                            <fo:table-column column-width="8cm"/>
-                            <fo:table-body>
-                                <xsl:for-each select="investigators/coi">
-                                    <fo:table-row>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <fo:inline font-weight="bold">CoI:</fo:inline>
-                                                <xsl:text>&#160;</xsl:text>
-                                                <xsl:value-of select="firstName"/>
-                                                <xsl:text>&#160;</xsl:text>
-                                                <xsl:value-of select="lastName"/>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <fo:inline font-weight="bold">Status:</fo:inline>
-                                                <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
-                                                <xsl:variable name="status" select="status"/>
-                                                <xsl:if test="$status = 'Grad Thesis'">T</xsl:if>
-                                                <xsl:if test="$status = 'PhD'">P</xsl:if>
-                                                <xsl:if test="$status = 'Grad No Thesis'">G</xsl:if>
-                                                <xsl:if test="$status = 'Other'">O</xsl:if>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <fo:inline font-weight="bold">Affil.:</fo:inline>
-                                                <xsl:text>&#160;</xsl:text>
-                                                <xsl:value-of select="institution"/>
-                                            </fo:block>
-                                        </fo:table-cell>
-                                    </fo:table-row>
-                                </xsl:for-each>
-                            </fo:table-body>
-                        </fo:table>
-                    </xsl:if>
-                    <!-- END CIs -->
-
                     <!-- BEGIN Reviewer -->
                     <xsl:for-each select="proposalClass/fastTurnaround[@reviewer]">
                         <fo:table table-layout="fixed" space-after="0pt">
@@ -874,8 +746,188 @@
             </fo:page-sequence>
             <!-- END first page -->
 
-            <!-- BEGIN science justification -->
+            <!-- BEGIN investigator information -->
             <fo:page-sequence master-reference="rest" initial-page-number="2">
+
+                <!-- BEGIN header -->
+                <fo:static-content
+                        flow-name="xsl-region-before"
+                        font-family="Times"
+                        font-size="10pt">
+                    <fo:table table-layout="fixed">
+                        <fo:table-column column-width="8cm"/>
+                        <fo:table-column column-width="3cm"/>
+                        <fo:table-column column-width="5cm"/>
+                        <fo:table-body>
+                            <fo:table-row>
+                                <fo:table-cell>
+                                    <fo:block font-style="italic">
+                                        <xsl:variable name="receiptDate" select="/proposal/proposalClass/ngo[partner=$this-partner]/receipt/timestamp"/>
+                                        <fo:inline><xsl:value-of select="$obs-name"/> Proposal, received <xsl:value-of select="substring($receiptDate, 0, 11)"/></fo:inline>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell>
+                                    <fo:block font-style="italic">
+                                        Section 1 Page <fo:page-number/>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell border="0.5pt solid black" text-align="center">
+                                    <fo:block font-weight="bold" font-size="12pt">
+                                        <xsl:value-of select="$proposal-id"/>
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                        </fo:table-body>
+                    </fo:table>
+                </fo:static-content>
+                <!-- END header -->
+
+                <!-- BEGIN second page body -->
+                <!-- The main body is called "xsl-region-body". -->
+                <fo:flow flow-name="xsl-region-body"
+                         font-family="Times"
+                         font-size="12pt">
+
+                    <!-- BEGIN title -->
+                    <fo:block font-weight="bold" font-size="18pt">
+                        Investigator Information
+                    </fo:block>
+                    <!-- END title -->
+
+                    <!-- BEGIN partner lead scientist -->
+                    <xsl:if test="count(proposalClass/*/ngo) > 1">
+                        <fo:block space-before="12pt">
+                            <fo:inline font-weight="bold">
+                                <xsl:call-template name="get-partner-name"><xsl:with-param name="partner" select="$this-partner"/></xsl:call-template>
+                                <xsl:text>&#160;</xsl:text>Lead Scientist:<xsl:text>&#160;</xsl:text>
+                            </fo:inline>
+                            <xsl:variable name="investigatorRef" select="/proposal/proposalClass/*/ngo[partner=$this-partner]/request/@lead"/>
+                            <xsl:variable name="investigator" select="/proposal/investigators/*[@id=$investigatorRef]"/>
+                            <xsl:value-of select="$investigator/firstName"/><xsl:text>&#160;</xsl:text>
+                            <xsl:value-of select="$investigator/lastName"/>
+                        </fo:block>
+                    </xsl:if>
+                    <!-- END partner lead scientist -->
+
+                    <!-- BEGIN PI -->
+                    <fo:table table-layout="fixed" space-before="12pt"
+                              space-after="8pt">
+                        <fo:table-column column-width="6cm"/>
+                        <fo:table-column column-width="2cm"/>
+                        <fo:table-column column-width="8cm"/>
+                        <fo:table-body>
+                            <fo:table-row>
+                                <fo:table-cell>
+                                    <fo:block>
+                                        <fo:inline font-weight="bold">PI:</fo:inline>
+                                        <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
+                                        <xsl:value-of select="investigators/pi/firstName"/>
+                                        <xsl:text>&#160;</xsl:text>
+                                        <xsl:value-of select="investigators/pi/lastName"/>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell>
+                                    <fo:block>
+                                        <fo:inline font-weight="bold">Status:</fo:inline>
+                                        <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
+                                        <xsl:variable name="status" select="investigators/pi/status"/>
+                                        <xsl:if test="$status = 'Grad Thesis'">T</xsl:if>
+                                        <xsl:if test="$status = 'PhD'">P</xsl:if>
+                                        <xsl:if test="$status = 'Grad No Thesis'">G</xsl:if>
+                                        <xsl:if test="$status = 'Other'">O</xsl:if>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell>
+                                    <fo:block>
+                                        <fo:inline font-weight="bold">Affil:</fo:inline>
+                                        <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
+                                        <xsl:value-of select="investigators/pi/address/institution"/>
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                            <fo:table-row>
+                                <fo:table-cell number-columns-spanned="3">
+                                    <fo:block>
+                                        <xsl:value-of select="investigators/pi/address/address"/>&#160;
+                                        <xsl:value-of select="investigators/pi/address/country"/>
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                            <fo:table-row>
+                                <fo:table-cell number-columns-spanned="2">
+                                    <fo:block>
+                                        Email:<xsl:text>&#160;</xsl:text>
+                                        <xsl:value-of select="investigators/pi/email"/>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell>
+                                    <fo:block>
+                                        Phone:<xsl:text>&#160;</xsl:text>
+                                        <xsl:value-of select="investigators/pi/phone"/>
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                        </fo:table-body>
+                    </fo:table>
+                    <!-- END PI -->
+
+                    <!-- This is how you create a horizontal rule. -->
+                    <fo:block text-align="center" space-after="8pt">
+                        <fo:leader leader-length="11.5cm"
+                                   leader-pattern="rule"
+                                   alignment-baseline="middle"
+                                   rule-thickness="0.5pt" color="black"/>
+                    </fo:block>
+
+                    <!-- BEGIN CIs -->
+                    <xsl:if test="count(investigators/coi) > 0">
+                        <fo:table table-layout="fixed" space-after="10pt">
+                            <fo:table-column column-width="6cm"/>
+                            <fo:table-column column-width="2cm"/>
+                            <fo:table-column column-width="8cm"/>
+                            <fo:table-body>
+                                <xsl:for-each select="investigators/coi">
+                                    <fo:table-row>
+                                        <fo:table-cell>
+                                            <fo:block>
+                                                <fo:inline font-weight="bold">CoI:</fo:inline>
+                                                <xsl:text>&#160;</xsl:text>
+                                                <xsl:value-of select="firstName"/>
+                                                <xsl:text>&#160;</xsl:text>
+                                                <xsl:value-of select="lastName"/>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                        <fo:table-cell>
+                                            <fo:block>
+                                                <fo:inline font-weight="bold">Status:</fo:inline>
+                                                <xsl:text>&#160;</xsl:text><xsl:text>&#160;</xsl:text>
+                                                <xsl:variable name="status" select="status"/>
+                                                <xsl:if test="$status = 'Grad Thesis'">T</xsl:if>
+                                                <xsl:if test="$status = 'PhD'">P</xsl:if>
+                                                <xsl:if test="$status = 'Grad No Thesis'">G</xsl:if>
+                                                <xsl:if test="$status = 'Other'">O</xsl:if>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                        <fo:table-cell>
+                                            <fo:block>
+                                                <fo:inline font-weight="bold">Affil.:</fo:inline>
+                                                <xsl:text>&#160;</xsl:text>
+                                                <xsl:value-of select="institution"/>
+                                            </fo:block>
+                                        </fo:table-cell>
+                                    </fo:table-row>
+                                </xsl:for-each>
+                            </fo:table-body>
+                        </fo:table>
+                    </xsl:if>
+                    <!-- END CIs -->
+                </fo:flow>
+                <!-- END second page body -->
+            </fo:page-sequence>
+            <!-- END investgator information -->
+
+            <!-- BEGIN science justification -->
+            <fo:page-sequence master-reference="rest" initial-page-number="3">
 
                 <!-- BEGIN header -->
                 <fo:static-content

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -167,52 +167,6 @@
                     </fo:block>
                     <!-- END title -->
 
-                    <!-- BEGIN Reviewer -->
-                    <xsl:for-each select="proposalClass/fastTurnaround[@reviewer]">
-                        <fo:table table-layout="fixed" space-after="0pt">
-                            <fo:table-column column-width="6cm"/>
-                            <fo:table-column column-width="2cm"/>
-                            <fo:table-column column-width="8cm"/>
-                            <fo:table-body>
-                                <fo:table-row>
-                                    <fo:table-cell>
-                                        <fo:block>
-                                            <fo:inline font-weight="bold">Reviewer:</fo:inline>
-                                            <xsl:text>&#160;</xsl:text>
-                                            <xsl:call-template name="investigator-name">
-                                                <xsl:with-param name="id" select="@reviewer"/>
-                                            </xsl:call-template>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </fo:table-row>
-                            </fo:table-body>
-                        </fo:table>
-                    </xsl:for-each>
-                    <!-- END Reviewer -->
-
-                    <!-- BEGIN Mentor -->
-                    <xsl:for-each select="proposalClass/fastTurnaround[@mentor]">
-                        <fo:table table-layout="fixed" space-after="10pt">
-                            <fo:table-column column-width="6cm"/>
-                            <fo:table-column column-width="2cm"/>
-                            <fo:table-column column-width="8cm"/>
-                            <fo:table-body>
-                                <fo:table-row>
-                                    <fo:table-cell>
-                                        <fo:block>
-                                            <fo:inline font-weight="bold">Mentor:</fo:inline>
-                                            <xsl:text>&#160;</xsl:text>
-                                            <xsl:call-template name="investigator-name">
-                                                <xsl:with-param name="id" select="@mentor"/>
-                                            </xsl:call-template>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </fo:table-row>
-                            </fo:table-body>
-                        </fo:table>
-                    </xsl:for-each>
-                    <!-- END Mentor -->
-
                     <!-- BEGIN abstract -->
                     <fo:block space-before="10pt" space-after="12pt"
                               text-align-last="start">
@@ -921,6 +875,53 @@
                         </fo:table>
                     </xsl:if>
                     <!-- END CIs -->
+
+                    <!-- BEGIN Reviewer -->
+                    <xsl:for-each select="proposalClass/fastTurnaround[@reviewer]">
+                        <fo:table table-layout="fixed" space-after="0pt">
+                            <fo:table-column column-width="6cm"/>
+                            <fo:table-column column-width="2cm"/>
+                            <fo:table-column column-width="8cm"/>
+                            <fo:table-body>
+                                <fo:table-row>
+                                    <fo:table-cell>
+                                        <fo:block>
+                                            <fo:inline font-weight="bold">Reviewer:</fo:inline>
+                                            <xsl:text>&#160;</xsl:text>
+                                            <xsl:call-template name="investigator-name">
+                                                <xsl:with-param name="id" select="@reviewer"/>
+                                            </xsl:call-template>
+                                        </fo:block>
+                                    </fo:table-cell>
+                                </fo:table-row>
+                            </fo:table-body>
+                        </fo:table>
+                    </xsl:for-each>
+                    <!-- END Reviewer -->
+
+                    <!-- BEGIN Mentor -->
+                    <xsl:for-each select="proposalClass/fastTurnaround[@mentor]">
+                        <fo:table table-layout="fixed" space-after="10pt">
+                            <fo:table-column column-width="6cm"/>
+                            <fo:table-column column-width="2cm"/>
+                            <fo:table-column column-width="8cm"/>
+                            <fo:table-body>
+                                <fo:table-row>
+                                    <fo:table-cell>
+                                        <fo:block>
+                                            <fo:inline font-weight="bold">Mentor:</fo:inline>
+                                            <xsl:text>&#160;</xsl:text>
+                                            <xsl:call-template name="investigator-name">
+                                                <xsl:with-param name="id" select="@mentor"/>
+                                            </xsl:call-template>
+                                        </fo:block>
+                                    </fo:table-cell>
+                                </fo:table-row>
+                            </fo:table-body>
+                        </fo:table>
+                    </xsl:for-each>
+                    <!-- END Mentor -->
+
                 </fo:flow>
                 <!-- END second page body -->
             </fo:page-sequence>


### PR DESCRIPTION
The goal of this change is to remove all investigator information from the first page of the NOAO PDF format generated by the PIT and put it in a separate page between TAC information and Observation Details, as it was thought that having this information on the first page might introduce bias.

This PR creates a new page and places the information there, as can be seen in the attached PDFs. (Note the old one was created with PIT 2017A and the other with the upcoming PIT 2017B.)

[US_2017A_001_summary_old.pdf](https://github.com/gemini-hlsw/ocs/files/747783/US_2017A_001_summary_old.pdf)
[US_2017A_001_summary_new.pdf](https://github.com/gemini-hlsw/ocs/files/747784/US_2017A_001_summary_new.pdf)
