### PR TITLE
REL-2926: Rolling back some of the changes in REL-2985.

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -1224,7 +1224,7 @@
                         </fo:table-cell>
                         <fo:table-cell>
                             <fo:block>
-                                <xsl:value-of select="format-number(totalTime, '0.0')"/>&#160;<xsl:value-of select="totalTime/@units"/>
+                                <xsl:value-of select="format-number(time, '0.0')"/>&#160;<xsl:value-of select="time/@units"/>
                             </fo:block>
                             <fo:block>
                                 <xsl:value-of select="format-number(progTime, '0.0')"/>&#160;<xsl:value-of select="progTime/@units"/>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -1342,7 +1342,7 @@
                         </fo:table-cell>
                         <fo:table-cell border="0.5pt solid black">
                             <fo:block text-align="center">
-                                <xsl:value-of select="format-number(totalTime, '0.0')"/>&#160;<xsl:value-of select="totalTime/@units"/>
+                                <xsl:value-of select="format-number(time, '0.0')"/>&#160;<xsl:value-of select="time/@units"/>
                             </fo:block>
                             <fo:block text-align="center">
                                 <xsl:value-of select="format-number(progTime, '0.0')"/>&#160;<xsl:value-of select="progTime/@units"/>

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -22,7 +22,7 @@ object Observation {
 
   def apply(m:M.Observation) = new Observation(m)
 
-  def unapply(o:Observation) = Some((o.blueprint, o.condition, o.target, o.calculatedTimes, o.band))
+  def unapply(o:Observation) = Some((o.blueprint, o.condition, o.target, o.progTime, o.band))
 
   val empty = new Observation(None, None, None, None, M.Band.BAND_1_2)
 }
@@ -105,7 +105,7 @@ class Observation private (val blueprint:Option[BlueprintBase],
   override lazy val hashCode = kernel.hashCode()
 
   def isPartialObservationOf(o:Observation) =
-    calculatedTimes.isEmpty  && // If I have time defined, I might be incomplete but I'm not partial
+    progTime.isEmpty  && // If I have time defined, I might be incomplete but I'm not partial
     (band == o.band) && // must be the same band
     (blueprint.isEmpty || target.isEmpty || condition.isEmpty || calculatedTimes.isEmpty) && // Must have *some* empty component
     isPartial(blueprint, o.blueprint) &&

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -141,7 +141,7 @@ case object SemesterConverter2017ATo2017B extends SemesterConverter {
     case o @ <observation>{ns @ _*}</observation> if (o \\ "time").nonEmpty =>
 
       // The time field from previous versions is being instead used to represent program time, and the time field
-      // will now be modified to represent total time, i.e. progTime + partTime (partmer ca;ibraation time).
+      // will now be modified to represent total time, i.e. progTime + partTime (partner calibration time).
       object TimeToProgTime extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
           case t @ <time>{ts @ _*}</time> => <progTime units={t.attribute("units")}>{ts}</progTime>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -4,13 +4,10 @@ Gemini Phase I Schema Changes
 ##########################
 
 * Formerly, the time field in Observation referred to program time.
-  As per REL-2985, we are now dividing time into multiple categories to make the breakdown of where time is being
-  used clear, and the user must now enter integration time.
-  This has resulted in a number of new fields in Observation, namely intTime, progTime, partTime, and time, where
-  progTime and partTime are now functions of intTime as per the new Overheads class, and time is the sum of these
-  and represents total time. This upconversion is slightly complicated: old proposals have their former time field
-  migrated to progTime, and this is used to reverse-calculate intTime in the Observation class if intTime does not
-  exist.
+  As per REL-2926, we are now dividing time into multiple categories to include calculated calibration overheads.
+  This has resulted in a number of new fields in Observation, namely progTime, partTime, and time, where
+  partTime is a function of progTime as per the new Overheads class, and time is the sum of these
+  and represents total time.
 * Texes is not available this semester.
 * Two new filters available for F2: 'K-blue (2.06 um)' and 'K-red (2.31 um)'.
 * Altair LGS is disabled for this semester due to the GN laser not working.

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Observation.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Observation.xsd
@@ -17,7 +17,6 @@
     <xsd:complexType name="Observation">
 
         <xsd:sequence>
-            <xsd:element name="intTime"  type="TimeAmount"/>
             <xsd:element name="progTime" type="TimeAmount"/>
             <xsd:element name="partTime" type="TimeAmount"/>
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
@@ -1,25 +1,25 @@
 package edu.gemini.model.p1.overheads
 
 import edu.gemini.model.p1.immutable._
-import org.specs2.mutable.Specification
 
 import scala.collection.immutable.HashMap
 
-class OverheadsSpec extends Specification {
-  "Overheads" should {
-    "calculate all times properly in both directions" in {
-      forall(OverheadsSpec.instMap) { case ((_, _), (blueprint, expected)) =>
-        val overheads = Overheads(blueprint())
-        val results = for (o <- Overheads(blueprint())) yield {
-          val calculated = o.calculate(OverheadsSpec.intTime)
-          val intTime    = o.intTimeFromProgTime(calculated.progTime)
-          (calculated, intTime)
-        }
-        results shouldNotEqual None and(OverheadsSpec.almostEqual(results.get._1, expected) shouldEqual true) and(OverheadsSpec.almostEqual(results.get._2, OverheadsSpec.intTime) shouldEqual true)
-      }
-    }
-  }
-}
+// None of this is applicable anymore in light of the change from REL-2985 to REL-2926.
+//class OverheadsSpec extends org.specs2.mutable.Specification {
+//  "Overheads" should {
+//    "calculate all times properly in both directions" in {
+//      forall(OverheadsSpec.instMap) { case ((_, _), (blueprint, expected)) =>
+//        val overheads = Overheads(blueprint())
+//        val results = for (o <- Overheads(blueprint())) yield {
+//          val calculated = o.calculate(OverheadsSpec.intTime)
+//          val intTime    = o.intTimeFromProgTime(calculated.progTime)
+//          (calculated, intTime)
+//        }
+//        results shouldNotEqual None and(OverheadsSpec.almostEqual(results.get._1, expected) shouldEqual true) and(OverheadsSpec.almostEqual(results.get._2, OverheadsSpec.intTime) shouldEqual true)
+//      }
+//    }
+//  }
+//}
 
 object OverheadsSpec {
   private val precision = 0.01

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -34,7 +34,7 @@ object Phase1FolderFactory {
         blueprintE  <- extractBlueprintEntry(o).right
         target      <- extractTarget(site, o, time).right
         siteQuality <- extractSiteQuality(o).right
-        timeValue   <- extractIntTime(o).right
+        timeValue   <- extractProgTime(o).right
       } yield Folder(site, namer,
                 bMap + blueprintE,
                 ObsQuad(blueprintE._1, target, siteQuality, timeValue) :: oList)
@@ -58,9 +58,9 @@ object Phase1FolderFactory {
         s2 <- SpSiteQualityFactory.create(s1).right
       } yield s2
 
-    private def extractIntTime(o: Observation): Either[String, TimeValue] =
+    private def extractProgTime(o: Observation): Either[String, TimeValue] =
       for {
-        time <- o.intTime.toRight("Observation missing integration time").right
+        time <- o.progTime.toRight("Observation missing program time").right
       } yield new TimeValue(time.toHours.hours, TimeValue.Units.hours)
 
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
@@ -17,7 +17,7 @@ import edu.gemini.spModel.template.TemplateParameters
 import org.specs2.mutable.SpecificationLike
 import scala.collection.JavaConverters._
 import scalaz._, Scalaz._
-import Observation.{blueprint, target, condition, intTime}
+import Observation.{blueprint, target, condition, progTime}
 import Proposal.{ targets, observations }
 
 /**
@@ -141,7 +141,7 @@ abstract class TemplateSpec(xmlName: String) { this: SpecificationLike =>
         _ <- blueprint := Some(bp)
         _ <- target    := Some(st)
         _ <- condition := Some(Condition.empty)
-        _ <- intTime   := Some(TimeAmount.empty)
+        _ <- progTime  := Some(TimeAmount.empty)
       } yield ()
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -463,7 +463,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     }
 
     private lazy val missingObsDetailsCheck =
-      p.observations.filter(_.intTime.isEmpty) match {
+      p.observations.filter(_.calculatedTimes.isEmpty) match {
         case Nil => None
         case h :: Nil => Some(new Problem(Severity.Error, "One observation has no observation time.", "Observations", indicateObservation(h)))
         case h :: tail => Some(new Problem(Severity.Error, s"${1 + tail.length} observations have no observation times.", "Observations", indicateObservation(h)))
@@ -504,8 +504,8 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       )
 
     private lazy val badVisibility = for {
-      o @ Observation(Some(_), Some(_), Some(t), Some(_), _, _) <- p.observations
-      v                                                         <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
+      o @ Observation(Some(_), Some(_), Some(t), _, _) <- p.observations
+      v                                                <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
       if v == TargetVisibility.Bad
     } yield new Problem(Severity.Error,
         visibilityMessage("Target is inaccessible at %s during %s. Consider an alternative.", p.semester, o),
@@ -513,8 +513,8 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
         indicateObservation(o))
 
     private lazy val iffyVisibility = for {
-      o @ Observation(Some(_), Some(_), Some(_), Some(_), _, _) <- p.observations
-      v                                                         <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
+      o @ Observation(Some(_), Some(_), Some(_), _, _) <- p.observations
+      v                                                <- if (p.proposalClass.isSpecial) TargetVisibilityCalc.getOnDec(p.semester, o) else TargetVisibilityCalc.get(p.semester, o)
       if v == TargetVisibility.Limited
     } yield new Problem(Severity.Warning,
         visibilityMessage("Target has limited visibility at %s during %s.", p.semester, o),

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
@@ -47,7 +47,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
   def -(e:ObsListElem) = {
 
     def update(o:Observation) = e match {
-      case _:ObsElem        => o.copy(intTime = None)
+      case _:ObsElem        => o.copy(progTime = None)
       case _:ConditionGroup => o.copy(condition = None)
       case _:TargetGroup    => o.copy(target = None)
       case _:BlueprintGroup => o.copy(blueprint = None)
@@ -130,7 +130,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
       // To stamp and clear we fold over the associated groups. When stamping we also want to be sure to switch the
       // band to whatever this model's primary band is. This lets us paste stuff between BAND_1_2 and BAND_3.
       def stamp(o:Observation) = (o /: toStamp)((o, g) => g.stamp(target, o).copy(band = band))
-      def clear(o:Observation) = (o.copy(intTime = None) /: toClear)((o, g) => g.clear(o))
+      def clear(o:Observation) = (o.copy(progTime = None) /: toClear)((o, g) => g.clear(o))
 
       // Our list of dropped Observations,
       val os = source._1.selected(source._2)
@@ -186,7 +186,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
   def cut(elem:ObsListElem):ObsListModel = elem match {
     case target:ObsGroup[_] =>
       val (_, toClear) = Seq(gs._1, gs._2, gs._3).splitAt(depth(target))
-      def clear(o:Observation) = (o.copy(intTime = None) /: toClear)((o, g) => g.clear(o))
+      def clear(o:Observation) = (o.copy(progTime = None) /: toClear)((o, g) => g.clear(o))
       val os = selected(target)
       (this /: os.zip(os.map(clear)))(_.replacePair(_))
     case o:ObsElem          => this - o
@@ -220,7 +220,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
         val innerGroups:List[ObsListElem] = osByA.groupBy(gb).toList.sortBy(_._1.toString).map {
           case (b, osByAB) =>
             val innerInnerGroups:List[ObsListElem] = osByAB.groupBy(gc).toList.sortBy(_._1.toString).map {
-              case (c, osByABC) => (a |> b |> c, osByABC.filterNot(_.o.intTime.isEmpty))
+              case (c, osByABC) => (a |> b |> c, osByABC.filterNot(_.o.calculatedTimes.isEmpty))
             }.filterNot(p => p._1.isEmpty && p._2.isEmpty).flatMap(cons).toList
             (a |> b, innerInnerGroups)
         }.filterNot(p => p._1.isEmpty && p._2.isEmpty).flatMap(cons).toList

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -236,7 +236,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
       viewer.onSelectionChanged {s =>
         enabled = canEdit && ~(for (m <- model) yield {
             ~s.map {
-              case ObsElem(o)    => o.intTime.isDefined
+              case ObsElem(o)    => o.calculatedTimes.isDefined
               case g:ObsGroup[_] => m.childrenOf(g).nonEmpty
             }
           })
@@ -403,9 +403,9 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
 
     override def foreground(e:ObsListElem) = {
       case Item => e match {
-        case ObsElem(o) if o.intTime.isEmpty => Color.LIGHT_GRAY
-        case g:ObsGroup[_] if g.isEmpty      => Color.LIGHT_GRAY
-        case _                               => Color.BLACK
+        case ObsElem(o) if o.calculatedTimes.isEmpty => Color.LIGHT_GRAY
+        case g:ObsGroup[_] if g.isEmpty              => Color.LIGHT_GRAY
+        case _                                       => Color.BLACK
       }
     }
 
@@ -425,7 +425,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
         b <- o.blueprint if !b.site.isExchange
         t <- o.target
         _ <- t.coords(s.midPoint)
-        _ <- o.intTime
+        _ <- o.calculatedTimes
       } yield true)
 
     override def alignment(e:ObsListElem) = {
@@ -455,7 +455,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
     def icon(e:ObsListElem) = {
       case Item    => e match {
         case g:ObsGroup[_] => g.icon
-        case ObsElem(o)    => if (o.intTime.isEmpty) obsDisIcon else ICON_CLOCK
+        case ObsElem(o)    => if (o.calculatedTimes.isEmpty) obsDisIcon else ICON_CLOCK
       }
       case Guiding => presentation(e, guiding, _.icon)
       case Vis     => semPresentation(e, visibility, _.icon)
@@ -464,9 +464,9 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band, queueLookup: Target => U
 
     def text(e:ObsListElem) = {
       case Item    => e match {
-        case ObsElem(o) if o.intTime.isDefined => "Observation"
-        case ObsElem(o)                        => empty("observation time")
-        case e:ObsGroup[_] if e.isEmpty        => e.grouping match {
+        case ObsElem(o) if o.calculatedTimes.isDefined => "Observation"
+        case ObsElem(o)                                => empty("observation time")
+        case e:ObsGroup[_] if e.isEmpty                => e.grouping match {
           case ObsListGrouping.Target    => empty("target")
           case ObsListGrouping.Blueprint => empty("resource configuration")
           case ObsListGrouping.Condition => empty("observing conditions")


### PR DESCRIPTION
It appears this morning that due to some unforeseen issues during the science planning phase of REL-2985, science has requested that we roll back some of the changes and that these calculations eventually be moved back to the ITC.

Thus, instead of users entering integration time in the PIT and program time, calibration (partner) time, and total time being a function of this (with old programs needing to upconvert the old time field to program time and reverse-calculate integration time), we will eliminate integration time from the PIT and simply use - as before - program time as the input, but calculate calibration time from this and sum to get total time.

This implements the rollbacks necessary to do this, fixes the UI, and comments out much unnecessary code. Since much of this code might be required from the ITC perspective, I am not currently removing it entirely.