### PR TITLE
REL-2928: (Part A)

### DIFF
--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryParam.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryParam.scala
@@ -144,7 +144,9 @@ object LchQueryParam {
 
     def partnerList: List[PartnerInfo] = {
       val taa = toSPProg.getTimeAcctAllocation
-      taa.getCategories.asScala.toList.map(c => PartnerInfo(c.getDisplayName, taa.getAward(c).getTotalHours()))
+      taa.getCategories.asScala.toList.map { c =>
+        PartnerInfo(c.getDisplayName, taa.getAward(c).getProgramHours)
+      }
     }
 
     def tooStatus: TooType =
@@ -164,7 +166,7 @@ object LchQueryParam {
 
     // Allocated time in ms.
     def allocatedTime: Long =
-      toSPProg.getTimeAcctAllocation.getSum().getTotalAward().toMillis();
+      toSPProg.getTimeAcctAllocation.getSum().getProgramAward().toMillis();
 
     // Remaining time in ms.
     def remainingTime: Long =

--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryParam.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryParam.scala
@@ -144,7 +144,7 @@ object LchQueryParam {
 
     def partnerList: List[PartnerInfo] = {
       val taa = toSPProg.getTimeAcctAllocation
-      taa.getCategories.asScala.toList.map(c => PartnerInfo(c.getDisplayName, taa.getHours(c)))
+      taa.getCategories.asScala.toList.map(c => PartnerInfo(c.getDisplayName, taa.getAward(c).getTotalHours()))
     }
 
     def tooStatus: TooType =
@@ -164,7 +164,7 @@ object LchQueryParam {
 
     // Allocated time in ms.
     def allocatedTime: Long =
-      (toSPProg.getTimeAcctAllocation.getTotalTime * 60 * 60 * 1000).toLong
+      toSPProg.getTimeAcctAllocation.getSum().getTotalAward().toMillis();
 
     // Remaining time in ms.
     def remainingTime: Long =

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -431,7 +431,7 @@ public class GeneralRule implements IRule {
                     if (t == 0.0) {
                         probs.addError(PREFIX+"BAND3TIME_RULE_ZERO_MESSAGE", ZERO_MESSAGE, elements.getProgramNode()); // REL-337
                     }
-                    if (t > elements.getProgram().getAwardedTime().getTimeAmount()) {
+                    if (t > elements.getProgram().getAwardedProgramTime().getTimeAmount()) {
                         probs.addError(PREFIX+"BAND3TIME_RULE_ALLOC_MESSAGE", ALLOC_MESSAGE, elements.getProgramNode()); // REL-336
                     }
                     if (probs.getProblemCount() != 0) {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -27,6 +27,8 @@ import Scalaz._
  */
 object SpProgramFactory {
 
+  private val MsPerHour = Duration.ofHours(1).toMillis
+
   private val NGO_TIME_ACCT = Map(
     AR -> TimeAcctCategory.AR,
     AU -> TimeAcctCategory.AU,
@@ -202,7 +204,7 @@ object SpProgramFactory {
           val jmap = ratios.map { case (cat, rat) =>
             // REL-2928 TODO: handle splitting program and partner award.  Here
             // we just keep everything as the program award for now.
-            val ms    = ((hrs * rat) * 3600000).round // ms for this category
+            val ms    = ((hrs * rat) * MsPerHour).round // ms for this category
             val award = new TimeAcctAward(Duration.ofMillis(ms), Duration.ZERO)
             (cat, award)
           }.toMap.asJava

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -1,5 +1,6 @@
 package edu.gemini.phase2.skeleton.factory
 
+import edu.gemini.spModel.core.Affiliate
 import edu.gemini.spModel.gemini.obscomp.SPProgram.ProgramMode._
 import edu.gemini.spModel.too.TooType
 import edu.gemini.model.p1.immutable._
@@ -12,13 +13,14 @@ import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.gemini.obscomp.SPProgram.{PIInfo, ProgramMode}
 import edu.gemini.shared.util.TimeValue
 
-import edu.gemini.spModel.timeacct.{TimeAcctAllocation, TimeAcctCategory}
+import edu.gemini.spModel.timeacct.{TimeAcctAllocation, TimeAcctAward, TimeAcctCategory}
 import edu.gemini.spModel.gemini.phase1.{GsaPhase1Data => Gsa}
+
+import java.time.Duration
 
 import scala.collection.JavaConverters._
 import scalaz._
 import Scalaz._
-import edu.gemini.spModel.core.Affiliate
 
 /**
  * Factory for creating an SPProgram from a Phase 1 Proposal document.
@@ -197,8 +199,14 @@ object SpProgramFactory {
       timeAccountingRatios(proposal) match {
         case Nil    => None
         case ratios =>
-          val jmap  = ratios.toMap.mapValues(d => new java.lang.Double(d)).asJava
-          Some(new TimeAcctAllocation(hrs, jmap))
+          val jmap = ratios.map { case (cat, rat) =>
+            // REL-2928 TODO: handle splitting program and partner award.  Here
+            // we just keep everything as the program award for now.
+            val ms    = ((hrs * rat) * 3600000).round // ms for this category
+            val award = new TimeAcctAward(Duration.ofMillis(ms), Duration.ZERO)
+            (cat, award)
+          }.toMap.asJava
+          Some(new TimeAcctAllocation(jmap))
       }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -968,13 +968,6 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
             }
         }
 
-//        TimeValue awardedTime = getAwardedTime();
-//        if (awardedTime != null) {
-//            Pio.addParam(factory, paramSet, AWARDED_TIME_PROP,
-//                    String.valueOf(awardedTime.getTimeAmount()),
-//                    awardedTime.getTimeUnits().name());
-//        }
-
         // Write the time accounting information.
         if (_timeAllocation != null) {
             ParamSet timeAcctPset;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -839,9 +839,9 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
      * @return String version of the awarded time, else the default
      * value.
      */
-    public TimeValue getAwardedTime() {
+    public TimeValue getAwardedProgramTime() {
         if (_timeAllocation == null) return new TimeValue(0, TimeValue.Units.hours);
-        return TimeValue.millisecondsToTimeValue(_timeAllocation.getSum().getTotalAward().toMillis(), TimeValue.Units.hours);
+        return TimeValue.millisecondsToTimeValue(_timeAllocation.getSum().getProgramAward().toMillis(), TimeValue.Units.hours);
     }
 
     public TimeAcctAllocation getTimeAcctAllocation() {
@@ -983,7 +983,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
             // Write the awarded time (for GSA only -- will be ignored on
             // import)
-            final double hrs = _timeAllocation.getSum().getTotalHours();
+            final double hrs = _timeAllocation.getSum().getProgramHours();
             Pio.addParam(factory, paramSet, AWARDED_TIME_PROP, Double.toString(hrs), "hours");
         }
         if ((_minTimeValue != null) && (_minTimeValue.getTimeAmount() > 0)) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -45,7 +45,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     // for serialization
     private static final long serialVersionUID = 4L;
 
-    public static final String VERSION = "2017A-1";
+    public static final String VERSION = "2017B-1";
 
     /** This property records the program queue/classical state. */
     public static final String PROGRAM_MODE_PROP = "programMode";

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -841,7 +841,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
      */
     public TimeValue getAwardedTime() {
         if (_timeAllocation == null) return new TimeValue(0, TimeValue.Units.hours);
-        return new TimeValue(_timeAllocation.getTotalTime(), TimeValue.Units.hours);
+        return new TimeValue(_timeAllocation.getSum().getTotalAward().toMillis(), TimeValue.Units.hours);
     }
 
     public TimeAcctAllocation getTimeAcctAllocation() {
@@ -983,8 +983,8 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
             // Write the awarded time (for GSA only -- will be ignored on
             // import)
-            Pio.addParam(factory, paramSet, AWARDED_TIME_PROP,
-                    String.valueOf(_timeAllocation.getTotalTime()), "hours");
+            final double hrs = _timeAllocation.getSum().getTotalHours();
+            Pio.addParam(factory, paramSet, AWARDED_TIME_PROP, String.valueOf(hrs), "hours");
         }
         if ((_minTimeValue != null) && (_minTimeValue.getTimeAmount() > 0)) {
             Pio.addParam(factory, paramSet, MINIMUM_TIME_PROP,

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -841,7 +841,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
      */
     public TimeValue getAwardedTime() {
         if (_timeAllocation == null) return new TimeValue(0, TimeValue.Units.hours);
-        return new TimeValue(_timeAllocation.getSum().getTotalAward().toMillis(), TimeValue.Units.hours);
+        return TimeValue.millisecondsToTimeValue(_timeAllocation.getSum().getTotalAward().toMillis(), TimeValue.Units.hours);
     }
 
     public TimeAcctAllocation getTimeAcctAllocation() {
@@ -984,7 +984,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
             // Write the awarded time (for GSA only -- will be ignored on
             // import)
             final double hrs = _timeAllocation.getSum().getTotalHours();
-            Pio.addParam(factory, paramSet, AWARDED_TIME_PROP, String.valueOf(hrs), "hours");
+            Pio.addParam(factory, paramSet, AWARDED_TIME_PROP, Double.toString(hrs), "hours");
         }
         if ((_minTimeValue != null) && (_minTimeValue.getTimeAmount() > 0)) {
             Pio.addParam(factory, paramSet, MINIMUM_TIME_PROP,

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
@@ -112,7 +112,7 @@ public final class ObsTimesService {
      */
     public static long getRemainingProgramTime(final ISPProgram prog) {
         final long awarded = ImOption.apply(prog.getDataObject()).
-                map(dataObj -> ((SPProgram)dataObj).getAwardedTime()).
+                map(dataObj -> ((SPProgram)dataObj).getAwardedProgramTime()).
                 getOrElse(TimeValue.ZERO_HOURS).
                 getMilliseconds();
         final long progTime = getCorrectedObsTimes(prog).getTimeCharges().getTime(ChargeClass.PROGRAM);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAllocation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAllocation.java
@@ -13,12 +13,13 @@ public final class TimeAcctAllocation implements Serializable {
 
     public static final TimeAcctAllocation EMPTY = new TimeAcctAllocation();
 
-    private final Map<TimeAcctCategory, Double> allocMap;
+    private final Map<TimeAcctCategory, TimeAcctAward> allocMap;
 
-    private transient double totalTime;
+    private final TimeAcctAward sum;
 
     private TimeAcctAllocation() {
         allocMap = Collections.emptyMap();
+        sum      = TimeAcctAward.ZERO;
     }
 
     /**
@@ -28,73 +29,36 @@ public final class TimeAcctAllocation implements Serializable {
      * @param allocationMap hours for all relevant categories; hours must be
      * greater than or equal to 0
      */
-    public TimeAcctAllocation(final Map<TimeAcctCategory, Double> allocationMap) {
-        final Map<TimeAcctCategory, Double> tmpAllocMap = new TreeMap<>(allocationMap);
+    public TimeAcctAllocation(final Map<TimeAcctCategory, TimeAcctAward> allocationMap) {
+        final Map<TimeAcctCategory, TimeAcctAward> tmpAllocMap = new TreeMap<>(allocationMap);
 
-        for (final Map.Entry<TimeAcctCategory, Double> me : tmpAllocMap.entrySet()) {
-            final Double d = me.getValue();
-            if (d == null) {
+        TimeAcctAward tmp = TimeAcctAward.ZERO;
+
+        for (final Map.Entry<TimeAcctCategory, TimeAcctAward> me : tmpAllocMap.entrySet()) {
+            final TimeAcctAward a = me.getValue();
+            if (a == null) {
                 throw new IllegalArgumentException(
-                        String.format("null time accounting allocation for category %s", me.getKey().name())
+                        String.format("null time accounting award for category %s", me.getKey().name())
                 );
             }
-            if (d < 0.0) {
-                throw new IllegalArgumentException(
-                        String.format("negative time accounting allocation (%f) for category %s", d, me.getKey().name())
-                );
-            }
-            totalTime += d;
+            tmp = tmp.plus(a);
         }
+
+        sum      = tmp;
         allocMap = Collections.unmodifiableMap(tmpAllocMap);
     }
-
-    /**
-     * Computes a TimeAcctAllocation from a total time and a ratio for each
-     * category.  The total time is divided among the categories according to
-     * the portion indicated in the ratioMap.
-     *
-     * @param totalHours total amount of time distributed across all categories
-     * @param ratioMap fraction of time to allocate to each of the time
-     * accounting categories; the sum of the values of the ratio map should
-     * equal 1 (ignorning rounding errors in floating point math)
-     *
-     * @throws IllegalArgumentException if sum of fractions in
-     * <code>ratioMap</code> does not equal 1
-     */
-    public TimeAcctAllocation(final double totalHours, final Map<TimeAcctCategory, Double> ratioMap) {
-        final Map<TimeAcctCategory, Double> tmpAllocMap = new TreeMap<>();
-
-        if (ratioMap.size() == 0) {
-            // not clear how to award time, so the total time and allocation
-            // map will be empty
-            allocMap = Collections.emptyMap();
-            return;
-        }
-
-        // Award a proportional amount of time to each category.
-        for (final Map.Entry<TimeAcctCategory, Double> me : ratioMap.entrySet()) {
-            final double hours = totalHours * me.getValue();
-            tmpAllocMap.put(me.getKey(), hours);
-            totalTime += hours;
-        }
-
-        // Make sure that the totalTime we computed matches the totalHours
-        // provided this method.  In other words, verify that the ratioMap
-        // was what we expected it to be, fractions adding up to 1.0.
-        if (Math.abs(totalHours - totalTime) > 1e-5) {
-            throw new IllegalArgumentException("ratioMap not valid");
-        }
-
-        allocMap = Collections.unmodifiableMap(tmpAllocMap);
-    }
-
 
     /**
      * Gets the number of hours associated with the given category.
      */
-    public double getHours(final TimeAcctCategory category) {
-        final Double res = allocMap.get(category);
-        return (res == null) ? 0 : res;
+    public TimeAcctAward getAward(final TimeAcctCategory category) {
+        final TimeAcctAward res = allocMap.get(category);
+        return (res == null) ? TimeAcctAward.ZERO : res;
+    }
+
+    private double ratio(TimeAcctAward award) {
+        if (sum.isZero()) return 0;
+        return ((double) award.getTotalAward().toMillis()) / ((double) sum.getTotalAward().toMillis());
     }
 
     /**
@@ -102,9 +66,7 @@ public final class TimeAcctAllocation implements Serializable {
      * the given category.
      */
     public double getPercentage(final TimeAcctCategory category) {
-        if (totalTime == 0) return 0;
-        final double hours = getHours(category);
-        return hours/totalTime * 100;
+        return ratio(getAward(category)) * 100;
     }
 
     /**
@@ -123,14 +85,10 @@ public final class TimeAcctAllocation implements Serializable {
      */
     public SortedMap<TimeAcctCategory, Double> getRatios() {
         final SortedMap<TimeAcctCategory, Double> res = new TreeMap<>();
-        if (totalTime == 0) return res;
+        if (sum.isZero()) return res;
 
-        for (final Map.Entry<TimeAcctCategory, Double> me : allocMap.entrySet()) {
-            final double time  = me.getValue();
-            if (time == 0) continue;
-
-            final double ratio = time / totalTime;
-            res.put(me.getKey(), ratio);
+        for (final Map.Entry<TimeAcctCategory, TimeAcctAward> me : allocMap.entrySet()) {
+            res.put(me.getKey(), ratio(me.getValue()));
         }
 
         return res;
@@ -139,22 +97,14 @@ public final class TimeAcctAllocation implements Serializable {
     /**
      * Gets the total time allocated to all the categories combined.
      */
-    public double getTotalTime() {
-        return totalTime;
-    }
-
-    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
-        totalTime = 0;
-        for (final Double d : allocMap.values()) {
-            totalTime += d;
-        }
+    public TimeAcctAward getSum() {
+        return sum;
     }
 
     public String toString() {
         final StringBuilder buf = new StringBuilder();
 
-        for (final Map.Entry<TimeAcctCategory, Double> me : allocMap.entrySet()) {
+        for (final Map.Entry<TimeAcctCategory, TimeAcctAward> me : allocMap.entrySet()) {
             if (buf.length() > 0) {
                 buf.append(", ");
             }
@@ -165,21 +115,15 @@ public final class TimeAcctAllocation implements Serializable {
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         final TimeAcctAllocation that = (TimeAcctAllocation) o;
-
-        if (Double.compare(that.totalTime, totalTime) != 0) return false;
-        if (!allocMap.equals(that.allocMap)) return false;
-
-        return true;
+        return Objects.equals(allocMap, that.allocMap);
     }
 
     @Override
     public int hashCode() {
-        final long temp = Double.doubleToLongBits(totalTime);
-        return 31 * allocMap.hashCode() + (int) (temp ^ (temp >>> 32));
+        return Objects.hash(allocMap);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAward.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAward.java
@@ -1,0 +1,82 @@
+package edu.gemini.spModel.timeacct;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.Objects;
+
+
+/**
+ * A tuple combining program and partner time awards.
+ */
+public final class TimeAcctAward implements Serializable {
+    public static final TimeAcctAward ZERO = new TimeAcctAward(Duration.ZERO, Duration.ZERO);
+
+    private final Duration programAward;
+    private final Duration partnerAward;
+
+    public TimeAcctAward(Duration programAward, Duration partnerAward) {
+        if (programAward == null)
+            throw new IllegalArgumentException("null programAward in TimeAcctAward");
+
+        if (partnerAward == null)
+            throw new IllegalArgumentException("null partnerAward in TimeAcctAward");
+
+        if (programAward.isNegative())
+            throw new IllegalArgumentException("Negative programAward in TimeAcctAward");
+
+        if (partnerAward.isNegative())
+            throw new IllegalArgumentException("Negative partnerAward in TimeAcctAward");
+
+        this.programAward = programAward;
+        this.partnerAward = partnerAward;
+    }
+
+    public Duration getProgramAward() {
+        return programAward;
+    }
+
+    public Duration getPartnerAward() {
+        return partnerAward;
+    }
+
+    public Duration getTotalAward() {
+        return programAward.plus(partnerAward);
+    }
+
+    // Convenience method to provide total award converted to hours.
+    public double getTotalHours() {
+        final long ms = getTotalAward().toMillis();
+        return ((double) ms) / 3600000.0;
+    }
+
+    public TimeAcctAward plus(TimeAcctAward that) {
+        return new TimeAcctAward(programAward.plus(that.programAward), partnerAward.plus(that.partnerAward));
+    }
+
+    public boolean isZero() {
+        return programAward.isZero() && partnerAward.isZero();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TimeAcctAward that = (TimeAcctAward) o;
+        return Objects.equals(programAward, that.programAward) &&
+                Objects.equals(partnerAward, that.partnerAward);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(programAward, partnerAward);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("TimeAcctAward{");
+        sb.append("programAward=").append(programAward);
+        sb.append(", partnerAward=").append(partnerAward);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAward.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAward.java
@@ -11,6 +11,8 @@ import java.util.Objects;
 public final class TimeAcctAward implements Serializable {
     public static final TimeAcctAward ZERO = new TimeAcctAward(Duration.ZERO, Duration.ZERO);
 
+    private static final long MS_PER_HOUR = Duration.ofHours(1).toMillis();
+
     private final Duration programAward;
     private final Duration partnerAward;
 
@@ -46,7 +48,7 @@ public final class TimeAcctAward implements Serializable {
     // Convenience method to provide total award converted to hours.
     public double getTotalHours() {
         final long ms = getTotalAward().toMillis();
-        return ((double) ms) / 3600000.0;
+        return ((double) ms) / MS_PER_HOUR;
     }
 
     public TimeAcctAward plus(TimeAcctAward that) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAward.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctAward.java
@@ -33,22 +33,36 @@ public final class TimeAcctAward implements Serializable {
         this.partnerAward = partnerAward;
     }
 
+    private static double toHours(Duration d) {
+        return ((double) d.toMillis()) / MS_PER_HOUR;
+    }
+
     public Duration getProgramAward() {
         return programAward;
+    }
+
+    /** Convenience method to provide program award converted to hours. */
+    public double getProgramHours() {
+        return toHours(getProgramAward());
     }
 
     public Duration getPartnerAward() {
         return partnerAward;
     }
 
+    /** Convenience method to provide partner award converted to hours. */
+    public double getPartnerHours() {
+        return toHours(getPartnerAward());
+    }
+
+
     public Duration getTotalAward() {
         return programAward.plus(partnerAward);
     }
 
-    // Convenience method to provide total award converted to hours.
+    /** Convenience method to provide total award converted to hours. */
     public double getTotalHours() {
-        final long ms = getTotalAward().toMillis();
-        return ((double) ms) / MS_PER_HOUR;
+        return toHours(getTotalAward());
     }
 
     public TimeAcctAward plus(TimeAcctAward that) {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
@@ -263,7 +263,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
                 usedTime = otc.getTime(ChargeClass.PROGRAM);
 
                 // Get the remaining program time.
-                TimeValue awardedTime = program.getAwardedTime();
+                TimeValue awardedTime = program.getAwardedProgramTime();
                 remainingTime = awardedTime == null ? 0 : awardedTime.getMilliseconds() - usedTime;
                 if (awardedTime == null) {
                     LOGGER.warning("Program " + id + " has null awarded time.");

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/TimeValue.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/TimeValue.java
@@ -112,7 +112,7 @@ public final class TimeValue implements Cloneable, Comparable<TimeValue>, Serial
     /**
      * Constructs with the given number of milliseconds and units.
      */
-    public TimeValue(long milliseconds, Units timeUnits) {
+    private TimeValue(long milliseconds, Units timeUnits) {
         _milliseconds = milliseconds;
         _units        = timeUnits;
     }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/TimeValue.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/TimeValue.java
@@ -112,7 +112,7 @@ public final class TimeValue implements Cloneable, Comparable<TimeValue>, Serial
     /**
      * Constructs with the given number of milliseconds and units.
      */
-    private TimeValue(long milliseconds, Units timeUnits) {
+    public TimeValue(long milliseconds, Units timeUnits) {
         _milliseconds = milliseconds;
         _units        = timeUnits;
     }

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
@@ -21,6 +21,7 @@ import edu.gemini.spModel.io.impl.migration.to2016A.To2016A;
 import edu.gemini.spModel.io.impl.migration.to2016B.To2016B;
 import edu.gemini.spModel.io.impl.migration.to2016B.To2016B2;
 import edu.gemini.spModel.io.impl.migration.to2017A.To2017A;
+import edu.gemini.spModel.io.impl.migration.to2017B.To2017B;
 import edu.gemini.spModel.io.impl.migration.toPalote.Grillo2Palote;
 import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obscomp.SPGroup;
@@ -230,6 +231,9 @@ public final class PioSpXmlParser {
 
         // Update pre-2017A programs
         To2017A.updateProgram(doc);
+
+        // Update pre-2017B programs
+        To2017B.updateProgram(doc);
 
         // We will special case the Phase 1 container.
         Container p1Container = null;

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2017B/To2017B.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2017B/To2017B.scala
@@ -1,0 +1,37 @@
+package edu.gemini.spModel.io.impl.migration.to2017B
+
+import edu.gemini.spModel.io.PioSyntax._
+import edu.gemini.spModel.io.impl.SpIOTags
+import edu.gemini.spModel.io.impl.migration.Migration
+import edu.gemini.spModel.pio.xml.PioXmlFactory
+
+import edu.gemini.spModel.pio.{Pio, Document, Version}
+
+import scalaz._, Scalaz._
+
+/** 2017B Migration.
+ */
+object To2017B extends Migration {
+
+  val version = Version.`match`("2017B-1")
+
+  val conversions: List[Document => Unit] =
+    List(updateTimeAccounting)
+
+  val fact = new PioXmlFactory
+
+  // Changes the old implicit program award in hours to an explicit program
+  // award in milliseconds and adds explicit partner award of 0.
+  private def updateTimeAccounting(d: Document): Unit =
+    for {
+      cont <- d.containers.find(_.getKind == SpIOTags.PROGRAM)
+      dobj <- cont.dataObject
+      tact <- dobj.paramSet("timeAcct")
+      aloc <- tact.paramSets("timeAcctAlloc")
+      hrs  <- aloc.double("hours")
+    } {
+      aloc.removeChild("hours")
+      Pio.addLongParam(fact, aloc, "program", (hrs * 3600000).round)
+      Pio.addLongParam(fact, aloc, "partner", 0)
+    }
+}

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2017B/timeAcct.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2017B/timeAcct.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2017A-1" subtype="basic" key="f80b3ded-5725-4f2b-8b22-a94ac83eca3c" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="piInfo">
+        <param name="firstName" value=""/>
+        <param name="lastName" value=""/>
+        <param name="email" value=""/>
+        <param name="phone" value=""/>
+      </paramset>
+      <param name="queueBand" value="1"/>
+      <paramset name="timeAcct">
+        <paramset name="timeAcctAlloc">
+          <param name="category" value="AR"/>
+          <param name="hours" value="2.5"/>
+        </paramset>
+        <paramset name="timeAcctAlloc">
+          <param name="category" value="BR"/>
+          <param name="hours" value="1.0"/>
+        </paramset>
+        <paramset name="timeAcctAlloc">
+          <param name="category" value="CL"/>
+          <param name="hours" value="1.5"/>
+        </paramset>
+      </paramset>
+      <param name="awardedTime" value="5.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="f80b3ded-5725-4f2b-8b22-a94ac83eca3c"/>
+      <param name="68aa451f-9a32-42b4-861c-3b1c66b56acd" value="1"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2017B/TimeAcctMigrationTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2017B/TimeAcctMigrationTest.scala
@@ -1,0 +1,33 @@
+package edu.gemini.spModel.io.impl.migration.to2017B
+
+import edu.gemini.spModel.gemini.obscomp.SPProgram
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import edu.gemini.spModel.timeacct._
+import edu.gemini.spModel.timeacct.TimeAcctCategory._
+
+import org.specs2.mutable.Specification
+
+class TimeAcctMigrationTest extends Specification with MigrationTest {
+  val HRS = 3600000
+
+  def matchAward(a: TimeAcctAward, prog: Double): Boolean =
+    a.getProgramAward.toMillis == (prog * HRS).round &&
+      a.getPartnerAward.toMillis == 0l
+
+  "2017B Time Accounting Migration" should {
+    "Change implicit program award in hours to explicit/milliseconds" in withTestProgram2("timeAcct.xml") { p =>
+      val prog  = p.getDataObject.asInstanceOf[SPProgram]
+      val alloc = prog.getTimeAcctAllocation
+
+      val ar = alloc.getAward(AR)
+      val br = alloc.getAward(BR)
+      val cl = alloc.getAward(CL)
+      val us = alloc.getAward(US)
+
+      matchAward(alloc.getSum, 5) &&
+        matchAward(ar, 2.5) &&
+        matchAward(br, 1.0) &&
+        matchAward(cl, 1.5)
+    }
+  }
+}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/ExecHoursTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/ExecHoursTable.java
@@ -83,7 +83,7 @@ public class ExecHoursTable extends AbstractTable {
 
 			row.put(Columns.PROGRAM_ID, prog.getProgramID());
 			try {
-				row.put(Columns.ALLOCATED_HRS, program.getAwardedTime().getMilliseconds() / MS_PER_HOUR);
+				row.put(Columns.ALLOCATED_HRS, program.getAwardedProgramTime().getMilliseconds() / MS_PER_HOUR);
 			} catch (NullPointerException npe) {
 				LOGGER.warning("Program " + prog.getProgramID() + " has null awarded time.");
 				row.put(Columns.ALLOCATED_HRS, 0f);

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
@@ -106,7 +106,7 @@ public final class QueueProgramStatusExternalTable extends AbstractTable {
             }
 
             // Allocated time
-            final TimeValue allocatedTV = prog.getAwardedTime();
+            final TimeValue allocatedTV = prog.getAwardedProgramTime();
             if (allocatedTV == null) {
                 LOGGER.fine("Program " + id + " has null allocatedTime. Skipping.");
                 return Collections.emptyList();
@@ -128,7 +128,7 @@ public final class QueueProgramStatusExternalTable extends AbstractTable {
             row.put(Columns.PARTNERS, getPartners(prog.getTimeAcctAllocation()));
             row.put(Columns.TITLE, prog.getTitle());
             row.put(Columns.INST_MODE, ReportUtils.getScienceInstruments(progShell));
-            row.put(Columns.HOURS_ALLOC, prog.getAwardedTime().getMilliseconds() / MS_PER_HOUR);
+            row.put(Columns.HOURS_ALLOC, prog.getAwardedProgramTime().getMilliseconds() / MS_PER_HOUR);
             row.put(Columns.STATUS, ReportUtils.getExecutionStatus(progShell, prog, false));
             row.put(Columns.DATES, getDates(progShell));
             row.put(Columns.COMP, completion);
@@ -172,7 +172,7 @@ public final class QueueProgramStatusExternalTable extends AbstractTable {
     private String getPartners(final TimeAcctAllocation timeAcctAllocation) {
         final StringBuilder builder = new StringBuilder();
         for (TimeAcctCategory cat : timeAcctAllocation.getCategories()) {
-            if (!timeAcctAllocation.getAward(cat).isZero()) {
+            if (!timeAcctAllocation.getAward(cat).getProgramAward().isZero()) {
                 if (builder.length() > 0) {
                     builder.append("/");
                 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
@@ -172,7 +172,7 @@ public final class QueueProgramStatusExternalTable extends AbstractTable {
     private String getPartners(final TimeAcctAllocation timeAcctAllocation) {
         final StringBuilder builder = new StringBuilder();
         for (TimeAcctCategory cat : timeAcctAllocation.getCategories()) {
-            if (timeAcctAllocation.getHours(cat) > 0.0) {
+            if (!timeAcctAllocation.getAward(cat).isZero()) {
                 if (builder.length() > 0) {
                     builder.append("/");
                 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusInternalTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusInternalTable.java
@@ -2,7 +2,6 @@ package edu.gemini.spdb.reports.collection.table;
 
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.ISPProgram;
-import edu.gemini.spModel.core.ProgramType;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.shared.util.TimeValue;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
@@ -109,7 +108,7 @@ public class QueueProgramStatusInternalTable extends AbstractTable {
             }
 
             // Allocated time
-            TimeValue allocatedTV = prog.getAwardedTime();
+            TimeValue allocatedTV = prog.getAwardedProgramTime();
             if (allocatedTV == null) {
                 LOGGER.fine("Program " + id + " has null allocatedTime. Skipping.");
                 return  Collections.emptyList();

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
@@ -24,6 +24,7 @@ import edu.gemini.spModel.time.ObsTimeCharges;
 import edu.gemini.spModel.time.ObsTimeCorrection;
 import edu.gemini.spModel.util.SPTreeUtil;
 import edu.gemini.spModel.timeacct.TimeAcctAllocation;
+import edu.gemini.spModel.timeacct.TimeAcctAward;
 import edu.gemini.spModel.timeacct.TimeAcctCategory;
 import edu.gemini.spdb.reports.IColumn;
 import edu.gemini.spdb.reports.util.AbstractTable;
@@ -104,11 +105,11 @@ public class TimeAccountingSummaryTable extends AbstractTable {
         // If none, then we cannot report for this program.
         final SPProgram progDataObj = (SPProgram) programShell.getDataObject();
         final TimeAcctAllocation alloc = progDataObj.getTimeAcctAllocation();
-        if ((alloc == null) || (alloc.getSum().isZero())) {
+        if ((alloc == null) || (alloc.getSum().getProgramAward().isZero())) {
             LOGGER.fine("No time accounting information for " + id);
             return Collections.emptyList();
         }
-        final SortedMap<TimeAcctCategory, Double> ratios = alloc.getRatios();
+        final SortedMap<TimeAcctCategory, Double> ratios = alloc.getRatios(TimeAcctAward::getProgramAward);
         if (ratios.size() == 0) {
             LOGGER.fine("No time accounting category for " + id);
             return Collections.emptyList();

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
@@ -104,7 +104,7 @@ public class TimeAccountingSummaryTable extends AbstractTable {
         // If none, then we cannot report for this program.
         final SPProgram progDataObj = (SPProgram) programShell.getDataObject();
         final TimeAcctAllocation alloc = progDataObj.getTimeAcctAllocation();
-        if ((alloc == null) || (alloc.getTotalTime() == 0)) {
+        if ((alloc == null) || (alloc.getSum().isZero())) {
             LOGGER.fine("No time accounting information for " + id);
             return Collections.emptyList();
         }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -262,7 +262,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
 
         // Allocated time (awarded time in hours).
         try {
-            final double awardedTime = getDataObject().getAwardedTime().getTimeAmount();
+            final double awardedTime = getDataObject().getAwardedProgramTime().getTimeAmount();
             setTimeLabel(awardedTime, _w.allocatedTime);
         } catch (final Exception e) {
             DialogUtil.error(e);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -156,11 +156,11 @@ public class ProgramForm extends JPanel {
                             FormFactory.LABEL_COMPONENT_GAP_COLSPEC,
                             new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(36), FormSpec.NO_GROW),
                             new ColumnSpec(ColumnSpec.LEFT, Sizes.dluX(15), FormSpec.NO_GROW),
-                            new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(36), FormSpec.NO_GROW),
+                            new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(56), FormSpec.NO_GROW),
                             FormFactory.UNRELATED_GAP_COLSPEC,
                             FormFactory.DEFAULT_COLSPEC,
                             new ColumnSpec(ColumnSpec.LEFT, Sizes.DLUX11, FormSpec.NO_GROW),
-                            new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(36), FormSpec.NO_GROW)
+                            new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(58), FormSpec.NO_GROW)
                     },
                     new RowSpec[]{
                             FormFactory.DEFAULT_ROWSPEC,
@@ -199,9 +199,9 @@ public class ProgramForm extends JPanel {
         partnerTime.setToolTipText("Total time charged to the Gemini partner");
         timePanel.add(partnerTime, cc.xy(7, 5));
 
-        timePanel.add(new JLabel("Allocated"), cc.xy(9, 3));
+        timePanel.add(new JLabel("Allocated Program"), cc.xy(9, 3));
         allocatedTime = new JLabel("00:00:00");
-        allocatedTime.setToolTipText("The total time allocated for the observation, in hours:minutes:seconds");
+        allocatedTime.setToolTipText("The total program time allocated, in hours:minutes:seconds");
         timePanel.add(allocatedTime, cc.xy(9, 5));
 
         minimumTimeLabel = new JLabel("Minimum");
@@ -210,9 +210,9 @@ public class ProgramForm extends JPanel {
         minimumTime.setToolTipText("The minimal success time, in hours:minutes:seconds");
         timePanel.add(minimumTime, cc.xy(11, 5));
 
-        timePanel.add(new JLabel("Remaining"), cc.xy(13, 3));
+        timePanel.add(new JLabel("Remaining Program"), cc.xy(13, 3));
         remainingTime = new JLabel("00:00:00");
-        remainingTime.setToolTipText("Remaining Time (total of Allocated Time minus the sum of the Program Time fields in the observations)");
+        remainingTime.setToolTipText("Remaining Program Time (total of Allocated Program Time minus the sum of the Program Time fields in the observations)");
         timePanel.add(remainingTime, cc.xy(13, 5));
 
         add(timePanel, cc.xywh(1, 23, 11, 1));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
@@ -23,10 +23,6 @@ final class TimeAcctEditor implements ProgramTypeListener {
     // Used to format values as strings
     private final static DecimalFormat nf = new DecimalFormat("0.#");
 
-    private static double toHours(Duration d) {
-        return ((double) d.toMillis()) / MS_PER_HOUR;
-    }
-
     private static Duration toDuration(double hours) {
         return Duration.ofMillis(Math.round(hours * MS_PER_HOUR));
     }
@@ -91,9 +87,9 @@ final class TimeAcctEditor implements ProgramTypeListener {
 
     private void showTotalTime(final TimeAcctAllocation alloc) {
         final TimeAcctAward a = alloc.getSum();
-        ui.getTotalAwardLabel()  .setText(nf.format(toHours(a.getTotalAward())));
-        ui.getProgramAwardLabel().setText(nf.format(toHours(a.getProgramAward())));
-        ui.getPartnerAwardLabel().setText(nf.format(toHours(a.getPartnerAward())));
+        ui.getTotalAwardLabel()  .setText(nf.format(a.getTotalHours()));
+        ui.getProgramAwardLabel().setText(nf.format(a.getProgramHours()));
+        ui.getPartnerAwardLabel().setText(nf.format(a.getPartnerHours()));
     }
 
     private TimeValue getMinimumTime() {
@@ -139,10 +135,10 @@ final class TimeAcctEditor implements ProgramTypeListener {
 
         // Show the time for each category.
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
-            final double progHours = toHours(alloc.getAward(cat).getProgramAward());
+            final double progHours = alloc.getAward(cat).getProgramHours();
             ui.getProgramAwardField(cat).setText(nf.format(progHours)); // REL-434
 
-            final double partHours = toHours(alloc.getAward(cat).getPartnerAward());
+            final double partHours = alloc.getAward(cat).getPartnerHours();
             ui.getPartnerAwardField(cat).setText(nf.format(partHours)); // REL-434
         }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
@@ -18,15 +18,17 @@ import java.util.Locale;
 import java.util.Map;
 
 final class TimeAcctEditor implements ProgramTypeListener {
+    private static final long MS_PER_HOUR = Duration.ofHours(1).toMillis();
+
     // Used to format values as strings
     private final static DecimalFormat nf = new DecimalFormat("0.#");
 
     private static double toHours(Duration d) {
-        return ((double) d.toMillis()) / 3600000.0;
+        return ((double) d.toMillis()) / MS_PER_HOUR;
     }
 
     private static Duration toDuration(double hours) {
-        return Duration.ofMillis(Math.round(hours * 3600000.0));
+        return Duration.ofMillis(Math.round(hours * MS_PER_HOUR));
     }
 
     private static final Duration parseDuration(JTextField field) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
@@ -119,7 +119,7 @@ final class TimeAcctEditor implements ProgramTypeListener {
     private void showPercentTime(final TimeAcctAllocation alloc) {
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
             final JLabel lab = ui.getPercentLabel(cat);
-            final double percent = alloc.getPercentage(cat);
+            final double percent = alloc.getPercentage(cat, TimeAcctAward::getTotalAward);
             lab.setText(String.format("%.0f%%", percent));
         }
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
@@ -3,6 +3,7 @@ package jsky.app.ot.progadmin;
 import edu.gemini.shared.util.TimeValue;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.timeacct.TimeAcctAllocation;
+import edu.gemini.spModel.timeacct.TimeAcctAward;
 import edu.gemini.spModel.timeacct.TimeAcctCategory;
 import jsky.coords.HMS;
 
@@ -10,45 +11,61 @@ import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.*;
-import java.text.NumberFormat;
+import java.text.DecimalFormat;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
 final class TimeAcctEditor implements ProgramTypeListener {
     // Used to format values as strings
-    private final static NumberFormat nf = NumberFormat.getInstance(Locale.US);
-    static {
-        nf.setMinimumIntegerDigits(1);
-        nf.setMaximumFractionDigits(1);
+    private final static DecimalFormat nf = new DecimalFormat("0.#");
+
+    private static double toHours(Duration d) {
+        return ((double) d.toMillis()) / 3600000.0;
     }
 
+    private static Duration toDuration(double hours) {
+        return Duration.ofMillis(Math.round(hours * 3600000.0));
+    }
+
+    private static final Duration parseDuration(JTextField field) {
+        try {
+            return toDuration(Double.parseDouble(field.getText()));
+        } catch (NumberFormatException ex) {
+            return Duration.ZERO;
+        }
+    }
+
+
     private final TimeAcctUI ui;
+
+    private final DocumentListener hoursListener = new DocumentListener() {
+        @Override public void insertUpdate(final DocumentEvent event) {
+            update();
+        }
+
+        @Override public void removeUpdate(final DocumentEvent event) {
+            update();
+        }
+
+        @Override public void changedUpdate(final DocumentEvent event) {
+            update();
+        }
+
+        private void update() {
+            final TimeAcctAllocation alloc = getAllocation();
+            showTotalTime(alloc);
+            showPercentTime(alloc);
+        }
+    };
 
     public TimeAcctEditor(final TimeAcctUI ui, final ProgramTypeModel pkm) {
         this.ui = ui;
 
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
-            final JTextField field = ui.getHoursField(cat);
-            field.getDocument().addDocumentListener(new DocumentListener() {
-                @Override public void insertUpdate(final DocumentEvent event) {
-                    update();
-                }
-
-                @Override public void removeUpdate(final DocumentEvent event) {
-                    update();
-                }
-
-                @Override public void changedUpdate(final DocumentEvent event) {
-                    update();
-                }
-
-                private void update() {
-                    final TimeAcctAllocation alloc = getAllocation();
-                    showTotalTime(alloc);
-                    showPercentTime(alloc);
-                }
-            });
+            ui.getProgramAwardField(cat).getDocument().addDocumentListener(hoursListener);
+            ui.getPartnerAwardField(cat).getDocument().addDocumentListener(hoursListener);
         }
 
         final boolean enable = enableMinimumTime(pkm.getProgramType());
@@ -60,28 +77,21 @@ final class TimeAcctEditor implements ProgramTypeListener {
 
     public TimeAcctAllocation getAllocation() {
 
-        final Map<TimeAcctCategory, Double> hoursMap = new HashMap<>();
+        final Map<TimeAcctCategory, TimeAcctAward> allocMap = new HashMap<>();
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
-            final JTextField field = ui.getHoursField(cat);
-            final String hoursStr = field.getText();
-            try {
-                hoursMap.put(cat, Double.parseDouble(hoursStr));
-            } catch (final Exception ex) {
-                // ignore
-            }
+            final Duration  progAward = parseDuration(ui.getProgramAwardField(cat));
+            final Duration  partAward = parseDuration(ui.getPartnerAwardField(cat));
+            final TimeAcctAward award = new TimeAcctAward(progAward, partAward);
+            allocMap.put(cat, award);
         }
-        return new TimeAcctAllocation(hoursMap);
+        return new TimeAcctAllocation(allocMap);
     }
 
     private void showTotalTime(final TimeAcctAllocation alloc) {
-        // Show the total time awarded without trailing 0s
-        String hoursStr = String.format("%.2f", alloc.getTotalTime());
-        if (hoursStr.endsWith(".00")) {
-            hoursStr = hoursStr.substring(0, hoursStr.length() - 3);
-        } else if (hoursStr.endsWith("0")) {
-            hoursStr = hoursStr.substring(0, hoursStr.length() - 1);
-        }
-        ui.getTimeAwardedLabel().setText(hoursStr);
+        final TimeAcctAward a = alloc.getSum();
+        ui.getTotalAwardLabel()  .setText(nf.format(toHours(a.getTotalAward())));
+        ui.getProgramAwardLabel().setText(nf.format(toHours(a.getProgramAward())));
+        ui.getPartnerAwardLabel().setText(nf.format(toHours(a.getPartnerAward())));
     }
 
     private TimeValue getMinimumTime() {
@@ -127,9 +137,11 @@ final class TimeAcctEditor implements ProgramTypeListener {
 
         // Show the time for each category.
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
-            final JTextField field = ui.getHoursField(cat);
-            final double hours = alloc.getHours(cat);
-            field.setText(nf.format(hours)); // REL-434
+            final double progHours = toHours(alloc.getAward(cat).getProgramAward());
+            ui.getProgramAwardField(cat).setText(nf.format(progHours)); // REL-434
+
+            final double partHours = toHours(alloc.getAward(cat).getPartnerAward());
+            ui.getPartnerAwardField(cat).setText(nf.format(partHours)); // REL-434
         }
 
         // Show the percentage for each category.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
@@ -128,11 +128,26 @@ final class TimeAcctUI extends JPanel {
 
         final TimeAcctCategory[] catA = TimeAcctCategory.values();
 
+        // Column Headers
+        gbc.anchor    = GridBagConstraints.WEST;
+        gbc.gridy     = 0;
+        gbc.insets    = new Insets(10, 0, 0, 5);
+
+        gbc.gridx     = 1;
+        pan.add(new JLabel("Program"), gbc);
+        gbc.gridx     = 2;
+        pan.add(new JLabel("Partner"), gbc);
+        gbc.gridx     = 5;
+        pan.add(new JLabel("Program"), gbc);
+        gbc.gridx     = 6;
+        pan.add(new JLabel("Partner"), gbc);
+
+        // Time Accountig Allocation
         final int div = catA.length/2 + catA.length%2;
         for (int i=0; i<catA.length; ++i) {
             final TimeAcctCategory cat = catA[i];
 
-            int row = i % div;
+            int row = 1 + i % div;
             int col = (i / div) * 4;
 
             final JLabel lab = new JLabel(String.format("%s (%s)", cat.name(), cat.getDisplayName()));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
@@ -11,25 +11,37 @@ import java.awt.*;
  * User interface widgets for time accounting;
  */
 final class TimeAcctUI extends JPanel {
-    private final JLabel timeAwardedLabel;
+    private final JLabel totalAwardLabel;
+    private final JLabel programAwardLabel;
+    private final JLabel partnerAwardLabel;
+
     private final JTextField minTimeField;
-    private final Map<TimeAcctCategory, JTextField> hoursFieldMap;
+    private final Map<TimeAcctCategory, JTextField> programAwardFieldMap;
+    private final Map<TimeAcctCategory, JTextField> partnerAwardFieldMap;
     private final Map<TimeAcctCategory, JLabel> percentLabelMap;
 
     public TimeAcctUI() {
         super(new BorderLayout());
 
-        timeAwardedLabel = new JLabel();
-        minTimeField     = new JTextField();
+        totalAwardLabel   = new JLabel();
+        programAwardLabel = new JLabel();
+        partnerAwardLabel = new JLabel();
+        minTimeField      = new JTextField();
         minTimeField.setColumns(5);
 
-        hoursFieldMap = new HashMap<>();
-        percentLabelMap = new HashMap<>();
+        programAwardFieldMap = new HashMap<>();
+        partnerAwardFieldMap = new HashMap<>();
+        percentLabelMap      = new HashMap<>();
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
-            final JTextField tf = new JTextField();
-            tf.setColumns(5);
-            tf.setToolTipText("Enter the number of hours to charge to " + cat.getDisplayName());
-            hoursFieldMap.put(cat, tf);
+            final JTextField programTf = new JTextField();
+            programTf.setColumns(5);
+            programTf.setToolTipText("Enter the number of program hours to charge to " + cat.getDisplayName());
+            programAwardFieldMap.put(cat, programTf);
+
+            final JTextField partnerTf = new JTextField();
+            partnerTf.setColumns(5);
+            partnerTf.setToolTipText("Enter the number of partner hours to charge to " + cat.getDisplayName());
+            partnerAwardFieldMap.put(cat, partnerTf);
 
             final JLabel lab = new JLabel();
             lab.setHorizontalAlignment(JLabel.TRAILING);
@@ -57,30 +69,50 @@ final class TimeAcctUI extends JPanel {
 
         gbc.gridx  = 1;
         gbc.insets = inEmpty;
-        timeAwardedLabel.setForeground(Color.black);
-        pan.add(timeAwardedLabel, gbc);
+        totalAwardLabel.setForeground(Color.black);
+        pan.add(totalAwardLabel, gbc);
 
         gbc.gridx  = 2;
         gbc.insets = inLeft;
         pan.add(new JLabel("hours"), gbc);
 
-        gbc.gridx   = 3;
+        gbc.gridx  = 3;
+        gbc.insets = inLeft;
+        pan.add(new JLabel("("), gbc);
+
+        gbc.gridx  = 4;
+        gbc.insets = inEmpty;
+        pan.add(programAwardLabel, gbc);
+
+        gbc.gridx  = 5;
+        gbc.insets = inLeft;
+        pan.add(new JLabel("program +"), gbc);
+
+        gbc.gridx  = 6;
+        gbc.insets = inLeft;
+        pan.add(partnerAwardLabel, gbc);
+
+        gbc.gridx  = 7;
+        gbc.insets = inLeft;
+        pan.add(new JLabel("partner)"), gbc);
+
+        gbc.gridx   = 8;
         gbc.insets  = inEmpty;
         pan.add(Box.createHorizontalStrut(20), gbc);
 
-        gbc.gridx   = 4;
+        gbc.gridx   = 9;
         gbc.insets  = inRight;
         pan.add(new JLabel("Min Time (Band 3 Only)"), gbc);
 
-        gbc.gridx   = 5;
+        gbc.gridx   = 10;
         gbc.insets  = inEmpty;
         pan.add(minTimeField, gbc);
 
-        gbc.gridx   = 6;
+        gbc.gridx   = 11;
         gbc.insets  = inLeft;
         pan.add(new JLabel("hours"), gbc);
 
-        gbc.gridx   = 7;
+        gbc.gridx   = 12;
         gbc.insets  = inEmpty;
         gbc.fill    = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
@@ -101,7 +133,7 @@ final class TimeAcctUI extends JPanel {
             final TimeAcctCategory cat = catA[i];
 
             int row = i % div;
-            int col = (i / div) * 3;
+            int col = (i / div) * 4;
 
             final JLabel lab = new JLabel(String.format("%s (%s)", cat.name(), cat.getDisplayName()));
 
@@ -115,10 +147,16 @@ final class TimeAcctUI extends JPanel {
             gbc.gridx     = col+1;
             gbc.gridy     = row;
             gbc.insets    = new Insets(10, 0, 0, 5);
-            pan.add(hoursFieldMap.get(cat), gbc);
+            pan.add(programAwardFieldMap.get(cat), gbc);
+
+            gbc.anchor    = GridBagConstraints.WEST;
+            gbc.gridx     = col+2;
+            gbc.gridy     = row;
+            gbc.insets    = new Insets(10, 0, 0, 5);
+            pan.add(partnerAwardFieldMap.get(cat), gbc);
 
             gbc.anchor    = GridBagConstraints.EAST;
-            gbc.gridx     = col+2;
+            gbc.gridx     = col+3;
             gbc.gridy     = row;
             gbc.insets    = new Insets(10, 0, 0, (col == 0) ? 30 : 0);
             pan.add(percentLabelMap.get(cat), gbc);
@@ -127,16 +165,26 @@ final class TimeAcctUI extends JPanel {
         return pan;
     }
 
-    public JLabel getTimeAwardedLabel() {
-        return timeAwardedLabel;
+    public JLabel getTotalAwardLabel() {
+        return totalAwardLabel;
+    }
+    public JLabel getProgramAwardLabel() {
+        return programAwardLabel;
+    }
+    public JLabel getPartnerAwardLabel() {
+        return partnerAwardLabel;
     }
 
     public JTextField getMinimumTimeField() {
         return minTimeField;
     }
 
-    public JTextField getHoursField(final TimeAcctCategory cat) {
-        return hoursFieldMap.get(cat);
+    public JTextField getProgramAwardField(final TimeAcctCategory cat) {
+        return programAwardFieldMap.get(cat);
+    }
+
+    public JTextField getPartnerAwardField(final TimeAcctCategory cat) {
+        return partnerAwardFieldMap.get(cat);
     }
 
     public JLabel getPercentLabel(final TimeAcctCategory cat) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctUI.java
@@ -142,7 +142,7 @@ final class TimeAcctUI extends JPanel {
         gbc.gridx     = 6;
         pan.add(new JLabel("Partner"), gbc);
 
-        // Time Accountig Allocation
+        // Time Accounting Allocation
         final int div = catA.length/2 + catA.length%2;
         for (int i=0; i<catA.length; ++i) {
             final TimeAcctCategory cat = catA[i];


### PR DESCRIPTION
This PR changes the time accounting model to split the time award across program and partner.  Before the model was essentially a map from partner to double (hours) and now it is a map from partner to `TimeAcctAward` which in turn contains a `Duration` for the program award and a `Duration` for the partner award.

The data migration simply converts the old hours amount to an explicit program award in milliseconds and a 0 ms partner award.  The program admin editor is updated to allow editing both values.  (Bryan was opposed to making this split too visible, but this is only available to staff members and there's no good way to allow editing total hours without offering an editor for both parts.)