### PR TITLE
REL-2784 Make date formatting order consistent

### DIFF
--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/DBNightlyPlanInfo.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/DBNightlyPlanInfo.java
@@ -1,8 +1,8 @@
 package edu.gemini.obslog.obslog;
 
 import java.io.Serializable;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 //
 // Gemini Observatory/AURA
@@ -22,7 +22,7 @@ public class DBNightlyPlanInfo implements Serializable, Comparable<DBNightlyPlan
     // last modified timestamp
     private long _timestamp;
 
-    private static SimpleDateFormat _formatter = new SimpleDateFormat("yyyy-MMM-dd HH:hh:ss");
+    private static DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:hh:ss");
 
     private String _lastModified;
 
@@ -37,7 +37,7 @@ public class DBNightlyPlanInfo implements Serializable, Comparable<DBNightlyPlan
         _title = title;
         _planID = planID;
         _timestamp = timestamp;
-        _lastModified = _formatter.format(new Date(timestamp));
+        _lastModified = dateFormat.format(Instant.ofEpochMilli(_timestamp));
     }
 
     public String getTitle() {

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/DBNightlyPlanInfo.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/DBNightlyPlanInfo.java
@@ -22,7 +22,7 @@ public class DBNightlyPlanInfo implements Serializable, Comparable<DBNightlyPlan
     // last modified timestamp
     private long _timestamp;
 
-    private static SimpleDateFormat _formatter = new SimpleDateFormat("MM/dd/yy HH:hh:ss");
+    private static SimpleDateFormat _formatter = new SimpleDateFormat("yyyy-MMM-dd HH:hh:ss");
 
     private String _lastModified;
 

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/util/SummaryUtils.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/util/SummaryUtils.java
@@ -11,7 +11,7 @@ public class SummaryUtils {
      * given the current UTC time in ms.
      */
     public static String formatUTCDateTime(long time) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yy HH:mm:ss");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
         return _doFormatUTC(dateFormat, time);
     }
 

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/util/SummaryUtils.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/util/SummaryUtils.java
@@ -1,29 +1,28 @@
 package edu.gemini.obslog.util;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 public class SummaryUtils {
 
     /**
-     * Return a string with the UTC time in the format /mm/dd/yy hh:mm:ss,
+     * Return a string with the UTC time in the format yyyy-MMM-dd HH:mm:ss,
      * given the current UTC time in ms.
      */
     public static String formatUTCDateTime(long time) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
-        return _doFormatUTC(dateFormat, time);
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss")
+                .withZone(ZoneId.of("UTC"));
+        return dateFormat.format(Instant.ofEpochMilli(time));
     }
 
+    /**
+     * Return a string with the UTC time in the format HH:mm:ss,
+     * given the current UTC time in ms.
+     */
     public static String formatUTCTime(long time) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
-        return _doFormatUTC(dateFormat, time);
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss")
+                .withZone(ZoneId.of("UTC"));
+        return dateFormat.format(Instant.ofEpochMilli(time));
     }
-
-    private static String _doFormatUTC(SimpleDateFormat dateFormat, long time) {
-        Date date = new Date(time);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return dateFormat.format(date);
-    }
-
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -33,8 +33,9 @@ import edu.gemini.pit.ui.util.ToolButton
 import swing._
 import scala.swing.event.{ButtonClicked, ValueChanged, SelectionChanged}
 import javax.swing.{Icon, BorderFactory, ListSelectionModel}
-import java.util.{TimeZone, Date}
-import java.text.{SimpleDateFormat, DecimalFormat}
+import java.text.{DecimalFormat}
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
 
 import scalaz._
 import Scalaz._
@@ -400,11 +401,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean) e
 
       // Controller
       object Controller extends ListTableController[EphemerisElement, Column] {
-        val utc = {
-          val df = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss")
-          df.setTimeZone(TimeZone.getTimeZone("UTC"))
-          df
-        }
+        val dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss").withZone(ZoneId.of("UTC"));
 
         val magFormat = new DecimalFormat("##0.000")
 
@@ -421,7 +418,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean) e
         def getSubElement(e:EphemerisElement, c:Column) = c match {
           case RA  => raFormat.toString(e.coords.ra)
           case Dec => decFormat.toString(e.coords.dec)
-          case UTC => utc.format(new Date(e.validAt))
+          case UTC => dateFormat.format(Instant.ofEpochMilli(e.validAt))
           case Mag => e.magnitude.map(magFormat.format).orNull
         }
       }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -401,7 +401,7 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean) e
       // Controller
       object Controller extends ListTableController[EphemerisElement, Column] {
         val utc = {
-          val df = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss")
+          val df = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss")
           df.setTimeZone(TimeZone.getTimeZone("UTC"))
           df
         }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -6,13 +6,13 @@ import edu.gemini.model.p1.immutable._
 import edu.gemini.pit.ui.editor.Institutions
 import edu.gemini.pit.util.PDF
 import edu.gemini.pit.catalog._
-import java.util.TimeZone
 
 import edu.gemini.spModel.core.MagnitudeBand
 import view.obs.ObsListGrouping
 import edu.gemini.model.p1.visibility.TargetVisibilityCalc
 import edu.gemini.pit.ui.view.tac.TacView
-import java.text.SimpleDateFormat
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
 import java.io.File
 
 import edu.gemini.pit.model.{AppPreferences, Model}
@@ -183,9 +183,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       msg = s"""Ephemeris for target "$n" contains only one point; please specify at least two."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
-    lazy val utc = new SimpleDateFormat("yyyy-MMM-dd") {
-      setTimeZone(TimeZone.getTimeZone("UTC"))
-    }
+    lazy val dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd").withZone(ZoneId.of("UTC"))
 
     private lazy val initialEphemerisCheck = for {
       t @ NonSiderealTarget(_, n, e, _) <- p.targets
@@ -196,10 +194,10 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       diff = dsMin - p.semester.firstDay
       if diff >= 1.days
       msg = if (diff < 2.days)
-        s"""Ephemeris for target "$n" is undefined for ${utc.format(p.semester.firstDay)} UTC."""
+        s"""Ephemeris for target "$n" is undefined for ${dateFormat.format(Instant.ofEpochMilli(p.semester.firstDay))} UTC."""
       else {
         val lastDay = (dsMin < p.semester.lastDay + 1.days) ? (dsMin - 1.days) | p.semester.lastDay
-        s"""Ephemeris for target "$n" is undefined between ${utc.format(p.semester.firstDay)} and ${utc.format(lastDay)} UTC."""
+        s"""Ephemeris for target "$n" is undefined between ${dateFormat.format(Instant.ofEpochMilli(p.semester.firstDay))} and ${dateFormat.format(Instant.ofEpochMilli(lastDay))} UTC."""
       }
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
@@ -212,10 +210,10 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       diff = p.semester.lastDay - dsMax
       if diff >= 1.days
       msg = if (diff == 1.days)
-        s"""Ephemeris for target "$n" is undefined for ${utc.format(p.semester.lastDay)} UTC."""
+        s"""Ephemeris for target "$n" is undefined for ${dateFormat.format(Instant.ofEpochMilli(p.semester.lastDay))} UTC."""
       else {
         val firstDay = (dsMax > p.semester.firstDay) ? (dsMax + 1.days) | p.semester.firstDay
-        s"""Ephemeris for target "$n" is undefined between ${utc.format(firstDay)} and ${utc.format(p.semester.lastDay)} UTC."""
+        s"""Ephemeris for target "$n" is undefined between ${dateFormat.format(Instant.ofEpochMilli(firstDay))} and ${dateFormat.format(Instant.ofEpochMilli(p.semester.lastDay))} UTC."""
       }
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -183,7 +183,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       msg = s"""Ephemeris for target "$n" contains only one point; please specify at least two."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
-    lazy val utc = new SimpleDateFormat("dd-MMM-yyyy") {
+    lazy val utc = new SimpleDateFormat("yyyy-MMM-dd") {
       setTimeZone(TimeZone.getTimeZone("UTC"))
     }
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Block.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Block.java
@@ -17,7 +17,7 @@ import java.util.Date;
  */
 public final class Block implements Comparable<Block>, IntervalType<Block>, PioSerializable {
 
-    private static final DateFormat FORMAT = new SimpleDateFormat("dd-MMM HH:mm");
+    private static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MMM-dd HH:mm");
     private static final String PROP_START = "start";
     private static final String PROP_END = "end";
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Block.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Block.java
@@ -7,9 +7,8 @@ import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Represents a scheduling block, normally an observing night.
@@ -17,12 +16,12 @@ import java.util.Date;
  */
 public final class Block implements Comparable<Block>, IntervalType<Block>, PioSerializable {
 
-    private static final DateFormat FORMAT = new SimpleDateFormat("yyyy-MMM-dd HH:mm");
+    private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm");
     private static final String PROP_START = "start";
     private static final String PROP_END = "end";
 
     private final Interval interval;
-	
+
 	public Block(final Long low, final Long high) {
 	    interval = new Interval(low, high);
 	}
@@ -30,7 +29,7 @@ public final class Block implements Comparable<Block>, IntervalType<Block>, PioS
     public Block(final Interval interval) {
         this.interval = interval;
     }
-		
+
 	public Block(final ParamSet params) {
 		interval = new Interval(params);
 	}
@@ -69,11 +68,11 @@ public final class Block implements Comparable<Block>, IntervalType<Block>, PioS
 
     @Override
     public Block create(final long start, final long end) { return new Block(start, end); }
-	
+
 	public String getName() {
-		return FORMAT.format(new Date(getStart()));
+		return FORMAT.format(Instant.ofEpochMilli(getStart()));
 	}
-	
+
 	@Override
 	public String toString() {
 		return "Block " + getName();

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/ObsAdapter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/ObsAdapter.java
@@ -28,7 +28,7 @@ public class ObsAdapter implements Adapter<Obs> {
 		addObsProperties(variant, target, table);
 	}
 
-	static SimpleDateFormat TW_DF = new SimpleDateFormat("d-MMM-yy H:mm");
+	static SimpleDateFormat TW_DF = new SimpleDateFormat("yyyy-MMM-dd HH:mm");
 	static {
 		TW_DF.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ObservationState.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ObservationState.java
@@ -15,10 +15,10 @@ import org.dom4j.DocumentFactory;
 import org.dom4j.Element;
 
 import java.io.Serializable;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 public final class ObservationState implements Serializable {
     private static final long serialVersionUID = 2;

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ProgramHistoryItem.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ProgramHistoryItem.java
@@ -21,7 +21,7 @@ public final class ProgramHistoryItem implements Comparable<ProgramHistoryItem>,
     private static final ProgramHistoryItem[] EMPTY_ARRAY = {};
 
     private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("MMM d, yyyy");
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MMM-dd");
     private static final DateFormat TIME_FORMAT = new SimpleDateFormat("hh:mm:ss a");
 
     static {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/AllEventsLoggingService.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/AllEventsLoggingService.java
@@ -11,9 +11,9 @@ import edu.gemini.wdba.session.ISessionEventListener;
 import edu.gemini.wdba.session.ISessionEventProducer;
 import edu.gemini.wdba.glue.api.WdbaGlueException;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
@@ -23,7 +23,7 @@ import java.util.logging.Level;
 public class AllEventsLoggingService extends AbstractSessionEventConsumer implements ISessionEventListener {
 
     private static final Logger LOG = Logger.getLogger(AllEventsLoggingService.class.getName());
-    private  final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
+    private  final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss").withZone(ZoneId.of("UTC"));
 
     private UpdateAction _action = new UpdateAction();
 
@@ -34,9 +34,7 @@ public class AllEventsLoggingService extends AbstractSessionEventConsumer implem
     }
 
     private String _doFormatUTCTime(long time) {
-        Date date = new Date(time);
-        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return DATE_FORMAT.format(date);
+        return DATE_FORMAT.format(Instant.ofEpochMilli(time));
     }
 
     private void _logReasonEvent(StartIdleEvent sevt) {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/AllEventsLoggingService.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/AllEventsLoggingService.java
@@ -23,7 +23,7 @@ import java.util.logging.Level;
 public class AllEventsLoggingService extends AbstractSessionEventConsumer implements ISessionEventListener {
 
     private static final Logger LOG = Logger.getLogger(AllEventsLoggingService.class.getName());
-    private  final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("MM/dd/yy HH:mm:ss");
+    private  final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
 
     private UpdateAction _action = new UpdateAction();
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
@@ -56,7 +56,7 @@ public class ImagePrintDialog implements Printable, ActionListener {
     private boolean _newPrint;
     private double _printOffsetX;
     private double _printOffsetY;
-    private final SimpleDateFormat _dateFormatter = new SimpleDateFormat("MM/dd/yy HH:mm:ss");
+    private final SimpleDateFormat _dateFormatter = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
 
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
@@ -9,8 +9,8 @@ import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.print.*;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
@@ -56,7 +56,7 @@ public class ImagePrintDialog implements Printable, ActionListener {
     private boolean _newPrint;
     private double _printOffsetX;
     private double _printOffsetY;
-    private final SimpleDateFormat _dateFormatter = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
+    private final DateTimeFormatter _dateFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss");
 
 
     /**
@@ -239,7 +239,7 @@ public class ImagePrintDialog implements Printable, ActionListener {
         g2d.drawString(footer,
                 (float) _printOffsetX,
                 (float) (((canvasHeight + height) * scale) + pf.getImageableY()));
-        footer = _dateFormatter.format(new Date());
+        footer = _dateFormatter.format(Instant.now());
         width = metrics.stringWidth(footer) + 6;
         g2d.drawString(footer,
                 (float) (_printOffsetX + ((canvasWidth - width) * scale) - 15),

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EdProgramHelper.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EdProgramHelper.scala
@@ -22,8 +22,8 @@ object EdProgramHelper {
   case class ColumnInfo(name: String, prefWidth: Int, minWidth: Int, maxWidth: Int)
 
   val columnInfos = Array(
-    ColumnInfo("Start", 130, 130, 140),
-    ColumnInfo("End", 130, 130, 140),
+    ColumnInfo("Start", 160, 160, 180),
+    ColumnInfo("End", 160, 160, 180),
     //    ColumnInfo("F", 50, 50, 100),
     ColumnInfo("Syncs", 60, 60, 60),
     ColumnInfo("Keys Used", 600, 100, 10000)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/auxfile/AuxFileEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/auxfile/AuxFileEditor.scala
@@ -4,8 +4,9 @@ import edu.gemini.auxfile.api.AuxFile
 import edu.gemini.spModel.core.SPProgramID
 import jsky.app.ot.gemini.editor.ProgramForm
 import jsky.app.ot.vcs.VcsOtClient
-import java.text.SimpleDateFormat
-import java.util.{Collections, Date, TimeZone}
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
+import java.util.{Collections, Date}
 
 import jsky.util.gui.Resources
 
@@ -27,13 +28,11 @@ object AuxFileEditor {
       lab.text = size.toString
   })
 
-  private val Format = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss") {
-    setTimeZone(TimeZone.getTimeZone("UTC"))
-  }
+  private val DateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss").withZone(ZoneId.of("UTC"))
 
   private val DateCellRenderer = new LabelCellRenderer[Date]((lab, date) => {
     lab.horizontalAlignment = Alignment.Center
-    lab.text = Format.format(date)
+    lab.text = DateFormat.format(date.toInstant)
   })
 
   private val CheckIcon = Resources.getIcon("eclipse/check.gif")

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/auxfile/AuxFileEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/auxfile/AuxFileEditor.scala
@@ -27,7 +27,7 @@ object AuxFileEditor {
       lab.text = size.toString
   })
 
-  private val Format = new SimpleDateFormat("MM/dd/yy HH:mm:ss") {
+  private val Format = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss") {
     setTimeZone(TimeZone.getTimeZone("UTC"))
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -2,9 +2,10 @@ package jsky.app.ot.gemini.parallacticangle
 
 import java.awt.{Color, Insets}
 import java.beans.{PropertyChangeEvent, PropertyChangeListener}
-import java.text.{Format, SimpleDateFormat}
-import java.util.Date
+import java.text.Format
 import java.util.logging.Logger
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
 import javax.swing.BorderFactory
 import javax.swing.border.EtchedBorder
 
@@ -323,11 +324,10 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
       fmt <- formatter
     } {
       // Scheduling block date and time
-      val dateTimeStr = {
-        val df = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss z")
-        df.setTimeZone(TimeZonePreference.get)
-        df.format(new Date(sb.start))
-      }
+      val dateTimeStr = DateTimeFormatter
+        .ofPattern("yyyy-MMM-dd HH:mm:ss z")
+        .withZone(ZoneId.of(TimeZonePreference.get.getID))
+        .format(Instant.ofEpochMilli(sb.start))
 
       // Scheduling block duration, in minutes
       val durStr = sb.duration.toOption.map(_ / 60000.0).foldMap(n => f", $n%2.1f min")

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -324,7 +324,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
     } {
       // Scheduling block date and time
       val dateTimeStr = {
-        val df = new SimpleDateFormat("MM/dd/yy HH:mm:ss z")
+        val df = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss z")
         df.setTimeZone(TimeZonePreference.get)
         df.format(new Date(sb.start))
       }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -5,7 +5,8 @@ import java.awt.geom.{Line2D, GeneralPath}
 import java.awt.geom.Point2D.{ Double => Point }
 import java.awt.{ Graphics2D, Color, Graphics}
 import java.awt.RenderingHints._
-import java.text.SimpleDateFormat
+import java.time.{Instant, ZoneId}
+import java.time.format.DateTimeFormatter
 import java.util.{ Date, TimeZone }
 
 import edu.gemini.pot.sp.ISPObservation
@@ -190,9 +191,8 @@ object TpeEphemerisFeature {
   }
 
   val formatDate: Long => String = {
-    val df = new SimpleDateFormat("yyyy-MMM-dd HH:mm")
-    df.setTimeZone(TimeZone.getTimeZone("UTC"))
-    t => df.synchronized(df.format(new Date(t)))
+    val dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm").withZone(ZoneId.of("UTC"))
+    t => dateFormat.format(Instant.ofEpochMilli(t))
   }
 
   implicit class ListOfPoint2DOps(ps: List[Point]) {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -190,7 +190,7 @@ object TpeEphemerisFeature {
   }
 
   val formatDate: Long => String = {
-    val df = new SimpleDateFormat("dd-MMM HH:mm")
+    val df = new SimpleDateFormat("yyyy-MMM-dd HH:mm")
     df.setTimeZone(TimeZone.getTimeZone("UTC"))
     t => df.synchronized(df.format(new Date(t)))
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeEphemerisFeature.scala
@@ -191,7 +191,8 @@ object TpeEphemerisFeature {
   }
 
   val formatDate: Long => String = {
-    val dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm").withZone(ZoneId.of("UTC"))
+    // This needs to be shorter than usual in order to fit in the TPE display
+    val dateFormat = DateTimeFormatter.ofPattern("MMM-dd HH:mm").withZone(ZoneId.of("UTC"))
     t => dateFormat.format(Instant.ofEpochMilli(t))
   }
 

--- a/bundle/jsky.util/src/main/java/jsky/util/DateUtil.java
+++ b/bundle/jsky.util/src/main/java/jsky/util/DateUtil.java
@@ -17,12 +17,12 @@ import java.util.TimeZone;
 public class DateUtil {
 
     /**
-     * Return a string with the UTC time in the format /mm/dd/yy hh:mm:ss,
+     * Return a string with the UTC time in the format yyyy-MMM-dd hh:mm:ss,
      * given the current UTC time in ms.
      */
     public static String formatUTC(long time) {
         Date date = new Date(time);
-        SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yy HH:mm:ss");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss");
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         return dateFormat.format(date);
     }


### PR DESCRIPTION
This commit focuses on dates which don't follow the year, month and day order.
Where changed the format followed is yyyy-MMM-dd. Dates with different
format (like slashes as separator instead of dashes) but with the right order
get a pass for now.

Please watch out for any date format change that would break something that's not validated with a test. I tried not touch anything that looked like it was part of a path or filename though.

Not all dates are consistent for now because I couldn't find a large enough set of changes that could pass the tests. It was unfeasible to run the whole test suite for every date format change but from this commit I think I can check the tests for every date format change. I hope to at least fix the ones with different separators.