### PR TITLE
REL-3128: Populate previously unused horizonsObjectId field in ODB Browser output for use in LCH to uniquely identify nonsidereal targets.

### DIFF
--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
@@ -77,6 +77,12 @@ class LchQueryFunctor(queryType: LchQueryFunctor.QueryType,
         Some(new NonSidereal() {
           setName(target.getName)
           setType(targetType.orNull)
+          for {
+            n <- target.getNonSiderealTarget
+            h <- n.horizonsDesignation
+          } {
+            setHorizonsObjectId(h.des)
+          }
         })
       } else if (target.isSidereal) {
         target.getSkycalcCoordinates(None.asGeminiOpt).asScalaOpt.map { coords =>


### PR DESCRIPTION
Also patching 2017A ODB to include this change.