### PR TITLE
REL-3077: Remove Texes from available resource list for 2017B.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -8,7 +8,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
   var title = "Select Instrument"
   var description = s"The following instruments are available for semester ${sem.year}${sem.half}. See the Gemini website for information on instrument capabilities and configuration options."
 
-  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, Texes, Visitor)
+  def choices = List(Flamingos2, Dssi, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, Visitor)
 
   def apply(i:Instrument) = i match {
     case Flamingos2 => Left(inst.Flamingos2())

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -11,9 +11,9 @@ class RootSpec extends Specification {
       val root = new Root(Semester(2016, A))
       root.choices must contain(Instrument.Gsaoi)
     }
-    "include Texes" in {
-      val root = new Root(Semester(2017, A))
-      root.choices must contain(Instrument.Texes)
+    "Texes has been removed in 2017B" in {
+      val root = new Root(Semester(2017, B))
+      root.choices must not contain Instrument.Texes
     }
     "include Speckles" in {
       val root = new Root(Semester(2016, A))


### PR DESCRIPTION
This tiny PR removed Texes from the available resources for 2017B.

I inquired with Bryan to see what should be done when upconverting proposals from previous semesters that use Texes, and he said they should simply be displayed as-is, i.e. with Texes still listed as the resource: thus, there is nothing else to do on this front other than remove it from the list.