### PR TITLE
WIP - asterism suffering

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
@@ -59,13 +59,13 @@ object AgsHash {
     // Base Position
     Option(ctx.getTargets).foreach { t =>
       val time = Some(new java.lang.Long(when)).asGeminiOpt
-      val base = t.getBase
+      val asterism = t.getAsterism
 
       def toData(coord: GemOption[java.lang.Double]): Int =
         coord.asScalaOpt.map(_.doubleValue).##
 
-      val ra  = toData(base.getRaDegrees(time))
-      val dec = toData(base.getDecDegrees(time))
+      val ra  = toData(asterism.getRaDegrees(time))
+      val dec = toData(asterism.getDecDegrees(time))
 
       ra +=: dec +=: buf
     }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
@@ -7,12 +7,12 @@ import edu.gemini.spModel.gemini.altair.InstAltair
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.gmos.{InstGmosNorth, InstGmosSouth}
 import edu.gemini.spModel.obs.context.ObsContext
-
 import java.time.Instant
+
+import edu.gemini.spModel.target.SPTarget
 
 import scala.collection.mutable.ListBuffer
 import scala.util.hashing.{MurmurHash3 => M3}
-
 import scala.collection.JavaConverters._
 
 /** Computes an `Int` hash value that corresponds to the set of inputs to the
@@ -56,18 +56,17 @@ object AgsHash {
       c.cc.## +=: c.iq.## +=: c.sb.## +=: buf
     }
 
-    // Base Position
-    Option(ctx.getTargets).foreach { t =>
+    // Asterism
+    Option(ctx.getTargets).foreach { env =>
       val time = Some(new java.lang.Long(when)).asGeminiOpt
-      val asterism = t.getAsterism
-
-      def toData(coord: GemOption[java.lang.Double]): Int =
-        coord.asScalaOpt.map(_.doubleValue).##
-
-      val ra  = toData(asterism.getRaDegrees(time))
-      val dec = toData(asterism.getDecDegrees(time))
-
-      ra +=: dec +=: buf
+      def hashTarget(t: SPTarget): Unit = {
+        def toData(coord: GemOption[java.lang.Double]): Int =
+          coord.asScalaOpt.map(_.doubleValue).##
+        val ra  = toData(t.getRaDegrees(time))
+        val dec = toData(t.getDecDegrees(time))
+        ra +=: dec +=: buf
+      }
+      env.getAsterism.targets.foreach(hashTarget)
     }
 
     // Offset Positions, which are returned in a Set.  Order is not important

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -23,17 +23,21 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, probeBands).toList
 
-  override def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = {
-    val so = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
-    Future.successful(List((guideProbe, List(so))))
+  private def toSiderealTargets(ctx: ObsContext): List[SiderealTarget] = {
+    val when = ctx.getSchedulingBlockStart
+    val ts   = ctx.getTargets.getAsterism.targets.map(_.toSiderealTarget(when))
+    ts.list.toList
   }
+
+  override def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] =
+    Future.successful(List((guideProbe, toSiderealTargets(ctx))))
 
   override def select(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] = {
     // The science target is the guide star, but must be converted from SPTarget to SkyObject.
-    val siderealTarget = ctx.getTargets.getBase.toSiderealTarget(ctx.getSchedulingBlockStart)
-    val posAngle       = ctx.getPositionAngle
-    val assignment     = AgsStrategy.Assignment(guideProbe, siderealTarget)
-    val selection      = AgsStrategy.Selection(posAngle, List(assignment))
+    val siderealTargets = toSiderealTargets(ctx)
+    val assignments     = siderealTargets.map(AgsStrategy.Assignment(guideProbe, _))
+    val posAngle        = ctx.getPositionAngle
+    val selection       = AgsStrategy.Selection(posAngle, assignments)
     Future.successful(Some(selection))
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -71,7 +71,7 @@ object Strategy {
   }
 
   def isSidereal(ctx: ObsContext): Boolean =
-    ctx.getTargets.getBase.isSidereal
+    ctx.getTargets.getAsterism.isSidereal
 
   val InstMap = Map[SPComponentType, ObsContext => List[AgsStrategy]](
     SPComponentType.INSTRUMENT_ACQCAM     -> const(List(Pwfs1North, Pwfs2North, Pwfs1South, Pwfs2South)),

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/altair/AltairRule.java
@@ -291,7 +291,7 @@ public final class AltairRule implements IRule {
         if (altairTargets.isDefined()) {
             final Option<SPTarget> primaryAltairTarget = altairTargets.getValue().getPrimary();
             if (primaryAltairTarget.isDefined()) {
-                final Option<Coordinates> science = targets.getBase().getSkycalcCoordinates(when);
+                final Option<Coordinates> science = targets.getAsterism().getSkycalcCoordinates(when);
                 final Option<Coordinates> altair  = primaryAltairTarget.getValue().getSkycalcCoordinates(when);
                 return !science.equals(altair);
             }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gpi/GpiRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gpi/GpiRule.java
@@ -8,6 +8,7 @@ import edu.gemini.spModel.core.Magnitude;
 import edu.gemini.spModel.core.MagnitudeBand;
 import edu.gemini.spModel.gemini.gpi.Gpi;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 
 import java.util.*;
@@ -162,9 +163,9 @@ public class GpiRule implements IRule {
 
                 P2Problems problems = new P2Problems();
                 TargetEnvironment env = obsComp.getTargetEnvironment();
-                SPTarget base = env.getBase();
-                scala.Option<Magnitude> imag = base.getMagnitude(MagnitudeBand.I$.MODULE$);
-                scala.Option<Magnitude> hmag = base.getMagnitude(MagnitudeBand.H$.MODULE$);
+                Asterism asterism = env.getAsterism();
+                scala.Option<Magnitude> imag = asterism.ifSingleJava().getMagnitude(MagnitudeBand.I$.MODULE$);
+                scala.Option<Magnitude> hmag = asterism.ifSingleJava().getMagnitude(MagnitudeBand.H$.MODULE$);
                 // OT-74
                 if (imag.isEmpty()) {
                     problems.addError(PREFIX + "MAG_BAND_MESSAGE", MAG_BAND_MESSAGE + "I-band.", elements.getTargetObsComponentNode().getValue());
@@ -179,7 +180,7 @@ public class GpiRule implements IRule {
                     if (!inst.getObservingMode().isEmpty()) {
                         Gpi.ObservingMode obsMode = inst.getObservingMode().getValue();
                         MagnitudeBand band = inst.getFilter().getBand(); // OT-102: obsMode could be NONSTANDARD
-                        scala.Option<Magnitude> mag = base.getMagnitude(band);
+                        scala.Option<Magnitude> mag = asterism.ifSingleJava().getMagnitude(band);
                         if (mag.isEmpty()) {
                             // OT-99
                             problems.addError(PREFIX + "MAG_BAND_MESSAGE", MAG_BAND_MESSAGE + band + "-band",

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/nifs/NifsRule.java
@@ -18,6 +18,7 @@ import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obscomp.InstConstants;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 
@@ -184,17 +185,17 @@ public final class NifsRule implements IRule {
         P2Problems prob = new P2Problems();
         public IP2Problems check(ObservationElements elements)  {
             for (ObsContext ctx : elements.getObsContext()) {
-                final SPTarget baseTarget       = ctx.getTargets().getBase();
+                final Asterism asterism       = ctx.getTargets().getAsterism();
                 final Option<SPTarget> oiTarget = getOITarget(ctx);
                 final Option<SPTarget> aoTarget = getAOTarget(ctx);
 
-                if (baseTarget == null || oiTarget.isEmpty() || aoTarget.isEmpty()) return null;
+                if (asterism == null || oiTarget.isEmpty() || aoTarget.isEmpty()) return null;
                 //now, let's compare coordinates. If they are the same, raise an error
 
                 final Option<Long> when = elements.getSchedulingBlockStart();
 
-                baseTarget.getRaHours(when).foreach(baseC1 ->
-                baseTarget.getDecDegrees(when).foreach(baseC2 ->
+                asterism.getRaHours(when).foreach(baseC1 ->
+                asterism.getDecDegrees(when).foreach(baseC2 ->
 
                 oiTarget.getValue().getRaHours(when).foreach(oiC1 ->
                 oiTarget.getValue().getDecDegrees(when).foreach(oiC2 ->

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/trecs/TrecsRule.java
@@ -12,6 +12,7 @@ import edu.gemini.spModel.gemini.trecs.TReCSParams.Filter;
 import edu.gemini.spModel.gemini.trecs.TReCSParams.Mask;
 import edu.gemini.spModel.gemini.trecs.TReCSParams.WindowWheel;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
@@ -327,8 +328,8 @@ public class TrecsRule implements IRule {
             for (TargetObsComp targetObsComp : elements.getTargetObsComp()) {
 
                 TargetEnvironment env = targetObsComp.getTargetEnvironment();
-                SPTarget baseTarget = env.getBase();
-                if (baseTarget == null) return null;
+                Asterism asterism = env.getAsterism();
+                if (asterism == null) return null;
 
 
                 for (GuideProbeTargets guideTargets : env.getPrimaryGuideGroup()) {
@@ -337,7 +338,7 @@ public class TrecsRule implements IRule {
                         // Calculate the distance to the base position in arcmin
                         final Option<Long> when = elements.getSchedulingBlock().map(b -> b.start());
 
-                        Option<WorldCoords> oBasePos = _getWorldCoords(baseTarget, when);
+                        Option<WorldCoords> oBasePos = _getWorldCoords(asterism, when);
                         Option<WorldCoords> oPos = _getWorldCoords(target, when);
 
                         oBasePos.foreach(basePos ->
@@ -366,6 +367,14 @@ public class TrecsRule implements IRule {
                    tp.getDecDegrees(time).map(dec ->
                      new WorldCoords(ra, dec, 2000.)));
         }
+
+        // Return the world coordinates for the given astrism
+        private Option<WorldCoords> _getWorldCoords(Asterism tp, Option<Long> time) {
+          return tp.getRaDegrees(time).flatMap( ra ->
+                  tp.getDecDegrees(time).map(dec ->
+                          new WorldCoords(ra, dec, 2000.)));
+        }
+
     };
 
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/Canopus.java
@@ -9,6 +9,7 @@ import edu.gemini.spModel.gems.GemsGuideProbeGroup;
 import edu.gemini.spModel.guide.*;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.telescope.IssPort;
@@ -329,13 +330,13 @@ public enum Canopus {
         Option<SPTarget> spTargetOpt = getPrimaryCwfs3(ctx);
         if (spTargetOpt.isEmpty()) return None.instance();
 
-        SPTarget base   = ctx.getTargets().getBase();
+        Asterism asterism   = ctx.getTargets().getAsterism();
         SPTarget target = spTargetOpt.getValue();
 
         final Option<Long> when = ctx.getSchedulingBlockStart();
 
         return
-            base.getSkycalcCoordinates(when).flatMap(bc ->
+            asterism.getSkycalcCoordinates(when).flatMap(bc ->
             target.getSkycalcCoordinates(when).map(tc -> {
                 CoordinateDiff diff = new CoordinateDiff(bc, tc);
                 Offset o = diff.getOffset();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
@@ -92,11 +92,9 @@ public class GpiCB extends AbstractObsComponentCB {
         if (targetcomp != null) {
             final TargetObsComp toc = (TargetObsComp) targetcomp.getDataObject();
             if (toc != null) {
-                if (toc.getTargetEnvironment().getBase() != null) {
-                    ImList<Magnitude> magnitudes = toc.getTargetEnvironment().getBase().getMagnitudesJava();
-                    magnitudes.filter(new MagnitudeFilter(MagnitudeBand.H$.MODULE$)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_H_PROP));
-                    magnitudes.filter(new MagnitudeFilter(MagnitudeBand.I$.MODULE$)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_I_PROP));
-                }
+                  ImList<Magnitude> magnitudes = toc.getTargetEnvironment().getAsterism().ifSingleJava().getMagnitudesJava();
+                  magnitudes.filter(new MagnitudeFilter(MagnitudeBand.H$.MODULE$)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_H_PROP));
+                  magnitudes.filter(new MagnitudeFilter(MagnitudeBand.I$.MODULE$)).headOption().foreach(new MagnitudeSetter(Gpi.MAG_I_PROP));
             }
         }
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/context/ObsContext.java
@@ -17,6 +17,7 @@ import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obs.SchedulingBlock;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
@@ -266,10 +267,10 @@ public final class ObsContext {
 
     public Option<Coordinates> getBaseCoordinates() {
         final Option<Long> when = getSchedulingBlockStart();
-        SPTarget target = targets.getBase();
+        Asterism asterism = targets.getAsterism();
         return
-            target.getRaDegrees(when).flatMap(raDeg ->
-            target.getDecDegrees(when).map(decDeg ->
+            asterism.getRaDegrees(when).flatMap(raDeg ->
+            asterism.getDecDegrees(when).map(decDeg ->
                 new Coordinates(raDeg, decDeg)
             ));
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -84,6 +84,14 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
     }
 
     /**
+     * Gets the asterism in this environment. This method will never return <code>null</code>
+     * because the environment always has to contain an asterism.
+     */
+    public Asterism getAsterism() {
+      return Asterism$.MODULE$.single(base);
+    }
+
+    /**
      * Gets the collection of {@link GuideGroup}s in this target environment.
      *
      * @return the {@link GuideEnvironment} in this target environment

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -10,6 +10,7 @@ import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.TelescopePosWatcher;
 import edu.gemini.spModel.target.WatchablePos;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 
 import java.io.IOException;
@@ -74,14 +75,10 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
     public String getTitle() {
         // Always compute the name; the UI disallows changes.
         final TargetEnvironment env = getTargetEnvironment();
-        final SPTarget tp = env.getBase();
-        if (tp != null) {
-            final String initName  = tp.getName();
-            final String finalName = initName == null || initName.trim().isEmpty() ? "<Untitled>" : initName;
-            return helper.targetTag(tp.getTarget()) + ": " + finalName;
-        } else {
-            return super.getTitle();
-        }
+        final Asterism a = env.getAsterism();
+        final String initName  = a.getName();
+        final String finalName = initName == null || initName.trim().isEmpty() ? "<Untitled>" : initName;
+        return helper.targetTag(a) + ": " + finalName;
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
@@ -50,7 +50,7 @@ public class TargetObsCompCB extends AbstractObsComponentCB {
 
         // Patch for a problem in 2009B.1.1.1.  The "telescope:Base:name" param
         // was missing, which caused the FITS OBJECT keyword to be incorrect.
-        String baseName = env.getBase().getName();
+        String baseName = env.getAsterism().getName();
         if ((baseName != null) && !"".equals(baseName)) {
             DefaultConfigParameter cp = DefaultConfigParameter.getInstance("Base");
             ISysConfig sc = (ISysConfig) cp.getValue();

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obs/ObsTargetCalculatorService.scala
@@ -31,7 +31,7 @@ object ObsTargetCalculatorService {
       _.getDataObject
         .asInstanceOf[TargetObsComp]
         .getTargetEnvironment
-        .getBase
+        .getAsterism
         .getSkycalcCoordinates(block.map(_.start : java.lang.Long).asGeminiOpt).asScalaOpt
     }
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -1,15 +1,14 @@
 package edu.gemini.spModel.target.env
 
-import edu.gemini.spModel.core.Coordinates
+import edu.gemini.spModel.core._
 import edu.gemini.spModel.target.SPTarget
-import edu.gemini.shared.util.immutable.{Option => GOption}
+import edu.gemini.shared.util.immutable.{DefaultImList, ImList, Option => GOption}
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.skycalc.{Coordinates => SCoordinates}
-
-
 import java.time.Instant
 
-import scalaz.NonEmptyList
+import scalaz._
+import Scalaz._
 
 /** Collection of stars that make up the science target(s) for an observation,
   * along with any configuration details unique to the instrument in use.
@@ -26,6 +25,14 @@ trait Asterism {
     */
   def basePosition(time: Instant): Option[Coordinates] =
     ???  // we should supply the "smallest-circle" implementation here
+
+  /** An Asterism is considered sidereal if and only if all targets are sidereal. */
+  def isSidereal: Boolean =
+    targets.all(_.isSidereal)
+
+  /** An Asterism is considered non-sidereal if any targets is non-sidereal. */
+  def isNonSidereal: Boolean =
+    targets.any(_.isNonSidereal)
 
   //
   // "Base position" convenience methods already in use extensively throughout
@@ -60,15 +67,50 @@ trait Asterism {
 
   def getSkycalcCoordinates(time: GOLong): GOption[SCoordinates] =
     gcoords(time)(cs => new SCoordinates(cs.ra.toDegrees, cs.dec.toDegrees))
+
+  /** Module of partial methods that apply only to single-target asterisms. Accessors return empty
+    * if this is a GHOST asterism.
+    */
+  object ifSingle {
+
+    def getBase: Option[SPTarget] =
+      Some(Asterism.this) collect {
+        case Asterism.Single(t) => t
+      }
+
+    def getSpectralDistribution: Option[SpectralDistribution] =
+      getBase.flatMap(_.getSpectralDistribution)
+
+    def getSpatialProfile: Option[SpatialProfile] =
+      getBase.flatMap(_.getSpatialProfile)
+
+    def getSiderealTarget: Option[SiderealTarget] =
+      getBase.flatMap(_.getSiderealTarget)
+
+    def getMagnitude(band: MagnitudeBand): Option[Magnitude] =
+      getBase.flatMap(_.getMagnitude(band))
+
+    def getMagnitudesJava: ImList[Magnitude] =
+      getBase.map(_.getMagnitudesJava).getOrElse(DefaultImList.create[Magnitude]())
+
+    def getNonSiderealTarget: Option[NonSiderealTarget] =
+      getBase.flatMap(_.getNonSiderealTarget)
+
+  }
+
+  def ifSingleJava: ifSingle.type =
+    ifSingle
+
 }
 
 object Asterism {
 
+  final case class Single(t: SPTarget) extends Asterism {
+    val targets = NonEmptyList(t)
+    override def basePosition(time: Instant) = t.getCoordinates(Option(time.toEpochMilli))
+  }
+
   /** Construct a single-target Asterism by wrapping the given SPTarget. */
-  def single(t: SPTarget): Asterism =
-    new Asterism {
-      val targets = NonEmptyList(t)
-      override def basePosition(time: Instant) = t.getCoordinates(Option(time.toEpochMilli))
-    }
+  def single(t: SPTarget): Asterism = Single(t)
 
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -61,3 +61,14 @@ trait Asterism {
   def getSkycalcCoordinates(time: GOLong): GOption[SCoordinates] =
     gcoords(time)(cs => new SCoordinates(cs.ra.toDegrees, cs.dec.toDegrees))
 }
+
+object Asterism {
+
+  /** Construct a single-target Asterism by wrapping the given SPTarget. */
+  def single(t: SPTarget): Asterism =
+    new Asterism {
+      val targets = NonEmptyList(t)
+      override def basePosition(time: Instant) = t.getCoordinates(Option(time.toEpochMilli))
+    }
+
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -34,6 +34,10 @@ trait Asterism {
   def isNonSidereal: Boolean =
     targets.any(_.isNonSidereal)
 
+  /** An Asterism's name is the concatenation of it's target's names. */
+  def getName: String =
+    targets.map(_.getName).intercalate(", ")
+
   //
   // "Base position" convenience methods already in use extensively throughout
   // the codebase.  Defined in terms of the base position, these are methods

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -23,7 +23,7 @@ trait Asterism {
     * will be a computation that finds the coordinate minimizing the maximum
     * distance to any target in the asterism.
     */
-  def basePosition(time: Instant): Option[Coordinates] =
+  def basePosition(time: Option[Instant]): Option[Coordinates] =
     ???  // we should supply the "smallest-circle" implementation here
 
   /** An Asterism is considered sidereal if and only if all targets are sidereal. */
@@ -49,10 +49,7 @@ trait Asterism {
   type GODouble = GOption[java.lang.Double]
 
   private def gcoords[A](time: GOLong)(f: Coordinates => A): GOption[A] =
-    (for {
-      t <- time.asScalaOpt
-      c <- basePosition(Instant.ofEpochMilli(t))
-    } yield f(c)).asGeminiOpt
+    basePosition(time.asScalaOpt.map(Instant.ofEpochMilli(_))).map(f).asGeminiOpt
 
   def getRaHours(time: GOLong): GODouble =
     gcoords(time)(_.ra.toHours)
@@ -111,7 +108,7 @@ object Asterism {
 
   final case class Single(t: SPTarget) extends Asterism {
     val targets = NonEmptyList(t)
-    override def basePosition(time: Instant) = t.getCoordinates(Option(time.toEpochMilli))
+    override def basePosition(time: Option[Instant]) = t.getCoordinates(time.map(_.toEpochMilli))
   }
 
   /** Construct a single-target Asterism by wrapping the given SPTarget. */

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/obsComp/TargetObsCompHelper.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/obsComp/TargetObsCompHelper.scala
@@ -1,21 +1,27 @@
 package edu.gemini.spModel.target.obsComp
 
 import edu.gemini.spModel.core.{HorizonsDesignation, Target}
+import edu.gemini.spModel.target.env.Asterism
 
 class TargetObsCompHelper {
   import HorizonsDesignation._
 
-  def targetTag(t: Target): String =
-    t.fold(
-      _ => "TOO",
-      _ => "Target",
-      _.horizonsDesignation match {
-        case None                      => "Nonsidereal"
-        case Some(AsteroidNewStyle(_)) |
-             Some(AsteroidOldStyle(_)) => "Asteroid"
-        case Some(Comet(_))            => "Comet"
-        case Some(MajorBody(_))        => "Major Body"
-      }
-    )
+  def targetTag(a: Asterism): String =
+    a match {
+      case Asterism.Single(t) =>
+        t.getTarget.fold(
+          _ => "TOO",
+          _ => "Target",
+          _.horizonsDesignation match {
+            case None                      => "Nonsidereal"
+            case Some(AsteroidNewStyle(_)) |
+                 Some(AsteroidOldStyle(_)) => "Asteroid"
+            case Some(Comet(_))            => "Comet"
+            case Some(MajorBody(_))        => "Major Body"
+          }
+        )
+      case _ => "Asterism"
+    }
+
 
 }

--- a/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/TargetEnvironmentListener.scala
+++ b/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/core/listeners/TargetEnvironmentListener.scala
@@ -56,7 +56,7 @@ class TargetEnvironmentListener extends MarkerModelListener[Variant] {
       }
 
       // Check for non-sidereal targets.
-      if (targetEnvironment.getBase.isNonSidereal) {
+      if (targetEnvironment.getAsterism.isNonSidereal) {
         markerManager.addMarker(false, this, Marker.Severity.Warning, "Observation has a non-sidereal target.", variant, a)
       }
 

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -771,7 +771,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
      */
     public boolean isSidereal() {
         assert targetEnvironment != null;
-        return targetEnvironment.getBase().isSidereal();
+        return targetEnvironment.getAsterism().isSidereal();
     }
 
     /**
@@ -780,7 +780,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
      */
     public boolean isNonSidereal() {
         assert targetEnvironment != null;
-        return targetEnvironment.getBase().isNonSidereal();
+        return targetEnvironment.getAsterism().isNonSidereal();
     }
 
     public Object getConstraintsString() {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -575,11 +575,11 @@ public final class Obs implements Serializable, Comparable<Obs> {
     }
 
 	public double getRa() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getRaDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getAsterism().getRaDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
 	}
 
 	public double getDec() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getDecDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getAsterism().getDecDegrees(schedulingBlock.map(SchedulingBlock::start)).getOrElse(0.0) : 0.0);
 	}
 
     public Conds getConditions() {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -403,7 +403,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
     }
 
     public String getTargetName() {
-        return (targetEnvironment != null ? targetEnvironment.getBase().getName() : "");
+        return (targetEnvironment != null ? targetEnvironment.getAsterism().getName() : "");
     }
 
     public String getWavefrontSensors() {

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/NonSiderealCache.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/NonSiderealCache.scala
@@ -49,7 +49,7 @@ object NonSiderealCache {
    */
   def isHorizonsTarget(obs: Obs): Boolean =
     // QV only deals with "valid" observations, i.e. target environment, base and target all have to be set
-    obs.getTargetEnvironment.getBase.isNonSidereal
+    obs.getTargetEnvironment.getAsterism.isNonSidereal
 
   def get(nights: Seq[Night], obs: Obs): NonSiderealTarget = {
     require(isHorizonsTarget(obs))
@@ -82,8 +82,8 @@ object NonSiderealCache {
    * @return
    */
   def horizonsNameFor(obs: Obs): Option[HorizonsDesignation] =
-    obs.getTargetEnvironment.getBase.getTarget match {
-      case n: core.NonSiderealTarget => n.horizonsDesignation
+    obs.getTargetEnvironment.getAsterism.ifSingle.getBase.map(_.getTarget) match {
+      case Some(n: core.NonSiderealTarget) => n.horizonsDesignation
       case _ =>
         LOG.warning(s"Don't know how to get Horizons name for this target ${obs.getObsId}.")
         None

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
@@ -20,7 +20,7 @@ final class Ephemeris(val site: Site, val compressedData: Deflated[List[(Long, F
 
     // Decompress if needed
     if (_data == null) {
-      logger.info("Inflating compressed ephemeris.")
+      logger.finest("Inflating compressed ephemeris.")
       _data = ==>>.fromList(compressedData.inflate.map { case (t, r, d) =>
         t -> Coordinates.fromDegrees(r, d).getOrElse(sys.error(s"corrupted ephemeris data: $t $r $d"))
       })
@@ -30,7 +30,7 @@ final class Ephemeris(val site: Site, val compressedData: Deflated[List[(Long, F
     if (_task != null) _task.cancel()
     _task = new TimerTask {
       def run(): Unit = {
-        logger.info("Discarding inflated ephemeris.")
+        logger.finest("Discarding inflated ephemeris.")
         Ephemeris.this.synchronized(_data = null)
       }
     }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
@@ -23,8 +23,8 @@ class PlutoDemotionTest extends MigrationTest {
       .find(_.getType == SPComponentType.TELESCOPE_TARGETENV).get
       .getDataObject.asInstanceOf[TargetObsComp]
       .getTargetEnvironment
-      .getBase.getTarget match {
-          case NonSiderealTarget("Pluto", e, None, Nil, None, None) =>
+      .getAsterism.ifSingle.getBase.map(_.getTarget) match {
+          case Some(NonSiderealTarget("Pluto", e, None, Nil, None, None)) =>
             e.toList match {
               case List((t, c)) =>
 
@@ -34,7 +34,7 @@ class PlutoDemotionTest extends MigrationTest {
 
               case e => Assert.fail("Expected 1-element ephemeris, found " + e)
             }
-          case t => Assert.fail("Expected Pluto, found " + t)
+          case t => Assert.fail("Expected Some(Pluto), found " + t)
         }
 
 }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2017A/EphemerisConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2017A/EphemerisConversionTest.scala
@@ -24,7 +24,7 @@ class EphemerisConversionTest extends Specification with MigrationTest{
     "Convert non-sidereal ephemeris data to compressed ephemeris data" in withTestProgram2("vesta.xml") { p =>
       (for {
         oc <- p.getObservations.get(0).findObsComponentByType(SPComponentType.TELESCOPE_TARGETENV)
-        ns <- oc.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment.getBase.getNonSiderealTarget
+        ns <- oc.getDataObject.asInstanceOf[TargetObsComp].getTargetEnvironment.getAsterism.ifSingle.getNonSiderealTarget
       } yield ns.ephemeris).get ~= expected
     }
   }

--- a/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
+++ b/bundle/edu.gemini.spdb.rollover.servlet/src/main/scala/edu/gemini/rollover/servlet/RolloverObservation.scala
@@ -47,7 +47,7 @@ object RolloverObservation {
       targetComp <- findByType(o, TargetObsComp.SP_TYPE)
       dataObj    <- Option(targetComp.getDataObject.asInstanceOf[TargetObsComp])
       targetEnv  <- Option(dataObj.getTargetEnvironment)
-      science    <- Option(targetEnv.getBase)
+      science    <- Option(targetEnv.getAsterism)
       name       <- Option(science.getName)
     } yield {
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -126,7 +126,7 @@ public final class ObservationEnvironment {
     }
 
     public String getBasePositionName() {
-        return _targetEnv.getBase().getName();
+        return _targetEnv.getAsterism().getName();
     }
 
     public boolean isNorth() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/plot/ObsTargetDesc.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/plot/ObsTargetDesc.java
@@ -18,6 +18,7 @@ import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obs.TimingWindowSolver;
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeSummaryService;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.time.TimeAmountFormatter;
@@ -63,15 +64,15 @@ public class ObsTargetDesc extends TargetDesc {
         TargetEnvironment targetEnv = _findTargetEnv(obs);
         if (targetEnv == null) return null;
 
-        SPTarget basePos = targetEnv.getBase();
+        Asterism asterism = targetEnv.getAsterism();
 
         Function<Option<Long>, Option<WorldCoords>> pos = op ->
-            basePos.getRaDegrees(op).flatMap(x ->
-            basePos.getDecDegrees(op).map(y ->
+            asterism.getRaDegrees(op).flatMap(x ->
+            asterism.getDecDegrees(op).map(y ->
                 new WorldCoords(x, y, 2000.)
             ));
 
-                 String targetName = basePos.getName();
+                 String targetName = asterism.getName();
 
         String obsId = "";
         SPObservationID spObsId = obs.getObservationID();

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -159,7 +159,7 @@ object ObservationInfo {
 
   def apply(ctx: ObsContext, mt: MagnitudeTable):ObservationInfo = ObservationInfo(
     ctx.some,
-    Option(ctx.getTargets.getBase).map(_.getName),
+    Option(ctx.getTargets.getAsterism).map(_.getName),
     Option(ctx.getTargets.getAsterism).flatMap(_.getSkycalcCoordinates(ctx.getSchedulingBlockStart).asScalaOpt).map(_.toNewModel),
     Option(ctx.getInstrument.getType),
     AgsRegistrar.currentStrategy(ctx).map(toSupportedStrategy(ctx, _, mt)),

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -160,7 +160,7 @@ object ObservationInfo {
   def apply(ctx: ObsContext, mt: MagnitudeTable):ObservationInfo = ObservationInfo(
     ctx.some,
     Option(ctx.getTargets.getBase).map(_.getName),
-    Option(ctx.getTargets.getBase).flatMap(_.getSkycalcCoordinates(ctx.getSchedulingBlockStart).asScalaOpt).map(_.toNewModel),
+    Option(ctx.getTargets.getAsterism).flatMap(_.getSkycalcCoordinates(ctx.getSchedulingBlockStart).asScalaOpt).map(_.toNewModel),
     Option(ctx.getInstrument.getType),
     AgsRegistrar.currentStrategy(ctx).map(toSupportedStrategy(ctx, _, mt)),
     expandAltairModes(ctx).flatMap(c => AgsRegistrar.validStrategies(c).map(toSupportedStrategy(c, _, mt))).sorted,

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcParametersProvider.scala
@@ -55,13 +55,13 @@ object ItcParametersProvider {
     def spatialProfile: String \/ SpatialProfile =
       for {
         tEnv <- targetEnvironment
-        sp   <- tEnv.getBase.getSpatialProfile.fold("Spatial profile not available".left[SpatialProfile])(_.right)
+        sp   <- tEnv.getAsterism.ifSingle.getSpatialProfile.fold("Spatial profile not available".left[SpatialProfile])(_.right)
       } yield sp
 
     def spectralDistribution: String \/ SpectralDistribution =
       for {
         tEnv <- targetEnvironment
-        sd   <- tEnv.getBase.getSpectralDistribution.fold("Spectral distribution not available".left[SpectralDistribution])(_.right)
+        sd   <- tEnv.getAsterism.ifSingle.getSpectralDistribution.fold("Spectral distribution not available".left[SpectralDistribution])(_.right)
       } yield sd
 
     def instrumentPort: String \/ IssPort =
@@ -73,7 +73,7 @@ object ItcParametersProvider {
     def redshift: String \/ Redshift =
       for {
         tEnv <- targetEnvironment
-      } yield tEnv.getBase.getSiderealTarget.flatMap(_.redshift).getOrElse(Redshift.zero)
+      } yield tEnv.getAsterism.ifSingle.getSiderealTarget.flatMap(_.redshift).getOrElse(Redshift.zero)
 
     def sequence: ConfigSequence = Option(owner.getContextObservation).fold(new ConfigSequence) {
       ConfigBridge.extractSequence(_, null, ConfigValMapInstances.IDENTITY_MAP, true)


### PR DESCRIPTION
This adds the initial easy bits in the `SPTarget` to `Asterism` migration in `TargetEnvironment`. For now `getAsterism` is an *additional* method that simply wraps the existing `base` in a single-element asterism. Eventually `getBase` will be removed and the `TargetEnvironment` itself will be modified to actually deal with asterisms internally.

Much more to come. I will ask for feedback when I hit things with non-obvious answers.