### PR TITLE
REL-3086: Add entry to configuration for 2017B P1 monitor to handle CFHT

### DIFF
--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2017B.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2017B.xml
@@ -56,6 +56,11 @@
         <to>pit.ca@gemini.edu</to>
     </type>
 
+    <type name="cfht">
+        <dir>/home/software/proposals/cfh/proposals/2017B</dir>
+        <to>pit.cfh@gemini.edu</to>
+    </type>
+
     <type name="cl">
         <dir>/home/software/proposals/cl/proposals/2017B</dir>
         <to>pit.cl@gemini.edu</to>
@@ -127,6 +132,10 @@
         <translation>
             <from>cl</from>
             <to>CL</to>
+        </translation>
+        <translation>
+            <from>cfh</from>
+            <to>CFHT</to>
         </translation>
         <translation>
             <from>kr</from>


### PR DESCRIPTION
Bryan brought it to my attention that CFHT submissions were handled by the backend servers but not the P1 monitor.

Further investigation revealed that the P1 monitor has never been configured to handle CFHT submissions, i.e. generate a summary PDF and issue an email when they are received.

This adds entries to the conf file for the P1 monitor to handle CFHT submissions.