### PR TITLE
REL-3128: Populate previously unused horizonsObjectId field in ODB Browser output for use in LCH to uniquely identify nonsidereal targets.

### DIFF
--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
@@ -77,6 +77,12 @@ class LchQueryFunctor(queryType: LchQueryFunctor.QueryType,
         Some(new NonSidereal() {
           setName(target.getName)
           setType(targetType.orNull)
+          for {
+            n <- target.getNonSiderealTarget
+            h <- n.horizonsDesignation
+          } {
+            setHorizonsObjectId(h.des)
+          }
         })
       } else if (target.isSidereal) {
         target.getSkycalcCoordinates(None.asGeminiOpt).asScalaOpt.map { coords =>


### PR DESCRIPTION
The LTTS uses the ODB browser to look up target information from the ODB, and has had, for nonsidereal targets, a `horizonsObjectId` field meant to contain the unique Horizons numerical identifier for a nonsidereal target; however, this field has never been set (I suspect it wasn't available in the old target model, but is easily obtained in the new target model).

LTTS - by design - assumed that this field was never set (as indicated in the comments for Horizons lookups) and searched for targets through Horizons by name. This yielded the issue that many target searches by name produce multiple results, and LTTS could not disambiguate between them to select the correct one, and thus - when this happened - set an RA and Dec of 0 to the nonsidereal target.

Now that we are fixing LTTS to work with the new Horizons protocol, this should also be fixed so that the LTTS uses - when possible - the unique Horizons ID and only falls back on the name search when no ID is made available through the ODB browser.

This fix modifies the ODB browser to populate this field when the data is available.