### PR TITLE
REL-246: reorder baseline cals to place flats before arcs

### DIFF
--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/BaselineReorderTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/BaselineReorderTest.scala
@@ -1,0 +1,79 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
+import edu.gemini.spModel.config2.ItemKey
+import edu.gemini.spModel.gemini.calunit.CalUnitParams._
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2
+import org.junit.Assert._
+import org.junit.{Before, Test}
+
+final class BaselineReorderTest extends GcalExecTest {
+
+  val observeTypeItem  = new ItemKey("observe:observeType")
+
+  @Before override def setUp(): Unit = {
+    super.setUp(progId)
+
+    addObsComponent(Flamingos2.SP_TYPE)
+
+    // 2 baseline night observations (4 datasets)
+    (1 to 2).foreach { _ =>
+      addSeqComponent(getObs.getSeqComponent, SeqRepeatSmartGcalObs.BaselineNight.SP_TYPE)
+    }
+  }
+
+  val flat = CalImpl(Set(Lamp.IR_GREY_BODY_HIGH), Shutter.OPEN,   Filter.ND_20, Diffuser.IR, 1,  4.0, 1, arc = false)
+  val arc  = CalImpl(Set(Lamp.AR_ARC),            Shutter.CLOSED, Filter.NIR,   Diffuser.IR, 1, 15.0, 1, arc = true )
+
+  @Test def testOrderChange(): Unit = {
+
+    // Originally, arcs came before flats.
+    setupGcal(arc, flat)
+    exec(1)
+    exec(2)
+
+    // Now flats come before arcs
+    setupGcal(flat, arc)
+
+    // Generate the sequence.
+    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+
+    assertEquals(4, cs.getAllSteps.size)
+
+    // Even though flats come before arcs, the first two steps are already
+    // executed so they don't flip to flat, arc.
+    val actual   = cs.getItemValueAtEachStep(observeTypeItem)
+    val expected = List("ARC", "FLAT", "FLAT", "ARC")  // yes, Strings
+
+    actual.zip(expected).foreach { case (a,e) => assertEquals(a, e) }
+  }
+
+  @Test def testPartialExecution(): Unit = {
+
+    // Originally, arcs came before flats.  Do just one of the two baseline
+    // calibration steps.
+    setupGcal(arc, flat)
+    exec(1)
+
+    // Now flats come before arcs
+    setupGcal(flat, arc)
+
+    // Generate the sequence.
+    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+
+    assertEquals(4, cs.getAllSteps.size)
+
+    // Even though flats come before arcs, the first step was already
+    // executed so it doesn't flip to "FLAT".  The second step is not executed
+    // though so unfortunately it will be a second ARC.  I don't think there
+    // is a way around this.  I also don't think this is a big deal since we
+    // won't have any partially executed baseline calibrations that we intend
+    // to come back to and finish anyway.
+
+    val actual   = cs.getItemValueAtEachStep(observeTypeItem)
+    val expected = List("ARC", "ARC", "FLAT", "ARC")  // yes, Strings
+
+    actual.zip(expected).foreach { case (a,e) => assertEquals(a, e) }
+  }
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/CalImpl.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/CalImpl.scala
@@ -1,0 +1,31 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.spModel.gemini.calunit.CalUnitParams.{Diffuser, Filter, Shutter, Lamp}
+import edu.gemini.spModel.gemini.calunit.smartgcal.Calibration
+
+import java.lang.{Boolean => JBoolean, Double => JDouble, Integer => JInteger}
+
+import scala.beans.BeanProperty
+import scala.collection.JavaConverters._
+
+final case class CalImpl(lamps: Set[Lamp],
+           @BeanProperty shutter: Shutter,
+           @BeanProperty filter: Filter,
+           @BeanProperty diffuser: Diffuser,
+                         observe: Int,
+                         exposureTime: Double,
+                         coadds: Int,
+                         arc: Boolean) extends Calibration {
+
+  // Satisfy the Calibration interface
+
+  def isFlat: JBoolean               = !isArc
+  def isArc: JBoolean                = arc
+  def isBasecalNight: JBoolean       = true
+  def isBasecalDay: JBoolean         = true
+
+  def getLamps: java.util.Set[Lamp] = lamps.asJava
+  def getObserve: JInteger          = observe
+  def getExposureTime: JDouble      = exposureTime
+  def getCoadds: JInteger           = coadds
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/GcalExecTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/GcalExecTest.scala
@@ -1,0 +1,34 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.shared.util.immutable.{Some => GSome}
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.dataset.{Dataset, DatasetLabel}
+import edu.gemini.spModel.event.{EndDatasetEvent, ObsExecEvent, StartDatasetEvent}
+import edu.gemini.spModel.gemini.calunit.smartgcal.{Calibration, CalibrationProviderHolder}
+import edu.gemini.spModel.obslog.ObsExecLog
+import edu.gemini.spModel.test.SpModelTestBase
+
+
+abstract class GcalExecTest extends SpModelTestBase {
+  val progId = SPProgramID.toProgramID("GS-3000A-Q-1")
+  val obsId  = new SPObservationID(progId, 1)
+
+  def label(num: Int): DatasetLabel    = new DatasetLabel(obsId, num)
+  def dataset(num: Int): Dataset       = new Dataset(label(num), "file%d".format(num), System.currentTimeMillis())
+
+  def startEvt(num: Int): ObsExecEvent = new StartDatasetEvent(System.currentTimeMillis(), dataset(num))
+  def endEvt(num: Int): ObsExecEvent   = new EndDatasetEvent(System.currentTimeMillis(), label(num))
+
+  def exec(step: Int): Unit = {
+    exec(step, startEvt)
+    exec(step, endEvt)
+  }
+
+  private def exec(step: Int, evt: Int => ObsExecEvent): Unit = {
+    ObsExecLog.updateObsLog(getOdb, getObs.getObservationID, new GSome(label(step)), new GSome(evt(step)))
+  }
+
+  def setupGcal(cs: Calibration*): Unit =
+    CalibrationProviderHolder.setProvider(new TestCalibrationProvider(cs.toList))
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalExecutedStepTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalExecutedStepTest.scala
@@ -1,38 +1,19 @@
 package edu.gemini.spModel.gemini.seqcomp
 
-import edu.gemini.spModel.test.SpModelTestBase
-import edu.gemini.spModel.gemini.gnirs.InstGNIRS
-import org.junit.{Test, Before}
-import org.junit.Assert._
 import edu.gemini.spModel.config.ConfigBridge
-import edu.gemini.spModel.config.map.ConfigValMapInstances
-import edu.gemini.spModel.gemini.calunit.smartgcal.{Calibration, CalibrationKey, CalibrationProvider, CalibrationProviderHolder}
-
-import collection.JavaConverters._
-import edu.gemini.spModel.gemini.calunit.CalUnitParams._
-import scala.beans.BeanProperty
+import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
 import edu.gemini.spModel.config2.ItemKey
-import edu.gemini.spModel.obslog.ObsExecLog
-import edu.gemini.spModel.core.SPProgramID
-import edu.gemini.pot.sp.SPObservationID
-import edu.gemini.spModel.dataset.{Dataset, DatasetLabel}
-import edu.gemini.spModel.event.{EndDatasetEvent, StartDatasetEvent, ObsExecEvent}
+import edu.gemini.spModel.gemini.calunit.CalUnitParams._
+import edu.gemini.spModel.gemini.gnirs.InstGNIRS
+import org.junit.Assert._
+import org.junit.{Before, Test}
 
 /**
  * Tests that executed steps don't change even if the mapping changes.
  */
-class SmartGcalExecutedStepTest extends SpModelTestBase {
-  val progId = SPProgramID.toProgramID("GN-6666A-Q-1")
-  val obsId  = new SPObservationID(progId, 1)
-
+class SmartGcalExecutedStepTest extends GcalExecTest {
   val shutterItem  = new ItemKey("calibration:shutter")
   val diffuserItem = new ItemKey("calibration:diffuser")
-
-  def label(num: Int): DatasetLabel = new DatasetLabel(obsId, num)
-
-  def dataset(num: Int): Dataset = new Dataset(label(num), "file%d".format(num), System.currentTimeMillis())
-  def startEvt(num: Int): ObsExecEvent = new StartDatasetEvent(System.currentTimeMillis(), dataset(num))
-  def endEvt(num: Int): ObsExecEvent = new EndDatasetEvent(System.currentTimeMillis(), label(num))
 
   @Before override def setUp() {
     super.setUp(progId)
@@ -43,11 +24,9 @@ class SmartGcalExecutedStepTest extends SpModelTestBase {
 
   val cal = CalImpl(Set(Lamp.arcLamps().get(0)), Shutter.OPEN, Filter.ND_10, Diffuser.IR, 1, 1.0, 1, arc = true)
 
-
   @Test def testNoExecutedSteps() {
-    val cals = List(cal)
-    CalibrationProviderHolder.setProvider(new TestCalibrationProvider(cals))
-    val cs = ConfigBridge.extractSequence(getObs, null, ConfigValMapInstances.IDENTITY_MAP)
+    setupGcal(cal)
+    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
     assertEquals(1, cs.getAllSteps.size)
 
@@ -56,29 +35,16 @@ class SmartGcalExecutedStepTest extends SpModelTestBase {
     assertEquals(cal.diffuser, step.getItemValue(diffuserItem))
   }
 
-  private def exec(step: Int) {
-    exec(step, startEvt)
-    exec(step, endEvt)
-  }
-
-  private def exec(step: Int, evt: Int => ObsExecEvent) {
-    ObsExecLog.updateObsLog(getOdb, getObs.getObservationID,
-      new edu.gemini.shared.util.immutable.Some[DatasetLabel](label(step)),
-      new edu.gemini.shared.util.immutable.Some[ObsExecEvent](evt(1)))
-  }
-
   @Test def testExecutedStepDoesNotChange() {
     // Execute the first step with shutter OPEN
-    val cals0 = List(cal)
-    CalibrationProviderHolder.setProvider(new TestCalibrationProvider(cals0))
+    setupGcal(cal)
     exec(1)
 
     // Change the calibration mapping to shutter CLOSED
-    val cals1 = List(cal.copy(shutter = Shutter.CLOSED))
-    CalibrationProviderHolder.setProvider(new TestCalibrationProvider(cals1))
+    setupGcal(cal.copy(shutter = Shutter.CLOSED))
 
     // Generate the sequence.
-    val cs = ConfigBridge.extractSequence(getObs, null, ConfigValMapInstances.IDENTITY_MAP)
+    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
     assertEquals(1, cs.getAllSteps.size)
 
@@ -93,17 +59,14 @@ class SmartGcalExecutedStepTest extends SpModelTestBase {
     addSeqComponent(getObs.getSeqComponent, SeqRepeatSmartGcalObs.Arc.SP_TYPE)
 
     // Execute the first step with shutter OPEN
-    val cals0 = List(cal)
-    CalibrationProviderHolder.setProvider(new TestCalibrationProvider(cals0))
+    setupGcal(cal)
     exec(1)
 
     // Change the calibration mapping to shutter CLOSED
-    val cals1 = List(cal.copy(shutter = Shutter.CLOSED))
-    CalibrationProviderHolder.setProvider(new TestCalibrationProvider(cals1))
-
+    setupGcal(cal.copy(shutter = Shutter.CLOSED))
 
     // Generate the sequence.
-    val cs = ConfigBridge.extractSequence(getObs, null, ConfigValMapInstances.IDENTITY_MAP)
+    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
     assertEquals(2, cs.getAllSteps.size)
 
@@ -117,33 +80,4 @@ class SmartGcalExecutedStepTest extends SpModelTestBase {
     assertEquals(Shutter.CLOSED, step1.getItemValue(shutterItem))
   }
 
-}
-
-case class CalImpl(
-                     lamps: Set[Lamp],
-       @BeanProperty shutter: Shutter,
-       @BeanProperty filter: Filter,
-       @BeanProperty diffuser: Diffuser,
-                     observe: Int,
-                     exposureTime: Double,
-                     coadds: Int,
-                     arc: Boolean) extends Calibration {
-  def isFlat = !isArc
-  def isArc  = arc
-  def isBasecalNight = true
-  def isBasecalDay = true
-
-  def getLamps = lamps.asJava
-  def getObserve = observe
-  def getExposureTime = exposureTime
-  def getCoadds = coadds
-}
-
-class TestCalibrationProvider(cals: List[Calibration]) extends CalibrationProvider {
-  def getVersionInfo =
-    null
-  def getVersion(calType: Calibration.Type, instrument: java.lang.String) =
-    null
-  def getCalibrations(key: CalibrationKey) =
-    cals.asJava
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/TestCalibrationProvider.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/TestCalibrationProvider.scala
@@ -1,0 +1,17 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.spModel.gemini.calunit.smartgcal.{CalibrationKey, CalibrationProvider, Calibration}
+
+import scala.collection.JavaConverters._
+
+
+final class TestCalibrationProvider(cals: List[Calibration]) extends CalibrationProvider {
+  def getVersionInfo =
+    null
+
+  def getVersion(calType: Calibration.Type, instrument: java.lang.String) =
+    null
+
+  def getCalibrations(key: CalibrationKey) =
+    cals.asJava
+}

--- a/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/provider/ProviderTest.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/provider/ProviderTest.java
@@ -98,7 +98,7 @@ public class ProviderTest {
                         GmosCommonType.Order.ONE,
                         GmosCommonType.AmpGain.LOW
                 );
-        
+
         // ===== test wavelength 500
         List<Calibration> calibrations =
                 provider.getCalibrations(new CalibrationKeyImpl.WithWavelength(key, 500.0));
@@ -106,18 +106,18 @@ public class ProviderTest {
         Assert.assertEquals(2, calibrations.size());
         //  check number 1
         Assert.assertEquals(CalUnitParams.Shutter.CLOSED,       calibrations.get(0).getShutter());
-        Assert.assertEquals(CalUnitParams.Filter.NONE,         calibrations.get(0).getFilter());
+        Assert.assertEquals(CalUnitParams.Filter.ND_30,         calibrations.get(0).getFilter());
         Assert.assertEquals(CalUnitParams.Diffuser.VISIBLE,     calibrations.get(0).getDiffuser());
-        Assert.assertEquals(30,                                 calibrations.get(0).getExposureTime(), 0.01);
+        Assert.assertEquals(12,                                 calibrations.get(0).getExposureTime(), 0.01);
         Assert.assertEquals(new Integer(1),                     calibrations.get(0).getCoadds());
-        Assert.assertTrue(calibrations.get(0).isArc());
+        Assert.assertTrue(calibrations.get(0).isFlat());
         //  check number 2
         Assert.assertEquals(CalUnitParams.Shutter.CLOSED,       calibrations.get(1).getShutter());
-        Assert.assertEquals(CalUnitParams.Filter.ND_30,         calibrations.get(1).getFilter());
+        Assert.assertEquals(CalUnitParams.Filter.NONE,          calibrations.get(1).getFilter());
         Assert.assertEquals(CalUnitParams.Diffuser.VISIBLE,     calibrations.get(1).getDiffuser());
-        Assert.assertEquals(12,                                 calibrations.get(1).getExposureTime(), 0.01);
+        Assert.assertEquals(30,                                 calibrations.get(1).getExposureTime(), 0.01);
         Assert.assertEquals(new Integer(1),                     calibrations.get(1).getCoadds());
-        Assert.assertTrue(calibrations.get(1).isFlat());
+        Assert.assertTrue(calibrations.get(1).isArc());
      }
 
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OT.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OT.java
@@ -325,7 +325,7 @@ public final class OT {
         new Thread("Smart GCAL Initializer") {
             @Override
             public void run() {
-                if (!storageDir.exists() && !storageDir.mkdir()) {
+                if (!storageDir.exists() && !storageDir.mkdirs()) {
                     LOG.log(Level.SEVERE, "Could not initialize smart gcal at " + storageDir.getAbsolutePath());
                     return;
                 }


### PR DESCRIPTION
This update would rearrange any flats in a baseline calibration to happen before any arcs (instead of the other way around as it is currently done).

Since we're modifying the sequence calculation, the question "what about existing executed sequences" naturally comes to mind.  Smart GCal was written to handle this type of change and simple monkey tests and a couple of unit tests confirm that it works, at least to some degree.  At any rate any problems with this feature are already present in the codebase.