### PR TITLE
REL-3068: Fixed weird page numbering in NOAO PDF format.

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -701,7 +701,7 @@
             <!-- END first page -->
 
             <!-- BEGIN investigator information -->
-            <fo:page-sequence master-reference="rest" initial-page-number="2">
+            <fo:page-sequence master-reference="rest">
 
                 <!-- BEGIN header -->
                 <fo:static-content
@@ -928,7 +928,7 @@
             <!-- END investgator information -->
 
             <!-- BEGIN science justification -->
-            <fo:page-sequence master-reference="rest" initial-page-number="3">
+            <fo:page-sequence master-reference="rest">
 
                 <!-- BEGIN header -->
                 <fo:static-content


### PR DESCRIPTION
The page numbering has always been a bit hokey in the PIT NOAO format PDF generation due to forcing odd page numbers.
This simply removes the forcing and allows the page numbers to proceed as normal.