### PR TITLE
REL-3056: Updated GMOS-N template XML for Hamamatsu detectors.

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_N_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_N_BP.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
 
 <document>
-  <container kind="program" type="Program" version="2015A-1" subtype="basic" key="33e8436d-5dbd-4646-9c83-4e3d00c3a46f" name="GMOS-N-BP">
+  <container kind="program" type="Program" version="2017A-1" subtype="basic" key="c313a6e9-cf0e-4a98-a2bf-192f3091d541" name="GMOS-N-BP-copy3">
     <paramset name="Science Program" kind="dataObj">
       <param name="title" value="GMOS-N PHASE I/II MAPPING BPS"/>
       <param name="programMode" value="QUEUE"/>
@@ -10,9 +10,9 @@
       <param name="programStatus" value="PHASE2"/>
       <param name="nextObsId" value="1"/>
       <paramset name="piInfo">
-        <param name="firstName" value="Kathy"/>
-        <param name="lastName" value="Roth"/>
-        <param name="email" value="kroth@gemini.edu"/>
+        <param name="firstName" value="Julia"/>
+        <param name="lastName" value="Scharwaecthter"/>
+        <param name="email" value="jscharwaechter@gemini.edu"/>
         <param name="phone" value=""/>
       </paramset>
       <param name="queueBand" value="1"/>
@@ -25,22 +25,22 @@
       <paramset name="gsa">
         <param name="sendToGsa" value="false"/>
         <param name="proprietaryMonths" value="0"/>
-        <param name="headerPrivate" value="false"/>
+        <param name="headerVisibility" value="PUBLIC"/>
       </paramset>
     </paramset>
-    <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="14511a15-5c3c-4faf-ae74-e8df2fb15083" name="Note">
+    <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5d33c10a-60c3-4a55-a856-a06d35a66ac8" name="Note">
       <paramset name="Note" kind="dataObj">
         <param name="title" value="Next libID = 43"/>
         <param name="NoteText" value=""/>
       </paramset>
     </container>
-    <container kind="group" type="Group" version="2009A-1" subtype="group" key="ee4d7c8a-7889-4644-9288-605333095629" name="Group">
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="c14cebad-ab0f-49ba-88f9-2c5a807d40b9" name="Group">
       <paramset name="Group" kind="dataObj">
         <param name="title" value="IMAGING BP"/>
         <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value="gmoss_grp1"/>
       </paramset>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="57c26946-5e06-4e8b-984a-e63d409119d5" name="GMOS-N-BP-1">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="f71fe92d-5423-4398-a1fa-9d95bce5bb94" name="GMOS-N-BP-copy3-1">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Imaging"/>
           <param name="libraryId" value="1"/>
@@ -50,20 +50,16 @@
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="9d298069-a057-4a3f-9372-6aafe7066e2a" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="87e0d018-9254-4c98-aaf3-e57152ba45bd" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="0"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
@@ -79,12 +75,12 @@
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="39ab9cb7-add1-47c3-b773-db6201c3e2c8" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="04b95e27-b29d-4fc9-a677-cebfd00b06ab" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c471da64-12f1-4d29-aa5c-ba71a7b3fb27" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="03308903-f0dc-42a2-b878-72e364e95a43" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -93,14 +89,14 @@
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="330f770e-7e2e-4f3a-b549-805d143a3e29" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="420e0a71-9c02-4aaa-86a7-5062b471da14" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="09121e90-a265-4b4e-83be-e5750a59cafb" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="db68a6b0-7afc-460f-8b67-09b3dfca0a7b" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="exposureTime" value="30.0"/>
               <param name="filter" value="r_G0303"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="11eb2434-37e2-4d75-be38-58eb5907081d" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="0d94736c-76b6-421f-9fcc-8744da7f9762" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <paramset name="offsets">
                   <paramset name="Offset1" sequence="0">
@@ -109,23 +105,23 @@
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                   <paramset name="Offset0" sequence="1">
-                    <param name="p" value="-4.0"/>
-                    <param name="q" value="-6.0"/>
+                    <param name="p" value="7.0"/>
+                    <param name="q" value="7.0"/>
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                   <paramset name="Offset3" sequence="2">
-                    <param name="p" value="4.0"/>
-                    <param name="q" value="-6.0"/>
+                    <param name="p" value="7.0"/>
+                    <param name="q" value="0.0"/>
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                   <paramset name="Offset2" sequence="3">
-                    <param name="p" value="8.0"/>
-                    <param name="q" value="0.0"/>
+                    <param name="p" value="0.0"/>
+                    <param name="q" value="7.0"/>
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6419bb5c-0114-4e90-b332-951a6cc000d4" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="9b451c14-f0c4-47bd-8656-14a05bf892fa" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
@@ -136,13 +132,13 @@
         </container>
       </container>
     </container>
-    <container kind="group" type="Group" version="2009A-1" subtype="group" key="a01134cc-e73e-4624-aeec-e221beaf40fa" name="Group">
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="688997cf-16f9-4eb2-9586-6995b979f567" name="Group">
       <paramset name="Group" kind="dataObj">
         <param name="title" value="LONGSLIT BP"/>
         <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value=""/>
       </paramset>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="36d4c9b1-c801-4ece-844b-3c80bff73255" name="GMOS-N-BP-2">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1fb2b3e7-f284-43e4-8e1d-213613ab4c9c" name="GMOS-N-BP-copy3-2">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Longslit: Acq (point source)"/>
           <param name="libraryId" value="2"/>
@@ -152,33 +148,42 @@
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="db183f93-3694-4c00-85e6-6133babd5a92" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="cc4f5d5a-33d4-46f9-abac-946121749b27" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This is the longslit acquisition template for science observation of a point source centered 
 in the middle of CCD2.
+
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
 The class has been set to 'Acquisition'.
 
-The FPU, binning and exposure time are sequenced.
-The first step is an imaging exposure with the CCD binned 2x2 (CCD2)
-The second step is a 20s image through the slit that is used to measure the slit center
-   with the CCD binned 1x1 and the ROI set to Central Stamp (300x300 pixels FOV).
-The third step is an image through the slit that is used to confirm the offsets have well
-   centered the science target within the slit , again the CCD is binned 1x1 with ROI
-   Central Stamp (300x300 pixel FOV)
+The FPU, binning and exposure time are sequenced in four steps:
 
-The user will need to adjust the exposure time to be appropriate for a given
-target. Use the ITC to find the exposure time needed. A S/N&gt;=10 is 
-recommended for acquisition observations. The exposure time of 
-the slit image (second step) should be left as defined at 20 seconds.
+Step 1: Imaging exposure with the CCD binned 2x2 using ROI CCD2 (central chip)
+Step 2: 20s image through the slit that is used to measure the slit center
+              with the CCD binned 1x1 and the ROI set to Central Stamp.
+Step 3: Image through the slit used to confirm that the offsets have well centered 
+              the science target within the slit (CCD is binned 1x1 with ROI Central Stamp)
+Step 4: Copy of step 3, which will only be used if it is necessary to further
+               adjust the centering of the star in the slit.
+
+In most cases, the user will only need to edit the following:
+
+-- FPU to match the science setup
+-- Filter: It is recommended to select the acquisition filter that provides the best
+     target signal, as wavelength offsets between the filter and spectroscopic setup
+     are automatically corrected for.
+-- Exposure time in steps 1, 3, and 4 as appropriate for the target. 
+     Use the ITC to find the exposure time needed. A S/N&gt;=10 is recommended 
+     for acquisition observations. The exposure time of  the slit image (step 2) 
+     should be left as defined at 20 seconds.
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="edc5e3b3-344a-45a5-b791-f1798816eb28" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a1df1544-5f76-4375-8677-c898030113a4" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Observer Instructions "/>
             <param name="NoteText">
@@ -208,20 +213,16 @@ Details:
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="78cc7e3f-be4b-4b4d-824d-3c5e9d438ced" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="9df4b171-2677-41ef-9302-f82ed141115e" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="10.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
@@ -237,12 +238,12 @@ Details:
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="2a6a53a9-34dd-4a6a-b70a-8ce96e8c4c23" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="8c973270-efe2-44a8-a151-840ae585320c" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="73a52952-8ad3-40c5-aeb8-e719b3f6e1c6" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="dcb36c26-d686-4726-8577-3dd429d37ec9" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -251,19 +252,19 @@ Details:
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="69c204b6-106d-4d45-b7e2-03087a886808" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="da3d1c03-0606-4231-af72-4f0a1279dd7e" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3c528f75-1f8c-4f10-8fc1-314b79688ed9" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="9432241b-5186-4539-ac16-d068231b5c5c" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Longslit"/>
               <param name="fpu" value="LONGSLIT_4"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="a325ea9c-4d21-42af-ac7c-b0c961dcc117" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="4a2f878e-7758-4285-b76f-d7b50976a1aa" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="a7b9848f-a31e-44d3-835a-9b86ef9987e2" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="823999a3-ecf8-4b56-b8be-c66822c92eea" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -274,7 +275,7 @@ Details:
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="723e3bcf-7c7a-48de-b408-27ff91d0e959" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="e953c5cb-2b9d-4901-88c5-dcf052893ea5" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ"/>
@@ -283,7 +284,7 @@ Details:
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="86956061-8291-4341-922a-87c3ade74cc0" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="c22aa1c6-fd4a-4fbd-afbf-205134372213" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Slit image"/>
               <param name="ampReadMode" value="FAST"/>
@@ -292,7 +293,7 @@ Details:
               <param name="ccdYBinning" value="ONE"/>
               <param name="exposureTime" value="20.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="d4691541-d888-40b2-8f42-6d4015be7aeb" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="bc79b542-d964-42f1-bcbe-86b654a61a6d" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=10, Q=0)"/>
                 <paramset name="offsets">
@@ -303,7 +304,7 @@ Details:
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="8182a3a3-f3d2-4390-8dad-7174052500a6" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="e4a5449b-3995-40d0-99d9-e6261628e2e4" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ"/>
@@ -311,7 +312,7 @@ Details:
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="64fcae30-1bb0-4210-b21a-f6735e98a6ee" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="c3eb267d-e21b-4682-9d69-524231780b02" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-slit Images"/>
               <param name="ampReadMode">
@@ -335,7 +336,7 @@ Details:
                 <value sequence="1">30.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="37f7652f-811e-41fd-978c-7b810f485d78" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="e9e14f1c-a6f5-4fc4-8a64-64f90b7501e9" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=0, Q=0)"/>
                 <paramset name="offsets">
@@ -346,7 +347,7 @@ Details:
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c1ba9da3-fb94-4075-bec1-2704db99e1a4" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="02d30bda-64b0-4f4c-82ca-6510d38993bf" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ"/>
@@ -356,7 +357,7 @@ Details:
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b6e261ec-2ada-4aa1-b548-4877aa204484" name="GMOS-N-BP-3">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="ebe88633-51f4-4069-ad2a-dd0287f63a67" name="GMOS-N-BP-copy3-3">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Longslit: Science with GCALflats"/>
           <param name="libraryId" value="3"/>
@@ -366,7 +367,7 @@ Details:
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="7d2a0dbc-4d7f-4d70-927b-753931584bad" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="24d865b6-d02f-4d31-be78-bf88f67b4dab" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -374,9 +375,13 @@ Details:
 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
-An offset sequence nods the target along the slit by +/- 15 arcsec.  A GMOS-S iterator 
-dithers the grating spectrally in 2 wavelength settings in order to cover the gap 
-between the CCDs and get full wavelength coverage.
+The instrument is configured based on the Phase I resource selections.
+An offset sequence nods the target along the slit by 15 arcsec (Q offsets).  
+A GMOS-N iterator dithers the grating spectrally in 2 wavelength settings in 
+order to cover the gap between the CCDs and get full wavelength coverage.
+
+The smartGCAL flats will automatically choose the best exposure 
+time for the given instrument configuration.
 
 The other required observations for a Longslit program include:
 
@@ -385,31 +390,27 @@ Longslit: Science
 
 and the Baseline Calibrations include:
 
-Longslit: CuAr
-Longslit: Standard Acquisition
-Longslit: Standard with GCALflats
-Longslit: Standard CuAr 
-Longslit: Twilight flat
+Longslit: Baseline CuAr
+Longslit: Baseline Standard Acquisition
+Longslit: Baseline Standard with GCALflats
+Longslit: Baseline Standard CuAr 
+Longslit: Baseline Twilight flat
 
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="0e95cabe-b1a5-4a5d-840f-91f05745eb63" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="073fc42b-738a-46e6-b35f-4e5081c796bc" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="900.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -427,12 +428,12 @@ Longslit: Twilight flat
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="bb208b61-31c5-4ba5-b3f5-479516aaf05a" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ecfb8f8b-3c20-4554-a0e9-a5a5cfa1e0ad" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="40f91ec7-f3ac-44a2-b526-da8ca060cc02" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c5f1882c-6fe4-43ca-a20e-0ef9a0bea685" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -441,13 +442,20 @@ Longslit: Twilight flat
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="4aab2141-8a35-442a-b040-521e7573eeab" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="6434991e-8591-49da-a144-e46b82e4b94a" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="43d3c5fb-ae45-4b3f-b521-5c5aafbab0d1" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="87c974d1-c29f-4826-9d30-830f60f19b5f" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="520.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="6d306962-167c-4c3a-9ec2-adde8c69ed08" name="Offset">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="681c6aaa-2c1c-44e9-97eb-ebe128358d30" name="Flat">
+              <paramset name="Flat" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="coadds" value="1"/>
+                <param name="exposureTime" value="10.0"/>
+              </paramset>
+            </container>
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="e05cfa3a-b611-4c84-a7f0-dda4e08608c5" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <paramset name="offsets">
                   <paramset name="Offset0" sequence="0">
@@ -462,14 +470,14 @@ Longslit: Twilight flat
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="99ef7e1f-cfee-4dbe-87ff-a3d3c03153d4" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="4f96343d-3e30-4dfb-a397-ceb390dca4fb" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="1d24459f-5ec5-4888-9530-e778bfd81097" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="3a8d4c32-e010-4e05-8231-be263832cd60" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -477,18 +485,18 @@ Longslit: Twilight flat
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="d0f5633c-9282-4912-8a4c-4c19f3cb4c7b" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="c91750d0-d979-4147-b6d5-e897774b8dd2" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="525.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="a9d5ddee-2752-42aa-b8e4-c4983858c66c" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="1de8a6b9-41fc-4ed3-a39f-ba4772150b1d" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
                 <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="2eee48fa-09bf-4a52-acfb-59e4cc208654" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="d5fa5913-a846-4af4-bc0b-508af1eafadd" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <paramset name="offsets">
                   <paramset name="Offset1" sequence="0">
@@ -503,17 +511,24 @@ Longslit: Twilight flat
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="a5538b72-956a-49ab-83df-fbfcdce0a84c" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c7195454-62aa-4ff5-9bda-76fc0272dc77" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="056173a3-55f9-47c9-8e31-4a2b09b91c43" name="Flat">
+              <paramset name="Flat" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="coadds" value="1"/>
+                <param name="exposureTime" value="10.0"/>
+              </paramset>
+            </container>
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="3a2ded8d-a905-4ce7-b906-6e5198b7291e" name="GMOS-N-BP-4">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="21cbf3ed-5c71-4b06-ad31-b97380301b3c" name="GMOS-N-BP-copy3-4">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Longslit: Baseline CuAr arc"/>
           <param name="libraryId" value="4"/>
@@ -523,33 +538,31 @@ Longslit: Twilight flat
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="2aeb29a8-f1ed-4752-be71-b2fadc38ec91" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e8540b42-2a0e-4c3b-8b55-c1267d8eebd5" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="10812b77-f996-4555-8c57-29a46176f81e" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5b689259-fe5c-4889-949d-b7946764abbd" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -567,35 +580,33 @@ is taken.
 
 - Because this CuAr is for the science target calibration the ROI is set to Full Frame.
 
-- The instrument is configured to use the B600 grating, a central wavelength
-of 520nm and 525nm and no filter. A 1.0arcsec longslit is used.
-It is assumed that GMOS is mounted on the side-looking ISS port.
+- It is assumed that GMOS is mounted on the side-looking ISS port.
 
-- The GMOS sequence that sequences the wavelength setting is the same as
-for the science observation such that arcs are taken at both wavelengths.
-The observation contain 2 wavelength settings, 520nm and 525nm. Two 
-wavelength settings are used to cover the gap between the CCDs and get full 
-wavelength coverage.
+- The instrument should be configured to use the same grating, 
+filter, central wavelength, FPU, and binning as the science observation.
+The GMOS sequence can be used to sequence the wavelength setting such that arcs 
+are taken at all central wavelengths used for the science observations.
+The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
+
+
+
 
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="23bed1a1-6418-46c5-b2b1-4365fd02007b" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="6f1c5707-d34b-4e6e-955a-22fbda47fab8" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="25.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -613,7 +624,7 @@ wavelength coverage.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="07212edb-f6bb-4c28-90a5-2a3c89ddfedd" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="87dfb3b0-e139-48e5-a188-ce9031219c14" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -625,12 +636,12 @@ wavelength coverage.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b5542437-0af2-4804-94ef-51dd8522f3be" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="55382ad3-b4e8-4dae-9dcb-5855ed715e56" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="2cd0a8e2-4b56-43f5-baf7-628929fdb768" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="1b9658f5-6483-485c-abdc-aae6b5f0f20e" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -639,16 +650,16 @@ wavelength coverage.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="96e0da5d-a661-487c-8eba-117b04deec62" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="7d12f368-e2c7-4a29-baf6-2c6e1822963f" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="03e85ab8-7d53-4f7d-b2cb-376b587d24d0" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="b6a13ec0-1349-41c2-a07d-869ef4cce1da" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda">
                 <value sequence="0">520.0</value>
                 <value sequence="1">525.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="0854a8ed-83f2-4252-ad21-3a9f4c730930" name="Arc">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="6a438da1-81bb-44d7-af1b-c102111db673" name="Arc">
               <paramset name="Arc" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -659,7 +670,7 @@ wavelength coverage.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="9c1b8e45-8e5b-425b-b34d-a60f2ad11bb1" name="GMOS-N-BP-5">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="f7d8762a-515e-45a4-9795-db81490b4e99" name="GMOS-N-BP-copy3-5">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Longslit: Baseline standard acquisition observation"/>
           <param name="libraryId" value="5"/>
@@ -669,7 +680,7 @@ wavelength coverage.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b5138b66-b83e-4879-86ef-68340303a507" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5fdd546f-6bfd-41d4-aff7-02210eda5175" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -682,38 +693,31 @@ There is no target component as an appropriate target will be supplied
 by the Gemini observing staff when it is convenient to observe the
 spectrophotometric baseline standards.
 
-The first step is an imaging exposure with the CCD binned 1x1 with ROI Central Stamp
-(300x300 pixels FOV).
-The second step is a 20sec image through the slit that is used to measure the slit center
-   with the CCD binned 1x1 and the ROI set to Central Stamp.
-The third step is an image through the slit that is used to confirm the offsets have well
-   centered the science target within the slit , again the CCD is binned 1x1 with ROI
-   Central Stamp (300x300 pixels FOV).
-The fourth step is a copy of the third step and is used only if necessary to further
-   adjust the centering of the star in the slit.
+The FPU, binning and exposure time are sequenced in four steps:
 
-The user may need to adjust the exposure times of the first and second steps as 
-appropriate for their science target. Use the ITC to find the exposure time needed. 
-A S/N&gt;=10 is recommended for acquisition observations. The exposure time of 
-the slit image (second step) should be left as defined at 20 seconds.
+Step 1: Imaging exposure with the CCD binned 1x1 with ROI Central Stamp (300x300 pixels FOV)
+Step 2: 20s image through the slit that is used to measure the slit center
+              with the CCD binned 1x1 and the ROI set to Central Stamp.
+Step 3: Image through the slit used to confirm that the offsets have well centered 
+              the science target within the slit (CCD is binned 1x1 with ROI Central Stamp)
+Step 4: Copy of step 3, which will only be used if it is necessary to further
+               adjust the centering of the star in the slit.
+
+The FPU should match the one used for the Baseline Standard observation.
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="3824e80e-946e-440a-9a03-af7678c1d4c8" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="1df4fdac-4b0b-413f-b7a0-cd3f6517e359" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="2.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
@@ -729,7 +733,7 @@ the slit image (second step) should be left as defined at 20 seconds.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="c326b2fe-da76-493f-9e95-e93ba56b00a8" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="4eab76c6-020d-4661-ac0a-19be5d7800d0" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -741,12 +745,12 @@ the slit image (second step) should be left as defined at 20 seconds.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e4c4a690-5a17-4d52-9fb2-a07ad54c8590" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="7f056152-b2bf-41d7-b0c2-15a4b2a1c22e" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="f8d4c18f-2244-4dc1-8a04-ee3783fa84dd" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="6daf82aa-c973-4d75-90c4-1d99de285f8b" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -755,19 +759,19 @@ the slit image (second step) should be left as defined at 20 seconds.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="62fb81a8-aa52-4c94-a511-8bd12e1154d6" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="cc086f16-a7e9-427b-a57f-6cfb3be72486" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="2c9472eb-74c7-4e8e-b952-9fe52bf325b2" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="2037c4b4-9aa1-4c31-a181-89c2bf1cda4c" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Longslit"/>
               <param name="fpu" value="LONGSLIT_4"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="be4a937e-d5da-4349-938d-9a49e4e5665e" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="6ee6feab-150d-4940-be90-0f191ab419f7" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="2b759f0c-3e26-4624-8c6d-4d1fd34391fb" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="c237f090-f8fa-4e07-8102-6200c49ea626" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -778,7 +782,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1bae9f20-7d24-4b56-bee1-ff85ae2751e9" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="fb0e04b2-59ce-433c-901f-3ac3be56c4ae" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ_CAL"/>
@@ -787,7 +791,7 @@ the slit image (second step) should be left as defined at 20 seconds.
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0d23d24c-5ef2-4541-b4b8-e0feff4503c2" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="4b3e7e89-d3af-4de1-88f6-41c560e07156" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Slit image"/>
               <param name="ampReadMode" value="FAST"/>
@@ -797,7 +801,7 @@ the slit image (second step) should be left as defined at 20 seconds.
               <param name="exposureTime" value="20.0"/>
               <param name="fpu" value="LONGSLIT_4"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="fc60682a-f73d-4b1d-8cbc-88a89976a49c" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="17723f02-53aa-4dbd-adfd-e1b7b42c0937" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=10, Q=0)"/>
                 <paramset name="offsets">
@@ -808,7 +812,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="40be7e87-35ee-4baf-9d2a-4e625093910d" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="e2c42f9e-b217-454b-b2a2-8503ec04e43d" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -816,7 +820,7 @@ the slit image (second step) should be left as defined at 20 seconds.
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3b8a23dd-8439-4c6c-900f-70609a6eff94" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ea560247-7adc-46b0-8b25-487f70fea525" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-slit Images"/>
               <param name="ampReadMode">
@@ -844,7 +848,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                 <value sequence="1">LONGSLIT_4</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="225ad73b-60f3-4866-ab58-82a7114ee021" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="d27fbc39-5dfd-4b07-b142-6b7d0fb7da31" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=0, Q=0)"/>
                 <paramset name="offsets">
@@ -855,7 +859,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6712e227-e966-4d66-85c2-c8e29ff524cd" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6f2e8bda-8709-4329-a556-a17f394d2616" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -865,7 +869,7 @@ the slit image (second step) should be left as defined at 20 seconds.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b0c3aec4-a202-4a62-9946-f1621ef5e22a" name="GMOS-N-BP-6">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1028f013-e16b-4074-9185-38f73d68c652" name="GMOS-N-BP-copy3-6">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Longslit: Baseline standard observation with GCALflats"/>
           <param name="libraryId" value="6"/>
@@ -875,7 +879,7 @@ the slit image (second step) should be left as defined at 20 seconds.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="473a7836-e7d2-4c60-86b5-be398d08fe4c" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b8837917-7c39-4400-b8a1-76bf430cd687" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -903,24 +907,22 @@ The target component has been removed as Gemini observing
 staff will select an appropriate standard star that is accessible
 when conditions are convenient for observing baseline standards.
 
+
+
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="1441350e-a592-4e31-b448-f2bc97b5bcc2" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="226f6169-e0fe-42d8-b86f-deba98fff2e3" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="120.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -938,7 +940,7 @@ when conditions are convenient for observing baseline standards.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="39d01e4f-4ea4-4814-a7b6-986bd86a4ee8" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="c626553d-b23e-426f-86fd-de2ae09aec84" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -950,12 +952,12 @@ when conditions are convenient for observing baseline standards.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="dabc570a-6ed1-4a50-9509-7218f245c78e" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="cf0150e5-87af-4350-9cad-74a04c010b1e" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="55cd98e0-c0c5-4519-b9f4-215a3ad71b6b" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="5d7c6d21-2941-40f2-8e49-fc35304262c8" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -964,15 +966,15 @@ when conditions are convenient for observing baseline standards.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="499fdac7-7867-4952-96d3-e35a6b9eb454" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="bb57c559-0731-4f67-a687-a7e6614d3335" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="e3b52238-8afc-4660-b248-c9de6b3bb163" name="Observe">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="dcf3d7fe-d04a-42b6-a357-55f7038b23c9" name="Observe">
             <paramset name="Observe" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="class" value="PARTNER_CAL"/>
             </paramset>
           </container>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="d9eb8157-9af5-45d8-821d-1f8689bafaf7" name="Flat">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="c394beb0-c9b5-44dd-8f17-acc9a1332136" name="Flat">
             <paramset name="Flat" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="coadds" value="1"/>
@@ -981,7 +983,7 @@ when conditions are convenient for observing baseline standards.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="873a3d52-ca45-4421-bc9e-b45399999600" name="GMOS-N-BP-7">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="942934eb-409d-4529-baf3-3ccf8d78e2cf" name="GMOS-N-BP-copy3-7">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Longslit: Baseline standard CuAr arc"/>
           <param name="libraryId" value="7"/>
@@ -991,7 +993,7 @@ when conditions are convenient for observing baseline standards.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5313aa09-c966-4f90-8201-be68680cdc64" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a111820d-e7d0-4d08-9261-0aae7313a3fe" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -1009,54 +1011,51 @@ is taken.
 
 - Because this CuAr is for the standard star observation the ROI is set to central spectrum.
 
-- The instrument is configured to use the B600 grating, a central wavelength
-of 520nm and no filter. A 1.0arcsec longslit is used. It is assumed that GMOS is 
-mounted on the side-looking ISS port.
+- It is assumed that GMOS is mounted on the side-looking ISS port.
+
+- The instrument should be configured to use the same grating, filter, 
+central wavelength, FPU, and binning as the Baseline Standard observation. 
+The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="954149e1-d214-4df3-a95f-e6842f9e5e6c" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="a91e4d8b-6f23-46e5-a1b1-c13cedf289b4" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="a566c86c-68f2-48b2-9e62-64ff56c76c7f" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="0be90a88-b9be-4922-a5e4-e29b0483630f" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="25.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -1074,7 +1073,7 @@ mounted on the side-looking ISS port.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="cc7bb024-28e2-4fb5-8831-0748273ef518" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="991b806f-a0d9-4f69-a123-4194dbdd5eb6" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -1086,12 +1085,12 @@ mounted on the side-looking ISS port.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="199b0dc0-0e71-4a73-aa37-cb390a6dbc2c" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="adb29d2c-e440-40e2-a95c-148c4cbb7382" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="099b7655-41f1-4816-b934-1ebcaf03bfe4" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="63d04f63-094c-4622-bb17-80216e8602b7" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -1100,9 +1099,9 @@ mounted on the side-looking ISS port.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="fc42d08c-6476-4376-836c-305050191dbd" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="8be17381-4c3a-4254-b03d-54c75226105b" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="3ff29935-6376-4ee7-a871-d4b06de2b14d" name="Arc">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="9b90c47e-d0e6-4396-8e22-ec24e792edba" name="Arc">
             <paramset name="Arc" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="class" value="DAY_CAL"/>
@@ -1112,7 +1111,7 @@ mounted on the side-looking ISS port.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="086becf1-9f2f-4c36-b3dc-5e9062f7af00" name="GMOS-N-BP-8">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="c139794b-ccdf-4598-beba-1d92f063cfb6" name="GMOS-N-BP-copy3-8">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Longslit: Baseline Twilight flat"/>
           <param name="libraryId" value="8"/>
@@ -1122,7 +1121,7 @@ mounted on the side-looking ISS port.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="8efcacac-4f8e-4161-8258-0eb3491f4dc2" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b9b9b1d9-3efc-4266-b643-cd88c45e1db4" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -1147,46 +1146,40 @@ The exposure is taken on the sky so the Translation stage should be
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="ea3fa420-9f5c-4a18-a63d-be4d394747c1" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="3b67109f-da99-4ec6-a45a-b8f4e1fb4b3f" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Twilight"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Twilight"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="ac1a589d-b78d-4232-8126-4c4be2a5cbb4" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="50d3f796-882a-4f3f-b4f5-258d2e81c891" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -1204,7 +1197,7 @@ The exposure is taken on the sky so the Translation stage should be
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="843a29c1-3f11-43f4-b952-8b6e51ff8a8c" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="f76264a7-f66d-4c08-a18d-e103eb807267" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -1216,12 +1209,12 @@ The exposure is taken on the sky so the Translation stage should be
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e73c4124-e141-413d-b324-6ed830375951" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="413abf3a-6580-43a8-b2c3-b5a739a26d87" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="faee5e89-2a2d-494a-a0d2-8bd00e092999" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="cc4180ba-dec0-4d04-ad56-0c9f5c790be5" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -1230,13 +1223,13 @@ The exposure is taken on the sky so the Translation stage should be
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c6d7b472-7ca9-4117-a475-693ca15ffe08" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="1957acde-1f1f-4287-84d7-74169d84f80d" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="859c1064-5f80-4fc9-b5f5-6478e453996d" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="30cdb21b-d3a2-47b0-b179-71d875d0230d" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="exposureTime" value="30.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="30f3b5e0-1375-451f-9369-27793804dd73" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c18dd407-bbff-496a-a1cd-53d100284652" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -1246,13 +1239,13 @@ The exposure is taken on the sky so the Translation stage should be
         </container>
       </container>
     </container>
-    <container kind="group" type="Group" version="2009A-1" subtype="group" key="0e68e412-a2c3-4ca3-9941-88dfc6fa11f9" name="Group">
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="b40b2ebd-12de-4ea9-b361-33b767c8f26a" name="Group">
       <paramset name="Group" kind="dataObj">
         <param name="title" value="LONGSLIT N&amp;S BP"/>
         <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value=""/>
       </paramset>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e4322285-5281-40a2-8d96-f10b3061daa9" name="GMOS-N-BP-9">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4b45ae95-e57f-48c1-b6ef-a67e4aa0693c" name="GMOS-N-BP-copy3-9">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="N&amp;S Longslit: Acq (faint point source)"/>
           <param name="libraryId" value="9"/>
@@ -1262,7 +1255,7 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="f224574d-a1b3-489a-a742-a08bc4ab9bae" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="e1ba843a-938f-4028-8904-c5fbd45f3887" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -1273,11 +1266,11 @@ It is assumed that GMOS is mounted on the side-looking ISS port.
 The class has been set to 'Acquisition'.
 
 The FPU, binning and exposure time are sequenced.
-The first step is an imaging exposure with the CCD binned 2x2 (CCD2)
-The second step is a 20s image through the slit that is used to measure the slit center
+Step 1: Imaging exposure with the CCD binned 2x2 (CCD2)
+Step 2: 20s image through the slit that is used to measure the slit center
    with the CCD binned 1x1 and the ROI set to Central Stamp (300x300 pixels FOV).
-The third step is an image through the slit that is used to confirm the offsets have well
-   centered the science target within the slit , again the CCD is binned 1x1 with ROI
+Step 3: Image through the slit that is used to confirm the offsets have well
+   centered the science target within the slit. Again the CCD is binned 1x1 with ROI
    Central Stamp (300x300 pixel FOV)
 
 The user will need to adjust the exposure time to be appropriate for a given
@@ -1288,7 +1281,7 @@ the slit image (second step) should be left as defined at 20 seconds.
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="fa0e06fa-575c-4df8-b59e-92b0e219c333" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="c0733c3d-b79f-461e-87cd-7a65f55e18f5" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Observer Instructions"/>
             <param name="NoteText">
@@ -1318,20 +1311,16 @@ Details:
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="eb1ff71b-9b2e-410e-8ae3-8952779464c5" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="d29e55cb-5f42-4850-8e08-5693900df568" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="NS_3"/>
@@ -1347,12 +1336,12 @@ Details:
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="0b923f81-570b-4edf-906d-dc3876d38c7c" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b6b69160-61ed-4fa3-8169-a8a771c93c11" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="f5ea8500-a3c9-45ec-abea-a265e081a808" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="aab560b3-d4c0-4e1d-b1da-b18b5514b091" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -1361,19 +1350,19 @@ Details:
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="b6673a41-6deb-4563-b63b-f32b4c2a8984" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="3f2610e9-6da8-40c4-a78a-9e779097123d" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="f6302b81-9854-4f21-8f02-4461996288d0" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="071705d6-a8eb-42cd-b9ee-64a8c33a940a" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Longslit"/>
               <param name="fpu" value="NS_3"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0683db4e-b725-4e2f-ab17-1d1c07f7531e" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="cd7c8e43-0eaa-4b56-bb54-486a396348a1" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="ba792cca-0f45-4726-9716-4e74184bee12" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="17309106-faf6-4fa8-82f5-72e649fb6dcf" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -1384,7 +1373,7 @@ Details:
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="a7e72033-8fd8-46b0-9e2a-5e45cf832391" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="971dfbe8-6893-4b94-a706-67fb1abf3d79" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ"/>
@@ -1393,7 +1382,7 @@ Details:
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="32ea2dd2-9415-4790-a8ac-0bd6126087e2" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ee70224e-9f7a-4e07-b64f-6f704c902453" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Slit image"/>
               <param name="ampReadMode" value="FAST"/>
@@ -1402,7 +1391,7 @@ Details:
               <param name="ccdYBinning" value="ONE"/>
               <param name="exposureTime" value="20.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="a24ecdab-eb34-465d-a7ff-bdff14e81de0" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="9b2367de-de42-4043-bf7a-70cd1fe61e33" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=10, Q=0)"/>
                 <paramset name="offsets">
@@ -1413,7 +1402,7 @@ Details:
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="ad784916-9fa3-4a4c-8c96-197359cbdd55" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1d2878e5-9bea-4504-af69-f78b7a896f05" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ"/>
@@ -1421,7 +1410,7 @@ Details:
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="fb731d87-4773-4546-bc3c-828da3652de6" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="8e5bc479-d9ce-4702-8ef6-09a765f33e07" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-slit Images"/>
               <param name="ampReadMode">
@@ -1445,7 +1434,7 @@ Details:
                 <value sequence="1">90.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="38f0f327-661a-4158-b42b-9e3ba822b4ad" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="08deb5fe-3f24-4d22-b07d-5ff484750dca" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=0, Q=0)"/>
                 <paramset name="offsets">
@@ -1456,7 +1445,7 @@ Details:
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="b5cd32b6-0cd5-490e-acc1-9cf3dd312f4a" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="28cdda06-6e09-4ec2-b56b-467741719182" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ"/>
@@ -1466,7 +1455,7 @@ Details:
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7cdc86b5-f16e-4ea8-b996-a50ac75262d0" name="GMOS-N-BP-10">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="44619eb8-2634-41f8-a30e-3a25dddae415" name="GMOS-N-BP-copy3-10">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="N&amp;S Longslit: Science with GCALflats"/>
           <param name="libraryId" value="10"/>
@@ -1476,20 +1465,61 @@ Details:
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="635f44a7-c1d6-4077-bcf3-344e58300033" name="GMOS-N">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a4b43a3e-98e1-4313-88f1-f1567c898d85" name="Note">
+          <paramset name="Note" kind="dataObj">
+            <param name="title" value="Description"/>
+            <param name="NoteText">
+              <value>This example shows a N&amp;S longslit science observation of a faint target with GCAL flats
+mixed in. The instrument is configured based on the Phase I resource selections.
+Nod offset is +-15arcsec, use the standard shuffling (1392 rows and a binning
+of X=2, Y=1. It is assumed that GMOS is mounted on the side-looking ISS port.
+
+The observations contain 1 science exposure and 1 GCALflat at each
+of 3 wavelength settings, 770nm, 780nm and 790nm. Three wavelength settings
+are used to cover the gap between the CCDs and get full wavelength
+coverage. An DtaX offset (0,4,-4) is used in each wavelength setting.
+
+The exposures are the follow:
+   science  at 780nm, DtaX=0
+   GCALflat at 780nm, DtaX=0
+   GCALflat at 780nm. DtaX=4
+   science  at 780nm DtaX=4
+   science  at 780nm, DtaX=-4
+   GCALflat at 780nm, DtaX=-4
+   GCALflat at 790nm. DtaX=0
+   science  at 790nm DtaX=0
+   science  at 790nm, DtaX=4
+   GCALflat at 790nm, DtaX=4
+   science  at 790nm, DtaX=-4
+   GCALflat at 790nm, DtaX=-4
+   science  at 770nm, DtaX=0
+   GCALflat at 770nm, DtaX=0
+   GCALflat at 770nm. DtaX=4
+   science  at 770nm DtaX=4
+   science  at 770nm, DtaX=-4
+   GCALflat at 770nm, DtaX=-4
+
+The DTAX offset dither sequence is recommended to help reduce the effect
+of charge traps in the data; see the N&amp;S web pages.  Here by using four
+GMOS-N Sequences to change central wavelength and dither the DTAX we save 
+on overhead with an efficient science-flat-flat-science-science-flat-flat-science 
+arrangement, minimizing the number of calibration congfiguration movements 
+required.
+
+</value>
+            </param>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="60167289-39c1-4481-8952-8b0b6517484c" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="60.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -1505,7 +1535,7 @@ Details:
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
             <param name="nsNumCycles" value="15"/>
-            <param name="nsDetectorRows" value="1536"/>
+            <param name="nsDetectorRows" value="1392"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
               <param name="advancedGuiding" value="GMOS OIWFS"/>
@@ -1525,58 +1555,12 @@ Details:
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5b646914-4fbb-4236-be0e-b72d4ef910ab" name="Note">
-          <paramset name="Note" kind="dataObj">
-            <param name="title" value="Description"/>
-            <param name="NoteText">
-              <value>This example shows a N&amp;S longslit science observation of a faint target with GCAL flats
-mixed in. The instrument is configured to use the R400 grating and the GG515 blocking 
-filter (to avoid contaminations of 2nd order in the spectra). A N&amp;S 0.75arcsec longslit is 
-used. Nod offset is +-5arcsec, use the standard shuffling (1536 rows and a binning
-of X=2, Y=1. It is assumed that GMOS is mounted on the side-looking ISS port.
-
-The observation contain 1 science exposure and 1 GCALflat at each
-of 3 wavelength settings, 770nm, 780nm and 790nm. Three wavelength settings
-are used to cover the gap between the CCDs and get full wavelength
-coverage. An DtaX offset (0,6,-6) is used in each wavelength setting.
-
-The exposures are the follow:
-   science  at 780nm, DtaX=0
-   GCALflat at 780nm, DtaX=0
-   GCALflat at 780nm. DtaX=6
-   science  at 780nm DtaX=6
-   science  at 780nm, DtaX=-6
-   GCALflat at 780nm, DtaX=-6
-   GCALflat at 790nm. DtaX=0
-   science  at 790nm DtaX=0
-   science  at 790nm, DtaX=6
-   GCALflat at 790nm, DtaX=6
-   science  at 790nm, DtaX=-6
-   GCALflat at 790nm, DtaX=-6
-   science  at 770nm, DtaX=0
-   GCALflat at 770nm, DtaX=0
-   GCALflat at 770nm. DtaX=6
-   science  at 770nm DtaX=6
-   science  at 770nm, DtaX=-6
-   GCALflat at 770nm, DtaX=-6
-
-The DTAX offset dither sequence is recommended to help reduce the effect
-of charge traps in the data; see the N&amp;S web pages.  Here by using four
-GMOS-N Sequences to change central wavelength and dither the DTAX we save 
-on overhead with an efficient science-flat-flat-science-science-flat-flat-science 
-arrangement, minimizing the number of calibration congfiguration movements 
-required.
-
-</value>
-            </param>
-          </paramset>
-        </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="5d840744-c3a8-49fe-9380-adb5e8c3d19e" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="d1cf79bb-43e3-4846-89a4-5997171995c3" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="df12b4c2-586f-401a-801e-d649fc2d615a" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="44e34ce8-ed3c-4349-9d4e-22bf81411c61" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -1585,41 +1569,41 @@ required.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="15d9f52d-7914-4a66-bda3-565020c11e0b" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="300a9db0-5fb5-42fd-ae58-a8bb3167a2b3" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="7eef291c-2b33-4840-91a3-f53290d457d3" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3189b0da-a0e1-450a-900d-ba8e235ddad2" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="780.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="81ba5b87-e381-4ea9-b5be-c9cb6fc39568" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ee03ce5c-8949-42d2-b205-723df9114faf" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="dtaXOffset" value="ZERO"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="fe88e576-98fc-4dc7-90be-570c2e3cea30" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="5b333aab-d144-4238-aaf8-5719bc20dadd" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="54953cd5-42d2-402c-95b9-ec89632d2b6f" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="9203b1b4-4b50-4a8b-9818-561c478a1b2a" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="113450e7-c7d7-4fce-b8b6-0a59653b1658" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="b1404f77-a197-411a-96ba-a39cb5a2dc5f" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="SIX"/>
+                <param name="dtaXOffset" value="FOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="43ad0835-e6b9-4313-b441-612702667573" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c07ee2ea-a4cb-4cb2-b7e4-4941be2b2d4a" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="3552bfe3-16a4-4c70-bdb6-7817a2e0b28d" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="46373244-6789-424b-baac-2122136f7764" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -1627,18 +1611,18 @@ required.
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0df72330-4477-4c7e-bb9e-8d5223ac8e4f" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="7f13f4de-4e9e-4005-93f4-90507fa95bb7" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="MSIX"/>
+                <param name="dtaXOffset" value="MFOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="6ecae2a2-c3db-4f9a-8760-48f8677b3c86" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="a5613f95-03c2-4673-84bc-27dea85340b9" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c43c8321-2500-426b-8542-b9fbc8b1617f" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f9683117-33fe-4a61-9adc-28483df96b5b" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
@@ -1646,21 +1630,21 @@ required.
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0155aa46-99a2-462c-b79c-a67fd1604d2b" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="aee44f92-1060-4510-a0c5-e40970adc8cc" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="790.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="66db2cd6-dc9c-4dbb-bb8f-f499e3dd584e" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="107c2916-72d0-48d2-b4be-67aad2258642" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="dtaXOffset" value="ZERO"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="9453db3c-a268-4a86-a6f6-410d0440a52e" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="5bdfbcd5-ebf5-475a-8e0a-78df199028bb" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="d2e7f43b-e754-4aca-8ecb-67f49fe497ec" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="fc0392c0-38f1-483b-ab2f-100daf1be376" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -1668,35 +1652,35 @@ required.
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="2a374cc2-e70d-489b-9ca7-bf927c00cc19" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0e9322c4-0734-4a81-a11a-2a57c82ab4f9" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="SIX"/>
+                <param name="dtaXOffset" value="FOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="fd276fd2-075e-4e66-8bce-4893dd870924" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="4d7a8c7c-7d4e-4d8c-a518-a301625723f1" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="bd07a043-31b6-4b7e-b95f-1f17c7df941c" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="00851daf-23b8-4242-9e6b-8f0c8566d453" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="e0839313-1bd6-4be6-b3b2-f3b819525878" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="9fefb7d9-86d1-4685-a530-d19211165d3c" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="MSIX"/>
+                <param name="dtaXOffset" value="MFOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c1d9ea76-057b-4785-bdca-270940c13211" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="dcdf9c5b-13ac-4630-8800-252e881092f6" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="d981dcc1-80c7-4739-bcb5-c2eefecb450b" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="4612632e-e4ec-4c73-ad3e-530d5f017423" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -1705,39 +1689,39 @@ required.
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1c26d3d0-09b2-4fc0-8360-b7b20dd2316e" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0d8e537f-a768-40f3-9cae-75e14c6e80f0" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="770.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="027af23d-f6bf-4c1d-9d36-083891bed7d1" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="d9482198-0f7c-4fb0-a398-0c8a59fadaa7" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="dtaXOffset" value="ZERO"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="669da25d-faee-4c8d-bb29-251ab25aee17" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="6325e47d-284f-4cd4-a386-85546e86982b" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="135cdf12-4d8b-479a-b811-96fbcb8a95f5" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="65fa6890-c484-4059-887e-d5abb8db4d18" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="7d050732-10db-4e68-b045-d4cf57e750e8" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="293416c7-5bc5-4ddf-bd2a-13ff47646b63" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="SIX"/>
+                <param name="dtaXOffset" value="FOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="581a91eb-8047-466f-83cf-d0ff99c6b0dc" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="50c878b3-6180-4be1-b0a5-23d0c8d781b9" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="0332029a-79df-40dd-b5c2-989bebefff2c" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="e048fb5b-075e-4610-ab50-b4916caf7e92" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -1745,18 +1729,18 @@ required.
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="21dad624-bf90-4c8a-8cd6-b7911a016983" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="35fdde31-6a26-4b79-b4b9-fce31abb94b1" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="MSIX"/>
+                <param name="dtaXOffset" value="MFOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="23da96d1-01d8-4de9-8182-994e2ae4b9ef" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="f3211da2-908c-41ce-b090-e4f06e48f201" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="049e7858-3447-4fd3-a384-3e750329bda2" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="fb5e8fa3-66d0-49c2-9023-fc76a03fa85a" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
@@ -1766,7 +1750,7 @@ required.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1941e6e1-e99e-48f0-8169-5f74b01cb00b" name="GMOS-N-BP-11">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7fe815ff-9fec-42e7-bd56-b72222226195" name="GMOS-N-BP-copy3-11">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="N&amp;S Longslit: Baseline CuAr arc"/>
           <param name="libraryId" value="11"/>
@@ -1776,33 +1760,31 @@ required.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="b353dd4f-0eab-40a3-b6a7-095d04ac81dc" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="039f6d59-a669-4cc9-be57-40e70cffadec" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="322382a0-04f3-4862-8bb5-7f7e4ac309bb" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="c4437a6d-2076-46b8-a2b4-6640bcef77cd" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -1818,34 +1800,30 @@ is taken.
 
 - The readout is "fast" in order to save time.
 
-- The instrument is configured to use the R400 grating, 2x2 binning, a central wavelengths
-of 750nm and 755nm and the OG515 blocking filter, to avoid 2nd order contamination
-in the spectrum. A N&amp;S 0.75arcsec longslit is used. It is assumed that GMOS is mounted on 
-the side-looking ISS port. 
+- The instrument is configured to match the science setup, including the wavelength dithers defined
+in the GMOS sequence. The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
 
-- The GMOS sequence that sequences the wavelength setting is the same as
-for the science observation such that arcs are taken at both wavelengths.
-The two wavelength settings are used to cover the gap between the CCDs and get full 
-wavelength coverage.
+- It is assumed that GMOS is mounted on the side-looking ISS port. 
+
+
+
+
  
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="b32e356c-a3bf-44b1-aabc-c451e8a0e10b" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="1a729319-14cd-4ae2-8b67-583197ee667e" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="25.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -1863,7 +1841,7 @@ wavelength coverage.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="18d43472-6420-45ed-85e0-d65fbfcbe21f" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="33dbe49a-c5e5-4002-b50b-a9cdb53cbbaf" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -1875,12 +1853,12 @@ wavelength coverage.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="19402c9d-683d-495f-9963-750852fa6999" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="0af4817e-febf-4c24-b710-1cb1805d5267" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="f9b7ff7e-9086-427f-8e21-c989e742b684" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="d71751e6-5aec-4763-bf32-959b7371f84d" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -1889,9 +1867,9 @@ wavelength coverage.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="ec2f9bc6-3f6c-46ff-9fb8-98153e550281" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="bc81d392-0b9d-4808-afa4-17e76ad43bf4" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0b479128-0aa2-468f-8366-e37b2f48867b" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ce839ba2-6135-46ca-af7a-0c30360da5b2" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda">
                 <value sequence="0">780.0</value>
@@ -1899,7 +1877,7 @@ wavelength coverage.
                 <value sequence="2">770.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="c18561ef-d818-4aa2-b948-c65ae308bab4" name="Arc">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="2c9c6d78-8fe8-4a40-82e5-3c39f71c63d8" name="Arc">
               <paramset name="Arc" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -1910,7 +1888,7 @@ wavelength coverage.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="006afb1b-3714-43ee-ad9d-82cc23917c49" name="GMOS-N-BP-12">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="6165bf89-c5ad-42f9-84d4-1443300a93ee" name="GMOS-N-BP-copy3-12">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="N&amp;S Longslit: Baseline Standard: acquisition observation"/>
           <param name="libraryId" value="12"/>
@@ -1920,7 +1898,7 @@ wavelength coverage.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="1b45e9fd-f57c-44b5-96a2-856302f15aae" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="c670d1e5-25de-4df2-a9ec-8ece19f5540e" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -1933,40 +1911,29 @@ There is no target component as an appropriate target will be supplied
 by the Gemini observing staff when it is convenient to observe the
 spectrophotometric baseline standards.
 
-The first step is an imaging exposure with the CCD binned 1x1 with ROI Central Stamp
+Step 1: Imaging exposure with the CCD binned 1x1 with ROI Central Stamp
 (300x300 pixels FOV).
-The second step is a 20sec image through the slit that is used to measure the slit center
+Step 2: 20sec image through the slit that is used to measure the slit center
    with the CCD binned 1x1 and the ROI set to Central Stamp.
-The third step is an image through the slit that is used to confirm the offsets have well
-   centered the science target within the slit , again the CCD is binned 1x1 with ROI
+Step 3: Image through the slit that is used to confirm the offsets have well
+   centered the science target within the slit. Again the CCD is binned 1x1 with ROI
    Central Stamp (300x300 pixels FOV).
-The fourth step is a copy of the third step and is used only if necessary to further
+Step 4: Copy of the third step and is used only if necessary to further
    adjust the centering of the star in the slit.
-
-The user may need to adjust the exposure times of the first and second steps as 
-appropriate for their science target. Use the ITC to find the exposure time needed. 
-A S/N&gt;=10 is recommended for acquisition observations. The exposure time of 
-the slit image (second step) should be left as defined at 20 seconds.
-
-
-- the user should set the filter in order to choose the one with an effective wavelength closest to  the central wavelength used for the spectroscopy</value>
+</value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="d31da774-dddd-4997-9445-3859983604cf" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="f2946b8c-a828-4eda-ba2c-0159d1698e38" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="2.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="NS_3"/>
@@ -1982,7 +1949,7 @@ the slit image (second step) should be left as defined at 20 seconds.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="27bd964e-e13c-4386-a3c5-33ec73e3e7ae" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b09d1b16-b678-4f5f-97d2-cbec3b6c1c87" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -1994,12 +1961,12 @@ the slit image (second step) should be left as defined at 20 seconds.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="0b55594e-fbd0-446e-85d3-567b0eb6f377" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="18931698-0295-48f7-9b5d-6a56db3cafd7" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="ec72c66e-7362-4e11-855f-9fac050a0567" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="b462bbe3-8864-42d8-8bd1-dcf98c847a17" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -2008,19 +1975,19 @@ the slit image (second step) should be left as defined at 20 seconds.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="880e50ed-9538-4b53-a960-063a1c4630a5" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="14ce8e4d-0f4d-429a-8787-6fad43ae38bc" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="5202ce0a-754e-4570-8800-2eaa69b689f1" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="7e973ea5-0328-470f-bdf1-91bb07fbb3c4" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Longslit"/>
               <param name="fpu" value="NS_3"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="288ec53c-548b-4748-83f5-473363bb7c7d" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="55737af1-b82e-4d19-9912-85afc664e909" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="a4116222-45bd-4290-ab51-a173db77a7f0" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="c819b5e3-3ff5-456e-9785-b8d7df111106" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -2031,7 +1998,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c257ed4f-69ca-4717-8c7b-0456f616e4a4" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c3947723-7ffc-4552-a836-097f3002a324" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ_CAL"/>
@@ -2040,7 +2007,7 @@ the slit image (second step) should be left as defined at 20 seconds.
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="4a0e5acf-31b3-4016-bc96-107fc3fef240" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="a670374f-4778-4832-bdde-e86977f1e8df" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Slit image"/>
               <param name="ampReadMode" value="FAST"/>
@@ -2050,7 +2017,7 @@ the slit image (second step) should be left as defined at 20 seconds.
               <param name="exposureTime" value="20.0"/>
               <param name="fpu" value="NS_3"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="94701db9-1f24-40b1-b714-cd1f768260ca" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="72e03868-894c-4b07-85db-0d130ba6b876" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=10, Q=0)"/>
                 <paramset name="offsets">
@@ -2061,7 +2028,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="a4cb1084-3335-4700-be55-b5be4ae6d231" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="ee5e9eba-249b-4cad-be82-98a5383ab04c" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -2069,7 +2036,7 @@ the slit image (second step) should be left as defined at 20 seconds.
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="62cda4ca-52cf-4211-aecd-315dd627f832" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="f01a1cbd-cc17-42be-a2fe-2bfe83d108a5" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-slit Images"/>
               <param name="ampReadMode">
@@ -2097,7 +2064,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                 <value sequence="1">NS_3</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="45c892e8-5218-48b8-9e18-fefbac64707b" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="a775e430-c9bb-4370-a386-ecca0d190f84" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=0, Q=0)"/>
                 <paramset name="offsets">
@@ -2108,7 +2075,7 @@ the slit image (second step) should be left as defined at 20 seconds.
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="84abd1d6-7f24-4971-b3f8-0d055d385df8" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c84e7520-814a-4670-88ec-2a5ff10e450e" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -2118,7 +2085,7 @@ the slit image (second step) should be left as defined at 20 seconds.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7b4e1ebc-e547-4258-a68d-416bf8f2a739" name="GMOS-N-BP-13">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="d0f92b3e-71e0-4ec4-be24-e8b9fe376f8d" name="GMOS-N-BP-copy3-13">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="N&amp;S Longslit: Baseline Standard: observation with GCALflats"/>
           <param name="libraryId" value="13"/>
@@ -2128,7 +2095,7 @@ the slit image (second step) should be left as defined at 20 seconds.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="f8cc7101-22e5-4bb9-a11c-1d608b78fe64" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="8a36ea12-177f-48c4-aa3b-933ada992b06" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -2139,10 +2106,12 @@ The class of the observes is 'Nighttime Partner Calibration'.
 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
-The observation uses Central Spectrum (central 1/3 of each of the 3 CCDs in y-direction)
+The observation uses Central Spectrum (central 1/3 of each of the 3 CCDs in y-direction).
 
-The PI must edit the central wavelength and ccd binning match the 
-configurations used in the science observation.  There is no need to 
+The smartGCAL flat will automatically choose the best exposure 
+time for the given instrument configuration.
+
+The instrument should be configured to match the science observations. There is no need to 
 dither a spectrophotometric standard observation either spectrally or spatially.
 
 For programs with multiple wavelength settings used to span the gaps
@@ -2162,20 +2131,16 @@ when conditions are convenient for observing baseline standards.
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="fc44f9b8-c9a8-451a-955e-8137dc727517" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="04e4e9c3-97a0-435b-88c8-eda05ae9fc2d" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="120.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -2193,7 +2158,7 @@ when conditions are convenient for observing baseline standards.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b02ccc33-25e0-4e21-8c0e-7438e0024d2d" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="c7ad570e-f7bc-46af-99f1-297c92beb776" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -2205,12 +2170,12 @@ when conditions are convenient for observing baseline standards.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="4f5497b5-d975-4564-8fc7-7780e5f34022" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="76c97140-a346-4306-b595-18cf64fb1d6c" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="8a2da299-454e-47ad-a4e2-de0456397b7a" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="38d2b021-f9dd-421d-854a-1246c89cf61f" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -2219,15 +2184,15 @@ when conditions are convenient for observing baseline standards.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="1102a91c-ddae-48cf-b336-60f7c79d0d62" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="31420daa-15eb-4c59-9e2f-d8efb5459989" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="4304e65e-7fa7-4b3c-b679-af3ea55b0eef" name="Observe">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="e226f017-cd42-42f2-afd5-16d157083016" name="Observe">
             <paramset name="Observe" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="class" value="PARTNER_CAL"/>
             </paramset>
           </container>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="07ff1789-078a-4e98-8f54-a28f0e114457" name="Flat">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="6b4c2f15-beae-4f6b-b4fe-295452d9d392" name="Flat">
             <paramset name="Flat" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="coadds" value="1"/>
@@ -2236,7 +2201,7 @@ when conditions are convenient for observing baseline standards.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="3ced807e-fbd6-4cb6-9b1c-371578b03058" name="GMOS-N-BP-14">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="11263b89-6ca0-481a-9735-b844c9cebcb6" name="GMOS-N-BP-copy3-14">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="N&amp;S Longslit: Baseline Standard CuAr arc"/>
           <param name="libraryId" value="14"/>
@@ -2246,33 +2211,31 @@ when conditions are convenient for observing baseline standards.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="6b454a34-52d3-481a-af43-0e2a7ac30465" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="551acb3c-4650-44b3-8ff3-6a9e68bea450" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="9f3abe9d-a2b5-406e-9736-926873a0c639" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="8324ddfb-76c5-4407-9984-c9b00afbaa4c" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -2291,29 +2254,28 @@ is taken.
 - Because this CuAr is for the standard star observation the ROI is set to central spectrum.
    (central 1/3 of each of the 3 CCDs in y-direction)
 
-- The instrument is configured to use the R400 grating, 2x2 binning, a central wavelengths
-   of 750nm and the OG515 blocking filter, to avoid 2nd order contamination
-    in the spectrum. A N&amp;S 0.75arcsec longslit is used. It is assumed that GMOS is mounted on 
-   the side-looking ISS port. 
+- The instrument is configured to match the Baseline Standard observation. 
+
+- It is assumed that GMOS is mounted on the side-looking ISS port. 
+
+- The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
+
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="a240aef1-ea83-4d29-87e9-deb5ec0bfa22" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="ad365020-d8a3-49f5-8b0f-49415de7b533" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="25.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -2331,7 +2293,7 @@ is taken.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="7c448107-0105-47b5-a207-0eb8dc08a6d8" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b6ff5621-667d-4420-bf90-b6738d817b6a" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -2343,12 +2305,12 @@ is taken.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="8831dfdf-2dad-4b89-92c3-80a42155fe02" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="94c5ae9d-6a3b-41cd-aef0-86d9d6594c9b" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="9510d2ca-b8ba-4915-85b8-aecb44957e78" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="e8413e96-0040-45d7-aedd-d2e7ca2d628f" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -2357,9 +2319,9 @@ is taken.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="b1db6021-c38a-456d-89f0-b41327d4ee73" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="a7502b90-dcdb-4447-9c7a-4b284e9e6329" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="91861099-23a2-4ce2-9f7e-a40822177415" name="Arc">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="66143c16-0211-4d8b-8ec8-06da9f91b98d" name="Arc">
             <paramset name="Arc" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="class" value="DAY_CAL"/>
@@ -2369,7 +2331,7 @@ is taken.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="a143ddd5-d907-40db-a744-18b71121b451" name="GMOS-N-BP-15">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="cd147d48-69ed-48b0-bb99-5556cd0f4e8f" name="GMOS-N-BP-copy3-15">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="N&amp;S Longslit: Baseline Twilight flat"/>
           <param name="libraryId" value="15"/>
@@ -2379,23 +2341,20 @@ is taken.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="fb892cfa-7669-45dd-b2a4-bb837a9495fd" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b4a31bbb-9a35-4faf-acbd-c3b0459a5ee7" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This is a Longslit twilight flat, to be taken as the baseline calibration
 (class=Daytime Calibration).
 
-The instrument is configured to use 2x2 binning, a central 
-wavelength of 750nm.
-
-It is assumed that GMOS is mounted on 
-the side-looking ISS port. 
+It is assumed that GMOS is mounted on the side-looking ISS port. 
 
 The guide star has been removed from the target component, since 
 twilight flats are taken at blank fields and without guiding. There is no
 reason to enter the actual coordinates of the blank field.
 
+The instrument should be configured to match the science observations.
 For programs with multiple wavelength settings used to span the gaps
 between the CCDs, only one of these wavelength settings will have a
 twilight flat taken.
@@ -2410,46 +2369,40 @@ The exposure is taken on the sky so the Translation stage should be
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="9828e4f2-cb66-4088-9d26-061157026e88" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="1c53f595-2f17-4ee4-9d8d-11825f49772c" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Twilight"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Twilight"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="7d083b13-a862-4819-b04c-5e0700da545a" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="66030c58-88a1-4845-82c6-5a00cfc499fe" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -2467,7 +2420,7 @@ The exposure is taken on the sky so the Translation stage should be
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="56ca06ab-6a53-4a3e-b250-80e88a901bf7" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="e79dac83-9508-4522-8ad1-38403b266796" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -2479,12 +2432,12 @@ The exposure is taken on the sky so the Translation stage should be
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e70264b5-d0fd-4b15-a8ed-4576f3394117" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="c195a3ac-0246-47c5-aa05-fe412d3068a3" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="e883efc6-a912-4d11-879e-c7529bb4b485" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="76efc71e-26b8-4368-ae1b-86cad1a49afa" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -2493,13 +2446,13 @@ The exposure is taken on the sky so the Translation stage should be
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="364787c0-f87b-4668-8dea-2b0179c3935f" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="d366ced4-acc9-4cad-874f-973b2362d378" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="6d78d391-65e7-484f-b91d-010e4162c0a6" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="d345ec9f-4384-40df-97e2-8cbd455ea52e" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="exposureTime" value="30.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="eacd61fb-a336-45c7-a439-b6dd27c84ca3" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="d6e284be-24f0-4444-acc1-db88d7561e8c" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -2508,9 +2461,9 @@ The exposure is taken on the sky so the Translation stage should be
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="afff4132-6be9-4a80-b8fe-e6ae1952b0fd" name="GMOS-N-BP-16">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="a1b24a11-b110-4e25-abe9-2366dd5c2da8" name="GMOS-N-BP-copy3-16">
         <paramset name="Observation" kind="dataObj">
-          <param name="title" value="N&amp;S Longslit: Baseline Dark: A=60, 15cy, 2x2, 1536pix"/>
+          <param name="title" value="N&amp;S Longslit: Baseline Dark: A=60, 15cy, 2x2, 1392pix"/>
           <param name="libraryId" value="16"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
@@ -2518,7 +2471,7 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="71749e61-b152-4dfe-a05e-d97ba3cef0f8" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="a6607511-56e7-4d5f-989a-9d1b577e07d7" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -2530,33 +2483,31 @@ The exposure is taken on the sky so the Translation stage should be
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e1ce1c7f-d434-43c0-8a48-81a3611737f7" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="701c0703-dd1e-40db-b290-d09514376fda" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Dark"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Dark"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="0c090aa4-d282-4862-925f-c9525b9a7bdf" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="31a0376c-0718-438e-b3fc-aad2b6e10172" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -2571,13 +2522,13 @@ There are four parameters that define a Nod &amp; Shuffle dark:
 
 Exposure time A=60sec. Note that the 60sec exposure time in A (in this example) 
 MUST BE SET in the DARK component exposure time. The exposure time is NOT 
-TAKEN from the GMOS-S component. 
+TAKEN from the GMOS-N component. 
 
-Offset (shuffle distance) = 1536 rows for N&amp;S LONGSLIT darks.
+Offset (shuffle distance) = 1392 rows for N&amp;S LONGSLIT darks.
 
 Number of N&amp;S cycles (same as the science exposure) = 15 in this example.
-Therefore, The total open shutter time is 1800sec per dark exposure in this example.
-Note that the number of N&amp;S cycles IS taken from the static GMOS-S component.
+Therefore, the total open shutter time is 1800sec per dark exposure in this example.
+Note that the number of N&amp;S cycles IS taken from the static GMOS-N component.
 For example, setting the Dark to have an Observe 15x will take 15 N&amp;S darks, 
 each having 15 N&amp;S cycles.
 
@@ -2597,20 +2548,16 @@ Number of N&amp;S observations is 15</value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="b7bb9739-eb36-4faf-bee2-89beef9dbfd5" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="93986720-47e0-426a-b202-21844de0cb15" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="60.0"/>
             <param name="posAngle" value="0"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
@@ -2624,7 +2571,7 @@ Number of N&amp;S observations is 15</value>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
             <param name="nsNumCycles" value="15"/>
-            <param name="nsDetectorRows" value="1536"/>
+            <param name="nsDetectorRows" value="1392"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
               <param name="advancedGuiding" value="GMOS OIWFS"/>
@@ -2644,12 +2591,12 @@ Number of N&amp;S observations is 15</value>
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="676e3c70-9506-4b0b-933e-900d9a65a333" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="aae4699f-e401-4712-a692-fac2b79c4c88" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="dd521911-398c-4996-b13c-96f3348e56f9" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c90c55b1-8165-4308-991d-a14061305a22" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -2658,9 +2605,9 @@ Number of N&amp;S observations is 15</value>
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="7563c9aa-9997-4ac6-96d0-6732144a5bdf" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="d5bedfbd-2c80-4a00-91d1-212ca8653439" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="dark" key="5b9cf8ff-2592-4592-9dfa-d03ffe457eee" name="Manual Dark">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="dark" key="6c42c2b2-999d-457d-a945-12bf268180f5" name="Manual Dark">
             <paramset name="Manual Dark" kind="dataObj">
               <param name="repeatCount" value="15"/>
               <param name="class" value="DAY_CAL"/>
@@ -2671,13 +2618,13 @@ Number of N&amp;S observations is 15</value>
         </container>
       </container>
     </container>
-    <container kind="group" type="Group" version="2009A-1" subtype="group" key="e22d831c-d27f-4ae5-9fa7-98e6bfeb8091" name="Group">
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="2045b3d5-ace4-437f-887e-ac3fe1fe6d52" name="Group">
       <paramset name="Group" kind="dataObj">
         <param name="title" value="MOS BP"/>
         <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value=""/>
       </paramset>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4cbfbc68-a0b2-4c4d-a178-986899b59803" name="GMOS-N-BP-17">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="2a12c748-4941-473f-9e4d-b11752756667" name="GMOS-N-BP-copy3-17">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Pre-imaging"/>
           <param name="libraryId" value="17"/>
@@ -2687,7 +2634,7 @@ Number of N&amp;S observations is 15</value>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="51129000-0656-4652-8a3d-064cdb41d57d" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="7b203573-bd09-4fd0-b222-7b9235eb7dae" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -2708,20 +2655,16 @@ can be submitted.</value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="83335f7d-4f54-4d9a-b884-d84fae36e0d7" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="bf4d9417-2cf5-4c54-a3f2-583813ffbe82" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
@@ -2737,12 +2680,12 @@ can be submitted.</value>
             <param name="mosPreimaging" value="YES"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="1bf68262-4ef7-4345-99b8-aa9454510586" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="28647a3b-fd08-4c36-9412-ed8dd77976e4" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="92938d4d-6918-474e-99bb-524e2ce8a857" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="aaa198e5-f74f-4e41-90a5-5c6124d10851" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -2751,9 +2694,9 @@ can be submitted.</value>
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="1d41716b-d3c3-461a-a674-828c99d74cb7" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="7b006677-f2cd-4912-a222-330cd7a63df9" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="e2fe5691-e6f5-4e98-ad52-d0262b691ad5" name="Offset">
+          <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="9b2c9077-8924-4d37-85a5-635821458321" name="Offset">
             <paramset name="Offset" kind="dataObj">
               <paramset name="offsets">
                 <paramset name="Offset1" sequence="0">
@@ -2778,7 +2721,7 @@ can be submitted.</value>
                 </paramset>
               </paramset>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="7cb6a477-e5a5-499d-9708-8c662a03d753" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="922bed25-8037-47ac-9f2f-beacb23cbe61" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="SCIENCE"/>
@@ -2787,7 +2730,7 @@ can be submitted.</value>
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="161b8393-f60a-43e2-8ae2-ec9402e41530" name="GMOS-N-BP-18">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="a1579c87-ab76-4c73-9b7f-d0b1e3d86eca" name="GMOS-N-BP-copy3-18">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Acq"/>
           <param name="libraryId" value="18"/>
@@ -2797,20 +2740,16 @@ can be submitted.</value>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="06532051-c752-4ded-9c28-c6eaa0849a39" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="7bccbfdf-71ca-46cb-803c-e21d0ee4842e" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
@@ -2828,7 +2767,7 @@ can be submitted.</value>
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="40af7054-6c23-49de-8bdd-b07ed959430c" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="6200676e-d61a-46a3-ad7f-18cc433bcfdc" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -2842,10 +2781,10 @@ IF either of the following applies,
     taken with other telescopes
 
 - the MOS mask was designed from GMOS-N pre-imaging obtained prior 
-   to April 2007 due to changes in the probe mapping.
+   to changes in the probe mapping.
 
 THEN the "MOS: Acq starting with the mask out of the beam" template should be 
-used instead..
+used instead.
 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
@@ -2871,8 +2810,8 @@ GNYYYY(A/B)(Q/C/DD/SV)PPP-MM
 Where YYYY is the year, (A/B) stands for either semester A or B, (Q/C/DD/SV) stands 
 for either Queue, Classical, Director's Discretionary or Science Verification programs, 
 PPP is the program number, and MM is the mask number (a MOS PI may design several
-masks for use, with a technical limit of 99 masks).The PI must also edit the slitwidth 
-under the Custom Mask MDF field.
+masks for use, with a technical limit of 99 masks).The PI must also edit the slit width 
+under the Custom Mask MDF field. 
 
 This observation is set up to use a CUSTOM ROI where only the pixels imaging the 
 acquisition box are read out.  No other pixels are saved.  The Custom ROI cannot be 
@@ -2882,12 +2821,12 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
             </param>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="86e2791d-6428-45b0-9648-936a5bc8d3bc" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="69d7df9b-993f-4bf8-9491-45e79c69d660" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="b2a80408-25a5-4bc1-b738-cd854daee22f" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="185ca9d2-6c76-47b5-b932-22bd434d5901" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -2896,9 +2835,9 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="1df11513-6b61-486c-8e09-36c3a0804651" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="ee5704e7-6e3e-4699-8afd-0cc566795d6a" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="d0b5f077-16a3-4e45-b983-6246fbeb490f" name="Offset">
+          <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="fcf31d43-aebc-4e1d-8115-1455e7cf6cee" name="Offset">
             <paramset name="Offset" kind="dataObj">
               <paramset name="offsets">
                 <paramset name="Offset0" sequence="0">
@@ -2908,7 +2847,7 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
                 </paramset>
               </paramset>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="71d7e3b5-8514-479f-a109-755f4b3f4eef" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="baadf8bb-7a52-479c-93d0-6640886a0370" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="4"/>
                 <param name="class" value="ACQ"/>
@@ -2917,7 +2856,7 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b61908e6-ed8f-4ac5-b536-1374118fbd1e" name="GMOS-N-BP-19">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="91c63d6e-dab4-40d8-ba9f-41da8dba35f6" name="GMOS-N-BP-copy3-19">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Acq starting with mask out of the beam"/>
           <param name="libraryId" value="19"/>
@@ -2927,7 +2866,7 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="f859255a-7559-46d5-a463-358851240176" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="d5c6b572-3865-4a49-aa52-e21fab4aa4a7" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -2939,7 +2878,7 @@ recommended MOS acquisition mode IF:
     taken with other telescopes
 
 - the MOS mask was designed from GMOS-N pre-imaging obtained prior 
-   to April 2007 due to changes in the probe mapping.
+   to changes in the probe mapping.
 
 Any MOS acquisition for MOS masks which were designed from more
 recent pre-imaging should use the default "MOS: Acq" template which starts
@@ -2981,7 +2920,7 @@ field image is read out using Full Frame.
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="d0935ea4-2246-442d-9acc-fa0658f1649b" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="52f4ee81-598e-479b-9412-21ac216ced61" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="gacq *filenumber* mosmask=#"/>
             <param name="NoteText">
@@ -3006,20 +2945,16 @@ gacq *filenumber*
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="850d0b96-38a8-4c29-98dd-4b45edf6cab8" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="d0fa4e66-b714-4f3d-bf82-266be75c54ed" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="10.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
@@ -3037,12 +2972,12 @@ gacq *filenumber*
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="f5c9228b-114f-4004-a5ae-15ae22a47be9" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e935aed5-164c-464c-8fc3-bb5a10a5d693" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="781d284a-b1b9-40ee-826d-1939eb185c91" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="8ed383d4-4fc1-4baa-afd7-b0b76847771f" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -3051,14 +2986,14 @@ gacq *filenumber*
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="05ee54dd-f4c3-488b-aaf9-45f9e5669352" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="64e8830f-14fa-4fb8-8ecf-b37c4c575fcc" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="fb716538-0528-44f2-a740-f85613fcad42" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="085dcb13-d562-4a5e-89c9-c0e13f4eac54" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Custom Mask MDF"/>
               <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1fd61844-8a5b-4903-b389-d3ea9d6dbb0b" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="2221f4f6-1c3c-4765-b2f0-0edd20677263" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="builtinROI" value="FULL_FRAME"/>
@@ -3066,7 +3001,7 @@ gacq *filenumber*
                 <param name="ccdYBinning" value="TWO"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="b613b8a2-244c-4b1a-8608-0fa9925ca666" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="164a5859-149a-4f88-977d-f956fcd35ac6" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <paramset name="offsets">
                     <paramset name="Offset0" sequence="0">
@@ -3076,7 +3011,7 @@ gacq *filenumber*
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="037bd82e-1263-4304-8299-c060377441c4" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="80e45030-25ed-4479-a360-992a88f04a70" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ"/>
@@ -3084,7 +3019,7 @@ gacq *filenumber*
                 </container>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="b8781473-0d04-45b5-989f-e246525b69ab" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="465addb7-49f7-4661-b657-d8afe27eb999" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Through-Mask images"/>
                 <param name="builtinROI">
@@ -3118,7 +3053,7 @@ gacq *filenumber*
                   <value sequence="3">CUSTOM_MASK</value>
                 </param>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="59842e78-3249-4e1e-a356-9eb7ca28cc70" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="6527fc20-e0f0-4f6b-bc3f-0a096353378b" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <paramset name="offsets">
                     <paramset name="Offset0" sequence="0">
@@ -3128,7 +3063,7 @@ gacq *filenumber*
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="d2c98e5d-3fee-44bd-a267-d68b146aac90" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="0e4c573b-df97-4a05-9f75-4c61a2841a73" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ"/>
@@ -3139,7 +3074,7 @@ gacq *filenumber*
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="3876cc80-4e87-418f-a661-fd95ef457280" name="GMOS-N-BP-20">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="93570bc8-3ed1-4357-b4ce-e8fb19566bf2" name="GMOS-N-BP-copy3-20">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Science with GCALflats"/>
           <param name="libraryId" value="20"/>
@@ -3149,7 +3084,7 @@ gacq *filenumber*
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="4a85b980-31a6-4b13-a386-0ebfa50fccf6" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="13c0cfd1-bb01-4b0a-b79b-8a088c2e8183" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -3158,24 +3093,9 @@ mixed in.
 The mask is for the program GNYYYYSQXXX-NN 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
-The observation contain 1 science exposure and 1 GCALflat at each
-of 3 wavelength settings, 520nm, 540nm, and 530nm. Three wavelength settings
-is used to cover the gap between the CCDs and get full wavelength
-coverage.
-Instead of using one GMOS sequence, 3 sequences are used. This makes
-it possible to order the exposures as follows:
-   science  at 520nm
-   GCALflat at 520nm
-   GCALflat at 540nm
-   science  at 540nm
-
-If only one GMOS sequence had been used the order would have been
-   science  520nm
-   GCALflat 520nm
-   science  540nm
-   GCALflat 540nm
-This would take longer because the science fold mirror used for taking the flats
-has to move more often.
+The instrument is configured based on the Phase I resource selections.
+Three wavelength settings are used to cover the gap between the CCDs and 
+get full wavelength coverage.
 
 The maskname used in this template will have to be edited in order to match the 
 MOS mask name used by the science program.  The mask name has the following
@@ -3191,27 +3111,23 @@ masks for use, with a technical limit of 99 masks).
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="ea1bb0e3-dcbb-4dd7-a5cb-2e5a141009e4" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="7cf7b449-9f3e-4e5b-aede-53291c2d106e" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="300.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
-            <param name="customSlitWidth" value="OTHER"/>
+            <param name="customSlitWidth" value="CUSTOM_WIDTH_1_00"/>
             <param name="filter" value="NONE"/>
             <param name="ccdXBinning" value="TWO"/>
             <param name="ccdYBinning" value="TWO"/>
@@ -3224,12 +3140,12 @@ masks for use, with a technical limit of 99 masks).
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="332b93fc-f049-49e2-aa99-fa5b35ba0e2b" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="17489a78-f512-445e-a237-b70428325482" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="51b4b9d3-d50a-45cf-b436-21904cce3883" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="3e1da1f6-b45f-4a50-9d07-d951fab9d3b6" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -3238,19 +3154,26 @@ masks for use, with a technical limit of 99 masks).
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="6bb8829b-fb24-43ef-84bb-15553c37ed8f" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2a3d32aa-8f27-4b07-87fd-2dc30f0051af" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0136e100-323b-4907-bfd0-75231cd5283c" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="388fded0-2336-4dec-9acd-d941eec56286" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="520.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="9fb002fc-ce6e-4916-a2c7-57dbe9c6d4f8" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="704f168e-8c8e-43ec-b377-a1874699323d" name="Flat">
+              <paramset name="Flat" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="coadds" value="1"/>
+                <param name="exposureTime" value="10.0"/>
+              </paramset>
+            </container>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="29f283b5-8dff-4798-aa91-522317e16061" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="SCIENCE"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="57380056-91ef-4728-a9f3-8c97b6d22f79" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="68f96169-a2ca-4694-a674-c1c275fe8dfb" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -3258,35 +3181,49 @@ masks for use, with a technical limit of 99 masks).
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="faed82b1-9228-4006-93bc-bd29117e6885" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="45c8a300-c8c5-4cd3-a55e-bca2b8c58e37" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="530.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="b990bda7-3d55-4fea-9131-614b7f32c829" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="26032384-b381-42c0-9b2b-12321a037d9c" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
                 <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="d008f167-4b52-4e88-801f-cef5675332f4" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="9340999f-9799-4646-9857-d0984ffc0edb" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="SCIENCE"/>
+              </paramset>
+            </container>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="eb9b0ff7-49eb-4c0e-83f4-1e70011e0f3d" name="Flat">
+              <paramset name="Flat" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="coadds" value="1"/>
+                <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="c7ddb646-9949-42d0-ba4d-32b660305e60" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="150ef984-546d-47c3-8a36-91a0cfc7f10c" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="540.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1f0c3aa6-6186-4e6b-b6cc-326a96526ed0" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="8272947f-0b70-4b4e-9d28-eaad67abf48e" name="Flat">
+              <paramset name="Flat" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="coadds" value="1"/>
+                <param name="exposureTime" value="10.0"/>
+              </paramset>
+            </container>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="faef3496-a3a4-4e9a-8693-b60b3f3fda33" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="SCIENCE"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="124582b8-14b3-47b2-99fa-df1442c58bb3" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="148f4a59-ea20-465e-befa-edf011e1028f" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -3296,7 +3233,7 @@ masks for use, with a technical limit of 99 masks).
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="8a1725ce-2219-41d0-8c67-e3c031a6c633" name="GMOS-N-BP-21">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7524bdf0-5d42-4fa8-9401-813478c34e97" name="GMOS-N-BP-copy3-21">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Baseline CuAr arc"/>
           <param name="libraryId" value="21"/>
@@ -3306,84 +3243,84 @@ masks for use, with a technical limit of 99 masks).
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="522c685c-6a05-4cca-8374-7ea6944f4768" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="584a6768-6c9a-40c2-9725-7da8d73d185e" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
-              <value>- This is a MOS CuAr arc, to be taken as the baseline calibration
+              <value>This is a MOS CuAr arc, to be taken as the baseline calibration
 during the day (class=Daytime Calibration).
 
-- The guide star has been removed from the target component, since the
+The guide star has been removed from the target component, since the
 telescope will be stationary at zenith for this observation.
 
-- The Translation Stage has been set to "Follow in Z Only" since the telescope is stationary
+The Translation Stage has been set to "Follow in Z Only" since the telescope is stationary
 and the Telescope Control System may not be up when this observation
 is taken.
 
-- The ROI is Full frame and the readout is "fast" in order to save time.
+The ROI is Full frame and the readout is "fast" in order to save time.
 
-- The instrument is configured to use a central wavelength
-of 520nm and 525nm and no filter. The mask is GNYYYYSQXXX-NN 
-Mask slit width is to be set by user. It is assumed that GMOS is 
-mounted on the side-looking ISS port.
+The mask is GNYYYYSQXXX-NN.
+The GMOS sequence that sequences the wavelength setting is the same as
+for the science observation such that arcs are taken at the three wavelengths
+used by the science observations.
 
-- The GMOS sequence that sequences the wavelength setting is the same as
-for the science observation such that arcs are taken at both wavelengths.
-The observation contain 2 wavelength settings, 520nm and 525nm. Two 
-wavelength settings are used to cover the gap between the CCDs and get full 
-wavelength coverage.
+It is assumed that GMOS is mounted on the side-looking ISS port.
+
+The instrument is configured to match the science setup. This includes:
+-- Mask name
+-- Mask slit width as appropriate for the given mask. The smartGCAL arc will automatically choose the best exposure 
+time for the given slit width.
+-- Disperser
+-- Filter
+-- Central wavelength(s)
+-- Binning
+
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="5c384030-db9f-47a2-ba45-de3163f5e0f2" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="1eaf4e50-3d26-42a1-bda5-24db19072bce" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="468b1840-7f3c-473b-9c7f-7f2d37f04df1" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="d9e7c1e5-5fc8-4723-af98-a6b1d6400b9f" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="20.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
-            <param name="customSlitWidth" value="OTHER"/>
+            <param name="customSlitWidth" value="CUSTOM_WIDTH_1_00"/>
             <param name="filter" value="NONE"/>
             <param name="ccdXBinning" value="TWO"/>
             <param name="ccdYBinning" value="TWO"/>
@@ -3396,7 +3333,7 @@ wavelength coverage.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="3720f9aa-e808-42c6-bf3b-9da8a8116c96" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="8606a702-83f3-4cd6-a2f2-898e7f84419a" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -3408,12 +3345,12 @@ wavelength coverage.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="5f031105-31a5-4419-bfa0-ef886b416741" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="cdaa6be9-390e-4914-9792-39d0effdf246" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="0cf8b6d3-3e65-4b2a-85b4-9c51e417da20" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="ecdd19d0-fa5f-48ea-bf82-8677b3cab3c2" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -3422,9 +3359,9 @@ wavelength coverage.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="3b2f748e-6bfd-44b0-a3a0-f213615c578a" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c36cc204-79b4-4205-a4e6-e64ca8b2f827" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="6724d230-36c3-4291-adb2-9a3f7f38b8bc" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="f39505cd-cbcf-4fcd-bb5f-ca19359e4af7" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda">
                 <value sequence="0">520.0</value>
@@ -3432,7 +3369,7 @@ wavelength coverage.
                 <value sequence="2">540.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="89cf972a-c6ef-4652-9663-f811d3030b19" name="Arc">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="9b50ab68-292c-40f7-a144-da41f9da316e" name="Arc">
               <paramset name="Arc" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -3443,7 +3380,7 @@ wavelength coverage.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="a26cba72-f146-4af7-a50a-0de7ab6b39a1" name="GMOS-N-BP-22">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="87990894-7831-4d48-80eb-adc0b6f5d5de" name="GMOS-N-BP-copy3-22">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Baseline Mask image"/>
           <param name="libraryId" value="22"/>
@@ -3453,33 +3390,31 @@ wavelength coverage.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="847f9886-48d5-49df-bb6d-119325d06498" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="b481cf7e-4914-4b5d-97af-3c8a06b29e66" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Mask image"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Mask image"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="ab53a983-e7cd-42b3-81f4-dfbfe4323c3b" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="cf1bdef7-78b9-4c6b-bc59-e6c940b57c71" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -3514,20 +3449,16 @@ Gemini Staff.
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="e1c6b3b5-8027-485a-b0b7-68dcc0391d6e" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="584ff7a9-572f-4a31-b94c-1c4dd2bdd2ab" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="1.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
@@ -3545,7 +3476,7 @@ Gemini Staff.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="ac40497f-f6a5-4776-a73b-8d2a6e890c64" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="2c488e55-10d1-4cba-b0dc-03a3cdec5033" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -3557,12 +3488,12 @@ Gemini Staff.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="85d75155-717e-4442-8bd6-936a88ebf2ec" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="3e580a0c-0819-4979-8fc7-b5c3e592da14" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="8ae24246-3a25-45d1-92d2-0b1f319d0aa3" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="9cad4818-352a-4fa2-a739-5f09aad5b33c" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -3571,19 +3502,19 @@ Gemini Staff.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2675a1c3-dfc7-4f13-8cfb-a02acf8129eb" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="b5e1c61a-7091-4db6-84f2-11c2bd4ab8e7" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="a8492a2d-f497-4db5-9600-3a2ab779866f" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0dff0025-6b75-4e41-ba50-6c34bf52533a" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Custom Mask MDF"/>
               <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0e3d6e3f-d93f-4841-be00-799d252b579d" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="e4620bdf-394e-40d2-a331-b4b4c1d9f4be" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Full Frame Image (for gmskcheck)"/>
                 <param name="builtinROI" value="FULL_FRAME"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="75e2aa23-22de-45b1-acf2-ba38651ca88d" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="cebb0681-a34b-4449-b64b-81eaaea5cfec" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="DAY_CAL"/>
@@ -3592,12 +3523,12 @@ Gemini Staff.
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="e36f73cb-2c9b-43db-b9cd-9dcf4b5caf86" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1398f642-a19c-489e-82f6-1bf11a980cf9" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Custom ROI Image (for gacq)"/>
                 <param name="builtinROI" value="CUSTOM"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="c74912eb-5984-4635-94e8-f0f2789635ec" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="24adbc8a-4470-4b1d-8d0f-197b864eab5a" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="DAY_CAL"/>
@@ -3609,7 +3540,7 @@ Gemini Staff.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e8fbddca-6edc-41fb-9ff8-3b34d07af97b" name="GMOS-N-BP-23">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="2c7bda22-1f13-457c-a42b-3b1bae059c0b" name="GMOS-N-BP-copy3-23">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Baseline Twilight flat"/>
           <param name="libraryId" value="23"/>
@@ -3619,40 +3550,36 @@ Gemini Staff.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="6cd8bc89-af9c-4061-88d1-2d58227ab0bb" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="6fe1f4d6-bbda-45f2-b765-22a3dd4be866" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Twilight"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Twilight"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="4abda53f-d469-4302-a440-aa295b8791b1" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="2311ad4d-c197-45dd-8ac2-e0b0c0140e52" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This is a MOS twilight flat, to be taken as the baseline calibration
 (class=Daytime Calibration).
-The instrument is configured to use a central wavelength
-of 520nm.
 The mask is GNYYYYSQXXX-NN.
 It is assumed that GMOS is mounted on the side-looking ISS port
 Mask slit width is to be set by user
@@ -3661,12 +3588,13 @@ The guide star has been removed from the target component, since
 twilight flats are taken at blank fields and without guiding. There is no
 reason to enter the actual coordinates of the blank field.
 
+The exposure time is set to 30sec in the GMOS sequence. This makes it
+easy for the observer to adjust it as needed for the brightness of the sky.
+
+The instrument is configured to match the science setup.
 For programs with multiple wavelength settings used to span the gaps
 between the CCDs, only one of these wavelength settings will have a
 twilight flat taken.
-
-The exposure time is set to 30sec in the GMOS sequence. This makes it
-easy for the observer to adjust it as needed for the brightness of the sky.
 
 The maskname used in this template will have to be edited in order to match the 
 MOS mask name used by the science program.  The mask name has the following
@@ -3681,20 +3609,16 @@ masks for use, with a technical limit of 99 masks).</value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="6a307328-ae9a-4cd8-bbfa-d759b3963872" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="039966ef-7558-44ef-9c3e-35b1d847e3cc" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="520.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -3714,7 +3638,7 @@ masks for use, with a technical limit of 99 masks).</value>
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="d97aeffd-edec-4a97-a21c-06a5bd2de340" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="f827751d-cec7-491c-bc24-8302c4da5b2e" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -3726,12 +3650,12 @@ masks for use, with a technical limit of 99 masks).</value>
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="dba73caf-5348-441a-8fbc-65654e3edf7d" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="93fb49a8-07b5-45a7-b38f-c1f3772deb75" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="4b0c6de5-6dff-4ce4-bdf2-a8b4af2524d4" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="5631eb82-05fe-49fb-9197-f7c3c2dc900d" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -3740,14 +3664,14 @@ masks for use, with a technical limit of 99 masks).</value>
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="8f233a9b-1f92-4ceb-aa03-9803178e3951" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c07adbe4-c09b-4f7f-b4d8-54a2f0e8f7eb" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3c8ab60a-fa44-4664-8962-644090285a1c" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="63084f68-8ec6-44bf-9521-b90b20468e69" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="520.0"/>
               <param name="exposureTime" value="30.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="03091e62-e0e7-4882-a09c-52b88c1d02b2" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="7987625d-00ed-4cd2-b6bc-959085bf45e7" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -3756,7 +3680,7 @@ masks for use, with a technical limit of 99 masks).</value>
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7efe810b-9066-467b-8a4b-83fce055888c" name="GMOS-N-BP-24">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="ed3865bc-63df-4d34-a4e7-cf58e06c9aa6" name="GMOS-N-BP-copy3-24">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Baseline Standard: acquisition observation"/>
           <param name="libraryId" value="24"/>
@@ -3766,7 +3690,7 @@ masks for use, with a technical limit of 99 masks).</value>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="aee59abb-43ba-4f25-869f-437f6a1bb8bd" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a121cb30-9fe1-4eff-9139-eb253ab9b0a7" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -3780,39 +3704,32 @@ There is no target component as an appropriate target will be supplied
 by the Gemini observing staff when it is convenient to observe the
 spectrophotometric baseline standards.
 
-The target is acquired using the g-filter, 
-(user can set it to that closest to the wavelength
-setting used for the spectroscopy)
-The FPU, binning and exposure time are sequenced.
-The first step is an imaging exposure with the CCD binned 1x1 with ROI Central Stamp
-(300x300 pixels FOV).
-The second step is a 20sec image through the slit that is used to measure the slit center
-   with the CCD binned 1x1 and the ROI set to Central Stamp.
-The third step is an image through the slit that is used to confirm the offsets have well
-   centered the science target within the slit , again the CCD is binned 1x1 with ROI
-   Central Stamp (300x300 pixels FOV).
+The target is acquired using the g-filter. (The filter can be set to the one closest in
+wavelength to the science observations, though this is not a requirement, as offsets
+are automatically taken into account.)
 
-The user may need to adjust the exposure times of the first and second steps as 
-appropriate for their science target. Use the ITC to find the exposure time needed. 
-A S/N&gt;=10 is recommended for acquisition observations. The exposure time of 
-the slit image (second step) should be left as defined at 10 seconds.</value>
+The FPU, binning and exposure time are sequenced.
+- Step 1: Imaging exposure with the CCD binned 1x1 with ROI Central Stamp
+(300x300 pixels FOV).
+- Step 2: 20sec image through the slit which is used to measure the slit center
+   with the CCD binned 1x1 and the ROI set to Central Stamp.
+- Step 3: Image through the slit which is used to confirm the offsets have well
+   centered the science target within the slit. Again the CCD is binned 1x1 with ROI
+   Central Stamp (300x300 pixels FOV).
+</value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="9da98eb2-6e6d-472a-9a9e-6726a830fc94" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="56f9f83c-907a-4841-b84e-441165bf5cd0" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="2.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
@@ -3828,7 +3745,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="8e3badd0-8e94-42d1-84f5-72b0819f1844" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="51cb35b8-158b-466e-80b9-d175d3eb4ac0" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -3840,12 +3757,12 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="11090560-c2ca-4e07-bc32-32011a5d5e02" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="2153cb75-8f3f-4a00-94bb-5971cd2ca9f2" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="2fa9a682-5e69-49e2-b8d1-b7bce5aaf641" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="3095486d-0f67-4620-920b-f2810cdff20c" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -3854,19 +3771,19 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="cc4c7d73-cfd4-4a87-af1a-f473ddb1ded6" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="5c629495-3200-497d-a74d-48499c3bcc08" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0ef77228-d251-4639-b0a3-b88865d9a7eb" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="9220a638-8a2a-40d1-9d7e-74fb11271757" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Longslit"/>
               <param name="fpu" value="LONGSLIT_4"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="e33e6974-e303-4809-a114-efff35bed31c" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="75d04b48-09b9-4397-9510-8ff5cfe615d0" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="7113e4f1-040c-41f2-b706-4b62a5e04ec2" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="03a78190-5b44-4dd8-a9e0-c56b27e279a2" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -3877,7 +3794,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="46afb686-bcfb-4589-abdc-65e88709ef84" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1b4bb682-394d-4da9-ae5f-cda106ba2648" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ_CAL"/>
@@ -3886,7 +3803,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3be106bf-a1f1-41be-84ce-401178939c5e" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="5ea79531-a8ad-42a7-8da2-636181f26559" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Slit image"/>
               <param name="ampReadMode" value="FAST"/>
@@ -3896,7 +3813,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
               <param name="exposureTime" value="20.0"/>
               <param name="fpu" value="LONGSLIT_4"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="ad88ce7d-48b3-4660-9b3f-1cf300ca7ab6" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="4b6b3bb0-08b1-4072-a603-eea0b1e50dcf" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=10, Q=0)"/>
                 <paramset name="offsets">
@@ -3907,7 +3824,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="25592a71-ee93-4278-8a48-0e307510c37f" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="8a3c9ff9-478b-4724-adba-8629f4e58307" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -3915,7 +3832,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="000c0b1f-d783-42c9-b87a-0b917f5f34b1" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="9b8d5909-3271-4993-9862-8c748ce0631f" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-slit Images"/>
               <param name="ampReadMode">
@@ -3943,7 +3860,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
                 <value sequence="1">LONGSLIT_4</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="ed2e049b-ab74-47ff-9a05-d6a3414ca9c5" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="23880a71-d825-4e80-837c-3a7c810a5482" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=0, Q=0)"/>
                 <paramset name="offsets">
@@ -3954,7 +3871,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1e2b9eba-969a-4b5d-bcb9-cf39695d0522" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="09c29932-5163-4219-8eaf-dbffe4cade21" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -3964,7 +3881,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="cccc7a22-aed2-4330-b77e-86d006d3779d" name="GMOS-N-BP-25">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="63d04772-ebe4-4cd2-8c96-a79eddc6d366" name="GMOS-N-BP-copy3-25">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Baseline Standard: observation with GCALflats"/>
           <param name="libraryId" value="25"/>
@@ -3974,7 +3891,7 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="1e776466-21a6-4d26-89db-d27b52521e22" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="885d67fe-7847-44b8-a5bc-caba170d32dc" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -4012,20 +3929,16 @@ spectrophotometric baseline standards.
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="b22808c9-dd1b-4ecf-a4e3-afdfd82fd06e" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="c8f2c7f6-503c-42c2-b465-8895a087a1ea" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="60.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="420.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -4043,7 +3956,7 @@ spectrophotometric baseline standards.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="5851c09b-4a10-49fe-8e8c-bb7d5dbac3a4" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="fc797143-ef43-49f5-8f85-3d4a69656169" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -4055,12 +3968,12 @@ spectrophotometric baseline standards.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="fc8ed603-95ab-451b-916c-e018a8171d0c" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="8cccea12-1769-4b4c-9e83-ff70f79f1a75" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="80615341-62a6-4428-9863-9f5ee0c64ba6" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="31374a75-7d5f-42e0-9ca4-04295358934a" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -4069,19 +3982,19 @@ spectrophotometric baseline standards.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="0ac3d1c3-3c52-4042-9843-9fcaafe7bfef" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c69176fb-674f-436f-abe6-80eed004e0bf" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="8ed9dd84-62da-4d9f-aa92-e27aec9080c8" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1be5f6c7-f41e-40e0-b7ee-91a818f73ce3" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="420.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="55192b2e-883c-41c7-bb48-74104db58ced" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1ea9b347-afed-47d6-8d7c-ed825e816b60" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="PARTNER_CAL"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="1b43f816-7ebe-4bfc-ad34-38d6082db455" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="c1cb94c9-3772-474e-8b16-e6972baff696" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -4089,35 +4002,35 @@ spectrophotometric baseline standards.
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0938d3ef-8704-4bec-9de2-23c5e1c6f6ef" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="62e2a86c-bc3b-4390-8141-ca6f173c67d5" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="520.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="37fe2856-ee5c-4d45-ad47-51a21ed060d0" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="c443554c-98ea-43cd-8d75-d9bda110ab91" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
                 <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="92df41a8-51e4-440a-bc0a-4ebde84a0e35" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="78eb5880-d8f6-405a-9c02-02f6ac3f924e" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="PARTNER_CAL"/>
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="c52793dc-8429-4bbd-a943-a94bf34b7861" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="b359576e-9191-4e46-b38b-4f401a486f7a" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="620.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="5a009109-c006-4d5a-8ab1-37240788ecba" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f23bb88c-2e18-41e2-b16f-0a48c01ed975" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="PARTNER_CAL"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="90b6f6de-6663-4339-afbd-9456c23b0809" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="97f6a612-e62a-4305-85c8-280c7c6c0869" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -4127,7 +4040,7 @@ spectrophotometric baseline standards.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="388ef6db-53dd-427d-b5ca-34ff4eddf0ff" name="GMOS-N-BP-26">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4827a5cf-e01f-4c2a-993d-d965c34afafb" name="GMOS-N-BP-copy3-26">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS: Baseline Standard CuAr arc"/>
           <param name="libraryId" value="26"/>
@@ -4137,42 +4050,39 @@ spectrophotometric baseline standards.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="12855c9a-e872-43ec-948e-17398c7c4af4" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="8aa5c8f5-00aa-4b35-b3b3-122295301c3c" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="34cb2773-0c6a-4353-aab2-eb206589aab2" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="bef52484-bc72-4885-83e0-cf3444827c92" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This example shows a longslit CuAr arc, to be taken as the baseline calibration
 during the day (class=Daytime Calibration)
 
-The instrument is configured to use three wavelengths to
-bracket the wavelengths detected in the MOS spectra. 
-The slit width is to be set by the user
+The instrument should be configured to match the Baseline Standard
+observation.
 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
@@ -4186,27 +4096,24 @@ is taken.
 The readout is "fast" in order to save time.
 
 The GMOS sequence that sequences the wavelength setting is the same as
-for the science observation such that arcs are taken at both wavelengths.
+for the science observation such that arcs are taken at the same central wavelengths
+as used for the Baseline Standard observation.
 
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="b052b2b4-9fb5-4afb-92a3-604cb6227cca" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="acd2d7be-94c0-4964-9042-3349f792efa3" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="300.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="B600_G5307"/>
             <param name="disperserLambda" value="420.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -4224,7 +4131,7 @@ for the science observation such that arcs are taken at both wavelengths.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="577d74f7-8863-432f-a313-e6d1ffab522e" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="cba3dd58-9c9f-4f2c-9009-07207614edbe" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -4236,12 +4143,12 @@ for the science observation such that arcs are taken at both wavelengths.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ec098195-8e1c-470d-ba76-cb75e5f68d35" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="dbb0aec1-c812-4b75-9826-e675f2f3db00" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="76b8f812-eccb-40de-aea7-87906e80f161" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="3954a3ce-f0a6-48eb-8cb5-574df926443d" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -4250,9 +4157,9 @@ for the science observation such that arcs are taken at both wavelengths.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="28f1fca5-37a0-46fa-9723-d5a93bd7ef7d" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="384b714d-ffaa-4b32-9dc1-29ade5c3f1db" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="2d55f8c2-5d5b-40cb-bcb1-761033400441" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="e6a284a9-7deb-4c61-977d-870b3a6bcc1f" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda">
                 <value sequence="0">420.0</value>
@@ -4260,7 +4167,7 @@ for the science observation such that arcs are taken at both wavelengths.
                 <value sequence="2">620.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="a97df585-3583-4cfb-9a1e-272f9c916f45" name="Arc">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="4b933738-44cc-4d6b-a70b-7aab263c2cba" name="Arc">
               <paramset name="Arc" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -4272,13 +4179,13 @@ for the science observation such that arcs are taken at both wavelengths.
         </container>
       </container>
     </container>
-    <container kind="group" type="Group" version="2009A-1" subtype="group" key="76a449a9-23cc-488c-b71e-ce1a016da128" name="Group">
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="06546bbe-0862-4722-b7c3-e699bd14e2ff" name="Group">
       <paramset name="Group" kind="dataObj">
         <param name="title" value="MOS N&amp;S BP"/>
         <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value=""/>
       </paramset>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b521dbfc-845a-4097-9c1c-08a1cfa5fca3" name="GMOS-N-BP-27">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4b9a4120-d276-4fc6-a209-bce5fd3b638c" name="GMOS-N-BP-copy3-27">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Acq"/>
           <param name="libraryId" value="27"/>
@@ -4288,20 +4195,16 @@ for the science observation such that arcs are taken at both wavelengths.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="86794f0e-a283-411a-8261-b759b7f34b14" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="b79f6096-b017-4210-886e-bb1385ae8ff7" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
@@ -4319,7 +4222,7 @@ for the science observation such that arcs are taken at both wavelengths.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a3b8dd15-fee9-4919-a33e-aaf6ea1e6205" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="13c45c65-5c51-469b-953d-5bb2c6e3374b" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -4333,10 +4236,10 @@ IF either of the following applies,
     taken with other telescopes
 
 - the MOS mask was designed from GMOS-N pre-imaging obtained prior 
-   to April 2007 due to changes in the probe mapping.
+   to changes in the probe mapping.
 
 THEN the "MOS: Acq starting with the mask out of the beam" template should be 
-used instead..
+used instead.
 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
@@ -4373,12 +4276,12 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
             </param>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="21e131e2-c4ee-4d2a-bcc2-ae5d4aa2d65a" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="69f0a272-c4f7-4789-8301-36d81943bf3b" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="f78f91b2-af81-466a-8a5f-3e3d34a7b69b" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="77e09ae6-7eb7-4c5b-a5aa-b6df0a8b6fe4" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -4387,9 +4290,9 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2aec1b55-dc09-443a-a205-81d04cca8e45" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="e6b34807-ea97-4ed4-a9aa-3849c692fec7" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="acffbac8-6041-46e7-9720-56d9bcd35441" name="Offset">
+          <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="0a0e2bed-c75c-4eb5-8dc3-338c305197a6" name="Offset">
             <paramset name="Offset" kind="dataObj">
               <paramset name="offsets">
                 <paramset name="Offset0" sequence="0">
@@ -4399,7 +4302,7 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
                 </paramset>
               </paramset>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="be0a2f70-5ae1-406a-acfb-128224d50679" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="7ce7bb3d-d3bb-4a7e-b54f-aa418aa7f2a9" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="4"/>
                 <param name="class" value="ACQ"/>
@@ -4408,7 +4311,7 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="33c21a1e-4815-4dbd-ba81-c165c8571c79" name="GMOS-N-BP-28">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="c41c4513-d1d4-41d9-bf00-fab31ee9cdbf" name="GMOS-N-BP-copy3-28">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Acq starting with mask out of the beam"/>
           <param name="libraryId" value="28"/>
@@ -4418,7 +4321,7 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="e11fc636-e244-4f19-9107-72143fa4f728" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="29eb8fd2-cc73-4d42-9280-e807fc68d7d0" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -4430,7 +4333,7 @@ recommended MOS acquisition mode IF:
     taken with other telescopes
 
 - the MOS mask was designed from GMOS-N pre-imaging obtained prior 
-   to April 2007 due to changes in the probe mapping.
+   to changes in the probe mapping.
 
 Any MOS acquisition for MOS masks which were designed from more
 recent pre-imaging should use the default "MOS: Acq" template which starts
@@ -4472,7 +4375,7 @@ field image is read out using Full Frame.
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a3adb08f-3694-4211-80f2-39c13218a09c" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="347ba18f-4458-4b56-8cb5-9424314a5a9f" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="gacq *filenumber* mosmask=#"/>
             <param name="NoteText">
@@ -4497,20 +4400,16 @@ gacq *filenumber*
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="d2347b0f-6dd5-4418-81ba-327f022f00d0" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="b6716216-eb91-4720-8617-b060b535fbba" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="10.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
@@ -4528,12 +4427,12 @@ gacq *filenumber*
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="c922e089-5c2e-4ea5-94c5-2b06ceb78d53" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="406dea7a-45b4-4dec-bf89-5d08ecc48921" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="17318889-196b-4f5c-964b-d5d6e2aae8ae" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="7e530944-7b34-41f4-bb73-3926c10aa11e" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -4542,14 +4441,14 @@ gacq *filenumber*
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="dd9530db-f5a4-4ea7-b15e-1c8bb775c7e1" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="d5b33b21-7443-4fba-946f-6e28fa3791d8" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="555b67dd-d79b-43bf-abbc-fd178f12f82b" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1697d1c1-f3fe-4b8b-b19f-aa749df16899" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Custom Mask MDF"/>
               <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="47920d68-3225-48a1-b5ea-bbe645a44c69" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="46560a4e-c822-4ed6-926a-b675b012278b" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="builtinROI" value="FULL_FRAME"/>
@@ -4557,7 +4456,7 @@ gacq *filenumber*
                 <param name="ccdYBinning" value="TWO"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="215726dd-8f18-4b72-a82c-f97a04f2e26a" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="7fef7b1f-6658-4166-addc-8249fc2e305d" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <paramset name="offsets">
                     <paramset name="Offset0" sequence="0">
@@ -4567,7 +4466,7 @@ gacq *filenumber*
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="04cd0b11-2843-4012-a59f-b66d4b3c706c" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="00e20f88-d189-44d4-a6b4-26990ed07886" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ"/>
@@ -4575,7 +4474,7 @@ gacq *filenumber*
                 </container>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="f90a87c5-0b34-4b51-abcf-b085b289e7f8" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="b9a5f96d-cb27-48b1-b0ff-a0ab5397af6d" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Through-Mask images"/>
                 <param name="builtinROI">
@@ -4609,7 +4508,7 @@ gacq *filenumber*
                   <value sequence="3">CUSTOM_MASK</value>
                 </param>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="0a64ca3e-98a8-4ad6-9f3c-c5a951fb9f0c" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="f5280d69-04d4-4300-94d5-73df4e448557" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <paramset name="offsets">
                     <paramset name="Offset0" sequence="0">
@@ -4619,7 +4518,7 @@ gacq *filenumber*
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1e20d6ce-5a58-4a99-920d-9dd6c08a9c63" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="0ec5c634-422f-4061-a836-2e0b64b439e2" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ"/>
@@ -4630,7 +4529,7 @@ gacq *filenumber*
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="29719e4f-1291-4ce0-bb86-91fd4c8c0b89" name="GMOS-N-BP-29">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="2d972de0-c190-4069-98bc-8898ff53eb97" name="GMOS-N-BP-copy3-29">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Science with GCALflats"/>
           <param name="libraryId" value="29"/>
@@ -4640,18 +4539,18 @@ gacq *filenumber*
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b619d6f3-5301-46ac-854a-96e16ba9dc85" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="69ea82c3-9e20-49cc-8603-0ab3a02fea85" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This example shows a MOS Nod&amp;Shuffle science observation with GCAL flats
 mixed in. 
 
-The instrument is configured to use a central wavelength
-of 780nm.  with the name  GNYYYYSQXXX-NN is used. 
+The instrument is configured based on the Phase I resource selections. 
+A mask with the name  GNYYYYSQXXX-NN is used. 
 The mask slit width is to be set by the user. The mask used in this example does not 
 exist, but the N&amp;S static component is set to use an offset (shuffle distance) of 
-70 detector rows, corresponding to a distance of 5.09".  This would be appropriate 
+63 detector rows, corresponding to a distance of 5.09".  This would be appropriate 
 for a MOS mask designed to use micro-shuffling with a slit length of 5.09".
 
 Note that this shuffle offset of 5.09 arc-seconds is NOT the same as the nod (sky offset) 
@@ -4718,20 +4617,16 @@ masks for use, with a technical limit of 99 masks).
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="027a6b2d-d1d7-4f42-a3a6-6da25c29c418" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="e3cbe75a-8b3c-460f-9959-077abe9cde88" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="60.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -4749,8 +4644,8 @@ masks for use, with a technical limit of 99 masks).
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
             <param name="nsNumCycles" value="15"/>
-            <param name="nsDetectorRows" value="70"/>
-            <param name="useElectronicOffsetting" value="false"/>
+            <param name="nsDetectorRows" value="63"/>
+            <param name="useElectronicOffsetting" value="true"/>
             <paramset name="nsShuffleOffset">
               <param name="advancedGuiding" value="GMOS OIWFS"/>
               <paramset name="Offset0" sequence="0">
@@ -4769,12 +4664,12 @@ masks for use, with a technical limit of 99 masks).
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="93d4ca09-1fd8-4815-b01d-6ff77c2af6ac" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e4626c8f-173f-4457-9f14-8bbe7461a16f" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="adc82ff9-630c-4604-8500-c46c4fd8b517" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="ab4bcfd9-c513-4e2d-9eea-9ccf29493ebe" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -4783,41 +4678,41 @@ masks for use, with a technical limit of 99 masks).
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="ebd38987-8108-42ee-ae7f-f846a8ac5429" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="9ba961f9-d062-492a-a27e-4545d7f9ba7e" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="02d67672-c8f8-4df1-9eb2-bb0786b9bee0" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="d93cef29-7308-42f8-9dfc-989f8ccba8a4" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="780.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="7c5a4c02-6e38-49ab-b4a8-99da14fb27dd" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="99cf0f5b-a003-4971-a979-5a7e2727da2c" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="dtaXOffset" value="ZERO"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="f864a5e4-648d-4106-8689-324733347f62" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="20cea1d9-59ef-48e4-b585-f66d61ac0a44" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="376ecaff-c863-424b-a120-37544a1e29c2" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="e3757578-74f4-4c67-921b-6ec0fb07b78c" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="75ec934e-bf79-4ac3-8354-16c98ff72cda" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="8a46a498-26cd-48b5-981a-5ce5f9f4af40" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="SIX"/>
+                <param name="dtaXOffset" value="FOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6be96aaf-1848-49ab-9c84-8734105f764e" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="055af8ac-befe-4a59-867b-50ed10887bbe" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="fecc8b70-28d3-4bbd-bef6-212d2c6d3318" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="a353c925-6a86-4847-acc5-ed0a29f2f311" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -4825,18 +4720,18 @@ masks for use, with a technical limit of 99 masks).
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ce41c523-5759-48cd-9429-0e64103ad160" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="5d579987-a79e-4751-87f5-13491d9b1b14" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="MSIX"/>
+                <param name="dtaXOffset" value="MFOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="90cee571-e43f-44f3-88db-20b505bc60c9" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="81b04bbb-5fe6-49ca-8b67-2c0a33895a43" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="ecaf4320-a65f-490a-ba0b-d11e76b0ed8b" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="a0aafa34-5bb4-420d-a375-5bb3666d3eaf" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
@@ -4844,21 +4739,21 @@ masks for use, with a technical limit of 99 masks).
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="80a9bf3e-59ad-42a8-8058-4e50a41e4770" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3cad9022-e1bf-44e2-a453-0f630d3b2c40" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="790.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="8759f997-9574-4c0a-aa80-5c927eab5c15" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="cc48ac97-e27e-4b52-8f26-353259e20b79" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="dtaXOffset" value="ZERO"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="5985d7e2-9e64-4dc9-8d06-d6acc2a371a9" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="d964416a-3fe6-44af-aac8-773a4f476015" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="024acf32-dc44-42ab-9c57-fd60e6fa68af" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="ab75b9ec-c076-4900-bf9f-0469cc539008" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -4866,35 +4761,35 @@ masks for use, with a technical limit of 99 masks).
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1a1db478-4f78-4906-98a1-e5cff01d3ac8" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="625b9ff4-7249-4274-9433-ec263ac0cb01" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="SIX"/>
+                <param name="dtaXOffset" value="FOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="f6d04e1a-87ad-43ab-b5f0-4e3c32b0e705" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="fe42a1ea-5fb2-4a53-88ce-efc8f6b2df50" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6f0037bd-d798-43c1-83f2-856b050827db" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="4aca5aa1-a2e0-4f0b-bdbb-9f118259c5c5" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0f7e24f9-e041-4509-8a38-f2f5179742e1" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="dab7c4fb-519f-459e-a7bf-0d3e3860fa3d" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="MSIX"/>
+                <param name="dtaXOffset" value="MFOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="0cdc8c08-3f5a-43ca-b98a-9fb6c457f6ac" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="26c389ff-5a17-45f3-b057-781db2a96197" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="ada3dffe-5d8d-4f09-bef5-a5023664f6b6" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="48973547-179f-4e4c-b22e-5bd3e19b976f" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -4903,39 +4798,39 @@ masks for use, with a technical limit of 99 masks).
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ca494c7e-ec14-45a9-b5f2-23c6bb6e5714" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="6ff822df-efbf-4496-93b3-9b97cda73c7a" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="770.0"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="fb669d34-721c-44bc-be61-53eebb76bf57" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="6dd020dd-7892-4c9c-84ec-b062da1a8ce9" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="dtaXOffset" value="ZERO"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="93efe4dc-60bc-4076-8a71-400782452b36" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="8c975cab-94dc-4dad-9429-d8feb0f8a3b7" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="a1882fa3-6ce0-42ed-885c-f0bbcab77442" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="930cc5f5-5fa2-4041-9bca-41d344f786ed" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ac9385bb-b065-479a-a3af-56c0569cca04" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="c5a48dd8-3afe-49c7-9884-761896bf0250" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="SIX"/>
+                <param name="dtaXOffset" value="FOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="d97ea422-3570-4e9c-a446-9adf81f3498b" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="d15976f0-5d44-4020-8fa8-cd0b6730cdc8" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="4fc21dfc-8b9e-4f7a-bc3c-10fb93970fff" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="c77ef2aa-c306-46e3-aa3e-546af473e79d" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
@@ -4943,18 +4838,18 @@ masks for use, with a technical limit of 99 masks).
                 </paramset>
               </container>
             </container>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="c718bdd1-04f2-44e0-865a-21f9322e47cb" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="32b5e98e-8976-4dcd-9f16-e26e4b313312" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
-                <param name="dtaXOffset" value="MSIX"/>
+                <param name="dtaXOffset" value="MFOUR"/>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="3666bad6-73b7-4f25-b96a-42cf5061dc19" name="Flat">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="50aee326-e02b-462b-b5a1-b81cbea4206f" name="Flat">
                 <paramset name="Flat" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="coadds" value="1"/>
                   <param name="exposureTime" value="10.0"/>
                 </paramset>
               </container>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="7d8409dc-79ba-48c0-9303-0f5746ab6aca" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="9b811c05-b6fb-46c7-9054-42ed88ea65ca" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="SCIENCE"/>
@@ -4964,7 +4859,7 @@ masks for use, with a technical limit of 99 masks).
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="0b816874-e4a1-4d22-a698-5536633e2c68" name="GMOS-N-BP-30">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="606a0a71-6557-4620-ab9b-b0c4bfb7ca58" name="GMOS-N-BP-copy3-30">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Baseline Dark A=60, 15cy, 2x2, 32pix"/>
           <param name="libraryId" value="30"/>
@@ -4974,7 +4869,7 @@ masks for use, with a technical limit of 99 masks).
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="78e028b1-3b87-4e33-b2b1-676183e7b2b6" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5d9d7729-7b34-4764-a541-dad7d29209a8" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -4990,7 +4885,7 @@ in the DARK component exposure time, the exposure time is NOT
 taken from the GMOS-N compoenent.   This is a *feature* that is
 very confusing so please be careful.
 
-Offset (shuffle distance) = 70 rows in this example.  This is in units
+Offset (shuffle distance) = 63 rows in this example.  This is in units
 of *unbinned* pixels no matter what the binning is set to.  For micro-shuffling
 this number must match the slit length in the MOS mask design.  For Band 
 Shuffling this number must match the band size used in the MOS mask design.
@@ -5013,20 +4908,16 @@ obtained on a best effort basis.</value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="3c1a21b9-fa50-4968-9aa7-5ad8b0da09a4" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="faf8d275-ccfa-4e22-a670-fd045cc592d4" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="60.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
@@ -5040,7 +4931,7 @@ obtained on a best effort basis.</value>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
             <param name="nsNumCycles" value="15"/>
-            <param name="nsDetectorRows" value="70"/>
+            <param name="nsDetectorRows" value="63"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
               <param name="advancedGuiding" value="GMOS OIWFS"/>
@@ -5060,33 +4951,31 @@ obtained on a best effort basis.</value>
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="196b94cb-7484-4a9c-aa63-f20af37c7f91" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="29470c84-127a-46b6-8c75-4acb7cea4591" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Dark"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Dark"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="9352f658-36bd-40aa-b308-8b095d886b58" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b0675ff8-e770-4fc5-a556-0aaef76bc862" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -5098,12 +4987,12 @@ obtained on a best effort basis.</value>
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="19304fa9-0928-4d80-a812-3eeae6d4e265" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="7f1a8fc0-4e61-4005-9ce3-5f4132c3b8f0" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="9fbb8c4a-cabf-46a4-88d8-1aea8016b980" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="b9fe7de7-e85c-4b8e-842a-58e89263eba3" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -5112,9 +5001,9 @@ obtained on a best effort basis.</value>
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="4f0db457-a637-48b2-94fb-cccaa848ea47" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="3d053fa0-e634-4137-ab44-776d7e8ade7c" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="dark" key="552ae231-35ea-4455-b195-270a4c27babd" name="Manual Dark">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="dark" key="1221f99d-40e4-440e-ad6d-b33713b21da0" name="Manual Dark">
             <paramset name="Manual Dark" kind="dataObj">
               <param name="repeatCount" value="15"/>
               <param name="class" value="DAY_CAL"/>
@@ -5124,7 +5013,7 @@ obtained on a best effort basis.</value>
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="5bace244-e819-47a1-a770-d18f64c842ab" name="GMOS-N-BP-31">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="479acb59-bb07-48be-a00c-cde47f0b6374" name="GMOS-N-BP-copy3-31">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Baseline CuAr arc"/>
           <param name="libraryId" value="31"/>
@@ -5134,33 +5023,31 @@ obtained on a best effort basis.</value>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="82bfe253-b4ed-4592-a44f-9081dfaf46d7" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="4bd30e62-a4be-4a58-8e23-fac4ae1ae354" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="d154a20d-027e-46c1-a8a4-a762b006e740" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="bde06820-aed5-439d-bf5a-bbd27ac41d98" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -5176,34 +5063,31 @@ is taken.
 
 - The ROI is Full frame and the readout is "fast" in order to save time.
 
-- The instrument is configured to use a central wavelength
-of 520nm and 525nm. The mask is GNYYYYSQXXX-NN
-Mask slit width is to be set by user. It is assumed that GMOS is 
-mounted on the side-looking ISS port.
+- The mask is GNYYYYSQXXX-NN. Mask slit width is to be set by user. The smartCAL arcs
+will automatically select the optimal exposure time for the given configuration.
 
-- The GMOS sequence that sequences the wavelength setting is the same as
-for the science observation such that arcs are taken at both wavelengths.
-The observation contain 2 wavelength settings, 520nm and 525nm. Two 
-wavelength settings are used to cover the gap between the CCDs and get full 
-wavelength coverage.
+- It is assumed that GMOS is mounted on the side-looking ISS port.
+
+- The instrument configuration should match the science observations,
+including wavelength dithers defined in the GMOS sequence.
+
+- The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
+
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="fdb19d89-58fe-4553-ae1b-0327bc3f56de" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="87a93971-29c3-40d4-8ce6-d9bacf46335b" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="20.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -5223,7 +5107,7 @@ wavelength coverage.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b889167d-472f-4c84-bb71-494fd4cd47f9" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="284e6029-c522-4072-8fd8-a5ba07651358" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -5235,12 +5119,12 @@ wavelength coverage.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b8fb6df9-2c90-4d03-aebe-0906c06b9fd0" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="27708ad6-c839-4445-a78e-f5e63f519156" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="22e07359-2111-4c32-9c51-3c24ea499a54" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c4b273d3-91bc-4e61-8271-e5d2ba802b08" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -5249,9 +5133,9 @@ wavelength coverage.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="6cd92ccc-ac24-41fc-8f62-d24bd2245496" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="935f337d-7687-4515-8a57-39469a16a8f0" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="a4f6df82-28cc-4cce-b040-c49a4981416d" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="69fdc30f-4f10-45c6-ad8c-bc78a5fbf9b7" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda">
                 <value sequence="0">780.0</value>
@@ -5259,7 +5143,7 @@ wavelength coverage.
                 <value sequence="2">770.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="d929e5c9-e873-45e7-9ac5-914066ce5f85" name="Arc">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="665a4fa1-e06d-4117-a552-1099e1947df5" name="Arc">
               <paramset name="Arc" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -5270,7 +5154,7 @@ wavelength coverage.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="12dec04a-efab-4e94-b931-297e7f006340" name="GMOS-N-BP-32">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="edd7150c-c9c4-4c85-9649-af385e1f98b9" name="GMOS-N-BP-copy3-32">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Baseline Twilight flat"/>
           <param name="libraryId" value="32"/>
@@ -5280,40 +5164,37 @@ wavelength coverage.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="1490ae6f-61f7-4966-bf1c-5cfdb6836457" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="b7c0b88c-2b5b-4f02-b27f-81923fcb710f" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Twilight"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Twilight"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="df244a89-73be-4d09-b6f3-b5a9bd3f3c92" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="adb6f89a-c422-4bbf-9360-1d718ea666bb" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This is a MOS twilight flat, to be taken as the baseline calibration
 (class=Daytime Calibration).
-The instrument is configured to use  a central wavelength
-of 520nm. 
+
 The mask is GNYYYYSQXXX-NN
 It is assumed that GMOS is mounted on the side-looking ISS port
 Mask slit width is to be set by user
@@ -5322,6 +5203,7 @@ The guide star has been removed from the target component, since
 twilight flats are taken at blank fields and without guiding. There is no
 reason to enter the actual coordinates of the blank field.
 
+The instrument should be configured to match the science observations.
 For programs with multiple wavelength settings used to span the gaps
 between the CCDs, only one of these wavelength settings will have a
 twilight flat taken.
@@ -5342,20 +5224,16 @@ masks for use, with a technical limit of 99 masks).</value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="a60391f3-b170-43ea-b117-af53279dd828" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="4f60aba7-ae2b-485a-902e-c3739d0d0401" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -5375,7 +5253,7 @@ masks for use, with a technical limit of 99 masks).</value>
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="07056846-8867-41f6-85a0-9c664e356af1" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b65f33b8-7ca3-420e-8d7a-878927627f89" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -5387,12 +5265,12 @@ masks for use, with a technical limit of 99 masks).</value>
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="2fe209cb-5d63-4a73-b32d-a6c785c34123" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="6d302167-c211-46a2-a92f-050895e40a7b" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="d591a06b-21f7-4a7b-a6be-074590d87a80" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="f37ae60c-5f4d-4d6a-b371-f151061308cd" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -5401,14 +5279,14 @@ masks for use, with a technical limit of 99 masks).</value>
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="723dbd7a-43c9-4496-848a-efb0948f9e76" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="5a8b4790-e688-4524-8f2f-ce1b0274a4eb" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1c28fd63-672a-48a7-80ec-6c97e4610224" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="d2b5011e-8d32-483d-a7a6-b4380b1cceed" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="780.0"/>
               <param name="exposureTime" value="30.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6ac5ea81-7b40-4bbd-b3b2-7f5a97e88d64" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="fab61f86-ba7f-43ec-8264-0fb4ddc528fd" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -5417,7 +5295,7 @@ masks for use, with a technical limit of 99 masks).</value>
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="454210cd-47a2-41a7-bd67-2ae860a75eab" name="GMOS-N-BP-33">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="9da61bc6-7b96-458d-a23f-3301da3364e8" name="GMOS-N-BP-copy3-33">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Baseline Standard: acquisition observation"/>
           <param name="libraryId" value="33"/>
@@ -5427,7 +5305,7 @@ masks for use, with a technical limit of 99 masks).</value>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="fcef7013-6bde-4cbb-9af0-55572286c466" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="9611ce6d-0502-4914-847d-f491bac0da54" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -5439,33 +5317,29 @@ The class has been set to 'Acquisition Calibration'.
 The target is acquired using the g-filter (user can set to that closest to the wavelength
 setting used for the spectroscopy)
 The FPU, binning and exposure time are sequenced.
-The first step is an imaging exposure with the CCD binned 1x1 with ROI
+Step 1: Imaging exposure with the CCD binned 1x1 with ROI
    Central Stamp.
-The second step is a 20s image through the slit that is used to measure the slit center
+Step 2: 20s image through the slit that is used to measure the slit center
    with the CCD binned 1x1 and the ROI set to Central Stamp.
-The third step is an image through the slit that is used to confirm the offsets have well
-   centered the science target within the slit , again the CCD is binned 1x1 with ROI
+Step 3: Image through the slit that is used to confirm the offsets have well
+   centered the science target within the slit. Again the CCD is binned 1x1 with ROI
    Central Stamp.
-The fourth step is another image though the slit and is used only if additional centering is required.
+Step 4: Another image though the slit which is used only if additional centering is required.
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="a7c2cafb-50ef-46a7-8e96-a4f0ac931a1e" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="c2d1cc29-db72-493d-91f1-93f4886feb33" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="2.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
@@ -5481,7 +5355,7 @@ The fourth step is another image though the slit and is used only if additional 
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="6861ea9e-78d4-426a-ba78-cc2bd649c609" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="5da9a405-6b7e-49cb-ab06-28af2b789511" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -5493,12 +5367,12 @@ The fourth step is another image though the slit and is used only if additional 
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="07687a66-eb5a-45e3-970b-fb93a279d886" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="fbb968cb-af4d-46c0-913c-d9d4a9f8d416" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="bf35608b-23b9-4b7c-ab5a-37d7bafc773c" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c9314f15-545e-4bb0-925b-09672291f1f7" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -5507,19 +5381,19 @@ The fourth step is another image though the slit and is used only if additional 
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="949ea3ad-77e4-40b6-aa00-af1c51bdd83d" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="21f265b1-8f24-4251-bab2-3571722c6d5c" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="578530a2-2005-498f-9275-4506086b0e38" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="77c51dd3-e5bf-47b4-9da8-36c2df66c4f3" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the Longslit"/>
               <param name="fpu" value="LONGSLIT_4"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="d8a7f797-f10f-4036-a181-770add934c62" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="44697fda-343d-44d7-ac72-4a866b3f725c" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="34e5e355-5f8f-498a-92c4-d9b5397d7a68" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="8c93c6e6-1444-473d-a879-b5b35f5a7c41" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -5530,7 +5404,7 @@ The fourth step is another image though the slit and is used only if additional 
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="140de3c3-6523-4e27-85bd-a2bf03bae896" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="be6aff9c-f168-4154-80f3-6f06afbb477f" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ_CAL"/>
@@ -5539,7 +5413,7 @@ The fourth step is another image though the slit and is used only if additional 
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="df9ad539-7a71-484b-8733-a20d7537b4a1" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="710d77d5-0983-436b-8e81-aa8be4ef678d" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Slit image"/>
               <param name="ampReadMode" value="FAST"/>
@@ -5549,7 +5423,7 @@ The fourth step is another image though the slit and is used only if additional 
               <param name="exposureTime" value="20.0"/>
               <param name="fpu" value="LONGSLIT_4"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="84715020-319d-4201-8b05-e2cf79ac83c3" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="a80b7d52-9a06-471e-8f8b-81c710f22509" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=10, Q=0)"/>
                 <paramset name="offsets">
@@ -5560,7 +5434,7 @@ The fourth step is another image though the slit and is used only if additional 
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="46fde71b-0b5a-4a67-8461-4dab8241f221" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="23d9857c-d582-40ff-a67a-d9f74b14e198" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -5568,7 +5442,7 @@ The fourth step is another image though the slit and is used only if additional 
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="86229cae-1c09-447b-a256-90467b9c6379" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="03cdc9c4-aa68-49da-aedb-76eb0301402a" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-slit Images"/>
               <param name="ampReadMode">
@@ -5596,7 +5470,7 @@ The fourth step is another image though the slit and is used only if additional 
                 <value sequence="1">LONGSLIT_4</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="08411037-90a3-418f-ba4e-b8f51788f861" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="c79a93fa-a1ea-4e74-ad53-74b8e4b3e077" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <param name="title" value="(P=0, Q=0)"/>
                 <paramset name="offsets">
@@ -5607,7 +5481,7 @@ The fourth step is another image though the slit and is used only if additional 
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="a9c39d18-3dba-4bd8-8eaf-7dbd92d8c53f" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="15b6df24-c8ac-46a8-9211-8b601eae27f9" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -5617,7 +5491,7 @@ The fourth step is another image though the slit and is used only if additional 
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="278f08ec-4ac7-43ea-83fa-381eae376a46" name="GMOS-N-BP-34">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="dc993157-ea3b-432d-950b-97fcfc5758e1" name="GMOS-N-BP-copy3-34">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Baseline Standard: observation with GCALflats"/>
           <param name="libraryId" value="34"/>
@@ -5627,7 +5501,7 @@ The fourth step is another image though the slit and is used only if additional 
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="1165951c-8bc3-4ca2-8883-c0d6c75ceae5" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5a22caec-63bf-4f60-9755-e894e826a3cc" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -5661,30 +5535,30 @@ There is no target component as an appropriate target will be supplied
 by the Gemini observing staff when it is convenient to observe the
 spectrophotometric baseline standards.
 
+The smartGCAL flat will automatically choose the best exposure 
+time for the given instrument configuration.
+
+
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="1d0587d3-1335-403e-b245-945211e5d5a6" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="88b98f1e-99b3-4fc0-aeb4-45363d787670" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="60.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
-            <param name="filter" value="NONE"/>
+            <param name="filter" value="OG515_G0306"/>
             <param name="ccdXBinning" value="TWO"/>
             <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
@@ -5696,7 +5570,7 @@ spectrophotometric baseline standards.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="c33d9689-d6ce-4752-b1a8-953a7c22d1e4" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="3277856f-c3b5-4081-ab25-8fa5dd2a6d59" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -5708,12 +5582,12 @@ spectrophotometric baseline standards.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e485d863-34dd-429b-b70c-78a01592bb53" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e960a71b-366a-4afd-b117-1ad65b835a45" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="d7b478e0-b1a3-4325-b24e-78d6e58a8c19" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="7e36e85b-c108-456c-b136-1943618978bc" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -5722,19 +5596,19 @@ spectrophotometric baseline standards.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="0f73e0d0-b5ee-4730-89df-b5d4b1f9006e" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="2b83a177-12fd-4f01-b091-efdc1e0f3f07" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="76b0b96c-6521-40a5-8774-933ee70bfb1e" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="37c56964-aceb-4ed7-bac8-cb0abf1c67f1" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="780.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c845853d-c88b-49a3-bedb-ce7b34112f11" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="327785e5-c2ca-4390-af10-44831b1102d3" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="PARTNER_CAL"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="50fc7191-b233-4017-9415-b47bac1a39ff" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="75f33095-c591-4f1f-93a8-48eacf61e7a2" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -5742,35 +5616,35 @@ spectrophotometric baseline standards.
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="e43e62a8-c267-4a6b-a204-014ee23208cb" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="625bd1d9-967e-4a25-9a99-183e3902a394" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="680.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="ddc353c6-8831-48ef-8e1f-a2b4115d7d55" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="b690f78e-3309-42a2-90ac-8e934d82332b" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
                 <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6230abfe-f10d-4697-b587-60c465965b42" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1a01f009-454f-4ff5-92d5-c9322d31b0f7" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="PARTNER_CAL"/>
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="4ddb8898-4229-470e-bde7-6aaeb609cff8" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="52865c28-ac51-46df-8d79-a31f891a4d8c" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda" value="880.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="276ca772-4375-4b12-bf8c-1e596dc164fc" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="987efcd6-38d7-4e55-aa3a-b353bb98debe" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="PARTNER_CAL"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="da45d3ec-b45c-43e1-b133-246b34e55155" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="552c49a8-5eff-4e85-beb1-030a48375fb7" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -5780,7 +5654,7 @@ spectrophotometric baseline standards.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="0107d8be-b025-4ac4-8620-24b75f5cf9b5" name="GMOS-N-BP-35">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="eb606ec2-e18b-4ba6-abd2-ebe369ae59ac" name="GMOS-N-BP-copy3-35">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS N&amp;S: Baseline Standard CuAr arc"/>
           <param name="libraryId" value="35"/>
@@ -5790,40 +5664,36 @@ spectrophotometric baseline standards.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="29bb8703-4b82-4737-9554-59e1f3b765af" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="167d4927-425d-4203-beb3-c4c6b6514ec6" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="6f173894-2470-46ea-b335-a5cf847877ea" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="60e92dfe-7c91-45f7-b0be-750064cfb829" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This example shows a longslit CuAr arc, to be taken as the baseline calibration
 during the day (class=Daytime Calibration)
-
-Three wavelengths are used to bracket the wavelengths detected in the MOS spectra.  
 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
@@ -5836,27 +5706,27 @@ is taken.
 
 The readout is "fast" in order to save time.
 
-The GMOS sequence that sequences the wavelength setting is the same as
-for the science observation such that arcs are taken at both wavelengths.
+The instrument configuration should be the same as the one used for the
+Baseline Standard observation, including the central wavelength settings
+defined in the GMOS sequence.
+
+The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="10ea08be-210f-42fb-bbf8-6a763267a0d0" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="bf69bf94-4c3e-469b-839f-eb67e3ece5f5" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="300.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
             <param name="disperserLambda" value="680.0"/>
             <param name="disperserOrder" value="ONE"/>
@@ -5874,7 +5744,7 @@ for the science observation such that arcs are taken at both wavelengths.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="8b373677-3cef-48ed-a76a-2e962e158ebb" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="7d14f58a-3079-4a59-8947-b4bdf057fd68" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -5886,12 +5756,12 @@ for the science observation such that arcs are taken at both wavelengths.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="34161df4-2bcd-46d6-95d2-8fbaa2ec13d7" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="cfd4d722-6cc1-4d51-a7a0-ecc62733e177" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="2bcb249d-baee-4ce9-ba35-405226b3a156" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="efe82256-06d6-41e0-98ce-bbaeabffb270" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -5900,9 +5770,9 @@ for the science observation such that arcs are taken at both wavelengths.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="9d246c83-be0e-4aa1-bc5e-613ad9483f0c" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="f938650e-ff58-4a40-af4e-06ada805a4da" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="1e07aac2-4c32-4bbb-b50b-e1b7eff6f0a2" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="43280da7-1344-405c-be3f-3224bd8485db" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda">
                 <value sequence="0">680.0</value>
@@ -5910,7 +5780,7 @@ for the science observation such that arcs are taken at both wavelengths.
                 <value sequence="2">880.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="46bf6d9b-4696-4f40-9a32-c35db116be18" name="Arc">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="39c60816-8f49-4cbd-a504-524034a21c4f" name="Arc">
               <paramset name="Arc" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -5922,13 +5792,13 @@ for the science observation such that arcs are taken at both wavelengths.
         </container>
       </container>
     </container>
-    <container kind="group" type="Group" version="2009A-1" subtype="group" key="ec39a86a-85ec-4d39-bc26-4c3657aab46d" name="Group">
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="c6dc0bf3-6761-49f8-9da5-a712fa8325dc" name="Group">
       <paramset name="Group" kind="dataObj">
         <param name="title" value="IFU BP"/>
         <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value=""/>
       </paramset>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e001d8ea-be07-4646-a6b3-a27732799073" name="GMOS-N-BP-36">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b42e602a-51fa-4b44-85ae-c4910a679b2b" name="GMOS-N-BP-copy3-36">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="IFU: Acq"/>
           <param name="libraryId" value="36"/>
@@ -5938,7 +5808,7 @@ for the science observation such that arcs are taken at both wavelengths.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="ba75ef82-ca8f-4cd6-906c-ce5422d9acae" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="79e27718-4295-4d21-8ccb-ed8eed5459aa" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -5948,33 +5818,36 @@ It is assumed that GMOS is mounted on the side-looking ISS port.
 The class is 'Acquisition'.
 
 The FPU, ROI, binning and exposure time are sequenced.
-The first step is an imaging exposure with the CCD binned 2x2
-The 2nd step is an image through the IFU, full frame readout with the CCD binned 1x1
+Step 1: Imaging exposure with the CCD binned 2x2
+Step 2: Image through the IFU, full frame readout with the CCD binned 1x1
 
 The user will need to adjust the exposure time to be appropriate for a given
 target. Use the ITC to find the exposure time needed. A S/N&gt;=10 is 
 recommended for acquisition observations. 
 
-For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
-For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the Templates: Spectroscopy Acquisition Observations folder.  If it is not possible to find a nearby reference star with well known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position of the target on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied.   The blind offset method is preferred because the user can  directly measure from the acquisition image where the science target will approximately fall in the IFU field of view. 
+For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  
+For more information on blind offsetting, please see 
+http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
+For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the 
+Templates: Spectroscopy Acquisition Observations folder.  If it is not possible to find a nearby reference star with well 
+known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position of the target 
+on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied.   
+The blind offset method is preferred because the user can directly measure from the acquisition image where the science target 
+will approximately fall in the IFU field of view. 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="0c3cc01d-62e0-4367-adf7-c95f67f749c9" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="d8b00788-0cec-4e35-bd9c-a0245d8e8a36" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="15.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
@@ -5990,12 +5863,12 @@ For help setting up the acquistion, see the Description note for the "Longslit A
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="8662234c-fab3-48a0-9de9-b259fdf255ff" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="1fa439d4-06a1-4c41-b4b5-0e51ea9679f8" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="845595f7-0da9-4166-a063-c9b5a5741536" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="09ec29cf-04cd-41f1-a4ea-ac1c7981ff47" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -6004,19 +5877,19 @@ For help setting up the acquistion, see the Description note for the "Longslit A
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="345f4726-ba88-4d6d-9b08-677e62b9d72c" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="7e837f86-e457-44b6-ba49-870195e3ee24" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="724799c2-fbe4-47c2-a752-3ef8d2dd7d9d" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="11cd9d66-503d-4edf-b996-977b0d226eb5" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the IFU"/>
               <param name="fpu" value="IFU_1"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="705511fa-e646-4d87-9404-15c81a03a6ec" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="bc4eebda-1795-4862-a9b9-15e136e50e7b" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="6b744cdd-4548-4ba2-8f86-f8741260e515" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="eed7fedc-f3ce-48a8-88f8-f1f1216744d0" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -6027,7 +5900,7 @@ For help setting up the acquistion, see the Description note for the "Longslit A
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="35b6cf1d-0f28-4f24-984d-7fd1e330dafe" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="b2bcc43d-4e31-4b1a-9535-b8b23a589fc7" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ"/>
@@ -6036,7 +5909,7 @@ For help setting up the acquistion, see the Description note for the "Longslit A
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="85aaf37b-1e2e-4353-a87f-37a82dc92ffd" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="14dae2e3-3a5c-4301-b311-ec8789d4d1ee" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-IFU images"/>
               <param name="builtinROI">
@@ -6056,7 +5929,7 @@ For help setting up the acquistion, see the Description note for the "Longslit A
                 <value sequence="1">60.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="4502ef6d-d01a-4ab4-8c8c-24b28c02d566" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="ba4e682b-e47b-4dde-8a9a-462cf4259870" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <paramset name="offsets">
                   <paramset name="Offset0" sequence="0">
@@ -6066,7 +5939,7 @@ For help setting up the acquistion, see the Description note for the "Longslit A
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="415ad102-a747-4ab9-8037-84a92d136dd6" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="4ca80df8-b81d-4422-a96e-873cf7b33548" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ"/>
@@ -6076,7 +5949,7 @@ For help setting up the acquistion, see the Description note for the "Longslit A
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1336249a-8f45-4b5d-a9e0-56ae204c2009" name="GMOS-N-BP-37">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="a72db9fc-d754-43d8-8a87-657d03f4e11a" name="GMOS-N-BP-copy3-37">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="IFU: Science with GCalflats"/>
           <param name="libraryId" value="37"/>
@@ -6086,7 +5959,7 @@ For help setting up the acquistion, see the Description note for the "Longslit A
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="7a6589b8-5318-42f1-876d-21491975be47" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="ac78fa02-c2a6-4aee-bb25-263825886137" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -6095,31 +5968,48 @@ For help setting up the acquistion, see the Description note for the "Longslit A
 The instrument is configured based on the Phase I resource selections.
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
-For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
-For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the Templates: Spectroscopy Acquisition Observations folder.  If it is not possible to find a nearby reference star with well known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position of the target on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied.   The blind offset method is preferred because the user can  directly measure from the acquisition image where the science target will approximately fall in the IFU field of view. </value>
+For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  
+For more information on blind offsetting, please see http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
+For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the Templates: Spectroscopy Acquisition Observations folder.  
+If it is not possible to find a nearby reference star with well known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position 
+of the target on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied. The blind offset method is preferred because 
+the user can  directly measure from the acquisition image where the science target will approximately fall in the IFU field of view. 
+
+The smartGCAL flat will automatically choose the best exposure 
+time for the given instrument configuration.
+
+
+The other required observations for a IFU program include:
+
+IFU: Acq
+IFU: Science
+
+and the Baseline Calibrations include:
+
+IFU: Baseline CuAr arc
+IFU: Baseline Standard: acquisition observation 
+IFU: Baseline Standard: observation with GCALflat
+IFU: Baseline Standard CuAr arc 
+IFU: Baseline Twilight </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="06eef80b-fc35-47d2-bf39-4eb171c7a1e0" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="77700abb-ff59-40c6-ba0b-b2fd25671b27" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="1200.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
-            <param name="disperserLambda" value="630.0"/>
+            <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
-            <param name="filter" value="r_G0303"/>
+            <param name="filter" value="i_G0302"/>
             <param name="ccdXBinning" value="ONE"/>
             <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
@@ -6131,12 +6021,12 @@ For help setting up the acquistion, see the Description note for the "Longslit A
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="42a4c4b5-3790-45e6-b54f-29e277bc2c1f" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="81955543-e2da-4844-be09-bc7278c77755" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="81e15586-3dd5-4e07-95b9-a44fc4fd5de7" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="4a587414-db06-40d8-98c1-5f40fa7f3595" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -6145,26 +6035,26 @@ For help setting up the acquistion, see the Description note for the "Longslit A
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="d051a90b-bc67-40b6-a09b-0aadd9e2f58d" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="f4790407-ad2c-481c-a1ba-1a7082bf399f" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="2ae19da4-1d39-4b86-85a8-59d8561e2a38" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3cacdb9a-0c38-4e4b-b8f8-32b8782f98de" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
-              <param name="disperserLambda" value="630.0"/>
+              <param name="disperserLambda" value="780.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="8fa3314f-704b-4212-b442-40144cf92501" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="0629e21b-65e0-4a9d-8b91-88de04fc993c" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
                 <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="fd61e30a-e567-4724-9d86-9e2bf88c0e42" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="fa3e427c-db34-4ead-894e-7caa1f1520cf" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="2"/>
                 <param name="class" value="SCIENCE"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="7f24729b-79db-4961-a5e3-15f8875f4759" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="4c745ca8-613c-4189-b675-db525485553a" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -6172,24 +6062,24 @@ For help setting up the acquistion, see the Description note for the "Longslit A
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="712e2279-ff17-4227-881a-3d0d0581d7b2" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3ce7b519-c9e5-4128-9f82-e52bc42140ce" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
-              <param name="disperserLambda" value="640.0"/>
+              <param name="disperserLambda" value="790.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="a4eaf3ee-eb12-4069-abb7-f8068ead1478" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="9bcb3f17-143f-49ce-98b9-40c4abb0720e" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
                 <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="103e5a18-b8dd-4452-8967-d9c7e8d6f874" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f7b63663-e69b-40d3-bc8c-b9f568c22313" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="2"/>
                 <param name="class" value="SCIENCE"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="cc30ac24-eacf-4548-b745-a1d7d73b0629" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="50ff8269-031e-4e57-9e4d-82b1dcf60be4" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -6197,24 +6087,24 @@ For help setting up the acquistion, see the Description note for the "Longslit A
               </paramset>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="5d970f28-9e69-4329-b8da-0eca0f7a1b1a" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="3e197f4a-4d28-4aa4-b3c0-47a7c87f023d" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
-              <param name="disperserLambda" value="620.0"/>
+              <param name="disperserLambda" value="770.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="8f0b74ac-47be-4bff-9530-7b2f59278428" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="28175b67-62b3-434c-b734-883d531d4609" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
                 <param name="exposureTime" value="10.0"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="384e4b2e-5582-4205-989f-71384df8ef67" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="1b1df709-a20f-4261-a914-d15dea4a1730" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="2"/>
                 <param name="class" value="SCIENCE"/>
               </paramset>
             </container>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="00c867d2-a73f-4076-b2e8-5d0c68677980" name="Flat">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="de0e850f-ff14-4301-996d-e1de7b527b85" name="Flat">
               <paramset name="Flat" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="coadds" value="1"/>
@@ -6224,7 +6114,7 @@ For help setting up the acquistion, see the Description note for the "Longslit A
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="dcc2b727-02d4-47bf-800a-c3847bc989a6" name="GMOS-N-BP-38">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="3703c635-0091-4659-a202-644c249524c2" name="GMOS-N-BP-copy3-38">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="IFU: Baseline CuAr arc"/>
           <param name="libraryId" value="38"/>
@@ -6234,39 +6124,36 @@ For help setting up the acquistion, see the Description note for the "Longslit A
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="be41e145-1bf0-4b91-9667-64b1fa0dc406" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="8c6bd666-0b7c-460d-9902-2ed3cdb93f21" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="92ffc69b-cbc0-4895-bfe5-606657f5df8f" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="3680c798-f183-4739-9ce9-0ab86ef7af1d" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
               <value>This example shows an IFU CuAr arc, to be taken as the baseline calibration
 during the day. 
-The central wavelength is set to 630nm.
 
 The guide star has been removed from the target component, since the
 telescope will be stationary at zenith for this observation.
@@ -6281,33 +6168,28 @@ PIs should ensure that the filter, grating, central wavelength, and FPU componen
 match that defined in their science observation.  This includes any changes made
 in a GMOS-N iterator (e.g. for spectral dithers).
 
-The exposure time is set in the "Arc: CuAr arc" component under the "Sequence" and 
-"GMOS-N Sequence" tabs, not in the main "GMOS-N" tab where the grating, filter, 
-central wavelength, binning, and IFU components are set.
+The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="ecb31622-785a-445a-b779-78741818f1f3" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="7cbe5638-9b77-4b80-94d8-cd5e01433bfb" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="300.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
-            <param name="disperserLambda" value="630.0"/>
+            <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
-            <param name="filter" value="r_G0303"/>
+            <param name="filter" value="i_G0302"/>
             <param name="ccdXBinning" value="ONE"/>
             <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
@@ -6319,7 +6201,7 @@ central wavelength, binning, and IFU components are set.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="47f96e68-fbf0-423a-ad4d-4b9c8c4b1903" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="ff748dc8-9dea-45d0-a31f-b103fff0a23c" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -6331,12 +6213,12 @@ central wavelength, binning, and IFU components are set.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="11b0cfb8-e142-4698-b25a-82783cb0a316" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="52049a52-37a5-4be7-a552-bf492f622a20" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="cfb8b498-9b14-4352-a1b8-fb47e5e808ae" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="9cfba5aa-2183-4b4f-b763-097a78876e2b" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -6345,17 +6227,17 @@ central wavelength, binning, and IFU components are set.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="880037e9-a8e0-47fe-bb6a-f6c736429ca8" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="7f381d16-1c9a-4f0e-bbbc-fb3a45248060" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="fbb7642f-b021-48ec-9768-b50ded22e37a" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="399759a2-e562-4df9-879a-4e2cddf4393f" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="disperserLambda">
-                <value sequence="0">630.0</value>
-                <value sequence="1">640.0</value>
-                <value sequence="2">620.0</value>
+                <value sequence="0">780.0</value>
+                <value sequence="1">790.0</value>
+                <value sequence="2">770.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="20cf9ede-e9f9-4ecc-b954-ca0b79f1c616" name="Arc">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="0a90893d-b8f7-476d-bfae-e185c15dc03f" name="Arc">
               <paramset name="Arc" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -6366,7 +6248,7 @@ central wavelength, binning, and IFU components are set.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="70f5be4e-6d03-4a5e-ac9d-5dda44c01f11" name="GMOS-N-BP-39">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="4ece8045-7450-48e4-97f3-cf52518dfc86" name="GMOS-N-BP-copy3-39">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="IFU: Baseline twilight"/>
           <param name="libraryId" value="39"/>
@@ -6376,52 +6258,46 @@ central wavelength, binning, and IFU components are set.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="c723f4ff-76a5-45bc-97d2-080f08d5fb76" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="f45645a1-8c52-4703-8967-a62b8b23f45a" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="Twilight"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="Twilight"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="4b558528-f848-43b8-a945-09d2a92f505e" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="111690f6-902c-4661-8f56-d46e3aa6c1f1" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="30.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
-            <param name="disperserLambda" value="630.0"/>
+            <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
-            <param name="filter" value="r_G0303"/>
+            <param name="filter" value="i_G0302"/>
             <param name="ccdXBinning" value="ONE"/>
             <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
@@ -6433,7 +6309,7 @@ central wavelength, binning, and IFU components are set.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a348b5e7-d235-4793-a71e-2ddd898d9b8b" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="0c3bfed5-0894-4d90-84c1-f87b6d8126f7" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -6454,7 +6330,7 @@ easy for the observer to adjust it as needed for the brightness of the sky.</val
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="702b502d-9676-4a29-8050-938069795f17" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="9e3857f6-8d6e-49b7-b044-a378cd04b0a2" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -6466,12 +6342,12 @@ easy for the observer to adjust it as needed for the brightness of the sky.</val
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="d63048bd-8fb1-4cc4-8ff5-75fb69b46908" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="84ee5ffe-7f83-4fae-a382-ba9507bddb15" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="d342e750-d79d-45e0-a6b2-2fd14406b1a8" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="10686222-b968-4e0c-af70-9c81f072ab3b" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -6480,13 +6356,13 @@ easy for the observer to adjust it as needed for the brightness of the sky.</val
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="783b623b-38eb-4387-9289-14e03b8a7b0f" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="740b1c26-ed2d-48ac-9085-c10e67b81578" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="a7eab1be-318a-4b66-aafa-1caa9051da0c" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="0e7a28d2-1026-4c0e-8fb8-3a2e0de39259" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="exposureTime" value="30.0"/>
             </paramset>
-            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="8973b7c6-9a78-48fc-94d5-6f9ffaa3f2f5" name="Observe">
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="90d4aafe-73d2-4d7b-b6ce-fb68a69ad752" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
                 <param name="class" value="DAY_CAL"/>
@@ -6495,7 +6371,7 @@ easy for the observer to adjust it as needed for the brightness of the sky.</val
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1cdb48e5-4c88-487a-b3bf-0c473b6039e7" name="GMOS-N-BP-40">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="8b30a06b-7b5b-48f1-bb6e-9491735654c9" name="GMOS-N-BP-copy3-40">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="IFU: Baseline Standard CuAr arc"/>
           <param name="libraryId" value="40"/>
@@ -6505,7 +6381,7 @@ easy for the observer to adjust it as needed for the brightness of the sky.</val
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="43fbd790-8a5c-4331-913e-226e9070c942" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="294bf61b-fd3a-4e3f-a565-bc0ac3289582" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -6521,59 +6397,57 @@ is taken.
 
 - The readout is "fast" in order to save time.
 
-- The instrument is configured to use 1x1 binning. It is assumed that GMOS is mounted 
-on the side-looking ISS port.
+- The instrument configuration should match the one of the Baseline Standard observation. 
+It is assumed that GMOS is mounted on the side-looking ISS port.
+
+- The smartGCAL arc will automatically choose the best exposure 
+time for the given instrument configuration.
+
 
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="9dadb253-0c22-40c8-b15e-8711d480bb88" name="Targets">
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="bd21b3ea-3dc8-495d-8ce1-611cfaf5554a" name="Targets">
           <paramset name="Targets" kind="dataObj">
             <paramset name="targetEnv">
               <paramset name="base">
-                <param name="name" value="CuAr"/>
-                <param name="system" value="J2000"/>
-                <param name="epoch" value="2000.0" units="years"/>
-                <param name="brightness" value=""/>
-                <param name="c1" value="00:00:00.000"/>
-                <param name="c2" value="00:00:00.00"/>
-                <param name="pm1" value="0.0" units="arcsecs/year"/>
-                <param name="pm2" value="0.0" units="arcsecs/year"/>
-                <param name="parallax" value="0.0" units="arcsecs"/>
-                <param name="rv" value="0.0" units="km/sec"/>
-                <param name="wavelength" value="-1.0" units="angstroms"/>
+                <paramset name="target">
+                  <param name="name" value="CuAr"/>
+                  <param name="redshift" value="0.0"/>
+                  <param name="parallax" value="0.0"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="0.0"/>
+                    <param name="dec" value="0.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
               </paramset>
               <paramset name="guideEnv">
-                <param name="active">
-                  <value sequence="0">GMOS OIWFS</value>
-                  <value sequence="1">PWFS1</value>
-                  <value sequence="2">PWFS2</value>
-                </param>
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoDisabledTag"/>
+                </paramset>
               </paramset>
             </paramset>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="68cc320b-c72e-4266-926f-163100e35739" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="1cd8a17c-4528-4d22-8f57-fd507634dfb3" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="300.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
-            <param name="disperserLambda" value="630.0"/>
+            <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
-            <param name="filter" value="r_G0303"/>
+            <param name="filter" value="i_G0302"/>
             <param name="ccdXBinning" value="ONE"/>
             <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
@@ -6585,7 +6459,7 @@ on the side-looking ISS port.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="92d290a6-21a0-47c3-97c2-ce91cf56e829" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="7c7574ce-8c00-4f47-81da-0cda2e0bf322" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -6597,12 +6471,12 @@ on the side-looking ISS port.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="136cde70-215c-4191-926b-ad829379105c" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b75fa0df-7530-4c08-8973-9cb344418f00" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="ca1b0431-a7e4-4348-b12e-a3ce76cacde8" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="8942eea1-0c90-420f-89f9-1946d8097320" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -6611,9 +6485,9 @@ on the side-looking ISS port.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="3469b0be-84c3-4872-8d70-597ff6699049" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="1380ba0e-db2d-4cc1-9d46-5212c680fe73" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="899efa19-4422-4c9a-b174-7db68720fa48" name="Arc">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartArc" key="a20cf44f-2119-40de-979f-9d5474f709cb" name="Arc">
             <paramset name="Arc" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="class" value="DAY_CAL"/>
@@ -6623,7 +6497,7 @@ on the side-looking ISS port.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="2f11d1f0-b400-437d-bdd5-571301677166" name="GMOS-N-BP-41">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1eefbb40-6212-4ab9-9061-eca627a9e53e" name="GMOS-N-BP-copy3-41">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="IFU: Baseline Standard: acquisition observation"/>
           <param name="libraryId" value="41"/>
@@ -6633,48 +6507,47 @@ on the side-looking ISS port.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a8b03fe0-d674-42d4-abdd-2596077b3011" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="e90d49b7-623c-4829-9af3-f2b8f23dc5a7" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
-              <value>This example shows an acquisition observation for an IFU standard observation.
+              <value>This example shows an acquisition observation for an IFU baseline standard observation.
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
-The class is 'Acquisition Calibration'
+The class is 'Acquisition Calibration'.
 
-The FPU, ROI, binning and exposure time are sequenced.
-The first step is an imaging exposure with the CCD binned 1x1 and ROI Central Stamp
-The 2nd step is an image through the IFU, full frame readout with the CCD binned 1x1
+There is no target component as an appropriate target will be supplied
+by the Gemini observing staff when it is convenient to observe the
+spectrophotometric baseline standards.
 
-The user will need to adjust the exposure time to be appropriate for a given
-target. Use the ITC to find the exposure time needed. A S/N&gt;=10 is 
-recommended for acquisition observations. 
+The FPU, ROI, and exposure time are sequenced:
+
+Step 1: Imaging exposure with the CCD binned 1x1 and ROI Central Stamp
+Step 2: Image through the IFU, full frame readout with the CCD binned 1x1
+Step 3: Copy of step 2 to further adjust the centering of the target in the IFU.
+
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="1c53dd35-bd8a-4633-bc35-d2157132caf7" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="a73834d2-0d95-470d-982d-daed8cd89311" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="2.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="FAST"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
             <param name="filter" value="r_G0303"/>
-            <param name="ccdXBinning" value="TWO"/>
-            <param name="ccdYBinning" value="TWO"/>
+            <param name="ccdXBinning" value="ONE"/>
+            <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
-            <param name="posAngleConstraint" value="PARALLACTIC_ANGLE"/>
+            <param name="posAngleConstraint" value="FIXED"/>
             <param name="stageMode" value="FOLLOW_XY"/>
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="CENTRAL_STAMP"/>
@@ -6682,7 +6555,7 @@ recommended for acquisition observations.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="6c5a4745-4ad1-48a3-bf11-2a858c2760e2" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="2365daba-4af5-413d-99c2-5901a0e17303" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -6694,12 +6567,12 @@ recommended for acquisition observations.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="664d71cf-1911-4fee-b8b7-6c24171f8474" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="214360e6-d6dc-40da-b17f-7cff0fee6bf7" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="42420c9d-8364-46bb-9419-a7aa7f9a28ae" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="8f1a5fef-72d3-4a4a-8276-97f82a1d0b07" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -6708,19 +6581,19 @@ recommended for acquisition observations.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="ecee8998-9f3d-4569-bb75-5e1d16a0fe35" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="c7800e6b-1d96-48f9-87d9-71827edf60c7" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="a277ca65-1fd8-45e0-a6bf-ae2713311d7b" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="7b01ff7b-db6c-45a5-a6b0-6c55cb592138" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Define the IFU"/>
               <param name="fpu" value="IFU_1"/>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="9912b85f-537f-4794-aa6a-2126b71eeca4" name="GMOS-N Sequence">
+            <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="ab965282-4565-41e6-8955-c18cb4a91c5f" name="GMOS-N Sequence">
               <paramset name="GMOS-N Sequence" kind="dataObj">
                 <param name="title" value="GMOS-N: Field Image"/>
                 <param name="fpu" value="FPU_NONE"/>
               </paramset>
-              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="bb624af3-1cc9-4f78-8151-7eba0f1ce248" name="Offset">
+              <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="fc809c17-5b5d-456d-9849-ac80c4cce2d9" name="Offset">
                 <paramset name="Offset" kind="dataObj">
                   <param name="title" value="(P=0, Q=0)"/>
                   <paramset name="offsets">
@@ -6731,7 +6604,7 @@ recommended for acquisition observations.
                     </paramset>
                   </paramset>
                 </paramset>
-                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="b0f5f1cc-f994-4e0f-94c5-2db355c9047e" name="Observe">
+                <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="0bb9b3d6-b9bf-47a9-ad15-b36800a21619" name="Observe">
                   <paramset name="Observe" kind="dataObj">
                     <param name="repeatCount" value="1"/>
                     <param name="class" value="ACQ_CAL"/>
@@ -6740,7 +6613,7 @@ recommended for acquisition observations.
               </container>
             </container>
           </container>
-          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="901b581f-1205-4dfe-8bd2-50703573871f" name="GMOS-N Sequence">
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GMOS" key="498e3e4a-7c44-4239-a14f-3141208974f8" name="GMOS-N Sequence">
             <paramset name="GMOS-N Sequence" kind="dataObj">
               <param name="title" value="GMOS-N: Through-IFU images"/>
               <param name="builtinROI">
@@ -6760,7 +6633,7 @@ recommended for acquisition observations.
                 <value sequence="1">20.0</value>
               </param>
             </paramset>
-            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="d7f69b07-85f4-487f-bd66-1ddc65442bbe" name="Offset">
+            <container kind="seqComp" type="Iterator" version="2009B-1" subtype="offset" key="b5c5521e-640a-429f-b628-100f87c6ab28" name="Offset">
               <paramset name="Offset" kind="dataObj">
                 <paramset name="offsets">
                   <paramset name="Offset0" sequence="0">
@@ -6770,7 +6643,7 @@ recommended for acquisition observations.
                   </paramset>
                 </paramset>
               </paramset>
-              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="dbaf59c1-1a06-4473-bcea-6c05d0db8a5e" name="Observe">
+              <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f1d91fc7-1641-4b32-a21d-0bed7d812094" name="Observe">
                 <paramset name="Observe" kind="dataObj">
                   <param name="repeatCount" value="1"/>
                   <param name="class" value="ACQ_CAL"/>
@@ -6780,7 +6653,7 @@ recommended for acquisition observations.
           </container>
         </container>
       </container>
-      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="5c839f2b-37f1-4771-92d6-def9332038b8" name="GMOS-N-BP-42">
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="0121d465-bad9-4e93-ac5c-4532e25fdeab" name="GMOS-N-BP-copy3-42">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="IFU: Baseline Standard: observation with GCALflats"/>
           <param name="libraryId" value="42"/>
@@ -6790,7 +6663,7 @@ recommended for acquisition observations.
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
         </paramset>
-        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="cc20a909-9f6b-45d8-82a3-e519c1ed19a8" name="Note">
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="e35e9b79-ab14-4f2d-b73f-1f5adeecce66" name="Note">
           <paramset name="Note" kind="dataObj">
             <param name="title" value="Description"/>
             <param name="NoteText">
@@ -6805,34 +6678,40 @@ The target component has been removed as Gemini observing
 staff will select an appropriate standard star that is accessible
 when conditions are convenient for observing baseline standards.
 
+The instrument configuration should match the one used for the
+science observations.
+
+The smartGCAL flat will automatically choose the best exposure 
+time for the given instrument configuration.
+
+
+
+
+
 </value>
             </param>
           </paramset>
         </container>
-        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="66371e33-810f-4c10-87d9-43d02cc74a58" name="GMOS-N">
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="442aca4d-cf7e-468e-9b0b-08cfa6e785b4" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
             <param name="exposureTime" value="300.0"/>
             <param name="posAngle" value="90"/>
             <param name="coadds" value="1"/>
-            <paramset name="parallacticAngleDuration">
-              <param name="parallacticAngleDurationMode" value="REMAINING_TIME"/>
-              <param name="explicitDuration" value="0"/>
-            </paramset>
             <param name="adc" value="NONE"/>
-            <param name="ampCount" value="SIX"/>
+            <param name="ampCount" value="TWELVE"/>
             <param name="gainChoice" value="LOW"/>
             <param name="ampReadMode" value="SLOW"/>
-            <param name="detectorManufacturer" value="E2V"/>
+            <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="R400_G5305"/>
-            <param name="disperserLambda" value="630.0"/>
+            <param name="disperserLambda" value="780.0"/>
             <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
-            <param name="filter" value="r_G0303"/>
+            <param name="filter" value="i_G0302"/>
             <param name="ccdXBinning" value="ONE"/>
             <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
-            <param name="posAngleConstraint" value="PARALLACTIC_ANGLE"/>
+            <param name="posAngleConstraint" value="FIXED"/>
             <param name="stageMode" value="FOLLOW_XY"/>
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
@@ -6840,7 +6719,7 @@ when conditions are convenient for observing baseline standards.
             <param name="mosPreimaging" value="NO"/>
           </paramset>
         </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="0b13f62d-de31-4f32-9729-82adc9e321f8" name="Observing Conditions">
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="073cbe83-6b12-41d6-b82a-855071a0fec6" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
             <param name="CloudCover" value="ANY"/>
             <param name="ImageQuality" value="ANY"/>
@@ -6852,12 +6731,12 @@ when conditions are convenient for observing baseline standards.
             <paramset name="timing-window-list"/>
           </paramset>
         </container>
-        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="6c25a7ec-af13-4b13-ad08-e68fb2e07e2d" name="Observing Log">
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="acd95727-e850-475d-9153-71aa09a146b0" name="Observing Log">
           <paramset name="Observing Log" kind="dataObj">
             <paramset name="obsQaRecord"/>
           </paramset>
         </container>
-        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="1c64cb16-b4cf-4e89-ac50-ad71775a9f43" name="Observation Exec Log">
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="f88cbf39-c816-4ab1-ae22-1755032a6fef" name="Observation Exec Log">
           <paramset name="Observation Exec Log" kind="dataObj">
             <paramset name="obsExecRecord">
               <paramset name="datasets"/>
@@ -6866,15 +6745,15 @@ when conditions are convenient for observing baseline standards.
             </paramset>
           </paramset>
         </container>
-        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="96574765-4ae8-48f6-965e-6bdb3f8f88d1" name="Sequence">
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="5e156293-eb14-4874-8516-523d098e8fbf" name="Sequence">
           <paramset name="Sequence" kind="dataObj"/>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="b118faac-23ac-4b2f-833a-8af7695e4b76" name="Observe">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f4529dd3-3cf7-4c30-bdc1-a3d103a238fd" name="Observe">
             <paramset name="Observe" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="class" value="PARTNER_CAL"/>
             </paramset>
           </container>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="2c18830c-af83-42e4-9544-dbae5e432f03" name="Flat">
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="SmartFlat" key="109925aa-351a-4cf0-8e7a-7f1aea35a4ba" name="Flat">
             <paramset name="Flat" kind="dataObj">
               <param name="repeatCount" value="1"/>
               <param name="coadds" value="1"/>
@@ -6887,2226 +6766,2236 @@ when conditions are convenient for observing baseline standards.
   </container>
   <container kind="versions" type="versions" version="1.0">
     <paramset name="node">
-      <param name="key" value="bb208b61-31c5-4ba5-b3f5-479516aaf05a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7524bdf0-5d42-4fa8-9401-813478c34e97"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="75e2aa23-22de-45b1-acf2-ba38651ca88d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e935aed5-164c-464c-8fc3-bb5a10a5d693"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8831dfdf-2dad-4b89-92c3-80a42155fe02"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="38d2b021-f9dd-421d-854a-1246c89cf61f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ca494c7e-ec14-45a9-b5f2-23c6bb6e5714"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="adb29d2c-e440-40e2-a95c-148c4cbb7382"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="43fbd790-8a5c-4331-913e-226e9070c942"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c1cb94c9-3772-474e-8b16-e6972baff696"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="322382a0-04f3-4862-8bb5-7f7e4ac309bb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="93570bc8-3ed1-4357-b4ce-e8fb19566bf2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1165951c-8bc3-4ca2-8883-c0d6c75ceae5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="66143c16-0211-4d8b-8ec8-06da9f91b98d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6ecae2a2-c3db-4f9a-8760-48f8677b3c86"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f4790407-ad2c-481c-a1ba-1a7082bf399f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3b8a23dd-8439-4c6c-900f-70609a6eff94"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4827a5cf-e01f-4c2a-993d-d965c34afafb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8f233a9b-1f92-4ceb-aa03-9803178e3951"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="606a0a71-6557-4620-ab9b-b0c4bfb7ca58"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0b55594e-fbd0-446e-85d3-567b0eb6f377"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b42e602a-51fa-4b44-85ae-c4910a679b2b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f859255a-7559-46d5-a463-358851240176"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0c3bfed5-0894-4d90-84c1-f87b6d8126f7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="df12b4c2-586f-401a-801e-d649fc2d615a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="073fc42b-738a-46e6-b35f-4e5081c796bc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a9d5ddee-2752-42aa-b8e4-c4983858c66c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ee5e9eba-249b-4cad-be82-98a5383ab04c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f6302b81-9854-4f21-8f02-4461996288d0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cc086f16-a7e9-427b-a57f-6cfb3be72486"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b521dbfc-845a-4097-9c1c-08a1cfa5fca3"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1b1df709-a20f-4261-a914-d15dea4a1730"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1e776466-21a6-4d26-89db-d27b52521e22"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b7c0b88c-2b5b-4f02-b27f-81923fcb710f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c74912eb-5984-4635-94e8-f0f2789635ec"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="99cf0f5b-a003-4971-a979-5a7e2727da2c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d2e7f43b-e754-4aca-8ecb-67f49fe497ec"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7d14f58a-3079-4a59-8947-b4bdf057fd68"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6b744cdd-4548-4ba2-8f86-f8741260e515"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c237f090-f8fa-4e07-8102-6200c49ea626"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="05ee54dd-f4c3-488b-aaf9-45f9e5669352"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a111820d-e7d0-4d08-9261-0aae7313a3fe"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3c1a21b9-fa50-4968-9aa7-5ad8b0da09a4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="adb6f89a-c422-4bbf-9360-1d718ea666bb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="96e0da5d-a661-487c-8eba-117b04deec62"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a121cb30-9fe1-4eff-9139-eb253ab9b0a7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="027a6b2d-d1d7-4f42-a3a6-6da25c29c418"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="75f33095-c591-4f1f-93a8-48eacf61e7a2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8efcacac-4f8e-4161-8258-0eb3491f4dc2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1c53f595-2f17-4ee4-9d8d-11825f49772c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="23bed1a1-6418-46c5-b2b1-4365fd02007b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7d12f368-e2c7-4a29-baf6-2c6e1822963f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0ac3d1c3-3c52-4042-9843-9fcaafe7bfef"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="78eb5880-d8f6-405a-9c02-02f6ac3f924e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7efe810b-9066-467b-8a4b-83fce055888c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="63084f68-8ec6-44bf-9521-b90b20468e69"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3666bad6-73b7-4f25-b96a-42cf5061dc19"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="69ea82c3-9e20-49cc-8603-0ab3a02fea85"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ebd38987-8108-42ee-ae7f-f846a8ac5429"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="31420daa-15eb-4c59-9e2f-d8efb5459989"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8fa3314f-704b-4212-b442-40144cf92501"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="167d4927-425d-4203-beb3-c4c6b6514ec6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a8492a2d-f497-4db5-9600-3a2ab779866f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fb0e04b2-59ce-433c-901f-3ac3be56c4ae"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="82bfe253-b4ed-4592-a44f-9081dfaf46d7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bf69bf94-4c3e-469b-839f-eb67e3ece5f5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fc44f9b8-c9a8-451a-955e-8137dc727517"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="465addb7-49f7-4661-b657-d8afe27eb999"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4f5497b5-d975-4564-8fc7-7780e5f34022"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6b4c2f15-beae-4f6b-b4fe-295452d9d392"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0ef77228-d251-4639-b0a3-b88865d9a7eb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c6dc0bf3-6761-49f8-9da5-a712fa8325dc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="59842e78-3249-4e1e-a356-9eb7ca28cc70"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7b203573-bd09-4fd0-b222-7b9235eb7dae"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2fe209cb-5d63-4a73-b32d-a6c785c34123"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cc48ac97-e27e-4b52-8f26-353259e20b79"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="55192b2e-883c-41c7-bb48-74104db58ced"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e4626c8f-173f-4457-9f14-8bbe7461a16f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e3b52238-8afc-4660-b248-c9de6b3bb163"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c4b273d3-91bc-4e61-8271-e5d2ba802b08"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0c3cc01d-62e0-4367-adf7-c95f67f749c9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9b2c9077-8924-4d37-85a5-635821458321"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="96574765-4ae8-48f6-965e-6bdb3f8f88d1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1b9658f5-6483-485c-abdc-aae6b5f0f20e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6f173894-2470-46ea-b335-a5cf847877ea"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="406dea7a-45b4-4dec-bf89-5d08ecc48921"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e4322285-5281-40a2-8d96-f10b3061daa9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="aee44f92-1060-4510-a0c5-e40970adc8cc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a143ddd5-d907-40db-a744-18b71121b451"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="87a93971-29c3-40d4-8ce6-d9bacf46335b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="47f96e68-fbf0-423a-ad4d-4b9c8c4b1903"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="688997cf-16f9-4eb2-9586-6995b979f567"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1bae9f20-7d24-4b56-bee1-ff85ae2751e9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="37c56964-aceb-4ed7-bac8-cb0abf1c67f1"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ec39a86a-85ec-4d39-bc26-4c3657aab46d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8a46a498-26cd-48b5-981a-5ce5f9f4af40"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="86956061-8291-4341-922a-87c3ade74cc0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="704f168e-8c8e-43ec-b377-a1874699323d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ac1a589d-b78d-4232-8126-4c4be2a5cbb4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b462bbe3-8864-42d8-8bd1-dcf98c847a17"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c1d9ea76-057b-4785-bdca-270940c13211"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a73834d2-0d95-470d-982d-daed8cd89311"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="23da96d1-01d8-4de9-8182-994e2ae4b9ef"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4ca80df8-b81d-4422-a96e-873cf7b33548"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="92df41a8-51e4-440a-bc0a-4ebde84a0e35"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6325e47d-284f-4cd4-a386-85546e86982b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e43e62a8-c267-4a6b-a204-014ee23208cb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1eaf4e50-3d26-42a1-bda5-24db19072bce"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8ae24246-3a25-45d1-92d2-0b1f319d0aa3"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cf0150e5-87af-4350-9cad-74a04c010b1e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="899efa19-4422-4c9a-b174-7db68720fa48"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="33dbe49a-c5e5-4002-b50b-a9cdb53cbbaf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="df244a89-73be-4d09-b6f3-b5a9bd3f3c92"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="de0e850f-ff14-4301-996d-e1de7b527b85"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="522c685c-6a05-4cca-8374-7ea6944f4768"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="226f6169-e0fe-42d8-b86f-deba98fff2e3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fe88e576-98fc-4dc7-90be-570c2e3cea30"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="75d04b48-09b9-4397-9510-8ff5cfe615d0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e22d831c-d27f-4ae5-9fa7-98e6bfeb8091"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c7ad570e-f7bc-46af-99f1-297c92beb776"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="cfb8b498-9b14-4352-a1b8-fb47e5e808ae"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4b9a4120-d276-4fc6-a209-bce5fd3b638c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="454210cd-47a2-41a7-bd67-2ae860a75eab"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fbb968cb-af4d-46c0-913c-d9d4a9f8d416"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c52793dc-8429-4bbd-a943-a94bf34b7861"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0e9322c4-0734-4a81-a11a-2a57c82ab4f9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="46fde71b-0b5a-4a67-8461-4dab8241f221"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b09d1b16-b678-4f5f-97d2-cbec3b6c1c87"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="dbaf59c1-1a06-4473-bcea-6c05d0db8a5e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="552c49a8-5eff-4e85-beb1-030a48375fb7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b61908e6-ed8f-4ac5-b536-1374118fbd1e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="aaa198e5-f74f-4e41-90a5-5c6124d10851"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ec2f9bc6-3f6c-46ff-9fb8-98153e550281"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9bcb3f17-143f-49ce-98b9-40c4abb0720e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="468b1840-7f3c-473b-9c7f-7f2d37f04df1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="17309106-faf6-4fa8-82f5-72e649fb6dcf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9c1b8e45-8e5b-425b-b34d-a60f2ad11bb1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7b01ff7b-db6c-45a5-a6b0-6c55cb592138"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b1db6021-c38a-456d-89f0-b41327d4ee73"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2c7bda22-1f13-457c-a42b-3b1bae059c0b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6419bb5c-0114-4e90-b332-951a6cc000d4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c313a6e9-cf0e-4a98-a2bf-192f3091d541"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="92d290a6-21a0-47c3-97c2-ce91cf56e829"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a80b7d52-9a06-471e-8f8b-81c710f22509"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d2347b0f-6dd5-4418-81ba-327f022f00d0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fc0392c0-38f1-483b-ab2f-100daf1be376"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7d050732-10db-4e68-b045-d4cf57e750e8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2311ad4d-c197-45dd-8ac2-e0b0c0140e52"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4b558528-f848-43b8-a945-09d2a92f505e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2037c4b4-9aa1-4c31-a181-89c2bf1cda4c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="499fdac7-7867-4952-96d3-e35a6b9eb454"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ad365020-d8a3-49f5-8b0f-49415de7b533"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="037bd82e-1263-4304-8299-c060377441c4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="69d7df9b-993f-4bf8-9491-45e79c69d660"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fc8ed603-95ab-451b-916c-e018a8171d0c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0e4c573b-df97-4a05-9f75-4c61a2841a73"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3552bfe3-16a4-4c70-bdb6-7817a2e0b28d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="72e03868-894c-4b07-85db-0d130ba6b876"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="11090560-c2ca-4e07-bc32-32011a5d5e02"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5d33c10a-60c3-4a55-a856-a06d35a66ac8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ecb31622-785a-445a-b779-78741818f1f3"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="52049a52-37a5-4be7-a552-bf492f622a20"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3a2ded8d-a905-4ce7-b906-6e5198b7291e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c3947723-7ffc-4552-a836-097f3002a324"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="76a449a9-23cc-488c-b71e-ce1a016da128"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0a90893d-b8f7-476d-bfae-e185c15dc03f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c471da64-12f1-4d29-aa5c-ba71a7b3fb27"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c07ee2ea-a4cb-4cb2-b7e4-4941be2b2d4a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f224574d-a1b3-489a-a742-a08bc4ab9bae"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="aae4699f-e401-4712-a692-fac2b79c4c88"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ac9385bb-b065-479a-a3af-56c0569cca04"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c670d1e5-25de-4df2-a9ec-8ece19f5540e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fecc8b70-28d3-4bbd-bef6-212d2c6d3318"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cebb0681-a34b-4449-b64b-81eaaea5cfec"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="702b502d-9676-4a29-8050-938069795f17"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="03cdc9c4-aa68-49da-aedb-76eb0301402a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9fbb8c4a-cabf-46a4-88d8-1aea8016b980"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ed3865bc-63df-4d34-a4e7-cf58e06c9aa6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="86e2791d-6428-45b0-9648-936a5bc8d3bc"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="eb606ec2-e18b-4ba6-abd2-ebe369ae59ac"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2bcb249d-baee-4ce9-ba35-405226b3a156"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7fe815ff-9fec-42e7-bd56-b72222226195"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d8a7f797-f10f-4036-a181-770add934c62"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b1404f77-a197-411a-96ba-a39cb5a2dc5f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7d2a0dbc-4d7f-4d70-927b-753931584bad"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="03308903-f0dc-42a2-b878-72e364e95a43"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="086becf1-9f2f-4c36-b3dc-5e9062f7af00"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e6b34807-ea97-4ed4-a9aa-3849c692fec7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1441350e-a592-4e31-b448-f2bc97b5bcc2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="c77ef2aa-c306-46e3-aa3e-546af473e79d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0e3d6e3f-d93f-4841-be00-799d252b579d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="21cbf3ed-5c71-4b06-ad31-b97380301b3c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="330f770e-7e2e-4f3a-b549-805d143a3e29"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d6e284be-24f0-4444-acc1-db88d7561e8c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="11eb2434-37e2-4d75-be38-58eb5907081d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0ec5c634-422f-4061-a836-2e0b64b439e2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e0839313-1bd6-4be6-b3b2-f3b819525878"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7bccbfdf-71ca-46cb-803c-e21d0ee4842e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="21dad624-bf90-4c8a-8cd6-b7911a016983"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="faef3496-a3a4-4e9a-8693-b60b3f3fda33"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5851c09b-4a10-49fe-8e8c-bb7d5dbac3a4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c5a48dd8-3afe-49c7-9884-761896bf0250"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d0935ea4-2246-442d-9acc-fa0658f1649b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2b83a177-12fd-4f01-b091-efdc1e0f3f07"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="161b8393-f60a-43e2-8ae2-ec9402e41530"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="479acb59-bb07-48be-a00c-cde47f0b6374"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="384e4b2e-5582-4205-989f-71384df8ef67"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6fe1f4d6-bbda-45f2-b765-22a3dd4be866"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2fa9a682-5e69-49e2-b8d1-b7bce5aaf641"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c443554c-98ea-43cd-8d75-d9bda110ab91"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="dd521911-398c-4996-b13c-96f3348e56f9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7987625d-00ed-4cd2-b6bc-959085bf45e7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7cdc86b5-f16e-4ea8-b996-a50ac75262d0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="77c51dd3-e5bf-47b4-9da8-36c2df66c4f3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="06eef80b-fc35-47d2-bf39-4eb171c7a1e0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7e36e85b-c108-456c-b136-1943618978bc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2aeb29a8-f1ed-4752-be71-b2fadc38ec91"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="991b806f-a0d9-4f69-a123-4194dbdd5eb6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="04cd0b11-2843-4012-a59f-b66d4b3c706c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c394beb0-c9b5-44dd-8f17-acc9a1332136"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0b816874-e4a1-4d22-a698-5536633e2c68"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="55382ad3-b4e8-4dae-9dcb-5855ed715e56"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="81ba5b87-e381-4ea9-b5be-c9cb6fc39568"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="442aca4d-cf7e-468e-9b0b-08cfa6e785b4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1d24459f-5ec5-4888-9530-e778bfd81097"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="29470c84-127a-46b6-8c75-4acb7cea4591"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="278f08ec-4ac7-43ea-83fa-381eae376a46"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="293416c7-5bc5-4ddf-bd2a-13ff47646b63"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1490ae6f-61f7-4966-bf1c-5cfdb6836457"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="81b04bbb-5fe6-49ca-8b67-2c0a33895a43"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="34e5e355-5f8f-498a-92c4-d9b5397d7a68"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="20cea1d9-59ef-48e4-b585-f66d61ac0a44"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4a85b980-31a6-4b13-a386-0ebfa50fccf6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0d8e537f-a768-40f3-9cae-75e14c6e80f0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b613b8a2-244c-4b1a-8608-0fa9925ca666"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e2c42f9e-b217-454b-b2a2-8503ec04e43d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7563c9aa-9997-4ac6-96d0-6732144a5bdf"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8f1a5fef-72d3-4a4a-8276-97f82a1d0b07"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="873a3d52-ca45-4421-bc9e-b45399999600"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9b811c05-b6fb-46c7-9054-42ed88ea65ca"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2eee48fa-09bf-4a52-acfb-59e4cc208654"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="69fdc30f-4f10-45c6-ad8c-bc78a5fbf9b7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="bf35608b-23b9-4b7c-ab5a-37d7bafc773c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cc4f5d5a-33d4-46f9-abac-946121749b27"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="03091e62-e0e7-4882-a09c-52b88c1d02b2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="665a4fa1-e06d-4117-a552-1099e1947df5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6712e227-e966-4d66-85c2-c8e29ff524cd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6f1c5707-d34b-4e6e-955a-22fbda47fab8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4b0c6de5-6dff-4ce4-bdf2-a8b4af2524d4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f938650e-ff58-4a40-af4e-06ada805a4da"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e001d8ea-be07-4646-a6b3-a27732799073"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9b50ab68-292c-40f7-a144-da41f9da316e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="56ca06ab-6a53-4a3e-b250-80e88a901bf7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bc4eebda-1795-4862-a9b9-15e136e50e7b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="94701db9-1f24-40b1-b714-cd1f768260ca"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="26c389ff-5a17-45f3-b057-781db2a96197"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="09121e90-a265-4b4e-83be-e5750a59cafb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="eb9b0ff7-49eb-4c0e-83f4-1e70011e0f3d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="aee59abb-43ba-4f25-869f-437f6a1bb8bd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c2d1cc29-db72-493d-91f1-93f4886feb33"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ec72c66e-7362-4e11-855f-9fac050a0567"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="04e4e9c3-97a0-435b-88c8-eda05ae9fc2d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6cd92ccc-ac24-41fc-8f62-d24bd2245496"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ac78fa02-c2a6-4aee-bb25-263825886137"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8f0b74ac-47be-4bff-9530-7b2f59278428"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0d94736c-76b6-421f-9fcc-8744da7f9762"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0155aa46-99a2-462c-b79c-a67fd1604d2b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8cccea12-1769-4b4c-9e83-ff70f79f1a75"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="024acf32-dc44-42ab-9c57-fd60e6fa68af"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cf1bdef7-78b9-4c6b-bc59-e6c940b57c71"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="225ad73b-60f3-4866-ab58-82a7114ee021"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1957acde-1f1f-4287-84d7-74169d84f80d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b5cd32b6-0cd5-490e-acc1-9cf3dd312f4a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9b90c47e-d0e6-4396-8e22-ec24e792edba"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b6e261ec-2ada-4aa1-b548-4877aa204484"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="edd7150c-c9c4-4c85-9649-af385e1f98b9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="06532051-c752-4ded-9c28-c6eaa0849a39"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f7d8762a-515e-45a4-9795-db81490b4e99"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b0f5f1cc-f994-4e0f-94c5-2db355c9047e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c139794b-ccdf-4598-beba-1d92f063cfb6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b8781473-0d04-45b5-989f-e246525b69ab"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5ea79531-a8ad-42a7-8da2-636181f26559"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f8d4c18f-2244-4dc1-8a04-ee3783fa84dd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cc4180ba-dec0-4d04-ad56-0c9f5c790be5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="da45d3ec-b45c-43e1-b133-246b34e55155"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="acd2d7be-94c0-4964-9042-3349f792efa3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="140de3c3-6523-4e27-85bd-a2bf03bae896"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fe42a1ea-5fb2-4a53-88ce-efc8f6b2df50"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="581a91eb-8047-466f-83cf-d0ff99c6b0dc"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c14cebad-ab0f-49ba-88f9-2c5a807d40b9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fd61e30a-e567-4724-9d86-9e2bf88c0e42"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="32b5e98e-8976-4dcd-9f16-e26e4b313312"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="07056846-8867-41f6-85a0-9c664e356af1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="87dfb3b0-e139-48e5-a188-ce9031219c14"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9d298069-a057-4a3f-9372-6aafe7066e2a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d9e7c1e5-5fc8-4723-af98-a6b1d6400b9f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a01134cc-e73e-4624-aeec-e221beaf40fa"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0121d465-bad9-4e93-ac5c-4532e25fdeab"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fcef7013-6bde-4cbb-9af0-55572286c466"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5fdd546f-6bfd-41d4-aff7-02210eda5175"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ad784916-9fa3-4a4c-8c96-197359cbdd55"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4d7a8c7c-7d4e-4d8c-a518-a301625723f1"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3b2f748e-6bfd-44b0-a3a0-f213615c578a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b6a13ec0-1349-41c2-a07d-869ef4cce1da"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0107d8be-b025-4ac4-8620-24b75f5cf9b5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="30cdb21b-d3a2-47b0-b179-71d875d0230d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1d0587d3-1335-403e-b245-945211e5d5a6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="c18dd407-bbff-496a-a1cd-53d100284652"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="124582b8-14b3-47b2-99fa-df1442c58bb3"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6ee6feab-150d-4940-be90-0f191ab419f7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="66371e33-810f-4c10-87d9-43d02cc74a58"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="09c29932-5163-4219-8eaf-dbffe4cade21"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6f0037bd-d798-43c1-83f2-856b050827db"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b75fa0df-7530-4c08-8973-9cb344418f00"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1a1db478-4f78-4906-98a1-e5cff01d3ac8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3e580a0c-0819-4979-8fc7-b5c3e592da14"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a1882fa3-6ce0-42ed-885c-f0bbcab77442"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c07adbe4-c09b-4f7f-b4d8-54a2f0e8f7eb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ac40497f-f6a5-4776-a73b-8d2a6e890c64"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="65fa6890-c484-4059-887e-d5abb8db4d18"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8a1725ce-2219-41d0-8c67-e3c031a6c633"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5a22caec-63bf-4f60-9755-e894e826a3cc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1d41716b-d3c3-461a-a674-828c99d74cb7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6f2e8bda-8709-4329-a556-a17f394d2616"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="eacd61fb-a336-45c7-a439-b6dd27c84ca3"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="50aee326-e02b-462b-b5a1-b81cbea4206f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="27bd964e-e13c-4386-a3c5-33ec73e3e7ae"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3f2610e9-6da8-40c4-a78a-9e779097123d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="30f3b5e0-1375-451f-9369-27793804dd73"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c5f1882c-6fe4-43ca-a20e-0ef9a0bea685"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1c28fd63-672a-48a7-80ec-6c97e4610224"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6527fc20-e0f0-4f6b-bc3f-0a096353378b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d981dcc1-80c7-4739-bcb5-c2eefecb450b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3703c635-0091-4659-a202-644c249524c2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1c64cb16-b4cf-4e89-ac50-ad71775a9f43"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d15976f0-5d44-4020-8fa8-cd0b6730cdc8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0136e100-323b-4907-bfd0-75231cd5283c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f5280d69-04d4-4300-94d5-73df4e448557"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="71749e61-b152-4dfe-a05e-d97ba3cef0f8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4bd30e62-a4be-4a58-8e23-fac4ae1ae354"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="027af23d-f6bf-4c1d-9d36-083891bed7d1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="681c6aaa-2c1c-44e9-97eb-ebe128358d30"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d008f167-4b52-4e88-801f-cef5675332f4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9b451c14-f0c4-47bd-8656-14a05bf892fa"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="781d284a-b1b9-40ee-826d-1939eb185c91"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8606a702-83f3-4cd6-a2f2-898e7f84419a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="edc5e3b3-344a-45a5-b791-f1798816eb28"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="11cd9d66-503d-4edf-b996-977b0d226eb5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="10ea08be-210f-42fb-bbf8-6a763267a0d0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="64e8830f-14fa-4fb8-8ecf-b37c4c575fcc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ec098195-8e1c-470d-ba76-cb75e5f68d35"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a1df1544-5f76-4375-8677-c898030113a4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ee4d7c8a-7889-4644-9288-605333095629"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="94c5ae9d-6a3b-41cd-aef0-86d9d6594c9b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="901b581f-1205-4dfe-8bd2-50703573871f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9da61bc6-7b96-458d-a23f-3301da3364e8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5a009109-c006-4d5a-8ab1-37240788ecba"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8aa5c8f5-00aa-4b35-b3b3-122295301c3c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5313aa09-c966-4f90-8201-be68680cdc64"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3680c798-f183-4739-9ce9-0ab86ef7af1d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ecaf4320-a65f-490a-ba0b-d11e76b0ed8b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ecfb8f8b-3c20-4554-a0e9-a5a5cfa1e0ad"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ad88ce7d-48b3-4660-9b3f-1cf300ca7ab6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="384b714d-ffaa-4b32-9dc1-29ade5c3f1db"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c922e089-5c2e-4ea5-94c5-2b06ceb78d53"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a353c925-6a86-4847-acc5-ed0a29f2f311"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="199b0dc0-0e71-4a73-aa37-cb390a6dbc2c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="87e0d018-9254-4c98-aaf3-e57152ba45bd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5f031105-31a5-4419-bfa0-ef886b416741"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="dab7c4fb-519f-459e-a7bf-0d3e3860fa3d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7c5a4c02-6e38-49ab-b4a8-99da14fb27dd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="efe82256-06d6-41e0-98ce-bbaeabffb270"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d4691541-d888-40b2-8f42-6d4015be7aeb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d0fa4e66-b714-4f3d-bf82-266be75c54ed"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6be96aaf-1848-49ab-9c84-8734105f764e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="347ba18f-4458-4b56-8cb5-9424314a5a9f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="47920d68-3225-48a1-b5ea-bbe645a44c69"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ecdd19d0-fa5f-48ea-bf82-8677b3cab3c2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ba75ef82-ca8f-4cd6-906c-ce5422d9acae"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="dbb0aec1-c812-4b75-9826-e675f2f3db00"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="93d4ca09-1fd8-4815-b01d-6ff77c2af6ac"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f01a1cbd-cc17-42be-a2fe-2bfe83d108a5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="08411037-90a3-418f-ba4e-b8f51788f861"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="740b1c26-ed2d-48ac-9085-c10e67b81578"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0854a8ed-83f2-4252-ad21-3a9f4c730930"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="69f0a272-c4f7-4789-8301-36d81943bf3b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3c528f75-1f8c-4f10-8fc1-314b79688ed9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4c745ca8-613c-4189-b675-db525485553a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2c18830c-af83-42e4-9544-dbae5e432f03"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="48973547-179f-4e4c-b22e-5bd3e19b976f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="42420c9d-8364-46bb-9419-a7aa7f9a28ae"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2c9c6d78-8fe8-4a40-82e5-3c39f71c63d8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4cbfbc68-a0b2-4c4d-a178-986899b59803"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b2bcc43d-4e31-4b1a-9535-b8b23a589fc7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="cccc7a22-aed2-4330-b77e-86d006d3779d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a0aafa34-5bb4-420d-a375-5bb3666d3eaf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="843a29c1-3f11-43f4-b952-8b6e51ff8a8c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b359576e-9191-4e46-b38b-4f401a486f7a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="724799c2-fbe4-47c2-a752-3ef8d2dd7d9d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5c629495-3200-497d-a74d-48499c3bcc08"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0b13f62d-de31-4f32-9729-82adc9e321f8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f39505cd-cbcf-4fcd-bb5f-ca19359e4af7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="90cee571-e43f-44f3-88db-20b505bc60c9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b40b2ebd-12de-4ea9-b361-33b767c8f26a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1f0c3aa6-6186-4e6b-b6cc-326a96526ed0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8c975cab-94dc-4dad-9429-d8feb0f8a3b7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="83335f7d-4f54-4d9a-b884-d84fae36e0d7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2221f4f6-1c3c-4765-b2f0-0edd20677263"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d051a90b-bc67-40b6-a09b-0aadd9e2f58d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="08deb5fe-3f24-4d22-b07d-5ff484750dca"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ce41c523-5759-48cd-9429-0e64103ad160"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="710d77d5-0983-436b-8e81-aa8be4ef678d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a4cb1084-3335-4700-be55-b5be4ae6d231"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ebe88633-51f4-4069-ad2a-dd0287f63a67"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="388ef6db-53dd-427d-b5ca-34ff4eddf0ff"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6165bf89-c5ad-42f9-84d4-1443300a93ee"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8ed9dd84-62da-4d9f-aa92-e27aec9080c8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f71fe92d-5423-4398-a1fa-9d95bce5bb94"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="84715020-319d-4201-8b05-e2cf79ac83c3"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="24adbc8a-4470-4b1d-8d0f-197b864eab5a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1c26d3d0-09b2-4fc0-8360-b7b20dd2316e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cd7c8e43-0eaa-4b56-bb54-486a396348a1"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0f73e0d0-b5ee-4730-89df-b5d4b1f9006e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="420e0a71-9c02-4aaa-86a7-5062b471da14"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0b479128-0aa2-468f-8366-e37b2f48867b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8272947f-0b70-4b4e-9d28-eaad67abf48e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1941e6e1-e99e-48f0-8169-5f74b01cb00b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4aca5aa1-a2e0-4f0b-bdbb-9f118259c5c5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1df11513-6b61-486c-8e09-36c3a0804651"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2d972de0-c190-4069-98bc-8898ff53eb97"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fb731d87-4773-4546-bc3c-828da3652de6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2c488e55-10d1-4cba-b0dc-03a3cdec5033"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="cc30ac24-eacf-4548-b745-a1d7d73b0629"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5d9d7729-7b34-4764-a541-dad7d29209a8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3ced807e-fbd6-4cb6-9b1c-371578b03058"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="942934eb-409d-4529-baf3-3ccf8d78e2cf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="afff4132-6be9-4a80-b8fe-e6ae1952b0fd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="00851daf-23b8-4242-9e6b-8f0c8566d453"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="76b8f812-eccb-40de-aea7-87906e80f161"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="701c0703-dd1e-40db-b290-d09514376fda"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="880037e9-a8e0-47fe-bb6a-f6c736429ca8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d93cef29-7308-42f8-9dfc-989f8ccba8a4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e883efc6-a912-4d11-879e-c7529bb4b485"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1221f99d-40e4-440e-ad6d-b33713b21da0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="46afb686-bcfb-4589-abdc-65e88709ef84"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9df4b171-2677-41ef-9302-f82ed141115e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0c090aa4-d282-4862-925f-c9525b9a7bdf"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3189b0da-a0e1-450a-900d-ba8e235ddad2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="578530a2-2005-498f-9275-4506086b0e38"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="45c8a300-c8c5-4cd3-a55e-bca2b8c58e37"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d63048bd-8fb1-4cc4-8ff5-75fb69b46908"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4f60aba7-ae2b-485a-902e-c3739d0d0401"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="00c867d2-a73f-4076-b2e8-5d0c68677980"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3954a3ce-f0a6-48eb-8cb5-574df926443d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="07ff1789-078a-4e98-8f54-a28f0e114457"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="625bd1d9-967e-4a25-9a99-183e3902a394"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="bd07a043-31b6-4b7e-b95f-1f17c7df941c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3cad9022-e1bf-44e2-a453-0f630d3b2c40"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="adc82ff9-630c-4604-8500-c46c4fd8b517"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3095486d-0f67-4620-920b-f2810cdff20c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="15d9f52d-7914-4a66-bda3-565020c11e0b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="da3d1c03-0606-4231-af72-4f0a1279dd7e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="136cde70-215c-4191-926b-ad829379105c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ee5704e7-6e3e-4699-8afd-0cc566795d6a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c845853d-c88b-49a3-bedb-ce7b34112f11"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a91e4d8b-6f23-46e5-a1b1-c13cedf289b4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d31da774-dddd-4997-9445-3859983604cf"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="073cbe83-6b12-41d6-b82a-855071a0fec6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3720f9aa-e808-42c6-bf3b-9da8a8116c96"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="284e6029-c522-4072-8fd8-a5ba07651358"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="847f9886-48d5-49df-bb6d-119325d06498"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d5fa5913-a846-4af4-bc0b-508af1eafadd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2a374cc2-e70d-489b-9ca7-bf927c00cc19"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f23bb88c-2e18-41e2-b16f-0a48c01ed975"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="049e7858-3447-4fd3-a384-3e750329bda2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="dcdf9c5b-13ac-4630-8800-252e881092f6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2675a1c3-dfc7-4f13-8cfb-a02acf8129eb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5b333aab-d144-4238-aaf8-5719bc20dadd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b32e356c-a3bf-44b1-aabc-c451e8a0e10b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0e7a28d2-1026-4c0e-8fb8-3a2e0de39259"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="19304fa9-0928-4d80-a812-3eeae6d4e265"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="aab560b3-d4c0-4e1d-b1da-b18b5514b091"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fb716538-0528-44f2-a740-f85613fcad42"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="76efc71e-26b8-4368-ae1b-86cad1a49afa"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a7e72033-8fd8-46b0-9e2a-5e45cf832391"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="63d04f63-094c-4622-bb17-80216e8602b7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="89cf972a-c6ef-4652-9663-f811d3030b19"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="071705d6-a8eb-42cd-b9ee-64a8c33a940a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="73a52952-8ad3-40c5-aeb8-e719b3f6e1c6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="93fb49a8-07b5-45a7-b38f-c1f3772deb75"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9912b85f-537f-4794-aa6a-2126b71eeca4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c0733c3d-b79f-461e-87cd-7a65f55e18f5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6c25a7ec-af13-4b13-ad08-e68fb2e07e2d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7cbe5638-9b77-4b80-94d8-cd5e01433bfb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f5ea8500-a3c9-45ec-abea-a265e081a808"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a775e430-c9bb-4370-a386-ecca0d190f84"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b889167d-472f-4c84-bb71-494fd4cd47f9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="be6aff9c-f168-4154-80f3-6f06afbb477f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="99ef7e1f-cfee-4dbe-87ff-a3d3c03153d4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="39c60816-8f49-4cbd-a504-524034a21c4f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a9c39d18-3dba-4bd8-8eaf-7dbd92d8c53f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7f13f4de-4e9e-4005-93f4-90507fa95bb7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="376ecaff-c863-424b-a120-37544a1e29c2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e3cbe75a-8b3c-460f-9959-077abe9cde88"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="76b0b96c-6521-40a5-8774-933ee70bfb1e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f45645a1-8c52-4703-8967-a62b8b23f45a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ddc353c6-8831-48ef-8e1f-a2b4115d7d55"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2365daba-4af5-413d-99c2-5901a0e17303"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="dba73caf-5348-441a-8fbc-65654e3edf7d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7cf7b449-9f3e-4e5b-aede-53291c2d106e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="84abd1d6-7f24-4971-b3f8-0d055d385df8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b4a31bbb-9a35-4faf-acbd-c3b0459a5ee7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="552ae231-35ea-4455-b195-270a4c27babd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9b2367de-de42-4043-bf7a-70cd1fe61e33"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="78e028b1-3b87-4e33-b2b1-676183e7b2b6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f2946b8c-a828-4eda-ba2c-0159d1698e38"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="42a4c4b5-3790-45e6-b54f-29e277bc2c1f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1a01f009-454f-4ff5-92d5-c9322d31b0f7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5d840744-c3a8-49fe-9380-adb5e8c3d19e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0be90a88-b9be-4922-a5e4-e29b0483630f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6230abfe-f10d-4697-b587-60c465965b42"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a670374f-4778-4832-bdde-e86977f1e8df"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6b454a34-52d3-481a-af43-0e2a7ac30465"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="50d3f796-882a-4f3f-b4f5-258d2e81c891"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f8cc7101-22e5-4bb9-a11c-1d608b78fe64"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="148f4a59-ea20-465e-befa-edf011e1028f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b6673a41-6deb-4563-b63b-f32b4c2a8984"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="17489a78-f512-445e-a237-b70428325482"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="25592a71-ee93-4278-8a48-0e307510c37f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="46560a4e-c822-4ed6-926a-b675b012278b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="51129000-0656-4652-8a3d-064cdb41d57d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="039f6d59-a669-4cc9-be57-40e70cffadec"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="62cda4ca-52cf-4211-aecd-315dd627f832"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ab965282-4565-41e6-8955-c18cb4a91c5f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="80a9bf3e-59ad-42a8-8058-4e50a41e4770"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3b67109f-da99-4ec6-a45a-b8f4e1fb4b3f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6724d230-36c3-4291-adb2-9a3f7f38b8bc"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="056173a3-55f9-47c9-8e31-4a2b09b91c43"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e485d863-34dd-429b-b70c-78a01592bb53"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="111690f6-902c-4661-8f56-d46e3aa6c1f1"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9828e4f2-cb66-4088-9d26-061157026e88"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c22aa1c6-fd4a-4fbd-afbf-205134372213"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8a2da299-454e-47ad-a4e2-de0456397b7a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f37ae60c-5f4d-4d6a-b371-f151061308cd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1336249a-8f45-4b5d-a9e0-56ae204c2009"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="35fdde31-6a26-4b79-b4b9-fce31abb94b1"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="949ea3ad-77e4-40b6-aa00-af1c51bdd83d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="90d4aafe-73d2-4d7b-b6ce-fb68a69ad752"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fd276fd2-075e-4e66-8bce-4893dd870924"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="88b98f1e-99b3-4fc0-aeb4-45363d787670"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="723dbd7a-43c9-4496-848a-efb0948f9e76"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="60e92dfe-7c91-45f7-b0be-750064cfb829"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9d246c83-be0e-4aa1-bc5e-613ad9483f0c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="185ca9d2-6c76-47b5-b932-22bd434d5901"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="03e85ab8-7d53-4f7d-b2cb-376b587d24d0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c41c4513-d1d4-41d9-bf00-fab31ee9cdbf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="64fcae30-1bb0-4210-b21a-f6735e98a6ee"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="77e09ae6-7eb7-4c5b-a5aa-b6df0a8b6fe4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b02ccc33-25e0-4e21-8c0e-7438e0024d2d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1028f013-e16b-4074-9185-38f73d68c652"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a3adb08f-3694-4211-80f2-39c13218a09c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1380ba0e-db2d-4cc1-9d46-5212c680fe73"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c6d7b472-7ca9-4117-a475-693ca15ffe08"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b9b9b1d9-3efc-4266-b643-cd88c45e1db4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="17318889-196b-4f5c-964b-d5d6e2aae8ae"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c4437a6d-2076-46b8-a2b4-6640bcef77cd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="34cb2773-0c6a-4353-aab2-eb206589aab2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b9fe7de7-e85c-4b8e-842a-58e89263eba3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="669da25d-faee-4c8d-bb29-251ab25aee17"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3ce7b519-c9e5-4128-9f82-e52bc42140ce"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b5542437-0af2-4804-94ef-51dd8522f3be"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="28647a3b-fd08-4c36-9412-ed8dd77976e4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="eb1ff71b-9b2e-410e-8ae3-8952779464c5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="930cc5f5-5fa2-4041-9bca-41d344f786ed"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="55cd98e0-c0c5-4519-b9f4-215a3ad71b6b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="55737af1-b82e-4d19-9912-85afc664e909"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e33e6974-e303-4809-a114-efff35bed31c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d29e55cb-5f42-4850-8e08-5693900df568"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8b373677-3cef-48ed-a76a-2e962e158ebb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="66030c58-88a1-4845-82c6-5a00cfc499fe"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="93efe4dc-60bc-4076-8a71-400782452b36"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="164a5859-149a-4f88-977d-f956fcd35ac6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7113e4f1-040c-41f2-b706-4b62a5e04ec2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8324ddfb-76c5-4407-9984-c9b00afbaa4c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a24ecdab-eb34-465d-a7ff-bdff14e81de0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4a2f878e-7758-4285-b76f-d7b50976a1aa"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="11b0cfb8-e142-4698-b25a-82783cb0a316"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ea560247-7adc-46b0-8b25-487f70fea525"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0b923f81-570b-4edf-906d-dc3876d38c7c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="039966ef-7558-44ef-9c3e-35b1d847e3cc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="dcc2b727-02d4-47bf-800a-c3847bc989a6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="21f265b1-8f24-4251-bab2-3571722c6d5c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="81e15586-3dd5-4e07-95b9-a44fc4fd5de7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cfd4d722-6cc1-4d51-a7a0-ecc62733e177"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="39d01e4f-4ea4-4814-a7b6-986bd86a4ee8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="28cdda06-6e09-4ec2-b56b-467741719182"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c43c8321-2500-426b-8542-b9fbc8b1617f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6a438da1-81bb-44d7-af1b-c102111db673"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6ac5ea81-7b40-4bbd-b3b2-7f5a97e88d64"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1b4bb682-394d-4da9-ae5f-cda106ba2648"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f90a87c5-0b34-4b51-abcf-b085b289e7f8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a6607511-56e7-4d5f-989a-9d1b577e07d7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d591a06b-21f7-4a7b-a6be-074590d87a80"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="81955543-e2da-4844-be09-bc7278c77755"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b0c3aec4-a202-4a62-9946-f1621ef5e22a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7f1a8fc0-4e61-4005-9ce3-5f4132c3b8f0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="21e131e2-c4ee-4d2a-bcc2-ae5d4aa2d65a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3cacdb9a-0c38-4e4b-b8f8-32b8782f98de"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="be4a937e-d5da-4349-938d-9a49e4e5665e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="584a6768-6c9a-40c2-9725-7da8d73d185e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="66db2cd6-dc9c-4dbb-bb8f-f499e3dd584e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="300a9db0-5fb5-42fd-ae58-a8bb3167a2b3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="dabc570a-6ed1-4a50-9509-7218f245c78e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="acd95727-e850-475d-9153-71aa09a146b0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b052b2b4-9fb5-4afb-92a3-604cb6227cca"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="18931698-0295-48f7-9b5d-6a56db3cafd7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="40be7e87-35ee-4baf-9d2a-4e625093910d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0629e21b-65e0-4a9d-8b91-88de04fc993c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="91861099-23a2-4ce2-9f7e-a40822177415"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="13c0cfd1-bb01-4b0a-b79b-8a088c2e8183"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3876cc80-4e87-418f-a661-fd95ef457280"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a1579c87-ab76-4c73-9b7f-d0b1e3d86eca"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1102a91c-ddae-48cf-b336-60f7c79d0d62"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c8f2c7f6-503c-42c2-b465-8895a087a1ea"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2f11d1f0-b400-437d-bdd5-571301677166"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ff748dc8-9dea-45d0-a31f-b103fff0a23c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ab53a983-e7cd-42b3-81f4-dfbfe4323c3b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="52f4ee81-598e-479b-9412-21ac216ced61"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f78f91b2-af81-466a-8a5f-3e3d34a7b69b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3e197f4a-4d28-4aa4-b3c0-47a7c87f023d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="86794f0e-a283-411a-8261-b759b7f34b14"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="294bf61b-fd3a-4e3f-a565-bc0ac3289582"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6c5a4745-4ad1-48a3-bf11-2a858c2760e2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9203b1b4-4b50-4a8b-9818-561c478a1b2a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e8fbddca-6edc-41fb-9ff8-3b34d07af97b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b5c5521e-640a-429f-b628-100f87c6ab28"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="364787c0-f87b-4668-8dea-2b0179c3935f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9cad4818-352a-4fa2-a739-5f09aad5b33c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="85aaf37b-1e2e-4353-a87f-37a82dc92ffd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bb57c559-0731-4f67-a687-a7e6614d3335"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="40f91ec7-f3ac-44a2-b526-da8ca060cc02"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="29eb8fd2-cc73-4d42-9280-e807fc68d7d0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4aab2141-8a35-442a-b040-521e7573eeab"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c91750d0-d979-4147-b6d5-e897774b8dd2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a4eaf3ee-eb12-4069-abb7-f8068ead1478"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7f381d16-1c9a-4f0e-bbbc-fb3a45248060"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="880e50ed-9538-4b53-a960-063a1c4630a5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a20cf44f-2119-40de-979f-9d5474f709cb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4fc21dfc-8b9e-4f7a-bc3c-10fb93970fff"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4a587414-db06-40d8-98c1-5f40fa7f3595"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="19402c9d-683d-495f-9963-750852fa6999"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d0f92b3e-71e0-4ec4-be24-e8b9fe376f8d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="36d4c9b1-c801-4ece-844b-3c80bff73255"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="823999a3-ecf8-4b56-b8be-c66822c92eea"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8e3badd0-8e94-42d1-84f5-72b0819f1844"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c819b5e3-3ff5-456e-9785-b8d7df111106"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5c384030-db9f-47a2-ba45-de3163f5e0f2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="db68a6b0-7afc-460f-8b67-09b3dfca0a7b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a348b5e7-d235-4793-a71e-2ddd898d9b8b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d5bedfbd-2c80-4a00-91d1-212ca8653439"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="18d43472-6420-45ed-85e0-d65fbfcbe21f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="77700abb-ff59-40c6-ba0b-b2fd25671b27"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="10812b77-f996-4555-8c57-29a46176f81e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9fefb7d9-86d1-4685-a530-d19211165d3c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9f3abe9d-a2b5-406e-9736-926873a0c639"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4b45ae95-e57f-48c1-b6ef-a67e4aa0693c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="783b623b-38eb-4387-9289-14e03b8a7b0f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8be17381-4c3a-4254-b03d-54c75226105b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9dadb253-0c22-40c8-b15e-8711d480bb88"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8c6bd666-0b7c-460d-9902-2ed3cdb93f21"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="20cf9ede-e9f9-4ecc-b954-ca0b79f1c616"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c626553d-b23e-426f-86fd-de2ae09aec84"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7c448107-0105-47b5-a207-0eb8dc08a6d8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b6ff5621-667d-4420-bf90-b6738d817b6a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="103e5a18-b8dd-4452-8967-d9c7e8d6f874"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="44619eb8-2634-41f8-a30e-3a25dddae415"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="676e3c70-9506-4b0b-933e-900d9a65a333"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7ce7bb3d-d3bb-4a7e-b54f-aa418aa7f2a9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="acffbac8-6041-46e7-9720-56d9bcd35441"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e05cfa3a-b611-4c84-a7f0-dda4e08608c5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a240aef1-ea83-4d29-87e9-deb5ec0bfa22"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="413abf3a-6580-43a8-b2c3-b5a739a26d87"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fc60682a-f73d-4b1d-8cbc-88a89976a49c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e8540b42-2a0e-4c3b-8b55-c1267d8eebd5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7cb6a477-e5a5-499d-9708-8c662a03d753"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="56f9f83c-907a-4841-b84e-441165bf5cd0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ecee8998-9f3d-4569-bb75-5e1d16a0fe35"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f88cbf39-c816-4ab1-ae22-1755032a6fef"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1e20d6ce-5a58-4a99-920d-9dd6c08a9c63"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="79e27718-4295-4d21-8ccb-ed8eed5459aa"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="29719e4f-1291-4ce0-bb86-91fd4c8c0b89"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1398f642-a19c-489e-82f6-1bf11a980cf9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="288ec53c-548b-4748-83f5-473363bb7c7d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1eefbb40-6212-4ab9-9061-eca627a9e53e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4a0e5acf-31b3-4016-bc96-107fc3fef240"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="80e45030-25ed-4479-a360-992a88f04a70"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="135cdf12-4d8b-479a-b811-96fbcb8a95f5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c84e7520-814a-4670-88ec-2a5ff10e450e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ca1b0431-a7e4-4348-b12e-a3ce76cacde8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9e3857f6-8d6e-49b7-b044-a378cd04b0a2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1cdb48e5-4c88-487a-b3bf-0c473b6039e7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0bb9b3d6-b9bf-47a9-ad15-b36800a21619"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4ddb8898-4229-470e-bde7-6aaeb609cff8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9b8d5909-3271-4993-9862-8c748ce0631f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b353dd4f-0eab-40a3-b6a7-095d04ac81dc"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a1b24a11-b110-4e25-abe9-2366dd5c2da8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b22808c9-dd1b-4ecf-a4e3-afdfd82fd06e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="a5613f95-03c2-4673-84bc-27dea85340b9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f9b7ff7e-9086-427f-8e21-c989e742b684"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="085dcb13-d562-4a5e-89c9-c0e13f4eac54"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a7c2cafb-50ef-46a7-8e96-a4f0ac931a1e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="107c2916-72d0-48d2-b4be-67aad2258642"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d929e5c9-e873-45e7-9ac5-914066ce5f85"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d5c6b572-3865-4a49-aa52-e21fab4aa4a7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="faed82b1-9228-4006-93bc-bd29117e6885"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6434991e-8591-49da-a144-e46b82e4b94a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b990bda7-3d55-4fea-9131-614b7f32c829"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3277856f-c3b5-4081-ab25-8fa5dd2a6d59"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0938d3ef-8704-4bec-9de2-23c5e1c6f6ef"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="dcb36c26-d686-4726-8577-3dd429d37ec9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="32ea2dd2-9415-4790-a8ac-0bd6126087e2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d9482198-0f7c-4fb0-a398-0c8a59fadaa7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7f24729b-79db-4961-a5e3-15f8875f4759"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6d302167-c211-46a2-a92f-050895e40a7b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0e68e412-a2c3-4ca3-9941-88dfc6fa11f9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="150ef984-546d-47c3-8a36-91a0cfc7f10c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2b759f0c-3e26-4624-8c6d-4d1fd34391fb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bc81d392-0b9d-4808-afa4-17e76ad43bf4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5985d7e2-9e64-4dc9-8d06-d6acc2a371a9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1df4fdac-4b0b-413f-b7a0-cd3f6517e359"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="35b6cf1d-0f28-4f24-984d-7fd1e330dafe"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="faf8d275-ccfa-4e22-a670-fd045cc592d4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0683db4e-b725-4e2f-ab17-1d1c07f7531e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a7502b90-dcdb-4447-9c7a-4b284e9e6329"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3c8ab60a-fa44-4664-8962-644090285a1c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fb5e8fa3-66d0-49c2-9023-fc76a03fa85a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7a6589b8-5318-42f1-876d-21491975be47"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="44697fda-343d-44d7-ac72-4a866b3f725c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a3b8dd15-fee9-4919-a33e-aaf6ea1e6205"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1be5f6c7-f41e-40e0-b7ee-91a818f73ce3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="34161df4-2bcd-46d6-95d2-8fbaa2ec13d7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c79a93fa-a1ea-4e74-ad53-74b8e4b3e077"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="57380056-91ef-4728-a9f3-8c97b6d22f79"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c3eb267d-e21b-4682-9d69-524231780b02"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c723f4ff-76a5-45bc-97d2-080f08d5fb76"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c9314f15-545e-4bb0-925b-09672291f1f7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="38f0f327-661a-4158-b42b-9e3ba822b4ad"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1fb2b3e7-f284-43e4-8e1d-213613ab4c9c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d7f69b07-85f4-487f-bd66-1ddc65442bbe"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="109925aa-351a-4cf0-8e7a-7f1aea35a4ba"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="80615341-62a6-4428-9863-9f5ee0c64ba6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="055af8ac-befe-4a59-867b-50ed10887bbe"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b619d6f3-5301-46ac-854a-96e16ba9dc85"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8942eea1-0c90-420f-89f9-1946d8097320"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d9eb8157-9af5-45d8-821d-1f8689bafaf7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ba4e682b-e47b-4dde-8a9a-462cf4259870"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="39ab9cb7-add1-47c3-b773-db6201c3e2c8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6c42c2b2-999d-457d-a945-12bf268180f5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="46bf6d9b-4696-4f40-9a32-c35db116be18"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e4620bdf-394e-40d2-a331-b4b4c1d9f4be"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="92ffc69b-cbc0-4895-bfe5-606657f5df8f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0af4817e-febf-4c24-b710-1cb1805d5267"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0cdc8c08-3f5a-43ca-b98a-9fb6c457f6ac"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b5e1c61a-7091-4db6-84f2-11c2bd4ab8e7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="22e07359-2111-4c32-9c51-3c24ea499a54"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="31374a75-7d5f-42e0-9ca4-04295358934a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0e95cabe-b1a5-4a5d-840f-91f05745eb63"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4ece8045-7450-48e4-97f3-cf52518dfc86"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="51b4b9d3-d50a-45cf-b436-21904cce3883"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f827751d-cec7-491c-bc24-8302c4da5b2e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1e2b9eba-969a-4b5d-bcb9-cf39695d0522"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="885d67fe-7847-44b8-a5bc-caba170d32dc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="45c892e8-5218-48b8-9e18-fefbac64707b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1697d1c1-f3fe-4b8b-b19f-aa749df16899"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ea1bb0e3-dcbb-4dd7-a5cb-2e5a141009e4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6ff822df-efbf-4496-93b3-9b97cda73c7a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9fb002fc-ce6e-4916-a2c7-57dbe9c6d4f8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e3757578-74f4-4c67-921b-6ec0fb07b78c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="85d75155-717e-4442-8bd6-936a88ebf2ec"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="922bed25-8037-47ac-9f2f-beacb23cbe61"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9da98eb2-6e6d-472a-9a9e-6726a830fc94"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="5d7c6d21-2941-40f2-8e49-fc35304262c8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f5c9228b-114f-4004-a5ae-15ae22a47be9"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="17723f02-53aa-4dbd-adfd-e1b7b42c0937"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="845595f7-0da9-4166-a063-c9b5a5741536"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ee03ce5c-8949-42d2-b205-723df9114faf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="cc4c7d73-cfd4-4a87-af1a-f473ddb1ded6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5e156293-eb14-4874-8516-523d098e8fbf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3be106bf-a1f1-41be-84ce-401178939c5e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d8b00788-0cec-4e35-bd9c-a0245d8e8a36"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a8b03fe0-d674-42d4-abdd-2596077b3011"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="14dae2e3-3a5c-4301-b311-ec8789d4d1ee"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e36f73cb-2c9b-43db-b9cd-9dcf4b5caf86"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f9683117-33fe-4a61-9adc-28483df96b5b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="78cc7e3f-be4b-4b4d-824d-3c5e9d438ced"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9cfba5aa-2183-4b4f-b763-097a78876e2b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a5538b72-956a-49ab-83df-fbfcdce0a84c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ab4bcfd9-c513-4e2d-9eea-9ccf29493ebe"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="86229cae-1c09-447b-a256-90467b9c6379"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5da9a405-6b7e-49cb-ab06-28af2b789511"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f864a5e4-648d-4106-8689-324733347f62"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5631eb82-05fe-49fb-9197-f7c3c2dc900d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6cd8bc89-af9c-4061-88d1-2d58227ab0bb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="dc993157-ea3b-432d-950b-97fcfc5758e1"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="705511fa-e646-4d87-9404-15c81a03a6ec"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4b3e7e89-d3af-4de1-88f6-41c560e07156"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="635f44a7-c1d6-4077-bcf3-344e58300033"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7e530944-7b34-41f4-bb73-3926c10aa11e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d342e750-d79d-45e0-a6b2-2fd14406b1a8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fcf31d43-aebc-4e1d-8115-1455e7cf6cee"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="276ca772-4375-4b12-bf8c-1e596dc164fc"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="46373244-6789-424b-baac-2122136f7764"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0df72330-4477-4c7e-bb9e-8d5223ac8e4f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bde06820-aed5-439d-bf5a-bbd27ac41d98"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="62fb81a8-aa52-4c94-a511-8bd12e1154d6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7b006677-f2cd-4912-a222-330cd7a63df9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e70264b5-d0fd-4b15-a8ed-4576f3394117"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ab75b9ec-c076-4900-bf9f-0469cc539008"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b5138b66-b83e-4879-86ef-68340303a507"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="584ff7a9-572f-4a31-b94c-1c4dd2bdd2ab"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="113450e7-c7d7-4fce-b8b6-0a59653b1658"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d1cf79bb-43e3-4846-89a4-5997171995c3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e11fc636-e244-4f19-9107-72143fa4f728"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0a0e2bed-c75c-4eb5-8dc3-338c305197a6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="69c204b6-106d-4d45-b7e2-03087a886808"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9ba961f9-d062-492a-a27e-4545d7f9ba7e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7d8409dc-79ba-48c0-9303-0f5746ab6aca"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3a8d4c32-e010-4e05-8231-be263832cd60"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0d23d24c-5ef2-4541-b4b8-e0feff4503c2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7c7574ce-8c00-4f47-81da-0cda2e0bf322"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2aec1b55-dc09-443a-a205-81d04cca8e45"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9611ce6d-0502-4914-847d-f491bac0da54"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0332029a-79df-40dd-b5c2-989bebefff2c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8ed383d4-4fc1-4baa-afd7-b0b76847771f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b7bb9739-eb36-4faf-bee2-89beef9dbfd5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="14ce8e4d-0f4d-429a-8787-6fad43ae38bc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e2fe5691-e6f5-4e98-ad52-d0262b691ad5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d366ced4-acc9-4cad-874f-973b2362d378"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1b45e9fd-f57c-44b5-96a2-856302f15aae"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="31a0376c-0718-438e-b3fc-aad2b6e10172"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fb669d34-721c-44bc-be61-53eebb76bf57"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="26032384-b381-42c0-9b2b-12321a037d9c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8973b7c6-9a78-48fc-94d5-6f9ffaa3f2f5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1de8a6b9-41fc-4ed3-a39f-ba4772150b1d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="50fc7191-b233-4017-9415-b47bac1a39ff"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="10686222-b968-4e0c-af70-9c81f072ab3b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a4116222-45bd-4290-ab51-a173db77a7f0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d964416a-3fe6-44af-aac8-773a4f476015"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c7ddb646-9949-42d0-ba4d-32b660305e60"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="03a78190-5b44-4dd8-a9e0-c56b27e279a2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0cf8b6d3-3e65-4b2a-85b4-9c51e417da20"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="76c97140-a346-4306-b595-18cf64fb1d6c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3469b0be-84c3-4872-8d70-597ff6699049"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="214360e6-d6dc-40da-b17f-7cff0fee6bf7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="f6d04e1a-87ad-43ab-b5f0-4e3c32b0e705"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="43280da7-1344-405c-be3f-3224bd8485db"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="345f4726-ba88-4d6d-9b08-677e62b9d72c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="388fded0-2336-4dec-9acd-d941eec56286"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a325ea9c-4d21-42af-ac7c-b0c961dcc117"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="eed7fedc-f3ce-48a8-88f8-f1f1216744d0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="099b7655-41f1-4816-b934-1ebcaf03bfe4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5b689259-fe5c-4889-949d-b7946764abbd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0a64ca3e-98a8-4ad6-9f3c-c5a951fb9f0c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1fa439d4-06a1-4c41-b4b5-0e51ea9679f8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c257ed4f-69ca-4717-8c7b-0456f616e4a4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bc79b542-d964-42f1-bcbe-86b654a61a6d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a7b9848f-a31e-44d3-835a-9b86ef9987e2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4b933738-44cc-4d6b-a70b-7aab263c2cba"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="28f1fca5-37a0-46fa-9723-d5a93bd7ef7d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="02d30bda-64b0-4f4c-82ca-6510d38993bf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6861ea9e-78d4-426a-ba78-cc2bd649c609"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7f056152-b2bf-41d7-b0c2-15a4b2a1c22e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ea3fa420-9f5c-4a18-a63d-be4d394747c1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8b30a06b-7b5b-48f1-bb6e-9491735654c9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="75ec934e-bf79-4ac3-8354-16c98ff72cda"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="23d9857c-d582-40ff-a67a-d9f74b14e198"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4502ef6d-d01a-4ab4-8c8c-24b28c02d566"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e960a71b-366a-4afd-b117-1ad65b835a45"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2a6a53a9-34dd-4a6a-b70a-8ce96e8c4c23"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2a12c748-4941-473f-9e4d-b11752756667"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="332b93fc-f049-49e2-aa99-fa5b35ba0e2b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="11263b89-6ca0-481a-9735-b844c9cebcb6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9510d2ca-b8ba-4915-85b8-aecb44957e78"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1ea9b347-afed-47d6-8d7c-ed825e816b60"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2ae19da4-1d39-4b86-85a8-59d8561e2a38"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="09ec29cf-04cd-41f1-a4ea-ac1c7981ff47"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="37f7652f-811e-41fd-978c-7b810f485d78"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d27fbc39-5dfd-4b07-b142-6b7d0fb7da31"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="12dec04a-efab-4e94-b931-297e7f006340"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fa3e427c-db34-4ead-894e-7caa1f1520cf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d0f5633c-9282-4912-8a4c-4c19f3cb4c7b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1a729319-14cd-4ae2-8b67-583197ee667e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a4f6df82-28cc-4cce-b040-c49a4981416d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9432241b-5186-4539-ac16-d068231b5c5c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5c839f2b-37f1-4771-92d6-def9332038b8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b481cf7e-4914-4b5d-97af-3c8a06b29e66"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="bb624af3-1cc9-4f78-8151-7eba0f1ce248"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8a3c9ff9-478b-4724-adba-8629f4e58307"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5b646914-4fbb-4236-be0e-b72d4ef910ab"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="625b9ff4-7249-4274-9433-ec263ac0cb01"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="90b6f6de-6663-4339-afbd-9456c23b0809"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9220a638-8a2a-40d1-9d7e-74fb11271757"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b8fb6df9-2c90-4d03-aebe-0906c06b9fd0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="93986720-47e0-426a-b202-21844de0cb15"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d97ea422-3570-4e9c-a446-9adf81f3498b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="50c878b3-6180-4be1-b0a5-23d0c8d781b9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c33d9689-d6ce-4752-b1a8-953a7c22d1e4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f76264a7-f66d-4c08-a18d-e103eb807267"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5d970f28-9e69-4329-b8da-0eca0f7a1b1a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e9e14f1c-a6f5-4fc4-8a64-64f90b7501e9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a566c86c-68f2-48b2-9e62-64ff56c76c7f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e048fb5b-075e-4610-ab50-b4916caf7e92"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1b43f816-7ebe-4bfc-ad34-38d6082db455"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="52865c28-ac51-46df-8d79-a31f891a4d8c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e4c4a690-5a17-4d52-9fb2-a07ad54c8590"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8a36ea12-177f-48c4-aa3b-933ada992b06"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e1ce1c7f-d434-43c0-8a48-81a3611737f7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="23880a71-d825-4e80-837c-3a7c810a5482"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d2c98e5d-3fee-44bd-a267-d68b146aac90"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="935f337d-7687-4515-8a57-39469a16a8f0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c326b2fe-da76-493f-9e95-e93ba56b00a8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fc797143-ef43-49f5-8f85-3d4a69656169"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="712e2279-ff17-4227-881a-3d0d0581d7b2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4612632e-e4ec-4c73-ad3e-530d5f017423"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="40af7054-6c23-49de-8bdd-b07ed959430c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b79f6096-b017-4210-886e-bb1385ae8ff7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="db183f93-3694-4c00-85e6-6133babd5a92"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="0dff0025-6b75-4e41-ba50-6c34bf52533a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="dd9530db-f5a4-4ea7-b15e-1c8bb775c7e1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="498e3e4a-7c44-4239-a14f-3141208974f8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="14511a15-5c3c-4faf-ae74-e8df2fb15083"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="84ee5ffe-7f83-4fae-a382-ba9507bddb15"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7b4e1ebc-e547-4258-a68d-416bf8f2a739"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6daf82aa-c973-4d75-90c4-1d99de285f8b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c18561ef-d818-4aa2-b948-c65ae308bab4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ee70224e-9f7a-4e07-b64f-6f704c902453"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3ff29935-6376-4ee7-a871-d4b06de2b14d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8c973270-efe2-44a8-a151-840ae585320c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4f0db457-a637-48b2-94fb-cccaa848ea47"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d2b5011e-8d32-483d-a7a6-b4380b1cceed"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d97aeffd-edec-4a97-a21c-06a5bd2de340"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d71751e6-5aec-4763-bf32-959b7371f84d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d7b478e0-b1a3-4325-b24e-78d6e58a8c19"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="28175b67-62b3-434c-b734-883d531d4609"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1e07aac2-4c32-4bbb-b50b-e1b7eff6f0a2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f1d91fc7-1641-4b32-a21d-0bed7d812094"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ada3dffe-5d8d-4f09-bef5-a5023664f6b6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e90d49b7-623c-4829-9af3-f2b8f23dc5a7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="3824e80e-946e-440a-9a03-af7678c1d4c8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="91c63d6e-dab4-40d8-ba9f-41da8dba35f6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b118faac-23ac-4b2f-833a-8af7695e4b76"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="68f96169-a2ca-4694-a674-c1c275fe8dfb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a26cba72-f146-4af7-a50a-0de7ab6b39a1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e4a5449b-3995-40d0-99d9-e6261628e2e4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="be41e145-1bf0-4b91-9667-64b1fa0dc406"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cd147d48-69ed-48b0-bb99-5556cd0f4e8f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="859c1064-5f80-4fc9-b5f5-6478e453996d"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7e973ea5-0328-470f-bdf1-91bb07fbb3c4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="215726dd-8f18-4b72-a82c-f97a04f2e26a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="987efcd6-38d7-4e55-aa3a-b353bb98debe"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="57c26946-5e06-4e8b-984a-e63d409119d5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3e1da1f6-b45f-4a50-9d07-d951fab9d3b6"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="555b67dd-d79b-43bf-abbc-fd178f12f82b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b8837917-7c39-4400-b8a1-76bf430cd687"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="33c21a1e-4815-4dbd-ba81-c165c8571c79"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c36cc204-79b4-4205-a4e6-e64ca8b2f827"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="12855c9a-e872-43ec-948e-17398c7c4af4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e6a284a9-7deb-4c61-977d-870b3a6bcc1f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="473a7836-e7d2-4c60-86b5-be398d08fe4c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c90c55b1-8165-4308-991d-a14061305a22"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="850d0b96-38a8-4c29-98dd-4b45edf6cab8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b6716216-eb91-4720-8617-b060b535fbba"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9453db3c-a268-4a86-a6f6-410d0440a52e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a4b43a3e-98e1-4313-88f1-f1567c898d85"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8182a3a3-f3d2-4390-8dad-7174052500a6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d5b33b21-7443-4fba-946f-6e28fa3791d8"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="07687a66-eb5a-45e3-970b-fb93a279d886"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="00e20f88-d189-44d4-a6b4-26990ed07886"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="68cc320b-c72e-4266-926f-163100e35739"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cdaa6be9-390e-4914-9792-39d0effdf246"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="577d74f7-8863-432f-a313-e6d1ffab522e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b6b69160-61ed-4fa3-8169-a8a771c93c11"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="b2a80408-25a5-4bc1-b738-cd854daee22f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8e5bc479-d9ce-4702-8ef6-09a765f33e07"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6a307328-ae9a-4cd8-bbfa-d759b3963872"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="27708ad6-c839-4445-a78e-f5e63f519156"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="cc7bb024-28e2-4fb5-8831-0748273ef518"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="87990894-7831-4d48-80eb-adc0b6f5d5de"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="07212edb-f6bb-4c28-90a5-2a3c89ddfedd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7e837f86-e457-44b6-ba49-870195e3ee24"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e1c6b3b5-8027-485a-b0b7-68dcc0391d6e"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="24d865b6-d02f-4d31-be78-bf88f67b4dab"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7d083b13-a862-4819-b04c-5e0700da545a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5bdfbcd5-ebf5-475a-8e0a-78df199028bb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="70f5be4e-6d03-4a5e-ac9d-5dda44c01f11"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fab61f86-ba7f-43ec-8264-0fb4ddc528fd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="54953cd5-42d2-402c-95b9-ec89632d2b6f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2153cb75-8f3f-4a00-94bb-5971cd2ca9f2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="33e8436d-5dbd-4646-9c83-4e3d00c3a46f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="8"/>
+      <param name="key" value="b0675ff8-e770-4fc5-a556-0aaef76bc862"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fdb19d89-58fe-4553-ae1b-0327bc3f56de"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f4529dd3-3cf7-4c30-bdc1-a3d103a238fd"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a60391f3-b170-43ea-b117-af53279dd828"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="551acb3c-4650-44b3-8ff3-6a9e68bea450"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="0f7e24f9-e041-4509-8a38-f2f5179742e1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="ce839ba2-6135-46ca-af7a-0c30360da5b2"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1bf68262-4ef7-4345-99b8-aa9454510586"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="15b6df24-c8ac-46a8-9211-8b601eae27f9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5202ce0a-754e-4570-8800-2eaa69b689f1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="971dfbe8-6893-4b94-a706-67fb1abf3d79"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2c9472eb-74c7-4e8e-b952-9fe52bf325b2"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4f96343d-3e30-4dfb-a397-ceb390dca4fb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="43ad0835-e6b9-4313-b441-612702667573"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="d345ec9f-4384-40df-97e2-8cbd455ea52e"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2d55f8c2-5d5b-40cb-bcb1-761033400441"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="60167289-39c1-4481-8952-8b0b6517484c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="be0a2f70-5ae1-406a-acfb-128224d50679"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="baadf8bb-7a52-479c-93d0-6640886a0370"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="723e3bcf-7c7a-48de-b408-27ff91d0e959"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4eab76c6-020d-4661-ac0a-19be5d7800d0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="9352f658-36bd-40aa-b308-8b095d886b58"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e8413e96-0040-45d7-aedd-d2e7ca2d628f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1c53dd35-bd8a-4633-bc35-d2157132caf7"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
-      <param name="c4684c83-b2a6-4326-a4ac-89dd7f83b6e3" value="1"/>
+      <param name="key" value="6dd020dd-7892-4c9c-84ec-b062da1a8ce9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6d306962-167c-4c3a-9ec2-adde8c69ed08"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e953c5cb-2b9d-4901-88c5-dcf052893ea5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="e73c4124-e141-413d-b324-6ed830375951"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="51cb35b8-158b-466e-80b9-d175d3eb4ac0"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5bace244-e819-47a1-a770-d18f64c842ab"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="327785e5-c2ca-4390-af10-44831b1102d3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="415ad102-a747-4ab9-8037-84a92d136dd6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1d2878e5-9bea-4504-af69-f78b7a896f05"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a97df585-3583-4cfb-9a1e-272f9c916f45"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bd21b3ea-3dc8-495d-8ce1-611cfaf5554a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="29bb8703-4b82-4737-9554-59e1f3b765af"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="62e2a86c-bc3b-4390-8141-ca6f173c67d5"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d0b5f077-16a3-4e45-b983-6246fbeb490f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c7800e6b-1d96-48f9-87d9-71827edf60c7"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8759f997-9574-4c0a-aa80-5c927eab5c15"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b65f33b8-7ca3-420e-8d7a-878927627f89"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4304e65e-7fa7-4b3c-b679-af3ea55b0eef"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c69176fb-674f-436f-abe6-80eed004e0bf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="8662234c-fab3-48a0-9de9-b259fdf255ff"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="13c45c65-5c51-469b-953d-5bb2c6e3374b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="4abda53f-d469-4302-a440-aa295b8791b1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b9a5f96d-cb27-48b1-b0ff-a0ab5397af6d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="37fe2856-ee5c-4d45-ad47-51a21ed060d0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="b690f78e-3309-42a2-90ac-8e934d82332b"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="92938d4d-6918-474e-99bb-524e2ce8a857"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5a8b4790-e688-4524-8f2f-ce1b0274a4eb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="000c0b1f-d783-42c9-b87a-0b917f5f34b1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="63d04772-ebe4-4cd2-8c96-a79eddc6d366"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c718bdd1-04f2-44e0-865a-21f9322e47cb"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="1cd8a17c-4528-4d22-8f57-fd507634dfb3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="71d7e3b5-8514-479f-a109-755f4b3f4eef"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="4b6b3bb0-08b1-4072-a603-eea0b1e50dcf"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="954149e1-d214-4df3-a95f-e6842f9e5e6c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="8c93c6e6-1444-473d-a879-b5b35f5a7c41"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fbb7642f-b021-48ec-9768-b50ded22e37a"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="c195a3ac-0246-47c5-aa05-fe412d3068a3"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="43d3c5fb-ae45-4b3f-b521-5c5aafbab0d1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="29f283b5-8dff-4798-aa91-522317e16061"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="faee5e89-2a2d-494a-a0d2-8bd00e092999"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="a72db9fc-d754-43d8-8a87-657d03f4e11a"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ba792cca-0f45-4726-9716-4e74184bee12"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="3d053fa0-e634-4137-ab44-776d7e8ade7c"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="d154a20d-027e-46c1-a8a4-a762b006e740"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="9340999f-9799-4646-9857-d0984ffc0edb"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="7eef291c-2b33-4840-91a3-f53290d457d3"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e226f017-cd42-42f2-afd5-16d157083016"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a277ca65-1fd8-45e0-a6bf-ae2713311d7b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="44e34ce8-ed3c-4349-9d4e-22bf81411c61"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="c1ba9da3-fb94-4075-bec1-2704db99e1a4"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2045b3d5-ace4-437f-887e-ac3fe1fe6d52"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fa0e06fa-575c-4df8-b59e-92b0e219c333"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e1ba843a-938f-4028-8904-c5fbd45f3887"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="5b9cf8ff-2592-4592-9dfa-d03ffe457eee"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="399759a2-e562-4df9-879a-4e2cddf4393f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6bb8829b-fb24-43ef-84bb-15553c37ed8f"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="6200676e-d61a-46a3-ad7f-18cc433bcfdc"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="2cd0a8e2-4b56-43f5-baf7-628929fdb768"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="e35e9b79-ab14-4f2d-b73f-1f5adeecce66"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="a7eab1be-318a-4b66-aafa-1caa9051da0c"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="dcf3d7fe-d04a-42b6-a357-55f7038b23c9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="02d67672-c8f8-4df1-9eb2-bb0786b9bee0"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f7b63663-e69b-40d3-bc8c-b9f568c22313"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fc42d08c-6476-4376-836c-305050191dbd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="2a3d32aa-8f27-4b07-87fd-2dc30f0051af"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="6d78d391-65e7-484f-b91d-010e4162c0a6"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="7fef7b1f-6658-4166-addc-8249fc2e305d"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="cc20a909-9f6b-45d8-82a3-e519c1ed19a8"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="5d579987-a79e-4751-87f5-13491d9b1b14"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="664d71cf-1911-4fee-b8b7-6c24171f8474"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="97f6a612-e62a-4305-85c8-280c7c6c0869"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="df9ad539-7a71-484b-8733-a20d7537b4a1"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="50ff8269-031e-4e57-9e4d-82b1dcf60be4"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="fb892cfa-7669-45dd-b2a4-bb837a9495fd"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="cba3dd58-9c9f-4f2c-9009-07207614edbe"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="1fd61844-8a5b-4903-b389-d3ea9d6dbb0b"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="bf4d9417-2cf5-4c54-a3f2-583813ffbe82"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="196b94cb-7484-4a9c-aa63-f20af37c7f91"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="f3211da2-908c-41ce-b090-e4f06e48f201"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="ed2e049b-ab74-47ff-9a05-d6a3414ca9c5"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="04b95e27-b29d-4fc9-a677-cebfd00b06ab"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
     <paramset name="node">
-      <param name="key" value="006afb1b-3714-43ee-ad9d-82cc23917c49"/>
-      <param name="d5384e27-dce9-4422-81b6-1e189e5669ac" value="1"/>
+      <param name="key" value="fc809c17-5b5d-456d-9849-ac80c4cce2d9"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c7195454-62aa-4ff5-9bda-76fc0272dc77"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e79dac83-9508-4522-8ad1-38403b266796"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="87c974d1-c29f-4826-9d30-830f60f19b5f"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="06546bbe-0862-4722-b7c3-e699bd14e2ff"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="bef52484-bc72-4885-83e0-cf3444827c92"/>
+      <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
     </paramset>
   </container>
 </document>


### PR DESCRIPTION
GMOS-N is switching from E2V to Hamamatsu detectors.
Thus, the template XML must be changed.