### PR TITLE
REL-2942: Change program support labels

### DIFF
--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/api/AuxFileTransferListener.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/api/AuxFileTransferListener.java
@@ -1,7 +1,3 @@
-//
-// $Id: AuxFileTransferListener.java 381 2006-06-06 14:00:01Z shane $
-//
-
 package edu.gemini.auxfile.api;
 
 import java.util.EventListener;

--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/workflow/AddressFetcher.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/workflow/AddressFetcher.java
@@ -81,7 +81,7 @@ public final class AddressFetcher {
 
 
         // add NGO
-        res.put(Role.NGO, Collections.unmodifiableList(parseAddresses(dataObj.getNGOContactEmail(), progId)));
+        res.put(Role.NGO, Collections.unmodifiableList(parseAddresses(dataObj.getPrimaryContactEmail(), progId)));
 
         // add contact scientist
         res.put(Role.CS, Collections.unmodifiableList(parseAddresses(dataObj.getContactPerson(), progId)));

--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/workflow/MailTransport.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/workflow/MailTransport.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.auxfile.workflow;
 
 import javax.mail.Message;
@@ -10,6 +6,7 @@ import javax.mail.MessagingException;
 /**
  * A simple wrapper around javax.mail.Transport.  Enables testing.
  */
+@FunctionalInterface
 public interface MailTransport {
     void send(Message message) throws MessagingException;
 }

--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/workflow/Mailer.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/workflow/Mailer.java
@@ -1,7 +1,3 @@
-//
-// $Id: Mailer.java 893 2007-07-19 19:43:20Z swalker $
-//
-
 package edu.gemini.auxfile.workflow;
 
 import edu.gemini.auxfile.copier.AuxFileType;
@@ -19,23 +15,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
 
-/**
- *
- */
 public class Mailer {
-
-    private static final MailTransport DEFAULT_TRANSPORT = new MailTransport() {
-        public void send(Message message) throws MessagingException {
-            Transport.send(message);
-        }
-    };
-
     private MailConfig _config;
     private MailTransport _transport;
     private IDBDatabaseService _odb;
 
     public Mailer(MailConfig config, IDBDatabaseService odb) {
-        this(config, odb, DEFAULT_TRANSPORT);
+        this(config, odb, Transport::send);
     }
 
     public Mailer(MailConfig config, IDBDatabaseService odb, MailTransport transport) {
@@ -141,7 +127,7 @@ public class Mailer {
 		msg.setText(buf.toString());
 
 		// Send the mail.
-		Transport.send(msg);
+		_transport.send(msg);
 	}
 
 

--- a/bundle/edu.gemini.auxfile.workflow/src/test/java/edu/gemini/auxfile/workflow/ProgramBuilder.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/test/java/edu/gemini/auxfile/workflow/ProgramBuilder.java
@@ -51,7 +51,7 @@ public final class ProgramBuilder {
             prog = odb.getFactory().createProgram(null, progId);
 
             SPProgram dataObj = (SPProgram) prog.getDataObject();
-            if (ngoEmails != null) dataObj.setNGOContactEmail(ngoEmails);
+            if (ngoEmails != null) dataObj.setPrimaryContactEmail(ngoEmails);
             if (csEmails != null) dataObj.setContactPerson(csEmails);
             if (piEmails != null) {
                 dataObj.setPIInfo(new SPProgram.PIInfo("Biff", "Henderson", piEmails, "123 456-7890", null));

--- a/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
+++ b/bundle/edu.gemini.lchquery.servlet/src/main/scala/edu/gemini/lchquery/servlet/LchQueryFunctor.scala
@@ -145,7 +145,7 @@ class LchQueryFunctor(queryType: LchQueryFunctor.QueryType,
         setSemester(prog.scienceSemester.orNull)
         setTitle(spProg.getTitle)
         setContactScientistEmail(spProg.getContactPerson)
-        setNgoEmail(spProg.getNGOContactEmail)
+        setNgoEmail(spProg.getPrimaryContactEmail)
         setNotifyPi(spProg.getNotifyPi.displayValue)
         setRollover(prog.rolloverStatus.displayValue)
 

--- a/bundle/edu.gemini.oodb.too.window/src/main/java/edu/gemini/too/email/TooEmail.java
+++ b/bundle/edu.gemini.oodb.too.window/src/main/java/edu/gemini/too/email/TooEmail.java
@@ -257,7 +257,7 @@ public class TooEmail {
         InternetAddress[] addrs = _lookupAddresses(too, DestinationType.cc);
 
         // First add in the NGOs.
-        String ngoEmail = prog.getNGOContactEmail();
+        String ngoEmail = prog.getPrimaryContactEmail();
         if (ngoEmail != null) {
             addrs = _merge(addrs, MailUtil.parseAddresses(ngoEmail));
         }

--- a/bundle/edu.gemini.oodb.too.window/src/test/java/edu/gemini/too/email/TooEmailTest.java
+++ b/bundle/edu.gemini.oodb.too.window/src/test/java/edu/gemini/too/email/TooEmailTest.java
@@ -61,7 +61,7 @@ public final class TooEmailTest extends SpModelTestBase {
         SPProgram prog = (SPProgram) getProgram().getDataObject();
         prog.setTitle(PROG_NAME);
         prog.setContactPerson(GEMINI_EMAIL);
-        prog.setNGOContactEmail(cat(NGO_EMAILS));
+        prog.setPrimaryContactEmail(cat(NGO_EMAILS));
         SPProgram.PIInfo piInfo = new SPProgram.PIInfo("Biff", "Henderson", PI_EMAIL, "999", null);
         prog.setPIInfo(piInfo);
         getProgram().setDataObject(prog);

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -66,7 +66,7 @@ object SpProgramFactory {
     prog.setThesis(isThesis(proposal))
 
     prog.setPIInfo(piInfo(proposal))
-    hostNgoEmail(proposal) foreach { e => prog.setNGOContactEmail(e) }
+    hostNgoEmail(proposal) foreach { e => prog.setPrimaryContactEmail(e) }
 
     // Note: not a typo -- "contact person" is an email
     gemEmail(proposal) foreach { e => prog.setContactPerson(e) }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -68,8 +68,8 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
     public static final String NGO_CONTACT_EMAIL_PROP = "ngoEmail";
 
-    /** The default value for the NGO contact email **/
-    public static final String DEFAULT_NGO_CONTACT_EMAIL = EMPTY_STRING;
+    /** The default value for the primary contact email **/
+    public static final String DEFAULT_PRIMARY_CONTACT_EMAIL = EMPTY_STRING;
 
     /** The default final active date */
     public static final Date DEFAULT_FINAL_ACTIVE_DATE = CalendarUtil.newDate(Calendar.JANUARY, 1, 2005);
@@ -119,17 +119,12 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
     public static final String GSA_PROP = "gsa";
 
-    public static final String IGNORED_PROBLEMS_PROP = "ignoredProblems";
-
     public static final String TOO_TYPE_PROP = "tooType";
-
-    /** The default value for the ignored problems List */
-    public static final List<String> DEFAULT_IGORED_PROBLEMS = null;
 
     /**
      * Program status values.
      */
-    public static enum ProgramStatus implements DisplayableSpType, DescribableSpType {
+    public enum ProgramStatus implements DisplayableSpType, DescribableSpType {
         NEW("New", "Created by New"),
         PHASE1("Phase 1", "Initialized from Phase 1"),
         PHASE2("Phase 2", "In Phase 2 preparation"),
@@ -143,7 +138,8 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
         private String _name;
         private String _desc;
-        private ProgramStatus(String name, String description) {
+
+        ProgramStatus(String name, String description) {
             _name = name;
             _desc = description;
         }
@@ -172,13 +168,10 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
         }
     }
 
-    /** An array holding the String names of the ProgramStatus **/
-//    public static String[] PROGRAMSTATUS = {ProgramStatus.NEW.name(), ProgramStatus.PHASE1.name(), ProgramStatus.PHASE2.name(), ProgramStatus.STARTED.name(), ProgramStatus.COMPLETED.name(), ProgramStatus.SENT.name(), };
-
     /**
      * Program execution models
      */
-    public static enum ProgramMode implements DisplayableSpType {
+    public enum ProgramMode implements DisplayableSpType {
         QUEUE("Queue"),
         CLASSICAL("Classical"),
         ;
@@ -188,7 +181,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
         private String _displayValue;
 
-        private ProgramMode(String name) {
+        ProgramMode(String name) {
             _displayValue = name;
         }
 
@@ -346,7 +339,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     /**
      * Values (yes/no), to indicate if it is a active program
      */
-    public static enum Active implements DisplayableSpType {
+    public enum Active implements DisplayableSpType {
 
         NO("No") {
             public String getObfuscatedValue() {
@@ -363,7 +356,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
         private String _displayValue;
 
-        private Active(String name) {
+        Active(String name) {
             _displayValue = name;
         }
 
@@ -414,7 +407,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     private String _contactPerson = DEFAULT_CONTACT_PERSON;
 
     /** The internal value **/
-    private String _ngoContactEmail = DEFAULT_NGO_CONTACT_EMAIL;
+    private String _primaryContactEmail = DEFAULT_PRIMARY_CONTACT_EMAIL;
 
     // The internal value
     private String _queueBand = DEFAULT_QUEUE_BAND;
@@ -438,7 +431,6 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     private boolean _completed = false;
 
     // Indicates if the PI should be notified when the observation is done
-//    private YesNoType _notifyPi = YesNoType.NO; // REL-209
     private YesNoType _notifyPi = YesNoType.YES; // REL-1150
 
     // indicates the final date that the program is active in the database.
@@ -448,9 +440,6 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
     private GsaAspect _gsa;
     private GsaPhase1Data _gsaPhase1Data;
-
-    // UX-1520
-//    private List<String> _ignoredProblems = DEFAULT_IGORED_PROBLEMS;
 
     // SW: prior to 2012B, this was extracted from the old Phase 1 document
     private TooType _too = TooType.none;
@@ -477,26 +466,17 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
             prog._piInfo = (PIInfo)_piInfo.clone();
         }
 
-        // UX-1520
-//        if (_ignoredProblems != null) {
-//            prog._ignoredProblems = new ArrayList(_ignoredProblems);
-//        }
-
         return prog;
     }
 
     @Override public boolean staffOnlyFieldsEqual(ISPDataObject to) {
         final SPProgram that = (SPProgram) to;
 
-//        final String thisPiEmail  = (_piInfo == null) ? null : _piInfo._email;
-//        final String thatPiEmail  = (that._piInfo == null) ? null : that._piInfo._email;
         final Affiliate thisPiAff = (_piInfo == null) ? null : _piInfo._affiliate;
         final Affiliate thatPiAff = (that._piInfo == null) ? null : that._piInfo._affiliate;
 
-        return //ObjectUtil.equals(thisPiEmail, thatPiEmail) &&
-               thisPiAff == thatPiAff &&
+        return thisPiAff == thatPiAff &&
                ObjectUtil.equals(_contactPerson, that._contactPerson) &&
-//               ObjectUtil.equals(_ngoContactEmail, that._ngoContactEmail) &&
                _rollover == that._rollover &&
                _isThesis == that._isThesis &&
                _isLibrary == that._isLibrary &&
@@ -525,11 +505,9 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
         // A PI can't edit his email or his affiliate
         if (_piInfo == null) _piInfo = that._piInfo;
         if (that._piInfo != null) {
-//            _piInfo._email     = that._piInfo._email;
             _piInfo._affiliate = that._piInfo._affiliate;
         }
         _contactPerson   = that._contactPerson;
-//        _ngoContactEmail = that._ngoContactEmail;
 
         _rollover        = that._rollover;
         _isThesis        = that._isThesis;
@@ -795,19 +773,19 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     }
 
     /**
-     * Returns the email for the NGO contact scientist for this proposal.
+     * Returns the email for the primary contact scientist for this proposal.
      */
-    public String getNGOContactEmail() {
-        return _ngoContactEmail;
+    public String getPrimaryContactEmail() {
+        return _primaryContactEmail;
     }
 
     /**
-     * Sets the value for the NGO contact email person for this proposal.
+     * Sets the value for the primary contact email person for this proposal.
      */
-    public void setNGOContactEmail(String newValue) {
-        String oldValue = _ngoContactEmail;
+    public void setPrimaryContactEmail(String newValue) {
+        String oldValue = _primaryContactEmail;
         if (!oldValue.equals(newValue)) {
-            _ngoContactEmail = newValue;
+            _primaryContactEmail = newValue;
             firePropertyChange(NGO_CONTACT_EMAIL_PROP, oldValue, newValue);
         }
     }
@@ -954,8 +932,8 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
             Pio.addParam(factory, paramSet, CONTACT_PERSON_PROP, contactPerson);
         }
 
-        String ngoContactEmail = getNGOContactEmail();
-        if (!ngoContactEmail.equals(DEFAULT_NGO_CONTACT_EMAIL)) {
+        String ngoContactEmail = getPrimaryContactEmail();
+        if (!ngoContactEmail.equals(DEFAULT_PRIMARY_CONTACT_EMAIL)) {
             Pio.addParam(factory, paramSet, NGO_CONTACT_EMAIL_PROP, ngoContactEmail);
         }
 
@@ -1078,7 +1056,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
             v = Pio.getValue(paramSet, NGO_CONTACT_EMAIL_PROP_OLD); // for backward compat
         }
         if (v != null) {
-            setNGOContactEmail(v);
+            setPrimaryContactEmail(v);
         }
         v = Pio.getValue(paramSet, QUEUE_BAND_PROP);
         if (v != null) {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
@@ -48,7 +48,6 @@ import edu.gemini.spModel.core.ProgramType;
 import edu.gemini.spModel.seqcomp.SeqConfigComp;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
-import edu.gemini.spModel.telescope.PosAngleConstraint;
 import edu.gemini.spModel.telescope.PosAngleConstraintAware;
 import edu.gemini.spModel.time.ChargeClass;
 import edu.gemini.spModel.time.ObsTimeCharges;
@@ -292,7 +291,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
                     band3MinimumTime == -1 ? null : band3MinimumTime,
                     band3RemainingTime == 0 ? null : band3RemainingTime,
                     program.getPILastName(),
-                    program.getNGOContactEmail(),
+                    program.getPrimaryContactEmail(),
                     program.getContactPerson());
             List<Group> groupList = new ArrayList<>();
             List<Note> noteList = new ArrayList<>();

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/mail/OdbMail.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/mail/OdbMail.java
@@ -1,6 +1,3 @@
-//
-// $Id: OdbMail.java 7519 2007-01-03 14:09:53Z shane $
-//
 package edu.gemini.dbTools.mail;
 
 import edu.gemini.dbTools.odbState.ObservationState;
@@ -72,23 +69,20 @@ public class OdbMail {
         final SortedMap<SPObservationID, ObservationState> oldObsMap = oldProg.getObservations();
         final SortedMap<SPObservationID, ObservationState> newObsMap = newProg.getObservations();
 
-        final Map<OdbMailEvent, List<SPObservationID>> eventMap = new HashMap<OdbMailEvent, List<SPObservationID>>();  // key is OdbMailEvent
+        final Map<OdbMailEvent, List<SPObservationID>> eventMap = new HashMap<>();  // key is OdbMailEvent
         for (final Object o : newObsMap.values()) {
             final ObservationState newObs = (ObservationState) o;
 
             // Get the last known status of the observation.  If not
             // previously known, then assume it was Phase2.
 
-            ObservationStatus oldStatus;
-            oldStatus = ObservationStatus.PHASE2;
+            ObservationStatus oldStatus = ObservationStatus.PHASE2;
             final SPObservationID obsId = newObs.getObservationId();
-            final ObservationState oldObs;
-            oldObs = oldObsMap.get(obsId);
+            final ObservationState oldObs = oldObsMap.get(obsId);
             if (oldObs != null) oldStatus = oldObs.getStatus();
 
             // Okay, compare the status values.
-            final ObservationStatus newStatus;
-            newStatus = newObs.getStatus();
+            final ObservationStatus newStatus = newObs.getStatus();
             if (newStatus.equals(oldStatus)) continue; // nothing changed
 
             // Okay, they have different status values.  See if there is
@@ -103,7 +97,7 @@ public class OdbMail {
             // observation.  Record that fact.
             List<SPObservationID> obsIdList = eventMap.get(event);
             if (obsIdList == null) {
-                obsIdList = new ArrayList<SPObservationID>();
+                obsIdList = new ArrayList<>();
                 eventMap.put(event, obsIdList);
             }
             obsIdList.add(obsId);

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ProgramContact.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ProgramContact.java
@@ -1,6 +1,3 @@
-//
-// $Id: ProgramContact.java 46768 2012-07-16 18:58:53Z rnorris $
-//
 package edu.gemini.dbTools.odbState;
 
 import edu.gemini.pot.sp.ISPProgram;
@@ -43,7 +40,7 @@ public class ProgramContact implements Serializable {
 
         final String piAddrs;
         piAddrs = piInfo.getEmail();
-        final String ngoAddrs = obj.getNGOContactEmail();
+        final String ngoAddrs = obj.getPrimaryContactEmail();
         final String gemContactAddrs = obj.getContactPerson();
 
         _emailAddresses = new ProgramEmailAddresses(piAddrs, ngoAddrs, gemContactAddrs);

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/tigratable/TigraTableRow.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/tigratable/TigraTableRow.java
@@ -1,6 +1,3 @@
-//
-// $Id: TigraTableRow.java 47188 2012-08-02 18:34:00Z swalker $
-//
 package edu.gemini.dbTools.tigratable;
 
 import edu.gemini.pot.sp.*;
@@ -8,7 +5,6 @@ import edu.gemini.sp.vcs2.VcsService;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.obs.ObservationStatus;
-import edu.gemini.spModel.obs.SPObservation;
 
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
@@ -64,7 +60,7 @@ public class TigraTableRow implements Serializable {
             }
 
             // NGO Contacts
-            String[] emailAddrs = _getEmails(progDataObject.getNGOContactEmail());
+            String[] emailAddrs = _getEmails(progDataObject.getPrimaryContactEmail());
             ttr._setNgoEmails(emailAddrs);
             ttr._setNgoContacts(_getContacts(emailAddrs));
 
@@ -103,8 +99,8 @@ public class TigraTableRow implements Serializable {
     private static String[] _getEmails(final String emailAddrsStr) {
         if (emailAddrsStr == null) return EMPTY_STRING_ARRAY;
 
-        final String[] splitEmailAddrs = emailAddrsStr.split("[,; ]"); // some ""
-        final List<String> emailList = new ArrayList<String>();
+        final String[] splitEmailAddrs = emailAddrsStr.split("[,; ]");
+        final List<String> emailList = new ArrayList<>();
         for (final String emailAddr : splitEmailAddrs) {
             final int at = emailAddr.indexOf('@');
             if (at == -1) continue; // some entries will be empty, some are just names
@@ -125,7 +121,7 @@ public class TigraTableRow implements Serializable {
      * username id portion (striping off the @domain part of the address).
      */
     private static String[] _getContacts(final String[] emailAddrs) {
-        final List<String> resList = new ArrayList<String>(emailAddrs.length);
+        final List<String> resList = new ArrayList<>(emailAddrs.length);
 
         for (final String emailAddr : emailAddrs) {
             final int at = emailAddr.trim().indexOf('@');
@@ -141,23 +137,14 @@ public class TigraTableRow implements Serializable {
     /**
      * Gets the observation status for the given observation, if there is one.
      */
-    private static ObservationStatus _getObsStatus(final ISPObservation obs)
-             {
-
-        final SPObservation obsDataObject;
-        obsDataObject = (SPObservation) obs.getDataObject();
-        if (obsDataObject == null) return null;
-
-        final ObservationStatus obsStatus;
-        obsStatus = ObservationStatus.computeFor(obs);
-        return obsStatus;
+    private static ObservationStatus _getObsStatus(final ISPObservation obs) {
+        return obs.getDataObject() == null ? null : ObservationStatus.computeFor(obs);
     }
 
     /**
      * Determines the instrument in use by the given observation.
      */
-    private static void _addInstruments(final TigraTableRow row, final ISPObservation obs)
-             {
+    private static void _addInstruments(final TigraTableRow row, final ISPObservation obs) {
         final List<ISPObsComponent> obsComps = obs.getObsComponents();
         if (obsComps == null) return;
 
@@ -173,7 +160,7 @@ public class TigraTableRow implements Serializable {
     private SPProgramID _progId;
 
     private String _piName;
-    private final List<String> _instruments = new ArrayList<String>();
+    private final List<String> _instruments = new ArrayList<>();
 
     private String[] _ngoContacts;
     private String[] _ngoEmails;
@@ -181,7 +168,7 @@ public class TigraTableRow implements Serializable {
 
     private Date _lastSync;
 
-    private final Map<ObservationStatus, Integer> _obsCounts = new TreeMap<ObservationStatus, Integer>(new ObservationStatusComparator());
+    private final Map<ObservationStatus, Integer> _obsCounts = new TreeMap<>(new ObservationStatusComparator());
     private int _total;
 
     private TigraTableRow() {

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/mail/test/TestProgramBase.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/mail/test/TestProgramBase.java
@@ -83,7 +83,7 @@ abstract class TestProgramBase {
         piInfo = new SPProgram.PIInfo("Joe", "Astronomer",
                                       getPiAddressesStr(), "666", Affiliate.UNITED_STATES);
         progObj.setPIInfo(piInfo);
-        progObj.setNGOContactEmail(getNgoAddressesStr());
+        progObj.setPrimaryContactEmail(getNgoAddressesStr());
         progObj.setContactPerson(getGeminiAddressesStr());
 
         prog.setDataObject(progObj);

--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/policy/ImplicitPolicy.scala
@@ -84,7 +84,7 @@ class ImplicitPolicy private (db: IDBDatabaseService, ps: Set[Principal]) {
 
   /** Retrieve the NGO user principal(s) associated with the specified program, if any. */
   def ngoUserPrincipals(id: SPProgramID): List[Principal] =
-    ~spProg(id).map(_.getNGOContactEmail).map(userPrincipalsForEmails)
+    ~spProg(id).map(_.getPrimaryContactEmail).map(userPrincipalsForEmails)
 
   /** Retrieve the Staff user principal(s) associated with the specified program, if any. */
   def staffUserPrincipals(id: SPProgramID): List[Principal] =

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/gemini/obscat/ObsQueryFunctor.java
@@ -175,7 +175,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor {
                 } else if (name.equals(ObsCatalogInfo.EMAIL)) {
                     // check against all three emails
                     final boolean b1 = a_sc.isTrueFor(piInfo.getEmail());
-                    final boolean b2 = a_sc.isTrueFor(spProg.getNGOContactEmail());
+                    final boolean b2 = a_sc.isTrueFor(spProg.getPrimaryContactEmail());
                     final boolean b3 = a_sc.isTrueFor(spProg.getContactPerson());
                     if (!(b1 || b2 || b3)) {
                         return false;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -123,7 +123,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
 
         // misc
         _w.secondaryContactBox.setText(getDataObject().getContactPerson());
-        _w.principalContactBox.setText(getDataObject().getNGOContactEmail());
+        _w.principalContactBox.setText(getDataObject().getPrimaryContactEmail());
 
         final TooType tooType = getDataObject().getTooType();
         final String typeStr = tooType.getDisplayValue();
@@ -338,7 +338,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
             getDataObject().setPIInfo(new SPProgram.PIInfo(piInfo.getFirstName(),
                     piInfo.getLastName(), piInfo.getEmail(), s, piInfo.getAffiliate()));
         } else if (tbwe == _w.principalContactBox) {
-            getDataObject().setNGOContactEmail(s);
+            getDataObject().setPrimaryContactEmail(s);
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -51,7 +51,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w = new ProgramForm();
         _edAux = new AuxFileEditor(_w);
 
-        _w.secondaryContactBox.setForeground(Color.black);
+        _w.contactBox.setForeground(Color.black);
 
         _w.titleBox.     addWatcher(this);
         _w.firstNameBox. addWatcher(this);
@@ -122,7 +122,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _showPiInfo();
 
         // misc
-        _w.secondaryContactBox.setText(getDataObject().getContactPerson());
+        _w.contactBox.setText(getDataObject().getContactPerson());
         _w.principalContactBox.setText(getDataObject().getPrimaryContactEmail());
 
         final TooType tooType = getDataObject().getTooType();
@@ -306,7 +306,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w.emailBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
         _w.phoneBox.setEnabled(enabled);
         _w.affiliationBox.setEnabled(enabled);
-        _w.secondaryContactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
+        _w.contactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
         _w.principalContactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()) || OTOptions.isNGO(getProgram().getProgramID()));
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -51,14 +51,14 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w = new ProgramForm();
         _edAux = new AuxFileEditor(_w);
 
-        _w.contactBox.setForeground(Color.black);
+        _w.secondaryContactBox.setForeground(Color.black);
 
         _w.titleBox.     addWatcher(this);
         _w.firstNameBox. addWatcher(this);
         _w.lastNameBox.  addWatcher(this);
         _w.emailBox.     addWatcher(this);
         _w.phoneBox.     addWatcher(this);
-        _w.ngoContactBox.addWatcher(this);
+        _w.principalContactBox.addWatcher(this);
 
         // add menu choices
         _w.affiliationBox.setForeground(Color.black);
@@ -83,7 +83,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w.minimumTime.setForeground(Color.black);
         _w.allocatedTime.setForeground(Color.black);
         _w.partnerTime.setForeground(Color.black);
-        _w.timeRemaining.setForeground(Color.black);
+        _w.remainingTime.setForeground(Color.black);
         _w.programTime.setForeground(Color.black);
         _w.progRefBox.setForeground(Color.black);
         _w.tooStatusLabel.setForeground(Color.black);
@@ -122,8 +122,8 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _showPiInfo();
 
         // misc
-        _w.contactBox.setText(getDataObject().getContactPerson());
-        _w.ngoContactBox.setText(getDataObject().getNGOContactEmail());
+        _w.secondaryContactBox.setText(getDataObject().getContactPerson());
+        _w.principalContactBox.setText(getDataObject().getNGOContactEmail());
 
         final TooType tooType = getDataObject().getTooType();
         final String typeStr = tooType.getDisplayValue();
@@ -282,14 +282,14 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
             final ObsTimeCharges otc = ObsTimesService.getCorrectedObsTimes(prog).getTimeCharges();
             setTimeLabel(otc.getTime(ChargeClass.PARTNER), _w.partnerTime);
             setTimeLabel(otc.getTime(ChargeClass.PROGRAM), _w.programTime);
-            setTimeLabel(ObsTimesService.getRemainingProgramTime(prog), _w.timeRemaining);
+            setTimeLabel(ObsTimesService.getRemainingProgramTime(prog), _w.remainingTime);
 
         } catch (final Exception e) {
             // This can fail, for example, if the program is null.
             DialogUtil.error(e);
             setTimeLabel(0, _w.partnerTime);
             setTimeLabel(0, _w.programTime);
-            setTimeLabel(0, _w.timeRemaining);
+            setTimeLabel(0, _w.remainingTime);
         }
     }
 
@@ -306,8 +306,8 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w.emailBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
         _w.phoneBox.setEnabled(enabled);
         _w.affiliationBox.setEnabled(enabled);
-        _w.contactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
-        _w.ngoContactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()) || OTOptions.isNGO(getProgram().getProgramID()));
+        _w.secondaryContactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
+        _w.principalContactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()) || OTOptions.isNGO(getProgram().getProgramID()));
     }
 
     /**
@@ -337,7 +337,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
             final SPProgram.PIInfo piInfo = getDataObject().getPIInfo();
             getDataObject().setPIInfo(new SPProgram.PIInfo(piInfo.getFirstName(),
                     piInfo.getLastName(), piInfo.getEmail(), s, piInfo.getAffiliate()));
-        } else if (tbwe == _w.ngoContactBox) {
+        } else if (tbwe == _w.principalContactBox) {
             getDataObject().setNGOContactEmail(s);
         }
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -135,7 +135,7 @@ public class ProgramForm extends JPanel {
         add(emailBox, cc.xywh(3, 15, 9, 1));
 
         principalContactBox = new TextBoxWidget();
-        final JLabel principalContactLabel = new JLabel("Principal Contact Email ");
+        final JLabel principalContactLabel = new JLabel("Principal Contact Email");
         principalContactLabel.setLabelFor(principalContactBox);
         add(principalContactLabel, cc.xy(1, 17));
         add(principalContactBox, cc.xywh(3, 17, 9, 1));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -140,9 +140,9 @@ public class ProgramForm extends JPanel {
         add(principalContactLabel, cc.xy(1, 17));
         add(principalContactBox, cc.xywh(3, 17, 9, 1));
 
-        add(new JLabel("Secondary Contact Email"), cc.xy(1, 19));
-        secondaryContactBox = new JLabel();
-        add(secondaryContactBox, cc.xywh(3, 19, 9, 1));
+        add(new JLabel("Contact Sci. Email"), cc.xy(1, 19));
+        contactBox = new JLabel();
+        add(contactBox, cc.xywh(3, 19, 9, 1));
 
         // --- Observing Time ---
         add(compFactory.createSeparator("Observing Time"), cc.xywh(1, 21, 11, 1));
@@ -239,7 +239,7 @@ public class ProgramForm extends JPanel {
     final TextBoxWidget phoneBox;
     final TextBoxWidget emailBox;
     final TextBoxWidget principalContactBox;
-    final JLabel secondaryContactBox;
+    final JLabel contactBox;
     final JLabel plannedLabel;
     final JLabel usedLabel;
     final JLabel totalPlannedExecTimeLabel;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -11,70 +11,9 @@ import java.awt.*;
 
 public class ProgramForm extends JPanel {
     public ProgramForm() {
-        initComponents();
-    }
+        final DefaultComponentFactory compFactory = DefaultComponentFactory.getInstance();
+        final CellConstraints cc = new CellConstraints();
 
-    private void initComponents() {
-        // JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
-        DefaultComponentFactory compFactory = DefaultComponentFactory.getInstance();
-        JLabel titleLabel = new JLabel();
-        titleBox = new TextBoxWidget();
-        JLabel progRefLabel = new JLabel();
-        progRefBox = new JLabel();
-        JLabel label2 = new JLabel();
-        tooStatusLabel = new JLabel();
-        JPanel panel2 = new JPanel();
-        notifyPiCheckBox = new JCheckBox();
-        activeCheckBox = new JCheckBox();
-        completedCheckBox = new JCheckBox();
-        JComponent piFormsSeparator = compFactory.createSeparator("Principal Investigator / Contact");
-        JLabel firstNameLabel = new JLabel();
-        firstNameBox = new TextBoxWidget();
-        JLabel lastNamelabel = new JLabel();
-        lastNameBox = new TextBoxWidget();
-        JLabel affiliationLabel = new JLabel();
-        affiliationBox = new JLabel();
-        JLabel phoneLabel = new JLabel();
-        phoneBox = new TextBoxWidget();
-        JLabel emailLabel = new JLabel();
-        emailBox = new TextBoxWidget();
-        JLabel ngoContactLabel = new JLabel();
-        ngoContactBox = new TextBoxWidget();
-        JLabel contactLabel = new JLabel();
-        contactBox = new JLabel();
-        JComponent obsTimeFormsSeparator = compFactory.createSeparator("Observing Time");
-        JPanel panel1 = new JPanel();
-        plannedLabel = new JLabel();
-        usedLabel = new JLabel();
-        totalPlannedExecTimeLabel = new JLabel();
-        totalPlannedPiTimeLabel = new JLabel();
-        JLabel programTimeLabel = new JLabel();
-        JLabel partnerTimeLabel = new JLabel();
-        JLabel allocatedTimeLabel = new JLabel();
-        minimumTimeLabel = new JLabel();
-        JLabel timeRemainingLabel = new JLabel();
-        totalPlannedExecTime = new JLabel();
-        totalPlannedPiTime = new JLabel();
-        programTime = new JLabel();
-        partnerTime = new JLabel();
-        allocatedTime = new JLabel();
-        minimumTime = new JLabel();
-        timeRemaining = new JLabel();
-        tabbedPane = new JTabbedPane();
-        addAttachmentButton = new JButton();
-        removeAttachmentButton = new JButton();
-        updateAttachmentButton = new JButton();
-        fetchAttachmentButton = new JButton();
-        openAttachmentButton = new JButton();
-        setAttachDescButton = new JButton();
-        attachDescField = new JTextField();
-        attachmentTable = new JTable();
-        JPanel panel4 = new JPanel();
-        JScrollPane scrollPane1 = new JScrollPane();
-        historyTable = new JTable();
-        CellConstraints cc = new CellConstraints();
-
-        //======== this ========
         setBorder(new EmptyBorder(6, 6, 6, 6));
         setLayout(new FormLayout(
                 new ColumnSpec[]{
@@ -120,106 +59,94 @@ public class ProgramForm extends JPanel {
                         new RowSpec(RowSpec.FILL, Sizes.DEFAULT, FormSpec.DEFAULT_GROW),
                         FormFactory.LINE_GAP_ROWSPEC,
                         new RowSpec(RowSpec.FILL, Sizes.DEFAULT, FormSpec.NO_GROW)
-                }));
+                })
+        );
 
-        //---- titleLabel ----
-        titleLabel.setText("Program Title");
+        final JLabel titleLabel = new JLabel("Program Title");
+        titleBox = new TextBoxWidget();
         titleLabel.setLabelFor(titleBox);
         add(titleLabel, cc.xy(1, 3));
         add(titleBox, cc.xywh(3, 3, 9, 1));
 
-        //---- progRefLabel ----
-        progRefLabel.setText("Program Reference");
-        add(progRefLabel, cc.xy(1, 5));
-
-        //---- progRefBox ----
-        progRefBox.setText("GN0000000");
+        add(new JLabel("Program Reference"), cc.xy(1, 5));
+        progRefBox = new JLabel("GN0000000");
         add(progRefBox, cc.xywh(3, 5, 9, 1));
 
-        //---- label2 ----
-        label2.setText("TOO Status");
-        add(label2, cc.xy(1, 7));
 
-        //---- tooStatusLabel ----
+        add(new JLabel("TOO Status"), cc.xy(1, 7));
+        tooStatusLabel = new JLabel();
         tooStatusLabel.setText("None");
         add(tooStatusLabel, cc.xy(3, 7));
 
-        //======== panel2 ========
-        {
-            panel2.setLayout(new GridBagLayout());
-            ((GridBagLayout) panel2.getLayout()).columnWidths = new int[]{0, 0, 0, 0};
-            ((GridBagLayout) panel2.getLayout()).rowHeights = new int[]{0, 0};
-            ((GridBagLayout) panel2.getLayout()).columnWeights = new double[]{0.0, 0.0, 0.0, 1.0E-4};
-            ((GridBagLayout) panel2.getLayout()).rowWeights = new double[]{1.0, 1.0E-4};
+        final GridBagLayout panel1Layout = new GridBagLayout();
+        panel1Layout.columnWidths = new int[]{0, 0, 0, 0};
+        panel1Layout.rowHeights = new int[]{0, 0};
+        panel1Layout.columnWeights = new double[]{0.0, 0.0, 0.0, 1.0E-4};
+        panel1Layout.rowWeights = new double[]{1.0, 1.0E-4};
+        final JPanel panel1 = new JPanel(panel1Layout);
 
-            //---- notifyPiCheckBox ----
-            notifyPiCheckBox.setText("Notify PI");
-            notifyPiCheckBox.setToolTipText("Enable/disable automatic notification of PI when data are collected");
-            panel2.add(notifyPiCheckBox, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
+        notifyPiCheckBox = new JCheckBox("Notify PI");
+        notifyPiCheckBox.setToolTipText("Enable/disable automatic notification of PI when data are collected");
+        panel1.add(notifyPiCheckBox, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
                     GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
                     new Insets(0, 0, 0, 0), 0, 0));
 
-            //---- activeCheckBox ----
-            activeCheckBox.setText("Active");
-            activeCheckBox.setToolTipText("Mark this program as active or inactive");
-            panel2.add(activeCheckBox, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
+        activeCheckBox = new JCheckBox("Active");
+        activeCheckBox.setToolTipText("Mark this program as active or inactive");
+        panel1.add(activeCheckBox, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
                     GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
                     new Insets(0, 15, 0, 0), 0, 0));
 
-            //---- completedCheckBox ----
-            completedCheckBox.setText("Completed");
-            panel2.add(completedCheckBox, new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0,
+        completedCheckBox = new JCheckBox("Completed");
+        panel1.add(completedCheckBox, new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0,
                     GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
                     new Insets(0, 15, 0, 0), 0, 0));
-        }
-        add(panel2, cc.xywh(5, 7, 7, 1));
-        add(piFormsSeparator, cc.xywh(1, 9, 11, 1));
 
-        //---- firstNameLabel ----
-        firstNameLabel.setText("First Name");
+        add(panel1, cc.xywh(5, 7, 7, 1));
+        add(compFactory.createSeparator("Principal Investigator / Contact"), cc.xywh(1, 9, 11, 1));
+
+
+        final JLabel firstNameLabel = new JLabel("First Name");
+        firstNameBox = new TextBoxWidget();
         firstNameLabel.setLabelFor(firstNameBox);
         add(firstNameLabel, cc.xy(1, 11));
         add(firstNameBox, cc.xy(3, 11));
 
-        //---- lastNamelabel ----
-        lastNamelabel.setText("Last Name");
+        final JLabel lastNamelabel = new JLabel("Last Name");
+        lastNameBox = new TextBoxWidget();
         lastNamelabel.setLabelFor(lastNameBox);
         add(lastNamelabel, cc.xywh(7, 11, 1, 1, CellConstraints.RIGHT, CellConstraints.DEFAULT));
         add(lastNameBox, cc.xywh(9, 11, 3, 1));
 
-        //---- affiliationLabel ----
-        affiliationLabel.setText("Support");
-        add(affiliationLabel, cc.xy(1, 13));
+        add(new JLabel("Support"), cc.xy(1, 13));
+        affiliationBox = new JLabel();
         add(affiliationBox, cc.xy(3, 13));
 
-        //---- phoneLabel ----
-        phoneLabel.setText("Phone");
+        final JLabel phoneLabel = new JLabel("Phone");
+        phoneBox = new TextBoxWidget();
         phoneLabel.setLabelFor(phoneBox);
         add(phoneLabel, cc.xywh(7, 13, 1, 1, CellConstraints.RIGHT, CellConstraints.DEFAULT));
         add(phoneBox, cc.xywh(9, 13, 3, 1));
 
-        //---- emailLabel ----
-        emailLabel.setText("PI / PC Email");
+        final JLabel emailLabel = new JLabel("PI / PC Email");
+        emailBox = new TextBoxWidget();
         emailLabel.setLabelFor(emailBox);
         add(emailLabel, cc.xy(1, 15));
         add(emailBox, cc.xywh(3, 15, 9, 1));
 
-        //---- ngoContactLabel ----
-        ngoContactLabel.setText("NGO Contact Email ");
-        ngoContactLabel.setLabelFor(ngoContactBox);
-        add(ngoContactLabel, cc.xy(1, 17));
-        add(ngoContactBox, cc.xywh(3, 17, 9, 1));
+        principalContactBox = new TextBoxWidget();
+        final JLabel principalContactLabel = new JLabel("Principal Contact Email ");
+        principalContactLabel.setLabelFor(principalContactBox);
+        add(principalContactLabel, cc.xy(1, 17));
+        add(principalContactBox, cc.xywh(3, 17, 9, 1));
 
-        //---- contactLabel ----
-        contactLabel.setText("Contact Sci. Email");
-        contactLabel.setLabelFor(ngoContactBox);
-        add(contactLabel, cc.xy(1, 19));
-        add(contactBox, cc.xywh(3, 19, 9, 1));
-        add(obsTimeFormsSeparator, cc.xywh(1, 21, 11, 1));
+        add(new JLabel("Secondary Contact Email"), cc.xy(1, 19));
+        secondaryContactBox = new JLabel();
+        add(secondaryContactBox, cc.xywh(3, 19, 9, 1));
 
-        //======== panel1 ========
-        {
-            panel1.setLayout(new FormLayout(
+        // --- Observing Time ---
+        add(compFactory.createSeparator("Observing Time"), cc.xywh(1, 21, 11, 1));
+        final JPanel timePanel = new JPanel(new FormLayout(
                     new ColumnSpec[]{
                             new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(36), FormSpec.NO_GROW),
                             FormFactory.LABEL_COMPONENT_GAP_COLSPEC,
@@ -241,136 +168,90 @@ public class ProgramForm extends JPanel {
                             FormFactory.DEFAULT_ROWSPEC,
                             FormFactory.LINE_GAP_ROWSPEC,
                             FormFactory.DEFAULT_ROWSPEC
-                    }));
+                    })
+        );
 
-            //---- plannedLabel ----
-            plannedLabel.setText("Planned");
-            panel1.add(plannedLabel, cc.xywh(1, 1, 3, 1, CellConstraints.CENTER, CellConstraints.DEFAULT));
+        plannedLabel = new JLabel("Planned");
+        timePanel.add(plannedLabel, cc.xywh(1, 1, 3, 1, CellConstraints.CENTER, CellConstraints.DEFAULT));
 
-            //---- usedLabel ----
-            usedLabel.setText("Used");
-            panel1.add(usedLabel, cc.xywh(5, 1, 3, 1, CellConstraints.CENTER, CellConstraints.DEFAULT));
+        usedLabel = new JLabel("Used");
+        timePanel.add(usedLabel, cc.xywh(5, 1, 3, 1, CellConstraints.CENTER, CellConstraints.DEFAULT));
 
-            //---- totalPlannedExecTimeLabel ----
-            totalPlannedExecTimeLabel.setText("Exec");
-            panel1.add(totalPlannedExecTimeLabel, cc.xy(1, 3));
+        totalPlannedExecTimeLabel = new JLabel("Exec");
+        timePanel.add(totalPlannedExecTimeLabel, cc.xy(1, 3));
+        totalPlannedExecTime = new JLabel("00:00:00");
+        totalPlannedExecTime.setToolTipText("The total time planned for the execution of  this program, in hours:minutes:seconds");
+        timePanel.add(totalPlannedExecTime, cc.xy(1, 5));
 
-            //---- totalPlannedPiTimeLabel ----
-            totalPlannedPiTimeLabel.setText("PI");
-            panel1.add(totalPlannedPiTimeLabel, cc.xy(3, 3));
+        totalPlannedPiTimeLabel = new JLabel("PI");
+        timePanel.add(totalPlannedPiTimeLabel, cc.xy(3, 3));
+        totalPlannedPiTime = new JLabel("00:00:00");
+        totalPlannedPiTime.setToolTipText("The total time planned to be charged to the PI for this program, in hours:minutes:seconds");
+        timePanel.add(totalPlannedPiTime, cc.xy(3, 5));
 
-            //---- programTimeLabel ----
-            programTimeLabel.setText("Program");
-            panel1.add(programTimeLabel, cc.xy(5, 3));
+        timePanel.add(new JLabel("Program"), cc.xy(5, 3));
+        programTime = new JLabel("00:00:00");
+        programTime.setToolTipText("Total time charged to the program");
+        timePanel.add(programTime, cc.xy(5, 5));
 
-            //---- partnerTimeLabel ----
-            partnerTimeLabel.setText("Partner");
-            panel1.add(partnerTimeLabel, cc.xy(7, 3));
+        timePanel.add(new JLabel("Partner"), cc.xy(7, 3));
+        partnerTime = new JLabel("00:00:00");
+        partnerTime.setToolTipText("Total time charged to the Gemini partner");
+        timePanel.add(partnerTime, cc.xy(7, 5));
 
-            //---- allocatedTimeLabel ----
-            allocatedTimeLabel.setText("Allocated");
-            panel1.add(allocatedTimeLabel, cc.xy(9, 3));
+        timePanel.add(new JLabel("Allocated"), cc.xy(9, 3));
+        allocatedTime = new JLabel("00:00:00");
+        allocatedTime.setToolTipText("The total time allocated for the observation, in hours:minutes:seconds");
+        timePanel.add(allocatedTime, cc.xy(9, 5));
 
-            //---- minimumTimeLabel ----
-            minimumTimeLabel.setText("Minimum");
-            panel1.add(minimumTimeLabel, cc.xy(11, 3));
+        minimumTimeLabel = new JLabel("Minimum");
+        timePanel.add(minimumTimeLabel, cc.xy(11, 3));
+        minimumTime = new JLabel("00:00:00");
+        minimumTime.setToolTipText("The minimal success time, in hours:minutes:seconds");
+        timePanel.add(minimumTime, cc.xy(11, 5));
 
-            //---- timeRemainingLabel ----
-            timeRemainingLabel.setText("Remaining");
-            panel1.add(timeRemainingLabel, cc.xy(13, 3));
+        timePanel.add(new JLabel("Remaining"), cc.xy(13, 3));
+        remainingTime = new JLabel("00:00:00");
+        remainingTime.setToolTipText("Remaining Time (total of Allocated Time minus the sum of the Program Time fields in the observations)");
+        timePanel.add(remainingTime, cc.xy(13, 5));
 
-            //---- totalPlannedExecTime ----
-            totalPlannedExecTime.setText("00:00:00");
-            totalPlannedExecTime.setToolTipText("The total time planned for the execution of  this program, in hours:minutes:seconds");
-            panel1.add(totalPlannedExecTime, cc.xy(1, 5));
+        add(timePanel, cc.xywh(1, 23, 11, 1));
 
-            //---- totalPlannedPiTime ----
-            totalPlannedPiTime.setText("00:00:00");
-            totalPlannedPiTime.setToolTipText("The total time planned to be charged to the PI for this program, in hours:minutes:seconds");
-            panel1.add(totalPlannedPiTime, cc.xy(3, 5));
-
-            //---- programTime ----
-            programTime.setText("00:00:00");
-            programTime.setToolTipText("Total time charged to the program");
-            panel1.add(programTime, cc.xy(5, 5));
-
-            //---- partnerTime ----
-            partnerTime.setText("00:00:00");
-            partnerTime.setToolTipText("Total time charged to the Gemini partner");
-            panel1.add(partnerTime, cc.xy(7, 5));
-
-            //---- allocatedTime ----
-            allocatedTime.setText("00:00:00");
-            allocatedTime.setToolTipText("The total time allocated for the observation, in hours:minutes:seconds");
-            panel1.add(allocatedTime, cc.xy(9, 5));
-
-            //---- minimumTime ----
-            minimumTime.setText("00:00:00");
-            minimumTime.setToolTipText("The minimal success time, in hours:minutes:seconds");
-            panel1.add(minimumTime, cc.xy(11, 5));
-
-            //---- timeRemaining ----
-            timeRemaining.setText("00:00:00");
-            timeRemaining.setToolTipText("Remaining Time (total of Allocated Time minus the sum of the Program Time fields in the observations)");
-            panel1.add(timeRemaining, cc.xy(13, 5));
-        }
-        add(panel1, cc.xywh(1, 23, 11, 1));
-
-        //======== tabbedPane1 ========
-        {
-            //======== panel4 ========
-            {
-                panel4.setLayout(new BorderLayout());
-
-                //======== scrollPane1 ========
-                {
-                    //---- historyTable ----
-                    historyTable.setBackground(Color.lightGray);
-                    scrollPane1.setViewportView(historyTable);
-                }
-                panel4.add(scrollPane1, BorderLayout.CENTER);
-            }
-            tabbedPane.addTab("Sync History", panel4);
-
-        }
+        // --- History ---
+        final JPanel historyPanel = new JPanel(new BorderLayout());
+        historyTable = new JTable();
+        historyTable.setBackground(Color.lightGray);
+        historyPanel.add(new JScrollPane(historyTable), BorderLayout.CENTER);
+        tabbedPane = new JTabbedPane();
+        tabbedPane.addTab("Sync History", historyPanel);
         add(tabbedPane, cc.xywh(1, 25, 11, 1));
-        // JFormDesigner - End of component initialization  //GEN-END:initComponents
     }
 
-    // JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
-    TextBoxWidget titleBox;
-    JLabel progRefBox;
-    JLabel tooStatusLabel;
-    JCheckBox notifyPiCheckBox;
-    JCheckBox activeCheckBox;
-    JCheckBox completedCheckBox;
-    TextBoxWidget firstNameBox;
-    TextBoxWidget lastNameBox;
-    JLabel affiliationBox;
-    TextBoxWidget phoneBox;
-    TextBoxWidget emailBox;
-    TextBoxWidget ngoContactBox;
-    JLabel contactBox;
-    JLabel plannedLabel;
-    JLabel usedLabel;
-    JLabel totalPlannedExecTimeLabel;
-    JLabel totalPlannedPiTimeLabel;
-    public JLabel minimumTimeLabel;
-    JLabel totalPlannedExecTime;
-    JLabel totalPlannedPiTime;
-    JLabel programTime;
-    JLabel partnerTime;
-    JLabel allocatedTime;
-    JLabel minimumTime;
-    JLabel timeRemaining;
-    public JButton addAttachmentButton;
-    public JButton removeAttachmentButton;
-    public JButton updateAttachmentButton;
-    public JButton fetchAttachmentButton;
-    public JButton openAttachmentButton;
-    public JButton setAttachDescButton;
-    public JTextField attachDescField;
-    public JTable attachmentTable;
-    JTable historyTable;
-    public JTabbedPane tabbedPane;
+    final TextBoxWidget titleBox;
+    final JLabel progRefBox;
+    final JLabel tooStatusLabel;
+    final JCheckBox notifyPiCheckBox;
+    final JCheckBox activeCheckBox;
+    final JCheckBox completedCheckBox;
+    final TextBoxWidget firstNameBox;
+    final TextBoxWidget lastNameBox;
+    final JLabel affiliationBox;
+    final TextBoxWidget phoneBox;
+    final TextBoxWidget emailBox;
+    final TextBoxWidget principalContactBox;
+    final JLabel secondaryContactBox;
+    final JLabel plannedLabel;
+    final JLabel usedLabel;
+    final JLabel totalPlannedExecTimeLabel;
+    final JLabel totalPlannedPiTimeLabel;
+    final JLabel totalPlannedExecTime;
+    final JLabel totalPlannedPiTime;
+    final JLabel programTime;
+    final JLabel partnerTime;
+    final JLabel allocatedTime;
+    final JLabel minimumTimeLabel;
+    final JLabel minimumTime;
+    final JLabel remainingTime;
+    final JTable historyTable;
+    public final JTabbedPane tabbedPane;
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/auxfile/AttachmentTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/auxfile/AttachmentTableModel.java
@@ -11,28 +11,28 @@ import javax.swing.table.AbstractTableModel;
 public final class AttachmentTableModel extends AbstractTableModel {
     public enum Col {
         NAME("Name", String.class) {
-            @Override public String getValue(AuxFile file) {
+            @Override public String getValue(final AuxFile file) {
                 return file.getName();
             }
         },
         SIZE("Size", Integer.class) {
-            @Override public Object getValue(AuxFile file) {
+            @Override public Object getValue(final AuxFile file) {
                 return file.getSize();
             }
         },
         LAST_MOD("Last Modified (UTC)", Date.class) {
-            @Override public Object getValue(AuxFile file) {
-                long l = file.getLastModified();
+            @Override public Object getValue(final AuxFile file) {
+                final long l = file.getLastModified();
                 return new Date(l);
             }
         },
         DESCRIPTION("Description", String.class) {
-            @Override public Object getValue(AuxFile file) {
+            @Override public Object getValue(final AuxFile file) {
                 return file.getDescription();
             }
         },
-        CHECKED("NGO Check?", Boolean.class) {
-            @Override public Object getValue(AuxFile file) {
+        CHECKED("Check?", Boolean.class) {
+            @Override public Object getValue(final AuxFile file) {
                 return file.isChecked();
             }
         }
@@ -42,20 +42,20 @@ public final class AttachmentTableModel extends AbstractTableModel {
         private final String displayValue;
         private final Class type;
 
-        Col(String displayValue, Class columnClass) {
+        Col(final String displayValue, final Class columnClass) {
             this.displayValue = displayValue;
             type = columnClass;
         }
 
         public String displayValue() { return displayValue; }
         public Class getColumnClass() { return type; }
-        public abstract Object getValue(AuxFile file);
+        public abstract Object getValue(final AuxFile file);
     }
 
     private final List<AuxFile> fileList;
 
-    public AttachmentTableModel(List<AuxFile> fileList) {
-        this.fileList = Collections.unmodifiableList(new ArrayList<AuxFile>(fileList));
+    public AttachmentTableModel(final List<AuxFile> fileList) {
+        this.fileList = Collections.unmodifiableList(new ArrayList<>(fileList));
     }
 
     public int getRowCount() {
@@ -66,24 +66,16 @@ public final class AttachmentTableModel extends AbstractTableModel {
         return Col.values().length;
     }
 
-    public Object getValueAt(int row, int col) {
-        AuxFile file = fileList.get(row);
+    public Object getValueAt(final int row, final int col) {
+        final AuxFile file = fileList.get(row);
         return Col.values()[col].getValue(file);
     }
 
-    public String getColumnName(int col) {
+    public String getColumnName(final int col) {
         return Col.values()[col].displayValue();
     }
 
-    public Class getColumnClass(int col) {
+    public Class getColumnClass(final int col) {
         return Col.values()[col].getColumnClass();
-    }
-
-    @Override public boolean isCellEditable(int rowIndex, int columnIndex) {
-        return false; // columnIndex == Col.CHECKED.ordinal();
-    }
-
-    @Override public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
-//        assert columnIndex == Col.CHECKED.ordinal(); // this is the only editable column
     }
 }


### PR DESCRIPTION
The REL task for this PR is confusing, as the requirements have changed several times.
In the end, the description should be ignored, and only the later comments read.

Essentially, this primarily affects the program details (`ProgramForm`), and generalizes the concept of the former `NGO Contact Email` label to `Principal Contact Email`, and changes the `NGO Check?` label in the table to `Check?` to follow suit.

I tried to make this change as transparent as possible by relabeling variables and methods to reflect the change. This will, however, introduce discrepancies into the OCS code base in a few places, such as the ODB Browser, where the principal contact email will still be exported as the NGO contact email due to the XML format, which we do not wish to change as the scope would be too large and affect too many existing things, such as GSA information.

Several discussions were had and several iterations of the requirements proposed, and it was decided that living with the few discrepancies / inconsistencies was acceptable and the preferred solution.

Since this task has been stretched across quite some time, it resulted in me investigating a good chunk of the code, and I performed some minor cleanup along the way, getting rid of old commented out code and cleaning up some warnings as well.