### PR TITLE
REL-2973: Added LRU cache for AGS estimation queries to eliminate ODB server load.

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsPresentation.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsPresentation.scala
@@ -76,11 +76,11 @@ object ObsPresentation {
       v <- m.visibility
     } yield v
 
-    vis.map(_ match {
+    vis.map {
       case TargetVisibility.Good    => Green(tooltip = msg("This target has good visibility at %s during %s."))
       case TargetVisibility.Limited => Yellow(tooltip = msg("<html>This target has limited visibility at %s during %s.<br>The observation time should be short and/or conditions constraints relaxed.</html>"))
       case _                        => Red(tooltip = msg("<html>This target is inaccessible at %s during %s.<br>Consider an alternative target.</html>"))
-    }).getOrElse(Blank)
+    }.getOrElse(Blank)
   }
 
   def gsa(obs: Observation): ObsPresentation = {

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/LruCache.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/LruCache.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.shared.util;
 
 import java.util.Map;

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -654,6 +654,7 @@ trait OcsBundle {
     project.in(file("bundle/edu.gemini.ags.client.impl")).dependsOn(
       bundle_edu_gemini_ags_client_api,
       bundle_edu_gemini_model_p1,
+      bundle_edu_gemini_shared_util,
       bundle_edu_gemini_util_ssl
     )
 

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -654,7 +654,6 @@ trait OcsBundle {
     project.in(file("bundle/edu.gemini.ags.client.impl")).dependsOn(
       bundle_edu_gemini_ags_client_api,
       bundle_edu_gemini_model_p1,
-      bundle_edu_gemini_shared_util,
       bundle_edu_gemini_util_ssl
     )
 


### PR DESCRIPTION
In the 2017A PIT call for proposals the ODB server was hammered with AGS http queries for guiding estimations.

Investigation into this shows that repeated, identical queries are made.
Thus, to reduce server load, we implement an LRU cache on query string for successful results.

Note that this also seems to occur with the GSA, as per my notes on REL-2973:
http://jira.gemini.edu:8080/browse/REL-2973

Perhaps it would similarly be worthwhile to add a cache for this as well, especially since these queries seem to be fairly time-intensive? I'd like to do so but am wondering if anyone has any reason to object to this.