### PR TITLE
REL-246: work around an issue with Smart GCal testing

### DIFF
--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/BaselineReorderTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/BaselineReorderTest.scala
@@ -27,53 +27,57 @@ final class BaselineReorderTest extends GcalExecTest {
   val arc  = CalImpl(Set(Lamp.AR_ARC),            Shutter.CLOSED, Filter.NIR,   Diffuser.IR, 1, 15.0, 1, arc = true )
 
   @Test def testOrderChange(): Unit = {
+    locking {
 
-    // Originally, arcs came before flats.
-    setupGcal(arc, flat)
-    exec(1)
-    exec(2)
+      // Originally, arcs came before flats.
+      setupGcal(arc, flat)
+      exec(1)
+      exec(2)
 
-    // Now flats come before arcs
-    setupGcal(flat, arc)
+      // Now flats come before arcs
+      setupGcal(flat, arc)
 
-    // Generate the sequence.
-    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+      // Generate the sequence.
+      val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
-    assertEquals(4, cs.getAllSteps.size)
+      assertEquals(4, cs.getAllSteps.size)
 
-    // Even though flats come before arcs, the first two steps are already
-    // executed so they don't flip to flat, arc.
-    val actual   = cs.getItemValueAtEachStep(observeTypeItem)
-    val expected = List("ARC", "FLAT", "FLAT", "ARC")  // yes, Strings
+      // Even though flats come before arcs, the first two steps are already
+      // executed so they don't flip to flat, arc.
+      val actual   = cs.getItemValueAtEachStep(observeTypeItem)
+      val expected = List("ARC", "FLAT", "FLAT", "ARC") // yes, Strings
 
-    actual.zip(expected).foreach { case (a,e) => assertEquals(a, e) }
+      actual.zip(expected).foreach { case (a, e) => assertEquals(a, e) }
+    }
   }
 
   @Test def testPartialExecution(): Unit = {
 
-    // Originally, arcs came before flats.  Do just one of the two baseline
-    // calibration steps.
-    setupGcal(arc, flat)
-    exec(1)
+    locking {
+      // Originally, arcs came before flats.  Do just one of the two baseline
+      // calibration steps.
+      setupGcal(arc, flat)
+      exec(1)
 
-    // Now flats come before arcs
-    setupGcal(flat, arc)
+      // Now flats come before arcs
+      setupGcal(flat, arc)
 
-    // Generate the sequence.
-    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+      // Generate the sequence.
+      val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
-    assertEquals(4, cs.getAllSteps.size)
+      assertEquals(4, cs.getAllSteps.size)
 
-    // Even though flats come before arcs, the first step was already
-    // executed so it doesn't flip to "FLAT".  The second step is not executed
-    // though so unfortunately it will be a second ARC.  I don't think there
-    // is a way around this.  I also don't think this is a big deal since we
-    // won't have any partially executed baseline calibrations that we intend
-    // to come back to and finish anyway.
+      // Even though flats come before arcs, the first step was already
+      // executed so it doesn't flip to "FLAT".  The second step is not executed
+      // though so unfortunately it will be a second ARC.  I don't think there
+      // is a way around this.  I also don't think this is a big deal since we
+      // won't have any partially executed baseline calibrations that we intend
+      // to come back to and finish anyway.
 
-    val actual   = cs.getItemValueAtEachStep(observeTypeItem)
-    val expected = List("ARC", "ARC", "FLAT", "ARC")  // yes, Strings
+      val actual   = cs.getItemValueAtEachStep(observeTypeItem)
+      val expected = List("ARC", "ARC", "FLAT", "ARC") // yes, Strings
 
-    actual.zip(expected).foreach { case (a,e) => assertEquals(a, e) }
+      actual.zip(expected).foreach { case (a, e) => assertEquals(a, e) }
+    }
   }
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalExecutedStepTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalExecutedStepTest.scala
@@ -25,59 +25,66 @@ class SmartGcalExecutedStepTest extends GcalExecTest {
   val cal = CalImpl(Set(Lamp.arcLamps().get(0)), Shutter.OPEN, Filter.ND_10, Diffuser.IR, 1, 1.0, 1, arc = true)
 
   @Test def testNoExecutedSteps() {
-    setupGcal(cal)
-    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+    locking {
+      setupGcal(cal)
 
-    assertEquals(1, cs.getAllSteps.size)
+      val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
-    val step = cs.getStep(0)
-    assertEquals(cal.shutter,  step.getItemValue(shutterItem))
-    assertEquals(cal.diffuser, step.getItemValue(diffuserItem))
+      assertEquals(1, cs.getAllSteps.size)
+
+      val step = cs.getStep(0)
+      assertEquals(cal.shutter, step.getItemValue(shutterItem))
+      assertEquals(cal.diffuser, step.getItemValue(diffuserItem))
+    }
   }
 
   @Test def testExecutedStepDoesNotChange() {
-    // Execute the first step with shutter OPEN
-    setupGcal(cal)
-    exec(1)
+    locking {
+      // Execute the first step with shutter OPEN
+      setupGcal(cal)
+      exec(1)
 
-    // Change the calibration mapping to shutter CLOSED
-    setupGcal(cal.copy(shutter = Shutter.CLOSED))
+      // Change the calibration mapping to shutter CLOSED
+      setupGcal(cal.copy(shutter = Shutter.CLOSED))
 
-    // Generate the sequence.
-    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+      // Generate the sequence.
+      val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
-    assertEquals(1, cs.getAllSteps.size)
+      assertEquals(1, cs.getAllSteps.size)
 
-    val step = cs.getStep(0)
+      val step = cs.getStep(0)
 
-    // Still Open because it was that way when we recorded the step executed
-    assertEquals(Shutter.OPEN, step.getItemValue(shutterItem))
+      // Still Open because it was that way when we recorded the step executed
+      assertEquals(Shutter.OPEN, step.getItemValue(shutterItem))
+    }
   }
 
   @Test def testUnexecutedStepAfterMappingChange() {
-    // Add another smart cal to the sequence so that we have two
-    addSeqComponent(getObs.getSeqComponent, SeqRepeatSmartGcalObs.Arc.SP_TYPE)
+    locking {
+      // Add another smart cal to the sequence so that we have two
+      addSeqComponent(getObs.getSeqComponent, SeqRepeatSmartGcalObs.Arc.SP_TYPE)
 
-    // Execute the first step with shutter OPEN
-    setupGcal(cal)
-    exec(1)
+      // Execute the first step with shutter OPEN
+      setupGcal(cal)
+      exec(1)
 
-    // Change the calibration mapping to shutter CLOSED
-    setupGcal(cal.copy(shutter = Shutter.CLOSED))
+      // Change the calibration mapping to shutter CLOSED
+      setupGcal(cal.copy(shutter = Shutter.CLOSED))
 
-    // Generate the sequence.
-    val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+      // Generate the sequence.
+      val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
 
-    assertEquals(2, cs.getAllSteps.size)
+      assertEquals(2, cs.getAllSteps.size)
 
-    val step0 = cs.getStep(0)
-    val step1 = cs.getStep(1)
+      val step0 = cs.getStep(0)
+      val step1 = cs.getStep(1)
 
-    // Still Open because it was that way when we recorded the step executed
-    assertEquals(Shutter.OPEN, step0.getItemValue(shutterItem))
+      // Still Open because it was that way when we recorded the step executed
+      assertEquals(Shutter.OPEN, step0.getItemValue(shutterItem))
 
-    // Closed in the unexecuted step.
-    assertEquals(Shutter.CLOSED, step1.getItemValue(shutterItem))
+      // Closed in the unexecuted step.
+      assertEquals(Shutter.CLOSED, step1.getItemValue(shutterItem))
+    }
   }
 
 }


### PR DESCRIPTION
While working on an unrelated feature, I noticed a sporadic failure with the Smart GCal test cases.  I believe the issue lies in an implementation class called `CalibrationProviderHolder`.  This class maintains a shared mutable reference to another class, the `CalibrationProvider`.  I'm not too interested in refactoring Smart GCal to fix this kind of thing because we have reimplemented it in a much less convoluted way already for ocs3.  Design questions aside, this creates a problem for the test cases which need to swap out the `CalibrationProvider` for testing and can't work in an environment in which the provider is changing out from under them.

There is some way to get limited serialization of sbt tests, but this needs to work across all test cases that are doing Smart Gcal.  I don't know of another way to handle this besides just using a shared lock, which is what this PR proposes.

__By the way, I'm looking forward to some kind of animated GIF indicating disgust with this whole thing, so please don't disappoint!__  Alternative suggestions are also welcome.