### PR TITLE
REL-3128: Patch OCS-2017A ODB to use Horizons queryString instead of des

### DIFF
--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
@@ -81,7 +81,7 @@ class LchQueryFunctor(queryType: LchQueryFunctor.QueryType,
             n <- target.getNonSiderealTarget
             h <- n.horizonsDesignation
           } {
-            setHorizonsObjectId(h.des)
+            setHorizonsObjectId(h.queryString)
           }
         })
       } else if (target.isSidereal) {


### PR DESCRIPTION
As per @tpolecat's comments on previous PR.