### PR TITLE
REL-2941: Changes to GSAOI guiding estimates for PIT 2017B

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -97,7 +97,7 @@ object GemsResultsAnalyzer {
    * @param shouldContinue function to determine if the search should continue: early termination possible if sufficient asterism found
    * @return a sorted List of GemsGuideStars
    */
-  def analyzeGoodEnough(obsContext: ObsContext, posAngles: Set[Angle], catalogSearch: List[GemsCatalogSearchResults], shouldContinue: (Strehl, Boolean) => Boolean): List[GemsGuideStars] = {
+  def analyzeGoodEnough(obsContext: ObsContext, posAngles: Set[Angle], catalogSearch: List[GemsCatalogSearchResults], shouldContinue: Strehl => Boolean): List[GemsGuideStars] = {
     obsContext.getBaseCoordinates.asScalaOpt.map(_.toNewModel).foldMap { base =>
 
       @tailrec
@@ -114,7 +114,7 @@ object GemsResultsAnalyzer {
             val factor = strehlFactor(obsContext.some)
 
             // tiptiltTargetsList should only contain Canopus WFS stars, so asterisms should only consist of these.
-            // Thus progressGoodEnough will only be called for Canopus WFS stars.
+            // Thus shouldContinue will only be called for Canopus WFS stars.
             val asterisms = MascotCat.findBestAsterismInTargetsList(tiptiltTargetsList, base.ra.toAngle.toDegrees, base.dec.toDegrees, band, factor, shouldContinue)
             val analyzedStars = asterisms.strehlList.map(analyzeAtAngles(obsContext, posAngles, _, flexureTargetsList, flexureGroup, tiptiltGroup))
             stars ::: analyzedStars.flatten

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -29,9 +29,6 @@ object GemsResultsAnalyzer {
   val instance = this
   val Log = Logger.getLogger(GemsResultsAnalyzer.getClass.getSimpleName)
 
-  // Canopus probes.
-  val canopusProbes: ISet[GuideProbe] = ISet.fromList(List(Canopus.Wfs.cwfs1, Canopus.Wfs.cwfs2, Canopus.Wfs.cwfs3))
-
   // sort by value only
   private val MagnitudeValueOrdering: scala.math.Ordering[Magnitude] = scala.math.Ordering.by(_.value)
 
@@ -53,8 +50,8 @@ object GemsResultsAnalyzer {
 
   /**
    * Analyze the given position angles and search results to select tip tilt asterisms and flexure stars.
-    *
-    * @param obsContext observation context
+   *
+   * @param obsContext observation context
    * @param posAngles position angles to try (should contain at least one element: the current pos angle)
    * @param catalogSearch results of catalog search
    * @param mascotProgress used to report progress of Mascot Strehl calculations and interrupt if requested

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -29,6 +29,9 @@ object GemsResultsAnalyzer {
   val instance = this
   val Log = Logger.getLogger(GemsResultsAnalyzer.getClass.getSimpleName)
 
+  // Canopus probes.
+  val canopusProbes: ISet[GuideProbe] = ISet.fromList(List(Canopus.Wfs.cwfs1, Canopus.Wfs.cwfs2, Canopus.Wfs.cwfs3))
+
   // sort by value only
   private val MagnitudeValueOrdering: scala.math.Ordering[Magnitude] = scala.math.Ordering.by(_.value)
 
@@ -50,7 +53,8 @@ object GemsResultsAnalyzer {
 
   /**
    * Analyze the given position angles and search results to select tip tilt asterisms and flexure stars.
-   * @param obsContext observation context
+    *
+    * @param obsContext observation context
    * @param posAngles position angles to try (should contain at least one element: the current pos angle)
    * @param catalogSearch results of catalog search
    * @param mascotProgress used to report progress of Mascot Strehl calculations and interrupt if requested
@@ -93,10 +97,10 @@ object GemsResultsAnalyzer {
    * @param obsContext observation context
    * @param posAngles position angles to try (should contain at least one element: 0. deg)
    * @param catalogSearch results of catalog search
-   * @param progressGoodEnough used to tell Mascot Strehl calculations when it can stop
+   * @param shouldContinue function to determine if the search should continue: early termination possible if sufficient asterism found
    * @return a sorted List of GemsGuideStars
    */
-  def analyzeGoodEnough(obsContext: ObsContext, posAngles: Set[Angle], catalogSearch: List[GemsCatalogSearchResults], progressGoodEnough: (Strehl, Boolean) => Boolean): List[GemsGuideStars] = {
+  def analyzeGoodEnough(obsContext: ObsContext, posAngles: Set[Angle], catalogSearch: List[GemsCatalogSearchResults], shouldContinue: (Strehl, Boolean) => Boolean): List[GemsGuideStars] = {
     obsContext.getBaseCoordinates.asScalaOpt.map(_.toNewModel).foldMap { base =>
 
       @tailrec
@@ -111,13 +115,17 @@ object GemsResultsAnalyzer {
             // Find asterisms with Mascot
             val band = bandpass(tiptiltGroup, obsContext.getInstrument)
             val factor = strehlFactor(obsContext.some)
-            val asterisms = MascotCat.findBestAsterismInTargetsList(tiptiltTargetsList, base.ra.toAngle.toDegrees, base.dec.toDegrees, band, factor, progressGoodEnough)
+
+            // tiptiltTargetsList should only contain Canopus WFS stars, so asterisms should only consist of these.
+            // Thus progressGoodEnough will only be called for Canopus WFS stars.
+            val asterisms = MascotCat.findBestAsterismInTargetsList(tiptiltTargetsList, base.ra.toAngle.toDegrees, base.dec.toDegrees, band, factor, shouldContinue)
             val analyzedStars = asterisms.strehlList.map(analyzeAtAngles(obsContext, posAngles, _, flexureTargetsList, flexureGroup, tiptiltGroup))
             stars ::: analyzedStars.flatten
           } else {
             stars
           }
         }
+
         pairs match {
           case Nil       => Nil
           case x :: Nil  => check(x)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
@@ -19,6 +19,8 @@ import Scalaz._
 object Mascot {
   val Log = Logger.getLogger(Mascot.getClass.getSimpleName)
 
+  // A function that is called for each asterism as it is found.
+  // If it returns false, the algorithm terminates.
   type ProgressFunction = (Strehl, Int, Int) => Boolean
 
   // Default star filter

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
@@ -92,17 +92,17 @@ object MascotCat {
    * @param centerRA the base position RA coordinate
    * @param centerDec the base position Dec coordinate
    * @param band determines which magnitudes are used in the calculations: (one of "B", "V", "R", "J", "H", "K")
-   * @param shouldStop called for each asterism as it is calculated, can cancel the calculations by returning true
+   * @param shouldContinue called for each asterism as it is calculated, can cancel the calculations by returning false
    * @return a tuple: (list of stars actually used, list of asterisms found)
    */
   def findBestAsterismInTargetsList(javaList: List[SiderealTarget],
                                     centerRA: Double, centerDec: Double,
                                     band: BandsList, factor: Double,
-                                    shouldStop: (Strehl, Boolean) => Boolean): StrehlResults = {
+                                    shouldContinue: (Strehl, Boolean) => Boolean): StrehlResults = {
     val progress:ProgressFunction = (s: Strehl, count: Int, total: Int) => {
       defaultProgress(s, count, total)
       // TODO: Why is the usable parameter always true?
-      shouldStop(s, true)
+      shouldContinue(s, true)
     }
 
     val (starList, strehlList) = findBestAsterism(javaList, centerRA, centerDec, factor, progress, Mascot.defaultFilter)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
@@ -3,7 +3,7 @@ package edu.gemini.ags.gems.mascot
 import java.util.logging.Logger
 
 import edu.gemini.ags.gems.mascot.Mascot.ProgressFunction
-import edu.gemini.spModel.core.{BandsList, MagnitudeBand}
+import edu.gemini.spModel.core.BandsList
 import edu.gemini.spModel.core.SiderealTarget
 import java.util.concurrent.CancellationException
 
@@ -98,11 +98,10 @@ object MascotCat {
   def findBestAsterismInTargetsList(javaList: List[SiderealTarget],
                                     centerRA: Double, centerDec: Double,
                                     band: BandsList, factor: Double,
-                                    shouldContinue: (Strehl, Boolean) => Boolean): StrehlResults = {
+                                    shouldContinue: Strehl => Boolean): StrehlResults = {
     val progress:ProgressFunction = (s: Strehl, count: Int, total: Int) => {
       defaultProgress(s, count, total)
-      // TODO: Why is the usable parameter always true?
-      shouldContinue(s, true)
+      shouldContinue(s)
     }
 
     val (starList, strehlList) = findBestAsterism(javaList, centerRA, centerDec, factor, progress, Mascot.defaultFilter)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
@@ -92,17 +92,17 @@ object MascotCat {
    * @param centerRA the base position RA coordinate
    * @param centerDec the base position Dec coordinate
    * @param band determines which magnitudes are used in the calculations: (one of "B", "V", "R", "J", "H", "K")
-   * @param progressCheck called for each asterism as it is calculated, can cancel the calculations by returning false
+   * @param shouldStop called for each asterism as it is calculated, can cancel the calculations by returning true
    * @return a tuple: (list of stars actually used, list of asterisms found)
    */
   def findBestAsterismInTargetsList(javaList: List[SiderealTarget],
                                     centerRA: Double, centerDec: Double,
                                     band: BandsList, factor: Double,
-                                    progressCheck: (Strehl, Boolean) => Boolean): StrehlResults = {
+                                    shouldStop: (Strehl, Boolean) => Boolean): StrehlResults = {
     val progress:ProgressFunction = (s: Strehl, count: Int, total: Int) => {
       defaultProgress(s, count, total)
-      // Why usable defaults to true?
-      progressCheck(s, true)
+      // TODO: Why is the usable parameter always true?
+      shouldStop(s, true)
     }
 
     val (starList, strehlList) = findBestAsterism(javaList, centerRA, centerDec, factor, progress, Mascot.defaultFilter)

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -144,16 +144,8 @@ trait GemsStrategy extends AgsStrategy {
     // Create a set of the angles to try.
     val anglesToTry = (0 until 360 by 45).map(Angle.fromDegrees(_)).toSet
 
-    // We can terminate the Mascot algorithm immediately if we find a usable 3-star asterism or no asterism is found.
-    def shouldContinue(s: Strehl, usable: Boolean): Boolean = !(
-      // A usable three star asterism.
-      (usable && s.stars.size >= 3) ||
-      // No asterism.
-      (s.stars.size < 2)
-    )
-
-    // Iterate over 45 degree position angles if no asterism is found at PA = 0.
-    val gemsCatalogResults = results.map(result => GemsResultsAnalyzer.analyzeGoodEnough(ctx, anglesToTry, result, shouldContinue))
+    // Iterate over 45 degree position angles if no 3-star asterism is found at PA = 0.
+    val gemsCatalogResults = results.map(result => GemsResultsAnalyzer.analyzeGoodEnough(ctx, anglesToTry, result, _.stars.size < 3))
 
     // We only want Canopus targets, so filter to those and then determine if the asterisms are big enough.
     gemsCatalogResults.map { ggsLst =>

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -128,9 +128,10 @@ class GemsStrategySpec extends Specification {
         gemsStrategy.analyze(newCtx, ProbeLimitsTable.loadOrThrow(), Canopus.Wfs.cwfs3, s).contains(AgsAnalysis.Usable(Canopus.Wfs.cwfs3, s, GuideSpeed.FAST, AgsGuideQuality.DeliversRequestedIq, RBandsList))
       } should beSome(true)
 
-      // Test estimate
+      // Test estimate: 2-star asterism grants 2/3 chance of success.
       val estimate = gemsStrategy.estimate(ctx, ProbeLimitsTable.loadOrThrow())(implicitly)
-      Await.result(estimate, 20.seconds) should beEqualTo(Estimate.GuaranteedSuccess)
+      val result = Await.result(estimate, 20.seconds).probability
+      math.abs(result - 2.0 / 3.0) should beLessThan(1e-4)
     }
     "support search/select and analyze on SN-1987A" in {
       val ra = Angle.fromHMS(5, 35, 28.020).getOrElse(Angle.zero)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -89,7 +89,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           TacProblems(p, s).all ++
           List(incompleteInvestigator, missingObsElementCheck, cfCheck, emptyTargetCheck,
             emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck,
-            badGuiding, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
+            badGuiding, cwfsCorrectionsIssue, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
             lgsCC50Check, texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
       ps.sorted
     }
@@ -479,6 +479,17 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       m <- o.meta
       g <- m.guiding if g.evaluation == GuidingEvaluation.FAILURE
     } yield new Problem(Severity.Warning, guidingMessage(o), "Observations", indicateObservation(o))
+
+    private lazy val cwfsCorrectionsIssue = for {
+      o <- p.observations
+      b <- o.blueprint if b.isInstanceOf[GsaoiBlueprint]
+      m <- o.meta
+      g <- m.guiding if g.evaluation != GuidingEvaluation.SUCCESS
+    } yield new Problem(Severity.Warning,
+      "Less than three CWFS stars. Corrections will not be optimal",
+      "Observations",
+      indicateObservation(o)
+    )
 
     private def visibilityMessage(tmpl: String, sem: Semester, o: Observation): String =
       tmpl.format(

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -486,7 +486,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       m <- o.meta
       g <- m.guiding if g.evaluation != GuidingEvaluation.SUCCESS
     } yield new Problem(Severity.Warning,
-      "Less than three CWFS stars. Corrections will not be optimal",
+      "Less than three CWFS stars. Corrections will not be optimal.",
       "Observations",
       indicateObservation(o)
     )


### PR DESCRIPTION
These are the modifications requested for the GSAOI guiding estimates for the 2017B PIT.

First off, I clarified the meaning of the progress method, which was extremely unclear, through some renaming. Indeed, there seemed to be some contradictions in the comments / naming.

Second, I now filter out non-Canopus stars. Previously, we returned 0 or 100% depending on whether or not an asterism could be found. As per Bryan's comments on REL-2941, we now return the number of CWFS probes with guide stars divided by three to give the estimate of success.

I also, as per Bryan's recommendation, added a warning if the number of CWFS guide stars is less than three.