### PR TITLE
REL-3069: Queue Visualization error on last day of semester

### DIFF
--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/Filter.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/Filter.scala
@@ -242,7 +242,7 @@ object Filter {
   // =======================  *** Set time filter ***
   case class SetTime(ctx: QvContext, min: Double = 0, max: Double = 15) extends SimpleRangeFilter {
     def label = "Set Time Hrs"
-    def getter: Obs => Double = { o => TimeUtils.asHours(SolutionProvider(ctx).remainingHours(ctx, o)) }
+    def getter: Obs => Double = { o => TimeUtils.asHours(SolutionProvider(ctx).remainingHours(ctx, o).getOrElse(0L)) }
     def lowest = 0
     def highest = Double.MaxValue
     override def desc = "Filter for targets with number of hours before the target sets tonight in the range min ≤ hours < max."

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/Filter.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/filter/core/Filter.scala
@@ -242,7 +242,7 @@ object Filter {
   // =======================  *** Set time filter ***
   case class SetTime(ctx: QvContext, min: Double = 0, max: Double = 15) extends SimpleRangeFilter {
     def label = "Set Time Hrs"
-    def getter: Obs => Double = { o => TimeUtils.asHours(SolutionProvider(ctx).remainingHours(ctx, o).getOrElse(0L)) }
+    def getter: Obs => Double = { o => TimeUtils.asHours(SolutionProvider(ctx).remainingHours(ctx, o).getOrElse(min.toLong)) }
     def lowest = 0
     def highest = Double.MaxValue
     override def desc = "Filter for targets with number of hours before the target sets tonight in the range min ≤ hours < max."

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SemesterData.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SemesterData.scala
@@ -109,7 +109,7 @@ object SemesterData {
 
   def semesters(site: Site): Seq[SemesterData] = Cache.semesters(site)
 
-  def current(site: Site): SemesterData = semesters(site, System.currentTimeMillis(), System.currentTimeMillis()).head
+  def current(site: Site, currentTime: Long = System.currentTimeMillis()): SemesterData = semesters(site, currentTime, currentTime).head
 
   def next(site: Site): SemesterData = semesters(site, System.currentTimeMillis(), System.currentTimeMillis() + TimeUtils.days(185))(1)
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SolutionProvider.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SolutionProvider.scala
@@ -27,6 +27,9 @@ object SolutionProvider {
     Site.GS -> new SolutionProvider(Site.GS)
   )
 
+  def currentNight(site: Site, currentTime: Long): Option[Night] =
+    SemesterData.current(site, currentTime).nights.find(n => n.end > currentTime)
+
   def apply(site: Site): SolutionProvider = providers(site)
   def apply(peer: Peer): SolutionProvider = providers(peer.site)
   def apply(ctx: QvContext): SolutionProvider = providers(ctx.site)
@@ -80,7 +83,7 @@ sealed class SolutionProvider(site: Site) extends Publisher {
     constraintsCache.value(Seq(night), valueType, obs).head
 
   def remainingHours(ctx: QvContext, o: Obs, currentTime: Long = System.currentTimeMillis()): Long = {
-    val n = SemesterData.current(ctx.site).nights.find(n => n.end > currentTime).get
+    val n = SolutionProvider.currentNight(ctx.site, currentTime).get
     val s = solution(Seq(n), Set[ConstraintType](Elevation), o).restrictTo(n.interval)
     val set = s.intervals.find(_.end < n.nauticalTwilightEnd).map(_.end).getOrElse(n.nauticalTwilightEnd)
     set - n.nauticalTwilightStart

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SolutionProvider.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SolutionProvider.scala
@@ -79,8 +79,8 @@ sealed class SolutionProvider(site: Site) extends Publisher {
   def value(valueType: ValueType, night: Night, obs: Obs): Double =
     constraintsCache.value(Seq(night), valueType, obs).head
 
-  def remainingHours(ctx: QvContext, o: Obs): Long = {
-    val n = SemesterData.current(ctx.site).nights.find(n => n.end > System.currentTimeMillis()).get
+  def remainingHours(ctx: QvContext, o: Obs, currentTime: Long = System.currentTimeMillis()): Long = {
+    val n = SemesterData.current(ctx.site).nights.find(n => n.end > currentTime).get
     val s = solution(Seq(n), Set[ConstraintType](Elevation), o).restrictTo(n.interval)
     val set = s.intervals.find(_.end < n.nauticalTwilightEnd).map(_.end).getOrElse(n.nauticalTwilightEnd)
     set - n.nauticalTwilightStart

--- a/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/chart/CategorizedDataTest.scala
+++ b/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/chart/CategorizedDataTest.scala
@@ -17,8 +17,8 @@ import org.junit.Test
  */
 class CategorizedDataTest {
 
-  val ra1hrs = RightAscension.fromHours(1.0)
-  val ra3hrs = RightAscension.fromHours(3.0)
+  val ra1hrs: RightAscension = RightAscension.fromHours(1.0)
+  val ra3hrs: RightAscension = RightAscension.fromHours(3.0)
 
   @Test def cat1() {
 
@@ -34,7 +34,7 @@ class CategorizedDataTest {
       builder.setRa(ra3hrs).setPriority(MEDIUM).apply
     )
 
-    val catData = new CategorizedXYValues(Axis.RA1.groups, Axis.Priorities.groups, observations, Chart.ObservationCount.value)
+    val catData = CategorizedXYValues(Axis.RA1.groups, Axis.Priorities.groups, observations, Chart.ObservationCount.value)
     assertEquals(3, catData.activeYGroups.size)
     assertEquals(3, catData.value(RA(1, 2), Priorities(Set(LOW))), 0.01)
     assertEquals(2, catData.value(RA(3, 4), Priorities(Set(LOW))), 0.01)
@@ -55,7 +55,7 @@ class CategorizedDataTest {
       builder.setRa(ra3hrs).setInstrument(InstGmosNorth.SP_TYPE).apply
     )
 
-    val catData = new CategorizedXYValues(Axis.RA1.groups, Axis.Instruments.groups, observations, Chart.ObservationCount.value)
+    val catData = CategorizedXYValues(Axis.RA1.groups, Axis.Instruments.groups, observations, Chart.ObservationCount.value)
     assertEquals(4, catData.activeYGroups.size)
 
   }

--- a/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/filter/core/FilterSpec.scala
+++ b/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/filter/core/FilterSpec.scala
@@ -24,7 +24,7 @@ class FilterSpec extends Specification with ScalaCheck with Arbitraries {
       forAll (dispersers, dispersers) { (obsDisp, filtDisp) =>
         val o = ObsBuilder(instrument = Array(InstGmosNorth.SP_TYPE), options = obsDisp.toSet).apply
         val f = Filter.GmosN.Dispersers(filtDisp.toSet)
-        f.predicate(o) == (obsDisp.intersect(filtDisp).length > 0)
+        f.predicate(o) == obsDisp.intersect(filtDisp).nonEmpty
       }
     }
   }

--- a/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/util/SemesterDataSpec.scala
+++ b/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/util/SemesterDataSpec.scala
@@ -1,0 +1,39 @@
+package edu.gemini.qv.plugin.util
+
+import java.time.{Instant, LocalDateTime, LocalDate, Month, ZoneId}
+
+import edu.gemini.spModel.core.{Semester, Site}
+import edu.gemini.util.skycalc.calc.Interval
+import org.specs2.mutable.Specification
+
+class SemesterDataSpec extends Specification {
+  val UTC = ZoneId.of("UTC")//Pacific/Honolulu")
+  val HST = ZoneId.of("Pacific/Honolulu")
+
+  "SemesterData" should {
+    "work on the last day of the semester" in {
+
+      // Some day of the semester
+      val start = LocalDate.of(2016, Month.DECEMBER, 31).atStartOfDay(UTC).toInstant.toEpochMilli
+      // Last day of the semester
+      val end = LocalDate.of(2017, Month.JANUARY, 31).atStartOfDay(UTC).toInstant.toEpochMilli
+
+      // Border of sunrise on the last day
+      val beforeSunrise = LocalDateTime.of(2017, Month.JANUARY, 31, 6, 0).atZone(HST).toInstant.toEpochMilli
+      val afterSunrise = LocalDateTime.of(2017, Month.JANUARY, 31, 7, 0).atZone(HST).toInstant.toEpochMilli
+
+      // After sunrise on the day before
+      val afterSunrisePreviousDay = LocalDateTime.of(2017, Month.JANUARY, 30, 7, 0).atZone(HST).toInstant.toEpochMilli
+
+      val interval = Interval(start, end)
+      // Prime the database
+      SemesterData.update(Site.GN, interval)
+      // 2016B should be found
+      val semester = SemesterData.current(Site.GN, end)
+      semester should beEqualTo(SemesterData(Site.GN, Semester.parse("2016B")))
+      semester.nights.find(n => n.end > beforeSunrise) should beSome
+      semester.nights.find(n => n.end > afterSunrisePreviousDay) should beSome
+      semester.nights.find(n => n.end > afterSunrise) should beSome
+    }
+  }
+}

--- a/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/util/SemesterDataSpec.scala
+++ b/bundle/edu.gemini.qv.plugin/src/test/scala/edu/gemini/qv/plugin/util/SemesterDataSpec.scala
@@ -31,9 +31,10 @@ class SemesterDataSpec extends Specification {
       // 2016B should be found
       val semester = SemesterData.current(Site.GN, end)
       semester should beEqualTo(SemesterData(Site.GN, Semester.parse("2016B")))
-      semester.nights.find(n => n.end > beforeSunrise) should beSome
-      semester.nights.find(n => n.end > afterSunrisePreviousDay) should beSome
-      semester.nights.find(n => n.end > afterSunrise) should beSome
+      SolutionProvider.currentNight(Site.GN, beforeSunrise) should beSome
+      SolutionProvider.currentNight(Site.GN, afterSunrisePreviousDay) should beSome
+      // With REL-3069 this returns None
+      SolutionProvider.currentNight(Site.GN, afterSunrise) should beSome
     }
   }
 }

--- a/bundle/edu.gemini.util.skycalc/src/main/scala/edu/gemini/util/skycalc/Night.scala
+++ b/bundle/edu.gemini.util.skycalc/src/main/scala/edu/gemini/util/skycalc/Night.scala
@@ -59,22 +59,22 @@ case class Night(site: Site, date: Long, bound: Bound = SunsetSunrise) {
   val sunrise: Long = sunCalc.rise
 
   /** Civil twilight end. */
-  val civilTwilightEnd = sunCalc.civilTwilightEnd
+  val civilTwilightEnd: Long = sunCalc.civilTwilightEnd
 
   /** Civil twilight start. */
-  val civilTwilightStart = sunCalc.civilTwilightStart
+  val civilTwilightStart: Long = sunCalc.civilTwilightStart
 
   /** Nautical twilight end. */
-  val nauticalTwilightEnd = sunCalc.nauticalTwilightEnd
+  val nauticalTwilightEnd: Long = sunCalc.nauticalTwilightEnd
 
   /** Nautical twilight start. */
-  val nauticalTwilightStart = sunCalc.nauticalTwilightStart
+  val nauticalTwilightStart: Long = sunCalc.nauticalTwilightStart
 
   /** Astronomical twilight end. */
-  val astroTwilightEnd = sunCalc.astroTwilightEnd
+  val astroTwilightEnd: Long = sunCalc.astroTwilightEnd
 
   /** Astronomical twilight start. */
-  val astroTwilightStart = sunCalc.astroTwilightStart
+  val astroTwilightStart: Long = sunCalc.astroTwilightStart
 
   /** Interval between sunset and sunrise. */
   val nightTime: Interval = sunCalc.nightTime


### PR DESCRIPTION
This is a very subtle bug where QV will break on the last day of the semester **after sunrise**

The PR brings a test case that reproduced the issue and a tentative fix. An issue with the fix is my lack of knowledge about QV, hence I cannot predict if there are any other side effects of the change.

Also extracting a value from an `Option` was the original symptom. That has been changed to instead return a default but I'm not sure if it is the correct one

I hope some of our users could build this and test QV to check for any problems due to this update