### PR TITLE
REL-1787: Fixed arithmetic overflow in converting from hh:mm:ss to Long in ms.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/sitequality/SiteQualityPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/sitequality/SiteQualityPanel.java
@@ -179,7 +179,7 @@ final class SiteQualityPanel extends JPanel {
                     ButtonFlattener.flatten(this);
                 }});
 
-                add(new JButton(Resources.getIcon("eclipse/download.gif")) {{
+                add(new JButton(Resources.getIcon("eclipse/openbrwsr.gif")) {{
                     setToolTipText("Import timing windows from text file");
                     setFocusable(false);
                     addActionListener(e -> {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/sitequality/TimingWindowImporter.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/sitequality/TimingWindowImporter.scala
@@ -127,7 +127,7 @@ object TimingWindowParser extends RegexParsers {
 
   // Convert hhhh:mm:ss as a duration to a Long in ms.
   private def hhmmssToLong(hh: Int, mm: Int, ss: Int = 0): Long =
-    1000 * (60 * (60 * hh + mm) + ss)
+    1000 * (60 * (60 * hh.toLong + mm.toLong) + ss.toLong)
 
   // Convenience method for spec testing.
   private[sitequality] def hhmmssStringToLong(hhmmss: String): Long =

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/sitequality/TimingWindowImporter.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/sitequality/TimingWindowImporter.scala
@@ -126,8 +126,8 @@ object TimingWindowParser extends RegexParsers {
     temporalParser(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC")), "Failed to parse date") ^^ { case ta => Instant.from(ta).toEpochMilli }
 
   // Convert hhhh:mm:ss as a duration to a Long in ms.
-  private def hhmmssToLong(hh: Int, mm: Int, ss: Int = 0): Long =
-    1000 * (60 * (60 * hh.toLong + mm.toLong) + ss.toLong)
+  private def hhmmssToLong(hh: Long, mm: Long, ss: Long = 0): Long =
+    1000 * (60 * (60 * hh + mm) + ss)
 
   // Convenience method for spec testing.
   private[sitequality] def hhmmssStringToLong(hhmmss: String): Long =

--- a/bundle/jsky.app.ot/src/test/scala/jsky/app/ot/gemini/editor/sitequality/TimingWindowImporterSpec.scala
+++ b/bundle/jsky.app.ot/src/test/scala/jsky/app/ot/gemini/editor/sitequality/TimingWindowImporterSpec.scala
@@ -63,6 +63,12 @@ object TimingWindowImporterSpec extends Specification with ScalaCheck {
       val (successes, _, results) = runParsing(t1Tup.right, t2Tup.right, t3Tup.right)
       (results.successes.length must_=== 3) and (results.successes.forall(_.getDuration == TimingWindow.WINDOW_REMAINS_OPEN_FOREVER) must beTrue)
     }
+
+    "not overflow for large times" in {
+      val t1Tup = ("2017-05-05", "00:00:00", "720:00", noInt, noString)
+      val (successes, _, results) = runParsing(t1Tup.right)
+      (results.successes.length must_=== 1) and (results.successes.forall(_.getDuration > 0) must beTrue)
+    }
   }
 
   // To avoid repeated type specifiers.


### PR DESCRIPTION
In `TimingWindowImporter`, in converting from an `hh` and `mm` (and optional `ss`) specified as `Int` to a `Long` in ms, I did not convert the `hh`, `mm`, and `ss` to `Long`s first, which resulted in 32-bit integer arithmetic overflow for large values of `hh` (e.g. 720 as stated in @andrewwstephens's comment in the REL task). 

Now I convert the time elements first to `Long`s so that the arithmetic is performed in 64 bits, and the computation acts as expected instead of resulting in a negative time value.

I also added a test case for this.

In addition, as per Andy's recommendation, I changed the icon for timing window imports for clarity.