### PR TITLE
REL-3091: Added empty overheads for Keck and Subaru instruments.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
@@ -80,6 +80,9 @@ object Overheads extends (BlueprintBase => Option[Overheads]) {
     override val acquisitionOverhead = Minutes(acquisitionOverheadMins)
   }
 
+  // Empty overheads for instruments from exchange partners, e.g. Keck and Subaru.
+  private lazy val EmptyOverheads          = SimpleOverheads(0.00,  0, 0.000).some
+
   // GMOS overheads are the same between sites.
   private lazy val GmosImagingOverheads    = SimpleOverheads(0.00,  6, 0.144).some
   private lazy val GmosLongslitOverheads   = SimpleOverheads(0.10, 16, 0.034).some
@@ -125,6 +128,9 @@ object Overheads extends (BlueprintBase => Option[Overheads]) {
     case gmosbp: GmosNBlueprintMos => gmosbp.nodAndShuffle ? GmosMosNsOverheads | GmosMosOverheads
     case gmosbp: GmosSBlueprintMos => gmosbp.nodAndShuffle ? GmosMosNsOverheads | GmosMosOverheads
 
+    // Keck and Subaru instruments have no overheads associated with them.
+    case _: KeckBlueprint   => EmptyOverheads
+    case _: SubaruBlueprint => EmptyOverheads
 
     // Any other configuration is unsupported.
     case _ => None

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/overheads/OverheadsSpec.scala
@@ -23,8 +23,10 @@ import scala.collection.immutable.HashMap
 
 object OverheadsSpec {
   private val precision = 0.01
+
   def almostEqual(t1: TimeAmount, t2: TimeAmount): Boolean =
     (t1.toHours.value - t2.toHours.value).abs < precision
+
   def almostEqual(times1: ObservationTimes, times2: ObservationTimes): Boolean =
     almostEqual(times1.progTime, times2.progTime) && almostEqual(times1.partTime, times2.partTime)
 
@@ -130,6 +132,14 @@ object OverheadsSpec {
     (("graces", "spec"), (
       () => GracesBlueprint(GracesFiberMode.values.apply(0), GracesReadMode.values.apply(0)),
       obsTimes(1.93, 0.00))
+      ),
+    (("keck", "all"), (
+      () => KeckBlueprint(KeckInstrument.values.apply(0)),
+      obsTimes(1.70, 0.00))
+      ),
+    (("subaru", "all"), (
+      () => SubaruBlueprint(SubaruInstrument.values.apply(0), None),
+      obsTimes(1.70, 0.00))
       )
   )
 }


### PR DESCRIPTION
Specifications were added to REL-2926 / REL-2985 for empty overheads when using Keck and Subaru instruments. This adds match cases to the `Overheads` class to return `Overheads` for `KeckBlueprint` and `SubaruBlueprint` so that the empty overheads are calculated instead of what happens when no match is performed and `None` is returned, in which case, no overheads are calculated at all.