### PR TITLE
REL-2941: Modification of GSAOI estimates for 2017B PIT

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -29,6 +29,9 @@ object GemsResultsAnalyzer {
   val instance = this
   val Log = Logger.getLogger(GemsResultsAnalyzer.getClass.getSimpleName)
 
+  // Canopus probes.
+  val canopusProbes: ISet[GuideProbe] = ISet.fromList(List(Canopus.Wfs.cwfs1, Canopus.Wfs.cwfs2, Canopus.Wfs.cwfs3))
+
   // sort by value only
   private val MagnitudeValueOrdering: scala.math.Ordering[Magnitude] = scala.math.Ordering.by(_.value)
 
@@ -50,7 +53,8 @@ object GemsResultsAnalyzer {
 
   /**
    * Analyze the given position angles and search results to select tip tilt asterisms and flexure stars.
-   * @param obsContext observation context
+    *
+    * @param obsContext observation context
    * @param posAngles position angles to try (should contain at least one element: the current pos angle)
    * @param catalogSearch results of catalog search
    * @param mascotProgress used to report progress of Mascot Strehl calculations and interrupt if requested
@@ -93,10 +97,10 @@ object GemsResultsAnalyzer {
    * @param obsContext observation context
    * @param posAngles position angles to try (should contain at least one element: 0. deg)
    * @param catalogSearch results of catalog search
-   * @param progressGoodEnough used to tell Mascot Strehl calculations when it can stop
+   * @param shouldContinue function to determine if the search should continue: early termination possible if sufficient asterism found
    * @return a sorted List of GemsGuideStars
    */
-  def analyzeGoodEnough(obsContext: ObsContext, posAngles: Set[Angle], catalogSearch: List[GemsCatalogSearchResults], progressGoodEnough: (Strehl, Boolean) => Boolean): List[GemsGuideStars] = {
+  def analyzeGoodEnough(obsContext: ObsContext, posAngles: Set[Angle], catalogSearch: List[GemsCatalogSearchResults], shouldContinue: (Strehl, Boolean) => Boolean): List[GemsGuideStars] = {
     obsContext.getBaseCoordinates.asScalaOpt.map(_.toNewModel).foldMap { base =>
 
       @tailrec
@@ -111,13 +115,17 @@ object GemsResultsAnalyzer {
             // Find asterisms with Mascot
             val band = bandpass(tiptiltGroup, obsContext.getInstrument)
             val factor = strehlFactor(obsContext.some)
-            val asterisms = MascotCat.findBestAsterismInTargetsList(tiptiltTargetsList, base.ra.toAngle.toDegrees, base.dec.toDegrees, band, factor, progressGoodEnough)
+
+            // tiptiltTargetsList should only contain Canopus WFS stars, so asterisms should only consist of these.
+            // Thus progressGoodEnough will only be called for Canopus WFS stars.
+            val asterisms = MascotCat.findBestAsterismInTargetsList(tiptiltTargetsList, base.ra.toAngle.toDegrees, base.dec.toDegrees, band, factor, shouldContinue)
             val analyzedStars = asterisms.strehlList.map(analyzeAtAngles(obsContext, posAngles, _, flexureTargetsList, flexureGroup, tiptiltGroup))
             stars ::: analyzedStars.flatten
           } else {
             stars
           }
         }
+
         pairs match {
           case Nil       => Nil
           case x :: Nil  => check(x)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
@@ -19,6 +19,8 @@ import Scalaz._
 object Mascot {
   val Log = Logger.getLogger(Mascot.getClass.getSimpleName)
 
+  // A function that is called for each asterism as it is found.
+  // If it returns false, the algorithm terminates.
   type ProgressFunction = (Strehl, Int, Int) => Boolean
 
   // Default star filter

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
@@ -92,17 +92,17 @@ object MascotCat {
    * @param centerRA the base position RA coordinate
    * @param centerDec the base position Dec coordinate
    * @param band determines which magnitudes are used in the calculations: (one of "B", "V", "R", "J", "H", "K")
-   * @param progressCheck called for each asterism as it is calculated, can cancel the calculations by returning false
+   * @param shouldStop called for each asterism as it is calculated, can cancel the calculations by returning true
    * @return a tuple: (list of stars actually used, list of asterisms found)
    */
   def findBestAsterismInTargetsList(javaList: List[SiderealTarget],
                                     centerRA: Double, centerDec: Double,
                                     band: BandsList, factor: Double,
-                                    progressCheck: (Strehl, Boolean) => Boolean): StrehlResults = {
+                                    shouldStop: (Strehl, Boolean) => Boolean): StrehlResults = {
     val progress:ProgressFunction = (s: Strehl, count: Int, total: Int) => {
       defaultProgress(s, count, total)
-      // Why usable defaults to true?
-      progressCheck(s, true)
+      // TODO: Why is the usable parameter always true?
+      shouldStop(s, true)
     }
 
     val (starList, strehlList) = findBestAsterism(javaList, centerRA, centerDec, factor, progress, Mascot.defaultFilter)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -128,9 +128,10 @@ class GemsStrategySpec extends Specification {
         gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow(), Canopus.Wfs.cwfs3, s).contains(AgsAnalysis.Usable(Canopus.Wfs.cwfs3, s, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, RBandsList))
       } should beSome(true)
 
-      // Test estimate
+      // Test estimate: 2-star asterism grants 2/3 chance of success.
       val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
-      Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
+      val result = Await.result(estimate, 20.seconds).probability
+      math.abs(result - 2.0 / 3.0) should beLessThan(1e-4)
     }
     "support search/select and analyze on SN-1987A" in {
       val ra = Angle.fromHMS(5, 35, 28.020).getOrElse(Angle.zero)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -89,7 +89,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           TacProblems(p, s).all ++
           List(incompleteInvestigator, missingObsElementCheck, cfCheck, emptyTargetCheck,
             emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck,
-            badGuiding, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
+            badGuiding, cwfsCorrectionsIssue, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
             lgsCC50Check, texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
       ps.sorted
     }
@@ -479,6 +479,17 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       m <- o.meta
       g <- m.guiding if g.evaluation == GuidingEvaluation.FAILURE
     } yield new Problem(Severity.Warning, guidingMessage(o), "Observations", indicateObservation(o))
+
+    private lazy val cwfsCorrectionsIssue = for {
+      o <- p.observations
+      b <- o.blueprint if b.isInstanceOf[GsaoiBlueprint]
+      m <- o.meta
+      g <- m.guiding if g.evaluation != GuidingEvaluation.SUCCESS
+    } yield new Problem(Severity.Warning,
+      "Less than three CWFS stars. Corrections will not be optimal",
+      "Observations",
+      indicateObservation(o)
+    )
 
     private def visibilityMessage(tmpl: String, sem: Semester, o: Observation): String =
       tmpl.format(


### PR DESCRIPTION
These are the modifications requested for the GSAOI guiding estimates for the 2017B PIT.

First off, I clarified the meaning of the `progress` method, which was extremely unclear, through some renaming.

Second, I now filter out non-Canopus stars. Previously, we returned 0 or 100% depending on whether or not an asterism could be found. As per Bryan's comments on REL-2941, we now return the number of CWFS probes with guide stars divided by three to give the estimate of success.

I also, as per Bryan's recommendation, added a warning if the number of CWFS guide stars is less than three.