### PR TITLE
Asterism Updates part B (again)

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -36,7 +36,6 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      *
      * @param base the science or main target for the observation
      */
-    @Deprecated
     public static TargetEnvironment create(SPTarget base) {
         return create(new Asterism.Single(base));
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -36,12 +36,23 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
      *
      * @param base the science or main target for the observation
      */
+    @Deprecated
     public static TargetEnvironment create(SPTarget base) {
-        ImList<SPTarget> user = ImCollections.emptyList();
-        return new TargetEnvironment(new Asterism.Single(base), GuideEnvironment$.MODULE$.Initial(), user);
+        return create(new Asterism.Single(base));
     }
 
-    /**
+  /**
+   * Creates a TargetEnvironment with a single-target asterism but no other
+   * associated stars.
+   *
+   * @param asterism the asterism for the observation
+   */
+    public static TargetEnvironment create(Asterism asterism) {
+      ImList<SPTarget> user = ImCollections.emptyList();
+      return new TargetEnvironment(asterism, GuideEnvironment$.MODULE$.Initial(), user);
+    }
+
+  /**
      * Creates a new TargetEnvironment with the given single-target asterism, guide
      * stars, and user targets. No references to the guide or user targets are
      * maintained, though it will share the references to the {@link SPTarget}s
@@ -58,7 +69,7 @@ public final class TargetEnvironment implements Serializable, Iterable<SPTarget>
         return new TargetEnvironment(new Asterism.Single(base), guide, user);
     }
 
-  private final Asterism asterism;
+    private final Asterism asterism;
     private final GuideEnvironment guide;
     private final ImList<SPTarget> user;
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -104,6 +104,10 @@ trait Asterism {
 
 object Asterism {
 
+  /** Construct a single-target Asterism with a [new] default "zero" SPTarget. */
+  def zero: Asterism =
+    Single(new SPTarget)
+
   // N.B. most members must be defs because `t` is mutable.
   final case class Single(t: SPTarget) extends Asterism {
     override def allSpTargets = NonEmptyList(t) // def because Nel isn't serializable

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OT.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/OT.java
@@ -26,6 +26,7 @@ import jsky.app.ot.modelconfig.GemsConfig;
 import jsky.app.ot.modelconfig.ModelConfig;
 import jsky.app.ot.too.TooPoll;
 import jsky.app.ot.tpe.TelescopePosEditor;
+import jsky.app.ot.tpe.feat.TpeAsterismFeature;
 import jsky.app.ot.userprefs.observer.ObservingPeer;
 import jsky.app.ot.userprefs.observer.ObservingSite;
 import jsky.util.gui.Resources;
@@ -199,7 +200,7 @@ public final class OT {
         // Note that the order of the buttons in the position editor toolbar
         // will correspond to the order in which the features are registered.
         final Class<?>[] features = new Class<?>[]{
-                jsky.app.ot.tpe.feat.TpeBasePosFeature.class,
+                TpeAsterismFeature.class,
                 jsky.app.ot.tpe.feat.TpeEphemerisFeature.class,
                 jsky.app.ot.tpe.feat.TpeGuidePosFeature.class,
                 jsky.app.ot.tpe.feat.TpeTargetPosFeature.class,

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TelescopePosEditor.java
@@ -11,6 +11,7 @@ import edu.gemini.spModel.gemini.seqcomp.SeqRepeatOffset;
 import edu.gemini.spModel.guide.GuideProbeAvailabilityVolatileDataObject;
 import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
 import edu.gemini.spModel.target.offset.OffsetPosSelection;
@@ -226,12 +227,12 @@ public final class TelescopePosEditor implements TpeMouseObserver {
     private void loadImage() {
         final double ra;
         final double dec;
-        SPTarget tp = _ctx.targets().baseOrNull();
-        if (tp != null) {
+        Asterism asterism = _ctx.targets().asterismOrNull();
+        if (asterism != null) {
             // Get the RA and Dec from the pos list.
             final Option<Long> when = _ctx.schedulingBlockStartJava();
-            ra = tp.getRaDegrees(when).getOrElse(0.0);
-            dec = tp.getDecDegrees(when).getOrElse(0.0);
+            ra  = asterism.getRaDegrees (when).getOrElse(0.0);
+            dec = asterism.getDecDegrees(when).getOrElse(0.0);
         } else {
             ra  = 0.0;
             dec = 0.0;
@@ -281,7 +282,7 @@ public final class TelescopePosEditor implements TpeMouseObserver {
         if (_ctx.isEmpty()) {
             _iw.clear();
         } else {
-            if (_ctx.targets().base().isEmpty()) {
+            if (_ctx.targets().asterism().isEmpty()) {
                 _iw.clear();
             } else {
                 loadImage();
@@ -313,9 +314,8 @@ public final class TelescopePosEditor implements TpeMouseObserver {
      * @throws CatalogException if a Catalog Problem is found
      */
     void getSkyImage(final TpeContext ctx) throws IOException, CatalogException {
-        final SPTarget _baseTarget = ctx.targets().baseOrNull();
-        if (_baseTarget == null) return;
-        BackgroundImageLoader.loadImageOnTheTpe(ctx);
+        if (ctx.targets().isDefined())
+          BackgroundImageLoader.loadImageOnTheTpe(ctx);
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -9,6 +9,7 @@ import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.*;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
@@ -626,9 +627,9 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
         if (_ctx.targets().asterism().isDefined()) {
             for (final SPTarget base: _ctx.targets().asterism().get().allSpTargetsJava()) {
               base.addWatcher(this);
-              basePosUpdate(base); // oops, this happens N times. now what?
             }
         }
+        resetBaseFromAsterism(); // ok even if asterism is undefined (goes to 0,0 in this case)
 
         repaint();
     }
@@ -777,17 +778,16 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
     }
 
     @Override
-    public void telescopePosUpdate(final WatchablePos tp) {
-        basePosUpdate((SPTarget) tp);
+    public void telescopePosUpdate(final WatchablePos unused) {
+      resetBaseFromAsterism();
     }
 
-    /**
-     * The Base position has been updated.
-     */
-    private void basePosUpdate(final SPTarget target) {
+    /** Reset our base position from the context asterism if any (zenith otherwise) and repaint. */
+    private void resetBaseFromAsterism() {
+        final Asterism asterism = _ctx.targets().asterismOrZero();
         final Option<Long> when = _ctx.schedulingBlockStartJava();
-        final double x = target.getRaDegrees(when).getOrElse(0.0);
-        final double y = target.getDecDegrees(when).getOrElse(0.0);
+        final double x = asterism.getRaDegrees(when).getOrElse(0.0);
+        final double y = asterism.getDecDegrees(when).getOrElse(0.0);
         WorldCoords pos = new WorldCoords(x, y, 2000.);
         setBasePos(pos);
         repaint();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -600,13 +600,13 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
             _ctx.instrument().get().removePropertyChangeListener(this);
         }
 
-        if (_ctx.targets().base().isDefined()) {
-            _ctx.targets().base().get().deleteWatcher(this);
+        if (_ctx.targets().asterism().isDefined()) {
+            _ctx.targets().asterism().get().allSpTargetsJava().foreach(a -> a.deleteWatcher(this));
         }
 
         _ctx = ctx;
 
-        if (_ctx.targets().base().isEmpty()) {
+        if (_ctx.targets().asterism().isEmpty()) {
             // There is no target to view, but we need to update the image
             // widgets with new WCS info.
             clear();
@@ -623,10 +623,11 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
             setPosAngle(_ctx.instrument().get().getPosAngleDegrees());
         }
 
-        if (_ctx.targets().base().isDefined()) {
-            final SPTarget base = _ctx.targets().base().get();
-            base.addWatcher(this);
-            basePosUpdate(base);
+        if (_ctx.targets().asterism().isDefined()) {
+            for (final SPTarget base: _ctx.targets().asterism().get().allSpTargetsJava()) {
+              base.addWatcher(this);
+              basePosUpdate(base); // oops, this happens N times. now what?
+            }
         }
 
         repaint();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpePositionMap.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpePositionMap.java
@@ -26,7 +26,7 @@ public final class TpePositionMap extends PosMap<SPTarget, SPTarget> {
 
     private TargetObsComp obsComp;
 
-    private boolean _findBase = false;
+    private boolean _findAsterism = false;
     private boolean _findUserTargets = false;
     private boolean _findGuideStars = false;
 
@@ -119,20 +119,9 @@ public final class TpePositionMap extends PosMap<SPTarget, SPTarget> {
         handlePosListReset();
     }
 
-    /**
-     * Turn on/off the ability to find the base position with a call to
-     * <tt>locate</tt>.
-     */
-    public void setFindBase(boolean find) {
-        _findBase = find;
-    }
-
-    /**
-     * Return true if the ability to find the base position with a call to
-     * <tt>locate</tt> is turned on.
-     */
-    public boolean isFindBase() {
-        return _findBase;
+    /** Turn on/off the ability to find asterism elements with a call to <tt>locate</tt>. */
+    public void setFindAsterism(boolean find) {
+        _findAsterism = find;
     }
 
     /**
@@ -142,15 +131,6 @@ public final class TpePositionMap extends PosMap<SPTarget, SPTarget> {
     public void setFindGuideStars(boolean find) {
         _findGuideStars = find;
     }
-
-    /**
-     * Return true if the ability to find a guide star with a call to
-     * <tt>locate</tt> is turned on.
-     */
-    public boolean isFindGuideStars() {
-        return _findGuideStars;
-    }
-
 
     /**
      * Turn on/off the ability to find a user position with a call to
@@ -190,8 +170,8 @@ public final class TpePositionMap extends PosMap<SPTarget, SPTarget> {
             // Is this position visible?
             SPTarget tp = pme.taggedPos;
 
-          if (env.getAsterism().allSpTargetsJava().contains(tp)) {
-                if (_findBase) {
+            if (env.getAsterism().allSpTargetsJava().contains(tp)) {
+                if (_findAsterism) {
                     return pme;
                 } else {
                     continue;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpePositionMap.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpePositionMap.java
@@ -190,7 +190,7 @@ public final class TpePositionMap extends PosMap<SPTarget, SPTarget> {
             // Is this position visible?
             SPTarget tp = pme.taggedPos;
 
-          if (tp == env.getArbitraryTargetFromAsterism()) {
+          if (env.getAsterism().allSpTargetsJava().contains(tp)) {
                 if (_findBase) {
                     return pme;
                 } else {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
@@ -12,13 +12,11 @@ import jsky.app.ot.tpe.*;
 import java.awt.*;
 import java.awt.geom.Point2D;
 
-public class TpeBasePosFeature extends TpePositionFeature {
+// TODO:ASTERISM: Draw base position … right now we only draw the targets
+public class TpeAsterismFeature extends TpePositionFeature {
 
-    /**
-     * Construct the feature with its name and description.
-     */
-    public TpeBasePosFeature() {
-        super("Base", "Show the location of the base position.");
+    public TpeAsterismFeature() {
+        super("Asterism", "Show the science target asterism.");
     }
 
     public void reinit(TpeImageWidget iw, TpeImageInfo tii) {
@@ -26,19 +24,17 @@ public class TpeBasePosFeature extends TpePositionFeature {
 
         // Tell the position map that the base position is visible.
         TpePositionMap pm = TpePositionMap.getMap(iw);
-        pm.setFindBase(true);
+        pm.setFindAsterism(true);
     }
 
     public void unloaded() {
         // Tell the position map that the base position is no longer visible.
         TpePositionMap pm = TpePositionMap.getExistingMap();
-        if (pm != null) pm.setFindBase(false);
+        if (pm != null) pm.setFindAsterism(false);
 
         super.unloaded();
     }
 
-    /**
-     */
     public boolean erase(final TpeMouseEvent tme) {
         // You can't erase the base position
         return false;
@@ -66,8 +62,6 @@ public class TpeBasePosFeature extends TpePositionFeature {
         return null;
     }
 
-    /**
-     */
     public void draw(final Graphics g, final TpeImageInfo tii) {
         final TpePositionMap pm = TpePositionMap.getMap(_iw);
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeBasePosFeature.java
@@ -55,12 +55,13 @@ public class TpeBasePosFeature extends TpePositionFeature {
 
         final TargetObsComp obsComp = getTargetObsComp();
         if (obsComp != null) {
-            // TODO:ASTERISM: handle multiple targets
-            final PosMapEntry<SPTarget> pme = pm.getPositionMapEntry(obsComp.getArbitraryTargetFromAsterism());
-            if ((pme != null) && (positionIsClose(pme, x, y)) && getContext().targets().shell().isDefined()) {
-                TargetSelection.setTargetForNode(getContext().targets().envOrNull(), getContext().targets().shell().get(), pme.taggedPos);
-                return pme.taggedPos;
-            }
+            for (final SPTarget spt: obsComp.getAsterism().allSpTargetsJava()) {
+              final PosMapEntry<SPTarget> pme = pm.getPositionMapEntry(spt);
+              if ((pme != null) && (positionIsClose(pme, x, y)) && getContext().targets().shell().isDefined()) {
+                  TargetSelection.setTargetForNode(getContext().targets().envOrNull(), getContext().targets().shell().get(), pme.taggedPos);
+                  return pme.taggedPos;
+              }
+          }
         }
         return null;
     }
@@ -73,17 +74,19 @@ public class TpeBasePosFeature extends TpePositionFeature {
         final TargetEnvironment env = getTargetEnvironment();
         if (env == null) return;
 
-        final Point2D.Double base = pm.getLocationFromTag(env.getArbitraryTargetFromAsterism());
-        if (base == null) return;
+        for (final SPTarget spt: env.getAsterism().allSpTargetsJava()) {
+          final Point2D.Double base = pm.getLocationFromTag(spt);
+          if (base == null) continue;
 
-        final int r = MARKER_SIZE;
-        final int d = 2 * r;
+          final int r = MARKER_SIZE;
+          final int d = 2 * r;
 
-        // Draw crosshairs
-        g.setColor(Color.yellow);
-        g.drawOval((int) (base.x - r), (int) (base.y - r), d, d);
-        g.drawLine((int) base.x, (int) (base.y - r), (int) base.x, (int) (base.y + r));
-        g.drawLine((int) (base.x - r), (int) base.y, (int) (base.x + r), (int) base.y);
+          // Draw crosshairs
+          g.setColor(Color.yellow);
+          g.drawOval((int) (base.x - r), (int) (base.y - r), d, d);
+          g.drawLine((int) base.x, (int) (base.y - r), (int) base.x, (int) (base.y + r));
+          g.drawLine((int) (base.x - r), (int) base.y, (int) (base.x + r), (int) base.y);
+        }
     }
 
     /**
@@ -93,10 +96,13 @@ public class TpeBasePosFeature extends TpePositionFeature {
         if (env == null) return None.instance();
 
         final TpePositionMap pm = TpePositionMap.getMap(_iw);
-        final PosMapEntry<SPTarget> pme = pm.getPositionMapEntry(env.getArbitraryTargetFromAsterism());
-        if (pme != null && positionIsClose(pme, tme.xWidget, tme.yWidget)) {
-            _dragObject = pme;
-            return new Some<>(pme.taggedPos);
+        // find any asterism member close to the drag target
+        for (final SPTarget spt: env.getAsterism().allSpTargetsJava()) {
+          final PosMapEntry<SPTarget> pme = pm.getPositionMapEntry(spt);
+          if (pme != null && positionIsClose(pme, tme.xWidget, tme.yWidget)) {
+              _dragObject = pme;
+              return new Some<>(pme.taggedPos);
+          }
         }
 
         return None.instance();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeGuidePosFeature.java
@@ -380,11 +380,6 @@ public class TpeGuidePosFeature extends TpePositionFeature
         if (obsComp == null) return;
         final TargetEnvironment env = obsComp.getTargetEnvironment();
 
-        // Get the base position.  If not found, give up.
-        final TpePositionMap pm = TpePositionMap.getMap(_iw);
-        final Point2D.Double base = pm.getLocationFromTag(env.getArbitraryTargetFromAsterism());
-        if (base == null) return;
-
         // Set up for drawing.
         final int size = MARKER_SIZE * 2;
         final Map<TextAttribute, Object> attrMap = new HashMap<>();
@@ -421,7 +416,7 @@ public class TpeGuidePosFeature extends TpePositionFeature
                                 String.format("%s (%d)", tagBase, index++);
 
                 // Find the position map entry for this star, if present.
-                final PosMapEntry<SPTarget> pme = pm.getPositionMapEntry(target);
+                final PosMapEntry<SPTarget> pme = TpePositionMap.getMap(_iw).getPositionMapEntry(target);
                 if (pme == null) continue;
                 final Point2D.Double p = pme.screenPos;
                 if (p == null) continue;

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/BackgroundImageLoader.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/image/BackgroundImageLoader.scala
@@ -180,9 +180,9 @@ object BackgroundImageLoader {
   private def requestedImage(tpe: TpeContext): Option[TargetImageRequest] =
     for {
       ctx    <- tpe.obsContext
-      base   <- tpe.targets.base
-      when   = ctx.getSchedulingBlockStart.asScalaOpt | Instant.now.toEpochMilli
-      coords <- base.getTarget.coords(when)
+      ast    <- tpe.targets.asterism
+      when   = ctx.getSchedulingBlockStart.asScalaOpt.map(ms => Instant.ofEpochMilli(ms.toLong))
+      coords <- ast.basePosition(when orElse Some(Instant.now))
       key    <- tpe.obsKey
       site   = Option(ObserverPreferences.fetch.observingSite())
     } yield TargetImageRequest(key, coords, ObsWavelengthExtractor.extractObsWavelength(tpe), site)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/ImageCatalogPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/ImageCatalogPanel.scala
@@ -169,9 +169,9 @@ final class ImageCatalogPanel(imageDisplay: CatalogImageDisplay) {
     val catalogButtonsUpdate = for {
         tpe    <- tpeContext
         ctx    <- tpe.obsContext
-        base   <- tpe.targets.base
-        when   = ctx.getSchedulingBlockStart.asScalaOpt | Instant.now.toEpochMilli
-        coords <- base.getTarget.coords(when)
+        ast    <- tpe.targets.asterism
+        when   = ctx.getSchedulingBlockStart.asScalaOpt.map(a => Instant.ofEpochMilli(a.toLong))
+        coords <- ast.basePosition(when orElse Some(Instant.now))
        } yield KnownImagesSets.cataloguesInUse(coords).map(showAsLoading)
 
     catalogButtonsUpdate.sequenceU

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -1,11 +1,10 @@
 package jsky.app.ot.tpe
 
 import edu.gemini.pot.sp._
-
 import edu.gemini.shared.util.immutable.{None => JNone, Option => JOption}
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core.Site
-import edu.gemini.spModel.data.{ISPDataObject, IOffsetPosListProvider}
+import edu.gemini.spModel.data.{IOffsetPosListProvider, ISPDataObject}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
 import edu.gemini.spModel.gemini.gems.Gems
@@ -13,15 +12,15 @@ import edu.gemini.spModel.gemini.altair.InstAltair
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.obscomp.SPInstObsComp
 import edu.gemini.spModel.rich.pot.sp._
-import edu.gemini.spModel.target.env.TargetEnvironment
-import edu.gemini.spModel.target.obsComp.{TargetSelection, TargetObsComp}
-import edu.gemini.spModel.target.offset.{OffsetPosSelection, OffsetPosBase, OffsetUtil, OffsetPosList}
+import edu.gemini.spModel.target.env.{Asterism, TargetEnvironment}
+import edu.gemini.spModel.target.obsComp.{TargetObsComp, TargetSelection}
+import edu.gemini.spModel.target.offset.{OffsetPosBase, OffsetPosList, OffsetPosSelection, OffsetUtil}
 import edu.gemini.spModel.target.SPTarget
-import edu.gemini.spModel.telescope.{IssPortProvider, IssPort}
+import edu.gemini.spModel.telescope.{IssPort, IssPortProvider}
 import edu.gemini.spModel.util.SPTreeUtil
 
 import scala.collection.JavaConverters._
-import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
+import edu.gemini.spModel.obs.{SPObservation, SchedulingBlock}
 import edu.gemini.skycalc.Offset
 
 object TpeContext {
@@ -75,14 +74,11 @@ final class TargetContext(obs: Option[ISPObservation]) extends TpeSubContext[ISP
 
   def envOrNull: TargetEnvironment = env.orNull
 
-  def envOrDefault: TargetEnvironment = env.getOrElse(TargetEnvironment.create(baseOrDefault))
+  def envOrDefault: TargetEnvironment = env.getOrElse(TargetEnvironment.create(new SPTarget))
 
-  // TODO:ASTERISM: deal with multi-target asterisms
-  def base: Option[SPTarget] = env.map(_.getArbitraryTargetFromAsterism)
+  def asterism: Option[Asterism] = env.map(_.getAsterism)
 
-  def baseOrNull: SPTarget = base.orNull
-
-  def baseOrDefault: SPTarget = base.getOrElse(new SPTarget)
+  def asterismOrNull: Asterism = asterism.orNull // can't call this from Java, so we provide it
 
   def selected: Option[SPTarget] = for {
     s <- shell

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -74,7 +74,7 @@ final class TargetContext(obs: Option[ISPObservation]) extends TpeSubContext[ISP
 
   def envOrNull: TargetEnvironment = env.orNull
 
-  def envOrDefault: TargetEnvironment = env.getOrElse(TargetEnvironment.create(new SPTarget))
+  def envOrDefault: TargetEnvironment = env.getOrElse(TargetEnvironment.create(new SPTarget));
 
   def asterism: Option[Asterism] = env.map(_.getAsterism)
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/TpeContext.scala
@@ -80,6 +80,8 @@ final class TargetContext(obs: Option[ISPObservation]) extends TpeSubContext[ISP
 
   def asterismOrNull: Asterism = asterism.orNull // can't call this from Java, so we provide it
 
+  def asterismOrZero: Asterism = asterism.getOrElse(Asterism.single(new SPTarget()))
+
   def selected: Option[SPTarget] = for {
     s <- shell
     e <- env

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -23,7 +23,7 @@ class TpeEphemerisFeature extends TpeImageFeature("Ephemeris", "Show interpolate
 
   override val getCategory = TpeImageFeatureCategory.target
   override val isEnabledByDefault = true
-  override def isEnabled(ctx: TpeContext) = ctx.targets.base.exists(_.getNonSiderealTarget.isDefined)
+  override def isEnabled(ctx: TpeContext) = ctx.targets.asterism.exists(_.isNonSidereal)
 
   def toScreenCoordinates(c: Coordinates): Option[Point] =
     scala.util.Try {
@@ -46,7 +46,7 @@ class TpeEphemerisFeature extends TpeImageFeature("Ephemeris", "Show interpolate
   }
 
   def getEphemeris: Ephemeris =
-    getContext.targets.base
+    getContext.targets.asterism
       .flatMap(_.getNonSiderealTarget)
       .fold(Ephemeris.empty)(_.ephemeris)
 


### PR DESCRIPTION
This subsumes #1235 and is a follow-on to #1222 that updates the TPE to handle asterisms. It does the following:
- The TPE base position is now defined as the base position of the Asterism. It is updated when any target in the asterism moves.
- The base position feature now draws all targets, and has been renamed the asterism feature.
- The base position itself is not drawn. A new feature is needed for this.

Further work here probably needs to wait until it's possible to construct and manipulate multi-target asterisms in the target list editor. There will certainly be usability issues to deal with. But this PR gets us to a sensible starting point.
