### PR TITLE
REL-3079: Altair LGS not available in 2017B.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
@@ -10,9 +10,12 @@ trait AltairNode {
   val allGuideStarTypes: Boolean
   val title       = "Adaptive Optics"
   val description = "Please select an adaptive optics option."
+
+  // REL-3079: GN laser is not available for 2017B.
   def choices     = if (allGuideStarTypes) {
-      List(AltairNone, AltairLGS(pwfs1 = false, aowfs = true), AltairLGS(pwfs1 = true), AltairLGS(pwfs1 = false, oiwfs = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+      //List(AltairNone, AltairLGS(pwfs1 = false, aowfs = true), AltairLGS(pwfs1 = true), AltairLGS(pwfs1 = false, oiwfs = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+      List(AltairNone, AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
     } else {
-      List(AltairNone, AltairLGS(pwfs1 = false), AltairLGS(pwfs1 = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+      List(AltairNone, AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
     }
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
@@ -16,6 +16,7 @@ trait AltairNode {
       //List(AltairNone, AltairLGS(pwfs1 = false, aowfs = true), AltairLGS(pwfs1 = true), AltairLGS(pwfs1 = false, oiwfs = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
       List(AltairNone, AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
     } else {
+      //List(AltairNone, AltairLGS(pwfs1 = false), AltairLGS(pwfs1 = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
       List(AltairNone, AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
     }
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -131,6 +131,12 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
  * This converter will upgrade to 2017B
  */
 case object SemesterConverter2017ATo2017B extends SemesterConverter {
+  // TODO: REL-3079 remove this when the GN laser is repaired.
+  val altairLgsNotAvailable: TransformFunction = {
+    case a @ <altair>{ns @ _*}</altair> if (a \\ "lgs").nonEmpty =>
+      StepResult(s"Altair Laser Guidestar is currently not offered", a).successNel
+  }
+
   val timeToProgTime: TransformFunction = {
     case o @ <observation>{ns @ _*}</observation> if (o \\ "time").nonEmpty =>
 
@@ -147,7 +153,7 @@ case object SemesterConverter2017ATo2017B extends SemesterConverter {
         // Too many attributes.
         <observation band={o.attribute("band")} enabled={o.attribute("enabled")} target={o.attribute("target")} condition={o.attribute("condition")} blueprint={o.attribute("blueprint")}>{TimeToProgTime.transform(ns)}</observation>).successNel
   }
-  override val transformers = List(timeToProgTime)
+  override val transformers = List(altairLgsNotAvailable, timeToProgTime)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -243,7 +243,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -268,7 +268,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -294,7 +294,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 8
+          changes must have length 9
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -530,7 +530,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain("GNIRS observation doesn't have a central wavelength range, assigning to '< 2.5um'")
           // Check that the centralWavelength node is added
           result must \\("centralWavelength") \> "< 2.5um"
@@ -703,7 +703,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           result \\ "niri" must \\("filter") \> "HeI (1.083 um)"
           result \\ "niri" must not(\\("filter") \> "J-continuum (1.122 um)")
           result \\ "niri" must not(\\("filter") \> "Jcont (1.065 um)")

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -223,7 +223,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     // TODO: Remove this if the laser is repaired.
     private lazy val altairLgsCheck = for {
       o <- p.observations
-      b <- o.blueprint if bpIsLgs(b)
+      b <- o.blueprint if bpIsLgs(b) && !bpIsGemsLgs(b)
     } yield new Problem(Severity.Error, "Altair Laser Guidestar is currently not offered.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
     def aoPerspectiveIsLgs(ao: AoPerspective): Boolean = ao match {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -88,7 +88,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           TimeProblems.partnerZeroTimeRequest(p, s) ++
           TacProblems(p, s).all ++
           List(incompleteInvestigator, missingObsElementCheck, cfCheck, emptyTargetCheck,
-            emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck,
+            emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck, altairLgsCheck,
             badGuiding, cwfsCorrectionsIssue, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
             lgsCC50Check, texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
       ps.sorted
@@ -219,6 +219,12 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       }
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
+    // REL-3079: No Altair LGS offered in 2017B.
+    // TODO: Remove this if the laser is repaired.
+    private lazy val altairLgsCheck = for {
+      o <- p.observations
+      b <- o.blueprint if bpIsLgs(b)
+    } yield new Problem(Severity.Error, "Altair Laser Guidestar is currently not offered.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
     def aoPerspectiveIsLgs(ao: AoPerspective): Boolean = ao match {
       case AoLgs => true


### PR DESCRIPTION
The laser at GN is not currently functional and thus proposals for 2017B must not allow Altair LGS options to be chosen.

This PR does three things:
1. Remove all Altair LGS options from the resource configuration.
2. When upconverting from a former semester, issue a message if an instrument is configured to use Altair LGS.
3. If a resource is found to use Altair LGS, report an error.