### PR TITLE
REL-3055: Set HAMAMATSU to default for GMOS-N static component.

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiHorizonsConstants.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiHorizonsConstants.java
@@ -1,12 +1,11 @@
 package edu.gemini.horizons.server.backend;
 
-//$Id: CgiHorizonsConstants.java 895 2007-07-24 20:18:09Z anunez $
 /**
  * Define a set of constants to be used to talk to the CGI
  * offered by the JPL Horizons service
  */
 public final class CgiHorizonsConstants {
-    public static final String HORIZONS_PROTOCOL = "http://";
+    public static final String HORIZONS_PROTOCOL = "https://";
     public static final String HORIZONS_SERVER = "ssd.jpl.nasa.gov";
     public static final String HORIZONS_CGI = "horizons_batch.cgi";
     public static final String HORIZONS_URL = HORIZONS_PROTOCOL + HORIZONS_SERVER + "/" + HORIZONS_CGI;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -850,7 +850,7 @@ public class GmosCommonType {
         E2V("E2V", E2V_NORTH_PIXEL_SIZE, E2V_SOUTH_PIXEL_SIZE, E2V_SHUFFLE_OFFSET, 6144, 4608, 4),
         HAMAMATSU("HAMAMATSU", HAMAMATSU_PIXEL_SIZE, HAMAMATSU_PIXEL_SIZE, HAMAMATSU_SHUFFLE_OFFSET, 6144, 4224, 5);
 
-        public static final DetectorManufacturer DEFAULT = E2V;
+        public static final DetectorManufacturer DEFAULT = HAMAMATSU;
         public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "detectorManufacturer");
 
         private final String _displayValue;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosSouth.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosSouth.java
@@ -74,7 +74,6 @@ public class InstGmosSouth extends
         setFilter(GmosSouthType.FilterSouth.DEFAULT);
         setFPUnit(GmosSouthType.FPUnitSouth.DEFAULT);
         setStageMode(GmosSouthType.StageModeSouth.FOLLOW_XYZ);
-        setDetectorManufacturer(GmosCommonType.DetectorManufacturer.HAMAMATSU);
     }
 
     public Map<String, PropertyDescriptor> getProperties() {


### PR DESCRIPTION
Previously, E2V was the default CCD manufacturer for GMOS-N.

This was set in `InstGmosCommon` and then overridden in `InstGmosSouth` to set the CCD manufacturer to HAMAMATSU.

Since now both sites will have HAMAMATSU as the default CCD manufacturer, the default in `InstGmosCommon` was changed from E2V to HAMAMATSU and the (no longer necessary) override removed from `InstGmosSouth`.