### PR TITLE
REL-3108: Improve GMOS-N ITC error message for IFU-2 + Hamamatsu CCDs

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -293,7 +293,7 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
 
             if (isIfu2() && gp.ccdType() == GmosCommonType.DetectorManufacturer.HAMAMATSU) {
                 throw new RuntimeException("The GMOS ITC does not yet support IFU-2 with the Hamamatsu CCDs.\n" +
-                "Please use the ITC in 1-slit mode to estimate sensitivity and see the GMOS IFU web pages for a discussion of spectral overlap.");
+                "Please use the ITC in 1-slit mode to estimate sensitivity, and see the GMOS IFU web pages for a discussion of spectral overlap.");
             }
 
         }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -292,7 +292,8 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
             }
 
             if (isIfu2() && gp.ccdType() == GmosCommonType.DetectorManufacturer.HAMAMATSU) {
-                throw new RuntimeException("Currently IFU-2 is not supported for Hamamatsu CCD.");
+                throw new RuntimeException("The GMOS ITC does not yet support IFU-2 with the Hamamatsu CCDs.\n" +
+                "Please use the ITC in 1-slit mode to estimate sensitivity and see the GMOS IFU web pages for a discussion of spectral overlap.");
             }
 
         }


### PR DESCRIPTION
They don't get much simpler than this...  Change an ITC error message to clarify that the ITC is what is limited, not the instrument itself.