### PR TITLE
REL-3119: Initial GHOST asterism model

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -156,11 +156,16 @@ object GhostAsterism {
 
   /** GHOST two-target standard resolution asterism type.  In this mode, two
     * targets are observed simultaneously with both IFUs at standard resolution.
+    *
+    * The base position for the asterism defaults to the midway point between
+    * the two targets, but may be explicitly specified if necessary to reach a
+    * particular PWFS2 guide star.
     */
   final case class TwoTarget(
                      bin:  StandardResBinning,
                      ifu1: GhostTarget,
-                     ifu2: GhostTarget) extends GhostAsterism {
+                     ifu2: GhostTarget,
+                     base: Option[Coordinates]) extends GhostAsterism {
 
     /** Defines the targets in this asterism to be the two science targets. */
     override def targets: NonEmptyList[SPTarget] =
@@ -169,11 +174,17 @@ object GhostAsterism {
     /** Calculates the coordinates exactly halfway along the great circle
       * connecting the two targets.
       */
-    override def basePosition(when: Instant): Option[Coordinates] =
+    def defaultBasePosition(when: Instant): Option[Coordinates] =
       for {
         c1 <- ifu1.coordinates(Some(when))
         c2 <- ifu2.coordinates(Some(when))
       } yield c1.interpolate(c2, 0.5)
+
+    /** Obtains the base position, which defaults to the half-way point between
+      * the two targets but may be explicitly specified instead.
+      */
+    override def basePosition(when: Instant): Option[Coordinates] =
+      base orElse defaultBasePosition(when)
 
     import StandardResBinning._
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -15,7 +15,12 @@ import Scalaz._
 /** Base trait for the three GHOST asterism types: two target, beam switching,
   * and high resolution.
   */
-sealed trait GhostAsterism extends Asterism
+sealed trait GhostAsterism extends Asterism {
+
+  /** All Targets that comprise the asterism. */
+  override def allTargets: NonEmptyList[Target] =
+    allSpTargets.map(_.getTarget)
+}
 
 /** GHOST asterism model.
   */
@@ -168,10 +173,6 @@ object GhostAsterism {
     override def allSpTargets: NonEmptyList[SPTarget] =
       NonEmptyList(ifu1.spTarget, ifu2.spTarget)
 
-    /** Defines the targets in this asterism to be the two science targets. */
-    override def targets: Target \/ (Target, Target) =
-      (ifu1.spTarget.getTarget, ifu2.spTarget.getTarget).right
-
     /** Calculates the coordinates exactly halfway along the great circle
       * connecting the two targets.
       */
@@ -230,10 +231,6 @@ object GhostAsterism {
 
     override def allSpTargets: NonEmptyList[SPTarget] =
       NonEmptyList(ghostTarget.spTarget)
-
-    /** Defines the target list to be the single standard resolution target. */
-    override def targets: Target \/ (Target, Target) =
-      ghostTarget.spTarget.getTarget.left
 
     /** Defines the base position to be the same as the target position. */
     override def basePosition(when: Option[Instant]): Option[Coordinates] =
@@ -322,11 +319,6 @@ object GhostAsterism {
 
     override def allSpTargets: NonEmptyList[SPTarget] =
       NonEmptyList(ghostTarget.spTarget)
-
-
-    /** Defines the target list to be the single high resolution target. */
-    override def targets: Target \/ (Target, Target) =
-      ghostTarget.spTarget.getTarget.left
 
     /** Defines the base position to be the same as the target position. */
     override def basePosition(when: Option[Instant]): Option[Coordinates] =

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -191,15 +191,12 @@ object GhostAsterism {
       val pm1 = Target.pm.get(ifu1.spTarget.getTarget)
       val pm2 = Target.pm.get(ifu2.spTarget.getTarget)
 
-      // TODO: First, is this correct?  Second, what to do if the epoch doesn't
-      // match?
-      val dra  = pm1.map(_.deltaRA)  |+| pm2.map(_.deltaRA)
-      val ddec = pm1.map(_.deltaDec) |+| pm2.map(_.deltaDec)
-
+      // TODO: handle the proper motion epoch, somehow.  Perhaps epoch doesn't
+      // belong in PM anyway.
       for {
-        r <- dra
-        d <- ddec
-      } yield (ProperMotion(r, d))  // TODO: epoch
+        dra  <- pm1.map(_.deltaRA)  |+| pm2.map(_.deltaRA)
+        ddec <- pm1.map(_.deltaDec) |+| pm2.map(_.deltaDec)
+      } yield ProperMotion(dra, ddec)
     }
 
     def ifu1GuideFiberState(cc: CloudCover): GuideFiberState =

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -40,7 +40,8 @@ object GhostAsterism {
 
     val All = NonEmptyList(enabled, disabled)
 
-    implicit val EqualOiwfsState = Equal.equalA[OiwfsState]
+    implicit val EqualOiwfsState: Equal[OiwfsState] =
+      Equal.equalA[OiwfsState]
   }
 
 
@@ -102,7 +103,8 @@ object GhostAsterism {
 
     val All = NonEmptyList(one, two)
 
-    implicit val EqualXBinning = Equal.equalA[XBinning]
+    implicit val OrderXBinning: Order[XBinning] =
+      Order.orderBy(_.intValue)
   }
 
 
@@ -125,7 +127,8 @@ object GhostAsterism {
 
     val All = NonEmptyList(one, two, four, eight)
 
-    implicit val EqualYBinning = Equal.equalA[YBinning]
+    implicit val OrderYBinning: Order[YBinning] =
+      Order.orderBy(_.intValue)
   }
 
 
@@ -147,7 +150,8 @@ object GhostAsterism {
 
     val All = NonEmptyList(bright, faint, veryFaint)
 
-    implicit val EqualStandardResBinning = Equal.equalA[StandardResBinning]
+    implicit val EqualStandardResBinning: Equal[StandardResBinning] =
+      Equal.equalA[StandardResBinning]
   }
 
   /** GHOST two-target standard resolution asterism type.  In this mode, two
@@ -270,7 +274,8 @@ object GhostAsterism {
 
     val All = NonEmptyList(bright, faint)
 
-    implicit val EqualHighResBinning = Equal.equalA[HighResBinning]
+    implicit val EqualHighResBinning: Equal[HighResBinning] =
+      Equal.equalA[HighResBinning]
   }
 
 
@@ -287,7 +292,8 @@ object GhostAsterism {
 
     val All = NonEmptyList(on, off)
 
-    implicit val EqualFiberAgitatorState = Equal.equalA[FiberAgitatorState]
+    implicit val EqualFiberAgitatorState: Equal[FiberAgitatorState] =
+      Equal.equalA[FiberAgitatorState]
   }
 
   /** The high resolution asterism comes in two flavors, normal high resolution

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -1,0 +1,368 @@
+package edu.gemini.spModel.gemini.ghost
+
+import edu.gemini.spModel.core.{Coordinates, Magnitude, MagnitudeBand, MagnitudeSystem, Offset}
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.Asterism
+
+import java.time.{Duration, Instant}
+
+import scalaz._
+import Scalaz._
+
+/** Base trait for the three GHOST asterism types: two target, beam switching,
+  * and high resolution.
+  */
+sealed trait GhostAsterism extends Asterism {
+  import GhostAsterism.{XBinning, YBinning}
+
+  def xBinning: XBinning
+  def yBinning: YBinning
+}
+
+/** GHOST asterism model.
+  */
+object GhostAsterism {
+
+  /** The GHOST guide fibers can be enabled or disabled for each science target.
+    * Typically they are enabled for bright targets (< B mag 18 for standard
+    * resolution, < B mag 17 for high resolution) but disabled for faint targets.
+    * OIWFS state can also be explicitly disabled, say, in a crowded field where
+    * OIWFS is less effective.
+    */
+  sealed trait OiwfsState extends Product with Serializable
+
+  object OiwfsState {
+    case object Enabled  extends OiwfsState
+    case object Disabled extends OiwfsState
+
+    val enabled: OiwfsState  = Enabled
+    val disabled: OiwfsState = Disabled
+
+    val All = NonEmptyList(enabled, disabled)
+
+    implicit val EqualOiwfsState = Equal.equalA[OiwfsState]
+  }
+
+
+  /** GHOST targets are associated with a guiding state (enabled or disabled),
+    * referring to whether the dedicated guide fibers surrounding the science
+    * target should be used.
+    *
+    * There is a default guiding state based on magnitude, but this can be
+    * explicitly overridden.
+    */
+  final case class GhostTarget(target: SPTarget, explicitOiwfsState: Option[OiwfsState]) {
+
+    def coordinates(when: Option[Instant]): Option[Coordinates] =
+      target.getCoordinates(when.map(_.toEpochMilli))
+  }
+
+  object GhostTarget {
+
+    /** The magnitude at which OIWFS state is disabled by default at standard
+      * resolution.
+      */
+    val StandardResCutoff: Magnitude =
+      Magnitude(18.0, MagnitudeBand.B, None, MagnitudeSystem.Vega)
+
+    /** The magnitude at which OIWFS state is disabled by default at high
+      * resolution.
+      */
+    val HighResCutoff: Magnitude =
+      Magnitude(17.0, MagnitudeBand.B, None, MagnitudeSystem.Vega)
+
+    private def defaultOiwfsState(t: GhostTarget, cutoff: Magnitude): OiwfsState =
+      t.target.getMagnitude(MagnitudeBand.B).forall(_.value < cutoff.value) ? OiwfsState.enabled | OiwfsState.disabled
+
+    private def oiwfsState(t: GhostTarget, cutoff: Magnitude): OiwfsState =
+      t.explicitOiwfsState | defaultOiwfsState(t, cutoff)
+
+    /** Computes the OiwfsState for the given target in standard resolution mode. */
+    def standardResOiwfsState(t: GhostTarget): OiwfsState =
+      oiwfsState(t, StandardResCutoff)
+
+    /** Computes the OiwfsState for the given target in high resolution mode. */
+    def highResOiwfsState(t: GhostTarget): OiwfsState =
+      oiwfsState(t, HighResCutoff)
+  }
+
+
+  /** X-binning options. */
+  sealed abstract class XBinning(val intValue: Int) extends Product with Serializable {
+    override def toString: String =
+      intValue.toString
+  }
+
+  object XBinning {
+    case object One extends XBinning(1)
+    case object Two extends XBinning(2)
+
+    val one: XBinning = One
+    val two: XBinning = Two
+
+    val All = NonEmptyList(one, two)
+
+    implicit val EqualXBinning = Equal.equalA[XBinning]
+  }
+
+
+  /** Y-binning options. */
+  sealed abstract class YBinning(val intValue: Int) extends Product with Serializable {
+    override def toString: String =
+      intValue.toString
+  }
+
+  object YBinning {
+    case object One   extends YBinning(1)
+    case object Two   extends YBinning(2)
+    case object Four  extends YBinning(4)
+    case object Eight extends YBinning(8)
+
+    val one: YBinning   = One
+    val two: YBinning   = Two
+    val four: YBinning  = Four
+    val eight: YBinning = Eight
+
+    val All = NonEmptyList(one, two, four, eight)
+
+    implicit val EqualYBinning = Equal.equalA[YBinning]
+  }
+
+
+  /** Binning options for standard resolution.  The exact detector binning
+    * values differ depending on whether in two-target or object+sky mode.
+    * (TODO: can these be set automatically in terms of target magnitude? The
+    *  ConOps doc lists faint and very faint both as starting at mag 18.)
+    */
+  sealed trait StandardResBinning extends Product with Serializable
+
+  object StandardResBinning {
+    case object Bright    extends StandardResBinning
+    case object Faint     extends StandardResBinning
+    case object VeryFaint extends StandardResBinning
+
+    val bright: StandardResBinning    = Bright
+    val faint: StandardResBinning     = Faint
+    val veryFaint: StandardResBinning = VeryFaint
+
+    val All = NonEmptyList(bright, faint, veryFaint)
+
+    implicit val EqualStandardResBinning = Equal.equalA[StandardResBinning]
+  }
+
+  /** GHOST two-target standard resolution asterism type.  In this mode, two
+    * targets are observed simultaneously with both IFUs at standard resolution.
+    */
+  final case class TwoTarget(
+                     bin:  StandardResBinning,
+                     ifu1: GhostTarget,
+                     ifu2: GhostTarget) extends GhostAsterism {
+
+    /** Defines the targets in this asterism to be the two science targets. */
+    override def targets: NonEmptyList[SPTarget] =
+      NonEmptyList(ifu1.target, ifu2.target)
+
+    /** Calculates the coordinates exactly halfway along the great circle
+      * connecting the two targets.
+      */
+    override def basePosition(when: Instant): Option[Coordinates] =
+      for {
+        c1 <- ifu1.coordinates(Some(when))
+        c2 <- ifu2.coordinates(Some(when))
+      } yield c1.interpolate(c2, 0.5)
+
+    import StandardResBinning._
+
+    override def xBinning: XBinning =
+      bin match {
+        case Bright | Faint    => XBinning.One
+        case VeryFaint         => XBinning.Two
+      }
+
+    override def yBinning: YBinning =
+      bin match {
+        case Bright            => YBinning.Two
+        case Faint | VeryFaint => YBinning.Four
+      }
+
+    def ifu1OiwfsState: OiwfsState =
+      GhostTarget.standardResOiwfsState(ifu1)
+
+    def ifu2OiwfsState: OiwfsState =
+      GhostTarget.standardResOiwfsState(ifu2)
+  }
+
+
+  /** GHOST beam switching standard resolution asterism type.  In this mode, a
+    * target and sky position at a fixed coordinate are observed simultaneously
+    * with both IFUs at standard resultion.  There are two sky positions and
+    * the telescope switches IFU1 and IFU2 between the science object and the
+    * sky positions.  By default, the second sky position is diametrically
+    * opposed to the first position so that movement of the positioners can
+    * be avoided in favor of pure telescope movement.  A different sky
+    * position can be explicitly configured regardless if necessary.
+    *
+    * Since both IFUs observe the science object (at different times),
+    * it is assumed that assigning a particular IFU to start with is not
+    * necessary.
+    */
+  final case class BeamSwitching(
+                     bin:          StandardResBinning,
+                     target:       GhostTarget,
+                     sky1:         Coordinates,
+                     explicitSky2: Option[Coordinates]) extends GhostAsterism {
+
+    /** Defines the target list to be the single standard resolution target. */
+    override def targets: NonEmptyList[SPTarget] =
+      NonEmptyList(target.target)
+
+    /** Defines the base position to be the same as the target position. */
+    override def basePosition(when: Instant): Option[Coordinates] =
+      target.coordinates(Some(when))
+
+    import StandardResBinning._
+
+    override def xBinning: XBinning =
+      bin match {
+        case Bright | Faint    => XBinning.One
+        case VeryFaint         => XBinning.Two
+      }
+
+    override def yBinning: YBinning =
+      bin match {
+        case Bright            => YBinning.Two
+        case Faint | VeryFaint => YBinning.Eight
+      }
+
+    /** Deterimines the OIWFS state for the IFU observing the science object.
+      * For the IFU observing a sky position, OiwfsState is always disabled.
+      */
+    def oiwfsState: OiwfsState =
+      GhostTarget.standardResOiwfsState(target)
+
+    // Calculate the diametrically opposed position, assuming we know where
+    // the target is.
+    private def defaultSky2(when: Instant): Option[Coordinates] =
+      basePosition(when).map { bc =>
+        val off = Coordinates.difference(bc, sky1).offset * -1
+        bc.offset(off.p.toAngle, off.q.toAngle)
+      }
+
+    /** Gets the coordinates of the second sky position for beam-switching,
+      * assuming it is explicitly provided or else we know where the science
+      * target is at the given time.
+      */
+    def sky2(when: Instant): Option[Coordinates] =
+      explicitSky2 orElse defaultSky2(when)
+  }
+
+
+  /** Binning options for high resolution.
+    */
+  sealed trait HighResBinning extends Product with Serializable
+
+  object HighResBinning {
+    case object Bright extends HighResBinning
+    case object Faint  extends HighResBinning
+
+    val bright: HighResBinning = Bright
+    val faint: HighResBinning  = Faint
+
+    val All = NonEmptyList(bright, faint)
+
+    implicit val EqualHighResBinning = Equal.equalA[HighResBinning]
+  }
+
+
+  /** Fiber agitator state.
+    */
+  sealed trait FiberAgitatorState extends Product with Serializable
+
+  object FiberAgitatorState {
+    case object On  extends FiberAgitatorState
+    case object Off extends FiberAgitatorState
+
+    val on: FiberAgitatorState  = On
+    val off: FiberAgitatorState = Off
+
+    val All = NonEmptyList(on, off)
+
+    implicit val EqualFiberAgitatorState = Equal.equalA[FiberAgitatorState]
+  }
+
+  /** The high resolution asterism comes in two flavors, normal high resolution
+    * mode and precision radial velocity (PRV) mode.  Normal high resolution
+    * mode can use bright or faint detector binning, but PRV is always bright.
+    * PRV can be set up with fiber agitation while normal high resolution mode
+    * cannot.
+    */
+  sealed trait HighResMode extends Product with Serializable {
+    import HighResMode._
+    import HighResBinning._
+
+    def xBinning: XBinning =
+      XBinning.One
+
+    def yBinning: YBinning =
+      this match {
+        case Normal(bin) =>
+          bin match {
+            case Bright => YBinning.One
+            case Faint  => YBinning.Eight
+          }
+
+        case Prv(_, _)   =>
+          YBinning.One
+      }
+  }
+
+  object HighResMode {
+
+    /** Normal high res mode can use bright or faint binning options. (Prv is
+      * always bright).
+      */
+    final case class Normal(bin: HighResBinning) extends HighResMode
+
+    /** Prv can be set up with a fiber agitator. The simultaneous calibration
+      * lamp can default to an appropriate value for the target magnitude, or
+      * can be explicitly set to a particular duration.
+      *
+      * (TODO: Do we need to be able to turn off the lamp altogether?  Perhaps
+      * that is the same as setting the duration to 0.)
+      */
+    final case class Prv(agitator: FiberAgitatorState, calDuration: Option[Duration]) extends HighResMode
+  }
+
+  /** High resolution GHOST asterism.
+    *
+    * The target is always observed using the high resolution IFU1.  The sky
+    * coordinates are observed using the sky fibers of IFU2, not SRIFU2. The
+    * guide fibers will be used by default because the target must be bright,
+    * but can be explicitly turned off.
+    */
+  final case class HighRes(
+                     mode:   HighResMode,
+                     target: GhostTarget,
+                     sky:    Coordinates) extends GhostAsterism {
+
+    /** Defines the target list to be the single high resolution target. */
+    override def targets: NonEmptyList[SPTarget] =
+      NonEmptyList(target.target)
+
+    /** Defines the base position to be the same as the target position. */
+    override def basePosition(when: Instant): Option[Coordinates] =
+      target.coordinates(Some(when))
+
+    override def xBinning: XBinning =
+      mode.xBinning
+
+    override def yBinning: YBinning =
+      mode.yBinning
+
+    /** Deterimines the OIWFS state for the HRIFU1.  Typically this will be
+      * enabled since the target is bright but may be explicitly turned off.
+      */
+    def oiwfsState: OiwfsState =
+      GhostTarget.highResOiwfsState(target)
+  }
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -29,14 +29,7 @@ trait Asterism {
     allSpTargets.list.toList.asImList
 
   /** All Targets that comprise the asterism. */
-  def allTargets: NonEmptyList[Target] =
-    targets.fold(NonEmptyList(_), p => NonEmptyList(p._1, p._2))
-
-  /** An asterism is a single generic target, or a pair of sidereal targets. These are currently the
-    * only possibilities.
-    * TODO: should we Church encode this instead?
-    */
-  def targets: Target \/ (Target, Target)
+  def allTargets: NonEmptyList[Target]
 
   /** Slew coordinates and AGS calculation base position. */
   def basePosition(time: Option[Instant]): Option[Coordinates]
@@ -102,7 +95,6 @@ object Asterism {
   // N.B. most members must be defs because `t` is mutable.
   final case class Single(t: SPTarget) extends Asterism {
     override def allSpTargets = NonEmptyList(t) // def because Nel isn't serializable
-    override def targets = t.getTarget.left
     override def allTargets = NonEmptyList(t.getTarget)
     override def basePosition(time: Option[Instant]) = t.getCoordinates(time.map(_.toEpochMilli))
     override def copyWithClonedTargets() = Single(t.clone)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -102,6 +102,7 @@ object Asterism {
   // N.B. most members must be defs because `t` is mutable.
   final case class Single(t: SPTarget) extends Asterism {
     override def allSpTargets = NonEmptyList(t) // def because Nel isn't serializable
+    override def targets = t.getTarget.left
     override def allTargets = NonEmptyList(t.getTarget)
     override def basePosition(time: Option[Instant]) = t.getCoordinates(time.map(_.toEpochMilli))
     override def copyWithClonedTargets() = Single(t.clone)


### PR DESCRIPTION
Based on a careful reading of the GHOST ConOps document, this PR represents an initial attempt at defining the GHOST asterism data model.  GHOST offers a fairly sophisticated set of modes and configuration options.  Not all options are applicable to all modes.  Rather than creating a generic `Asterism` implementation that contains mutually exclusive options, I'm attempting to constrain the choices to match those available in the various operating modes.  This helps guide user interface development and limits the possibility of ending up in an inconsistent state.

I expect there will be a number of iterations required to get the model in good shape.  When the changes die down I anticipate adding `Lens`es to make it easier to manipulate.

A few outstanding questions for science-staff include:

1) __Explicit Guide Fiber State__.  The ConOps document details the need to allow the user to explicitly enable or disable guide fibers.  Bryan asked a reasonable question that I didn't see an answer to yet.  Namely, do we really need this?  Usually we can default the state based on target magnitude.  Would the user know enough to go against the default settings or can the ability to turn guiding on or off explicitly be relegated to lower-level control screens that only a telescope operator would see?  As you can see in the model, making it overridable introduces a degree of additional complexity. 

2) __Cloud Cover__.  The rules for defaulting guide fiber state don't take into account cloud cover.  I assume that will be necessary.  Does anybody have more details there?

3) __Beam-Switching Modes__.  In my effort estimation document Bryan notes that we won't add explicit support for beam-switching modes.  This confuses me since it has a prominent place in the "Instrument Operating Modes" section.  If we are doing beam-switching as described in ConOps, I'd prefer to make it explicit and constrain the configuration as described rather than infer beam-switching from the asterism plus other targets in the target environment.  Does anybody have any further input about this?

4) __Explicit Binning__. This question is similar to the one about guiding state, but the model as it stands took the opposite approach.  Namely, binning is always defaulted here based on mode.  The ConOps document does mention a desire for the user to be able to explicitly set the value to anything but this is not (yet) implemented.  Is this really something that is needed in the user interface?

5) __Default Binning__.  Rather than specifying bright/faint/very faint can we infer this from the target magnitude (+ cloud cover?).  Table 9 doesn't make it clear how we would select between faint and very faint so I didn't do this.

6) __Two Target Base Position__.  I believe Bryan mentioned a desire to allow the definition of a base position at some point other than the default position between the two targets.  I don't see this mentioned in the ConOps document.  I'd prefer to avoid this complication unless it is really needed of course.
