### PR TITLE
REL-3055: Changing default amp count to 12 for GMOS-N for Hamamatsu.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -104,9 +104,8 @@ public class GmosCommonType {
         TWELVE("Twelve", DetectorManufacturer.HAMAMATSU),
         ;
 
-        public final static AmpCount DEFAULT = AmpCount.SIX;
-        public final static AmpCount DEFAULT_NORTH = AmpCount.TWELVE;
-        public final static AmpCount DEFAULT_SOUTH = AmpCount.TWELVE;
+        // Hamamatsu detectors use twelve amps, so make this the default.
+        public final static AmpCount DEFAULT = AmpCount.TWELVE;
         public final static ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "ampCount");
 
         private final String _displayValue;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -105,7 +105,7 @@ public class GmosCommonType {
         ;
 
         public final static AmpCount DEFAULT = AmpCount.SIX;
-        public final static AmpCount DEFAULT_NORTH = AmpCount.SIX;
+        public final static AmpCount DEFAULT_NORTH = AmpCount.TWELVE;
         public final static AmpCount DEFAULT_SOUTH = AmpCount.TWELVE;
         public final static ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "ampCount");
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
@@ -44,7 +44,7 @@ public class InstGmosNorth extends
     public static final PropertyDescriptor FILTER_PROP;
     public static final PropertyDescriptor FPUNIT_PROP;
 
-    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<String, PropertyDescriptor>();
+    private static final Map<String, PropertyDescriptor> PRIVATE_PROP_MAP = new TreeMap<>();
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP = Collections.unmodifiableMap(PRIVATE_PROP_MAP);
 
     private static PropertyDescriptor initProp(final String propName, final String getMethod, String setMethod) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosNorth.java
@@ -80,7 +80,6 @@ public class InstGmosNorth extends
         setFilter(GmosNorthType.FilterNorth.DEFAULT);
         setFPUnit(GmosNorthType.FPUnitNorth.DEFAULT);
         setStageMode(GmosNorthType.StageModeNorth.DEFAULT);
-        setAmpCount(GmosCommonType.AmpCount.DEFAULT_NORTH);
     }
 
     public Map<String, PropertyDescriptor> getProperties() {


### PR DESCRIPTION
With the change to Hamamatsu CCDs for GMOS-N, the default amp count must now be changed from 6 to 12.