### PR TITLE
REL-3100: Had to add commons to pit build file to fix dependencies.

### DIFF
--- a/bundle/edu.gemini.pit/build.sbt
+++ b/bundle/edu.gemini.pit/build.sbt
@@ -8,7 +8,8 @@ version := pitVersion.value.toOsgiVersion
 
 unmanagedJars in Compile ++= Seq(
   new File(baseDirectory.value, "../../lib/bundle/osgi.core-4.3.1.jar"),
-  new File(baseDirectory.value, "../../lib/bundle/org-apache-xmlrpc_2.10-3.0.0.jar"))
+  new File(baseDirectory.value, "../../lib/bundle/org-apache-xmlrpc_2.10-3.0.0.jar"),
+  new File(baseDirectory.value, "../../lib/bundle/org-apache-commons-httpclient_2.10-2.0.0.jar"))
 
 libraryDependencies ++= Seq(
   "org.scalaz"     %% "scalaz-core"       % ScalaZVersion,


### PR DESCRIPTION
Turns out that apache-xmlrpc is dependent on apache-commons-httpclient, and when we remove the latter from the horizons package, it breaks the OSGi wiring, resulting in an exception.