### PR TITLE
REL-3015: Allow selecting a different image server for Visitor & TEXES observations

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObsWavelengthExtractor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObsWavelengthExtractor.scala
@@ -33,10 +33,9 @@ object ObsWavelengthExtractor {
   private def extractObsWavelength(ctx: InstrumentContext, obs: ISPObservation): Option[Wavelength] = {
     // Extract a double value from a string in the configuration
     def extractDoubleFromString(c: ConfigSequence, key: ItemKey): Throwable \/ Double =
-      for {
-        s <- extractAs[String](c, key)
-        d <- \/.fromTryCatchNonFatal(s.toDouble)
-      } yield d
+      extractAs[String](c, key).flatMap(s => \/.fromTryCatchNonFatal(s.toDouble))
+        .orElse(extractAs[java.lang.Double](c, key).map(_.doubleValue()))
+        .orElse(extractAs[Double](c, key))
 
     // Helper method that enforces that whatever we get from the config
     // for the given key is not null and matches the type we expect.

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObservationCatalogOverrides.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/ObservationCatalogOverrides.scala
@@ -90,7 +90,7 @@ object ObservationCatalogOverrides {
   /**
     * Store the overridden catalog for a given node
     */
-  def storeOverride(key: SPNodeKey, c: ImageCatalog, wv: Wavelength): Task[Unit] = {
+  def storeOverride(key: SPNodeKey, c: ImageCatalog, wv: Option[Wavelength]): Task[Unit] = {
     def writeOverrides(overridesFile: Path, overrides: Overrides) = Task.delay {
       this.synchronized {
         \/.fromTryCatchNonFatal {
@@ -101,7 +101,7 @@ object ObservationCatalogOverrides {
 
     // Updates the overrides file, removing the existing entries if needed
     def newOverrides(overrides: Overrides): Overrides =
-      if (ImageCatalog.catalogForWavelength(wv.some) =/= c) {
+      if (ImageCatalog.catalogForWavelength(wv) =/= c) {
         overrides.copy(overrides = CatalogOverride(key, c) :: overrides.overrides.filter(_.key != key))
       } else {
         overrides.copy(overrides = overrides.overrides.filter(_.key != key))

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/ImageCatalogPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/ImageCatalogPanel.scala
@@ -125,12 +125,12 @@ final class ImageCatalogPanel(imageDisplay: CatalogImageDisplay) {
     }
   }
 
-  private def requestImage(catalog: ImageCatalog) = {
+  private def requestImage(catalog: ImageCatalog) =
     // Read the current key and wavelength on the tpe
     for {
         tpe <- TpeContext.fromTpeManager
         key <- tpe.obsKey
-        wv  <- ObsWavelengthExtractor.extractObsWavelength(tpe)
+        wv  =   ObsWavelengthExtractor.extractObsWavelength(tpe)
       } {
         // Update the image and store the override
         val actions =
@@ -140,7 +140,6 @@ final class ImageCatalogPanel(imageDisplay: CatalogImageDisplay) {
           } yield ()
         actions.unsafePerformSync
       }
-  }
 
   private def updateSelection(catalog: ImageCatalog): Unit =
     catalogRows.find(_.feedback.catalog === catalog).foreach { _.button.selected = true }


### PR DESCRIPTION
Fixes some eccentricities of the science model that affect the selection of image catalogs based on the central wavelength