### PR TITLE
REL-2941: Addition of dedicated AGS ODB server for PIT estimates

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -39,7 +39,7 @@ def common(pv: Version) = AppConfig(
     "org.osgi.framework.startlevel.beginning" -> "100",
     "org.osgi.framework.bootdelegation"       -> "*",
     "edu.gemini.pit.test"                     -> "true",
-    "edu.gemini.ags.host"                     -> "gnodb.gemini.edu",
+    "edu.gemini.ags.host"                     -> "gnauxodb.gemini.edu",
     "edu.gemini.ags.port"                     -> "8443"
   ),
   // log = Some("%a/log/qpt.%u.%g.log"),

--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -36,7 +36,8 @@ ocsAppManifest := {
               gnodbtest(v),
             odbproduction(v),
               gsodb(v),
-              gnodb(v)
+              gnodb(v),
+	      gnagsodb(v)
     )
   )
 }
@@ -499,6 +500,30 @@ def gnodb(version: Version) = AppConfig(
     "edu.gemini.spdb.dir"                  -> "/mount/wikiwiki/odbhome/ugemini/spdb/spdb.active",
     "edu.gemini.util.trpc.name"            -> "Gemini North ODB",
     "osgi.shell.telnet.ip"                 -> "10.2.4.77"
+  )
+) extending List(odbproduction(version), gnodb_credentials(version))
+
+// GN AGS ODB: hbfauxodb-lv1 / gnauxodb
+def gnagsodb(version: Version) = AppConfig(
+  id = "gnagsodb",
+  distribution = List(Linux64),
+  vmargs = List(
+    "-Dcom.cosylab.epics.caj.CAJContext.addr_list=10.2.2.255",
+    "-Dedu.gemini.site=north",
+    "-Dcron.archive.edu.gemini.dbTools.html.ftpHost=gsagn.hi.gemini.edu",
+    "-Dcron.odbMail.SITE_SMTP_SERVER=smtp.hi.gemini.edu",
+    "-Xms2G",
+    "-Xmx2G"
+  ),
+  props = Map(
+    "edu.gemini.auxfile.fits.dest"         -> "/gemsoft/var/data/ictd/GN@SEMESTER@/@PROG_ID@",
+    "edu.gemini.auxfile.fits.host"         -> "gnconfig.gemini.edu",
+    "edu.gemini.auxfile.other.dest"        -> "/gemsoft/var/data/finder/GNqueue/Finders/@SEMESTER@/@PROG_ID@",
+    "edu.gemini.auxfile.root"              -> "/home/software/.auxfile",
+    "edu.gemini.dataman.gsa.summit.host"   -> "fits.hi.gemini.edu",
+    "edu.gemini.oodb.mail.smtpHost"        -> "smtp.hi.gemini.edu",
+    "edu.gemini.util.trpc.name"            -> "Gemini North AGS ODB",
+    "osgi.shell.telnet.ip"                 -> "10.1.46.11"
   )
 ) extending List(odbproduction(version), gnodb_credentials(version))
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2017A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2017B", false, 2, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2017A", false, 1, 1, 2)
 
 pitVersion in ThisBuild := OcsVersion("2017B", true, 2, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2017A", false, 1, 1, 2)
+ocsVersion in ThisBuild := OcsVersion("2017A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2017B", true, 2, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2017B", false, 2, 1, 0)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion


### PR DESCRIPTION
This adds the configuration for the dedicated AGS ODB server and configures the PIT to use it.