### PR TITLE
REL-3061: Rewrote ImEither and fixed null pointer exceptions.

### DIFF
--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImEither.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImEither.java
@@ -9,29 +9,45 @@ import java.util.Optional;
 public interface ImEither<L,R> extends Serializable {
     ImEither<R,L> swap();
 
-    // Right biased qualifiers / operations.
+    // === Right biased qualifiers / operations ===
     <T> T foldRight(final T zero,
                     final Function<? super R, ? extends T> rightFunc);
+
     boolean exists(final Predicate<? super R> rightFunc);
+
     boolean forAll(final Predicate<? super R> rightFunc);
+
     void forEach(final Consumer<? super R> rightFunc);
+
     <R2> ImEither<L,R2> map(final Function<? super R, ? extends R2> rightFunc);
+
     <R2> ImEither<L,R2> flatMap(final Function<? super R, ? extends ImEither<L,R2>> rightFunc);
+
     boolean isRight();
+
     Optional<R> toOptional();
 
-    // Left biased qualifiers / operations.
+
+    // === Left biased qualifiers / operations ===
     <T> T foldLeft(final T zero,
                    final Function<? super L, ? extends T> leftFunc);
+
     boolean existsLeft(final Predicate<? super L> leftFunc);
+
     boolean forAllLeft(final Predicate<? super L> leftFunc);
+
     void forEachLeft(final Consumer<? super L> leftFunc);
+
     <L2> ImEither<L2,R> mapLeft(final Function<? super L, ? extends L2> leftFunc);
+
     <L2> ImEither<L2,R> flatMapLeft(final Function<? super L, ? extends ImEither<L2,R>> rightFunc);
+
     boolean isLeft();
+
     Optional<L> toOptionalLeft();
 
-    // Operations on both values.
+
+    // === Operations on both values ===
     <T> T biFold(final Function<? super L, ? extends T> leftFunc,
                  final Function<? super R, ? extends T> rightFunc);
 

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
@@ -1,5 +1,7 @@
 package edu.gemini.shared.util.immutable;
 
+import java.util.Optional;
+
 public class ImOption {
     public static <T> Option<T> apply(final T value) {
         if (value == null) {
@@ -15,5 +17,9 @@ public class ImOption {
 
     public static <T> Option<T> fromScalaOpt(final scala.Option<T> scalaOpt) {
         return scalaOpt.isDefined() ? new Some<>(scalaOpt.get()) : None.instance();
+    }
+
+    public static <T> Option<T> fromOptional(final Optional<T> optional) {
+        return optional.isPresent() ? new Some<>(optional.get()) : None.instance();
     }
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Left.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Left.java
@@ -1,0 +1,118 @@
+package edu.gemini.shared.util.immutable;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public final class Left<L,R> implements ImEither<L,R> {
+    private final L value;
+
+    public Left(final L value) throws NullPointerException {
+        this.value = Objects.requireNonNull(value, "Left cannot be initialized with null.");
+    }
+
+    @Override
+    public ImEither<R,L> swap() {
+        return new Right<>(value);
+    }
+
+    @Override
+    public <T> T foldRight(final T zero,
+                           final Function<? super R, ? extends T> rightFunc) {
+        return zero;
+    }
+
+    @Override
+    public boolean exists(final Predicate<? super R> rightFunc) {
+        return false;
+    }
+
+    @Override
+    public boolean forAll(final Predicate<? super R> rightFunc) {
+        return true;
+    }
+
+    @Override
+    public void forEach(final Consumer<? super R> rightFunc) {}
+
+    @Override
+    public <R2> ImEither<L,R2> map(final Function<? super R, ? extends R2> rightFunc) {
+        return new Left<>(value);
+    }
+
+    @Override
+    public <R2> ImEither<L,R2> flatMap(final Function<? super R, ? extends ImEither<L,R2>> rightFunc) {
+        return new Left<>(value);
+    }
+
+    @Override
+    public boolean isRight() {
+        return false;
+    }
+
+    @Override
+    public Optional<R> toOptional() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> T foldLeft(final T zero,
+                          final Function<? super L, ? extends T> leftFunc) {
+        return leftFunc.apply(value);
+    }
+
+    @Override
+    public boolean existsLeft(final Predicate<? super L> leftFunc) {
+        return leftFunc.test(value);
+    }
+
+    @Override
+    public boolean forAllLeft(final Predicate<? super L> leftFunc) {
+        return leftFunc.test(value);
+    }
+
+    @Override
+    public void forEachLeft(final Consumer<? super L> leftFunc) {
+        leftFunc.accept(value);
+    }
+
+    @Override
+    public <L2> ImEither<L2,R> mapLeft(final Function<? super L, ? extends L2> leftFunc) {
+        return new Left<>(leftFunc.apply(value));
+    }
+
+    @Override
+    public <L2> ImEither<L2,R> flatMapLeft(final Function<? super L, ? extends ImEither<L2,R>> leftFunc) {
+        return leftFunc.apply(value);
+    }
+
+    @Override
+    public boolean isLeft() {
+        return true;
+    }
+
+    @Override
+    public Optional<L> toOptionalLeft() {
+        return Optional.of(value);
+    }
+
+    @Override
+    public <T> T biFold(final Function<? super L, ? extends T> leftFunc,
+                        final Function<? super R, ? extends T> rightFunc) {
+        return leftFunc.apply(value);
+    }
+
+    @Override
+    public void biForEach(final Consumer<? super L> leftFunc,
+                          final Consumer<? super R> rightFunc) {
+        leftFunc.accept(value);
+    }
+
+    @Override
+    public <L2,R2> ImEither<L2,R2> biMap(final Function<? super L, ? extends L2> leftFunc,
+                                         final Function<? super R, ? extends R2> rightFunc) {
+        return new Left<>(leftFunc.apply(value));
+    }
+}

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Right.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/Right.java
@@ -1,0 +1,119 @@
+package edu.gemini.shared.util.immutable;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public final class Right<L,R> implements ImEither<L,R>, Serializable {
+    private final R value;
+
+    public Right(final R value) throws NullPointerException {
+        this.value = Objects.requireNonNull(value, "Right cannot be initialized with null.");
+    }
+
+    @Override
+    public ImEither<R,L> swap() {
+        return new Left<>(value);
+    }
+
+    @Override
+    public <T> T foldRight(final T zero,
+                           final Function<? super R, ? extends T> rightFunc) {
+        return rightFunc.apply(value);
+    }
+
+    @Override
+    public boolean exists(final Predicate<? super R> rightFunc) {
+        return rightFunc.test(value);
+    }
+
+    @Override
+    public boolean forAll(final Predicate<? super R> rightFunc) {
+        return rightFunc.test(value);
+    }
+
+    @Override
+    public <R2> ImEither<L,R2> map(final Function<? super R, ? extends R2> rightFunc) {
+        return new Right<>(rightFunc.apply(value));
+    }
+
+    @Override
+    public <R2> ImEither<L,R2> flatMap(final Function<? super R, ? extends ImEither<L,R2>> rightFunc) {
+        return rightFunc.apply(value);
+    }
+
+    @Override
+    public boolean isRight() {
+        return true;
+    }
+
+    @Override
+    public Optional<R> toOptional() {
+        return Optional.of(value);
+    }
+
+    @Override
+    public <T> T foldLeft(final T zero,
+                          final Function<? super L, ? extends T> leftFunc) {
+        return zero;
+    }
+
+    @Override
+    public boolean existsLeft(final Predicate<? super L> leftFunc) {
+        return false;
+    }
+
+    @Override
+    public boolean forAllLeft(final Predicate<? super L> leftFunc) {
+        return true;
+    }
+
+    @Override
+    public void forEachLeft(final Consumer<? super L> leftFunc) {}
+
+    @Override
+    public void forEach(final Consumer<? super R> rightFunc) {
+        rightFunc.accept(value);
+    }
+
+    @Override
+    public <L2> ImEither<L2,R> mapLeft(final Function<? super L, ? extends L2> leftFunc) {
+        return new Right<>(value);
+    }
+
+    @Override
+    public <L2> ImEither<L2,R> flatMapLeft(final Function<? super L, ? extends ImEither<L2,R>> leftFunc) {
+        return new Right<>(value);
+    }
+
+    @Override
+    public boolean isLeft() {
+        return true;
+    }
+
+    @Override
+    public Optional<L> toOptionalLeft() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> T biFold(Function<? super L, ? extends T> leftFunc,
+                        Function<? super R, ? extends T> rightFunc) {
+        return rightFunc.apply(value);
+    }
+
+    @Override
+    public void biForEach(final Consumer<? super L> leftFunc,
+                          final Consumer<? super R> rightFunc) {
+        rightFunc.accept(value);
+    }
+
+    @Override
+    public <L2,R2> ImEither<L2,R2> biMap(final Function<? super L, ? extends L2> leftFunc,
+                                         final Function<? super R, ? extends R2> rightFunc) {
+        return new Right<>(rightFunc.apply(value));
+    }
+}


### PR DESCRIPTION
This PR consists of two basic elements:

1. Rewriting the `ImEither` class as per @tpolecat's earlier recommendation to change `ImEither` into an interface with implementations `Left` and `Right` instead of the previous way, which included two `Options` in a concrete `ImEither` class. This would run the risk of having an `ImEither` with both `left` and `right` values set to `None`, which violates how this class is supposed to function.

2. There was an issue in `EdCompTargetList` where it was extremely rare, but it was possible that the `ImEither` in this class representing the selection of a target or group could be `null`. I have changed the variable to an `Option<ImEither>` instead to avoid this and eliminate the problem.

Note that the `ImEither` is still right-biased, as is the case with the scalaz disjunction, but for convenience, I have included methods specifically for left access so that we don't have to call `swap` to access left. If the sentiment is that this is not a good idea, I can change it back to be right-biased and drop the left-based operations / qualifiers.