### PR TITLE
REL-3031: Make F2 dark filter obsolete.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -125,7 +125,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
     /**
      * Filters
      */
-    public enum Filter implements DisplayableSpType, SequenceableSpType, LoggableSpType {
+    public enum Filter implements DisplayableSpType, SequenceableSpType, LoggableSpType, ObsoletableSpType {
 
         OPEN("Open", "Open", new Some<>(1.6)),
         Y("Y (1.02 um)", "Y", new Some<>(1.02)),
@@ -140,7 +140,11 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         K_RED("K-red (2.31 um)", "K-red", new Some<>(2.31)),
         JH("JH (spectroscopic)", "JH", new Some<>(1.39)),
         HK("HK (spectroscopic)", "HK", new Some<>(1.871)),
-        DARK("Dark", "Dark", None.DOUBLE);
+        DARK("Dark", "Dark", None.DOUBLE) {
+            @Override public boolean isObsolete() {
+                return true;
+            }
+        };
 
         /** The default Filter value **/
         public static final Filter DEFAULT = OPEN;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2Editor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/flamingos2/Flamingos2Editor.java
@@ -438,7 +438,11 @@ public class Flamingos2Editor extends ComponentEditor<ISPObsComponent, Flamingos
 
         ++row;
 
-        filterCtrl = ComboPropertyCtrl.enumInstance(Flamingos2.FILTER_PROP);
+        // REL-3031: changed so that obsolete items are respected.
+        // filterCtrl = ComboPropertyCtrl.enumInstance(Flamingos2.FILTER_PROP);
+        filterCtrl = new ComboPropertyCtrl(
+                Flamingos2.FILTER_PROP,
+                SpTypeUtil.getSelectableItems((Class<Flamingos2.Filter>) Flamingos2.FILTER_PROP.getPropertyType()).toArray());
         addCtrl(pan, leftLabelCol, row, filterCtrl);
 
         // Position Angle


### PR DESCRIPTION
As per @andrewwstephens' note on REL-3031, the F2 dark filter is now obsolete.