### PR TITLE
REL-3117: Initial Asterism trait

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -1,0 +1,63 @@
+package edu.gemini.spModel.target.env
+
+import edu.gemini.spModel.core.Coordinates
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.shared.util.immutable.{Option => GOption}
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.skycalc.{Coordinates => SCoordinates}
+
+
+import java.time.Instant
+
+import scalaz.NonEmptyList
+
+/** Collection of stars that make up the science target(s) for an observation,
+  * along with any configuration details unique to the instrument in use.
+  */
+trait Asterism {
+
+  /** All targets that comprise the asterism.  There must be at least one target.
+    */
+  def targets: NonEmptyList[SPTarget]
+
+  /** Slew coordinates and AGS calculation base position.  By default this
+    * will be a computation that finds the coordinate minimizing the maximum
+    * distance to any target in the asterism.
+    */
+  def basePosition(time: Instant): Option[Coordinates] =
+    ???  // we should supply the "smallest-circle" implementation here
+
+  //
+  // "Base position" convenience methods already in use extensively throughout
+  // the codebase.  Defined in terms of the base position, these are methods
+  // on SPTarget that are used directly in calls like
+  // targets.getBase.getRaDegrees(when)
+  //
+
+  type GOLong   = GOption[java.lang.Long]
+  type GODouble = GOption[java.lang.Double]
+
+  private def gcoords[A](time: GOLong)(f: Coordinates => A): GOption[A] =
+    (for {
+      t <- time.asScalaOpt
+      c <- basePosition(Instant.ofEpochMilli(t))
+    } yield f(c)).asGeminiOpt
+
+  def getRaHours(time: GOLong): GODouble =
+    gcoords(time)(_.ra.toHours)
+
+  def getRaDegrees(time: GOLong): GODouble =
+    gcoords(time)(_.ra.toDegrees)
+
+  def getRaString(time: GOLong): GOption[String] =
+    gcoords(time)(_.ra.toAngle.formatHMS)
+
+  def getDecDegrees(time: GOLong): GODouble =
+    gcoords(time)(_.dec.toDegrees)
+
+  def getDecString(time: GOLong): GOption[String] =
+    gcoords(time)(_.dec.formatDMS)
+
+  def getSkycalcCoordinates(time: GOLong): GOption[SCoordinates] =
+    gcoords(time)(cs => new SCoordinates(cs.ra.toDegrees, cs.dec.toDegrees))
+}


### PR DESCRIPTION
This simple PR just presents the proposed `Asterism` interface.  Having an `Asterism` trait will unlock progress on the `SingleTargetAsterism` implementation, `TargetEnvironment` update, and GHOST-specific asterism development.

One potentially controversial question is whether the targets should be `SPTarget` (which is mutable) or `Target` (which is immutable).  If this were new code here would be no question.  In `TargetEnvironment` though, the base position is an `SPTarget` so it seemed like the path of least resistance to make the asterism targets `SPTarget`s.  We drag targets around, for example, in the TPE so making these immutable implies replacing a lot of existing code. It seems like it would be prohibitively difficult.  I'm certainly happy to entertain the idea though if someone thinks I'm overestimating the complexity.