### PR TITLE
REL-2942: Program form contact email label changes.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
 
 /**
  * This is the editor for the Science Program component.
+ * NOTE: program labels are no longer compatible with data objects because of REL-2942.
  */
 public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> implements TextBoxWidgetWatcher {
     private static final Logger LOGGER = Logger.getLogger(EdProgram.class.getName());
@@ -51,14 +52,14 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w = new ProgramForm();
         _edAux = new AuxFileEditor(_w);
 
-        _w.contactBox.setForeground(Color.black);
+        _w.additionalSupportBox.setForeground(Color.black);
 
-        _w.titleBox.     addWatcher(this);
-        _w.firstNameBox. addWatcher(this);
-        _w.lastNameBox.  addWatcher(this);
-        _w.emailBox.     addWatcher(this);
-        _w.phoneBox.     addWatcher(this);
-        _w.principalContactBox.addWatcher(this);
+        _w.titleBox.           addWatcher(this);
+        _w.firstNameBox.       addWatcher(this);
+        _w.lastNameBox.        addWatcher(this);
+        _w.emailBox.           addWatcher(this);
+        _w.phoneBox.           addWatcher(this);
+        _w.principalSupportBox.addWatcher(this);
 
         // add menu choices
         _w.affiliationBox.setForeground(Color.black);
@@ -122,8 +123,8 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _showPiInfo();
 
         // misc
-        _w.contactBox.setText(getDataObject().getContactPerson());
-        _w.principalContactBox.setText(getDataObject().getPrimaryContactEmail());
+        _w.additionalSupportBox.setText(getDataObject().getContactPerson());
+        _w.principalSupportBox.setText(getDataObject().getPrimaryContactEmail());
 
         final TooType tooType = getDataObject().getTooType();
         final String typeStr = tooType.getDisplayValue();
@@ -306,8 +307,10 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w.emailBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
         _w.phoneBox.setEnabled(enabled);
         _w.affiliationBox.setEnabled(enabled);
-        _w.contactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
-        _w.principalContactBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()) || OTOptions.isNGO(getProgram().getProgramID()));
+        _w.additionalSupportBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
+
+        // This confusion is due to the fact that this widget used to be for NGO support, and has now been relabeled.
+        _w.principalSupportBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()) || OTOptions.isNGO(getProgram().getProgramID()));
     }
 
     /**
@@ -337,7 +340,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
             final SPProgram.PIInfo piInfo = getDataObject().getPIInfo();
             getDataObject().setPIInfo(new SPProgram.PIInfo(piInfo.getFirstName(),
                     piInfo.getLastName(), piInfo.getEmail(), s, piInfo.getAffiliate()));
-        } else if (tbwe == _w.principalContactBox) {
+        } else if (tbwe == _w.principalSupportBox) {
             getDataObject().setPrimaryContactEmail(s);
         }
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 
 /**
  * This is the editor for the Science Program component.
- * NOTE: program labels are no longer compatible with data objects because of REL-2942.
+ * NOTE: component names / labels are no longer congruent with data object member names because of REL-2942.
  */
 public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> implements TextBoxWidgetWatcher {
     private static final Logger LOGGER = Logger.getLogger(EdProgram.class.getName());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -138,9 +138,9 @@ public class ProgramForm extends JPanel {
         add(emailBox, cc.xywh(3, 15, 9, 1));
 
         principalSupportBox = new TextBoxWidget();
-        final JLabel principalContactLabel = new JLabel("Principal Support Email");
-        principalContactLabel.setLabelFor(principalSupportBox);
-        add(principalContactLabel, cc.xy(1, 17));
+        final JLabel principalSupportLabel = new JLabel("Principal Support Email");
+        principalSupportLabel.setLabelFor(principalSupportBox);
+        add(principalSupportLabel, cc.xy(1, 17));
         add(principalSupportBox, cc.xywh(3, 17, 9, 1));
 
         add(new JLabel("Additional Support Email"), cc.xy(1, 19));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -9,6 +9,9 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
 
+/**
+ * NOTE: program labels are no longer compatible with data objects because of REL-2942.
+ */
 public class ProgramForm extends JPanel {
     public ProgramForm() {
         final DefaultComponentFactory compFactory = DefaultComponentFactory.getInstance();
@@ -128,21 +131,21 @@ public class ProgramForm extends JPanel {
         add(phoneLabel, cc.xywh(7, 13, 1, 1, CellConstraints.RIGHT, CellConstraints.DEFAULT));
         add(phoneBox, cc.xywh(9, 13, 3, 1));
 
-        final JLabel emailLabel = new JLabel("PI / PC Email");
+        final JLabel emailLabel = new JLabel("Investigator Email");
         emailBox = new TextBoxWidget();
         emailLabel.setLabelFor(emailBox);
         add(emailLabel, cc.xy(1, 15));
         add(emailBox, cc.xywh(3, 15, 9, 1));
 
-        principalContactBox = new TextBoxWidget();
-        final JLabel principalContactLabel = new JLabel("Principal Contact Email");
-        principalContactLabel.setLabelFor(principalContactBox);
+        principalSupportBox = new TextBoxWidget();
+        final JLabel principalContactLabel = new JLabel("Principal Support Email");
+        principalContactLabel.setLabelFor(principalSupportBox);
         add(principalContactLabel, cc.xy(1, 17));
-        add(principalContactBox, cc.xywh(3, 17, 9, 1));
+        add(principalSupportBox, cc.xywh(3, 17, 9, 1));
 
-        add(new JLabel("Contact Sci. Email"), cc.xy(1, 19));
-        contactBox = new JLabel();
-        add(contactBox, cc.xywh(3, 19, 9, 1));
+        add(new JLabel("Additional Support Email"), cc.xy(1, 19));
+        additionalSupportBox = new JLabel();
+        add(additionalSupportBox, cc.xywh(3, 19, 9, 1));
 
         // --- Observing Time ---
         add(compFactory.createSeparator("Observing Time"), cc.xywh(1, 21, 11, 1));
@@ -238,8 +241,8 @@ public class ProgramForm extends JPanel {
     final JLabel affiliationBox;
     final TextBoxWidget phoneBox;
     final TextBoxWidget emailBox;
-    final TextBoxWidget principalContactBox;
-    final JLabel contactBox;
+    final TextBoxWidget principalSupportBox;
+    final JLabel additionalSupportBox;
     final JLabel plannedLabel;
     final JLabel usedLabel;
     final JLabel totalPlannedExecTimeLabel;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -10,7 +10,7 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 
 /**
- * NOTE: program labels are no longer compatible with data objects because of REL-2942.
+ * NOTE: component names / labels are no longer congruent with data object member names because of REL-2942.
  */
 public class ProgramForm extends JPanel {
     public ProgramForm() {


### PR DESCRIPTION
Same as PR for 2017B release branch, but merging into develop as well.

Science has requested (take three or four) that we change the labels in the ProgramForm for contact emails to reflect the way that the process now works as opposed to how it used to work with rigidly defined contacts.

I have updated the labels and the names of the widgets accordingly.

Unless someone comments on this PR insisting that I do so, at this point, I am not going to update the SPProgram accessors and member variables because this far into the process, it seems risky.

I made notes at the top of ProgramForm and EdProgram to indicate that there will be an inconsistency in labels / SPProgram data member names. This also translates to the ODB Browser, but that was - a week or two ago - agreed to be acceptable.