### PR TITLE
REL-3146: Fixed NullPointerException In IterFlatObsForm

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/IterFlatObsForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/IterFlatObsForm.java
@@ -104,12 +104,9 @@ public class IterFlatObsForm extends JPanel {
         arcs = new JCheckBox[4];
         for (int i=0; i < 4; ++i) {
             arcs[i] = new JCheckBox();
-            if (i != 3)
-                arcPanel.add(arcs[i], cc.xy(i*2 + 1, 1));
-            else {
+            if (i == 3)
                 arcs[i].setHorizontalAlignment(SwingConstants.LEADING);
-                arcPanel.add(arcs[i]);
-            }
+            arcPanel.add(arcs[i], cc.xy(i*2 + 1, 1));
         }
 
         add(arcPanel, cc.xywh(5, 9, 5, 1));


### PR DESCRIPTION
When I was cleaning up the class `IterFlatObsForm`, I forgot to add `Constraints` to the cleaned up code for adding arc `JCheckBox`es to the UI, which caused an NPE.

This cleans this up so the `Constraints` are in place and the alignment is still set properly, but in a simpler way.