### PR TITLE
REL-2928: Use only enabled observations of the appropriate band in time scaling

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
@@ -115,18 +115,6 @@ case class Proposal(meta:Meta,
 
   def resetObservationMeta:Proposal = copy(observations = observations.map(_.copy(meta = None)))
 
-  // Calculate the program time as a ratio of total time.
-  private def timeSum(extract: Observation => Option[TimeAmount]): TimeAmount =
-    TimeAmount.sum(observations.map(extract).flatten)
-
-  val programTime: TimeAmount = timeSum(_.progTime)
-  val partnerTime: TimeAmount = timeSum(_.partTime)
-
-  val programTimeRatio: Double = {
-    val totalTime = programTime |+| partnerTime
-    totalTime.isEmpty ? 1.0 | (programTime.hours / totalTime.hours)
-  }
-
   private def this(m:M.Proposal) = this(
     Meta(m.getMeta),
     Semester(m.getSemester),

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -89,23 +89,13 @@ object Phase1FolderFactory {
   }
 
 
-  // If there is an itac acceptance, then use its band assignment.  Otherwise
-  // just figure we will use the "normal" band 1/2 observations.
-  private def band(proposal: Proposal): Band =
-    (for {
-      itac   <- proposal.proposalClass.itac
-      accept <- itac.decision.right.toOption
-    } yield accept.band).getOrElse(1) match {
-      case 3 => Band.BAND_3
-      case _ => Band.BAND_1_2
-    }
-
   def create(site: core.Site, proposal: Proposal): Either[String, Phase1Folder] = {
     val empty: Either[String, Folder] = Right(Folder.empty(site))
 
-    val b       = band(proposal)
+    val b       = extractBand(proposal)
     val time    = proposal.semester.midPoint
-    val efolder = (empty/:proposal.observations.filter(obs => obs.band == b && obs.enabled)) { (e, obs) =>
+    val obs     = enabledObs(proposal)
+    val efolder = (empty/:obs) { (e, obs) =>
       e.right flatMap { _.add(obs, time) }
     }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -92,7 +92,6 @@ object Phase1FolderFactory {
   def create(site: core.Site, proposal: Proposal): Either[String, Phase1Folder] = {
     val empty: Either[String, Folder] = Right(Folder.empty(site))
 
-    val b       = extractBand(proposal)
     val time    = proposal.semester.midPoint
     val obs     = enabledObs(proposal)
     val efolder = (empty/:obs) { (e, obs) =>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -93,12 +93,9 @@ object Phase1FolderFactory {
     val empty: Either[String, Folder] = Right(Folder.empty(site))
 
     val time    = proposal.semester.midPoint
-    val obs     = enabledObs(proposal)
-    val efolder = (empty/:obs) { (e, obs) =>
-      e.right flatMap { _.add(obs, time) }
-    }
-
-    efolder.right map { _.toPhase1Folder }
+    val obs     = proposal.usableObservations
+    val efolder = obs.foldLeft(empty){ (e, obs) => e.right.flatMap( _.add(obs, time)) }
+    efolder.right.map(_.toPhase1Folder)
   }
 }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -186,7 +186,7 @@ object SpProgramFactory {
 
   def minBand3Time(proposal: Proposal): Option[TimeValue] =
     proposal.proposalClass match {
-      case q: QueueProposalClass => q.band3request.map(r => toTimeValue(r.minTime, programTimeRatio(proposal)))
+      case q: QueueProposalClass => q.band3request.map(r => toTimeValue(r.minTime, proposal.programTimeRatio))
       case _                     => None
     }
 
@@ -205,7 +205,7 @@ object SpProgramFactory {
             def durationRatio(ratio: Double): Duration =
               Duration.ofMillis((hrs * ratio * partnerShare * MsPerHour).round)
 
-            val progRatio = programTimeRatio(proposal)
+            val progRatio = proposal.programTimeRatio
             val award     = new TimeAcctAward(durationRatio(progRatio), durationRatio(1.0 - progRatio))
 
             (cat, award)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -186,7 +186,7 @@ object SpProgramFactory {
 
   def minBand3Time(proposal: Proposal): Option[TimeValue] =
     proposal.proposalClass match {
-      case q: QueueProposalClass => q.band3request.map(r => toTimeValue(r.minTime, proposal.programTimeRatio))
+      case q: QueueProposalClass => q.band3request.map(r => toTimeValue(r.minTime, programTimeRatio(proposal)))
       case _                     => None
     }
 
@@ -205,7 +205,7 @@ object SpProgramFactory {
             def durationRatio(ratio: Double): Duration =
               Duration.ofMillis((hrs * ratio * partnerShare * MsPerHour).round)
 
-            val progRatio = proposal.programTimeRatio
+            val progRatio = programTimeRatio(proposal)
             val award     = new TimeAcctAward(durationRatio(progRatio), durationRatio(1.0 - progRatio))
 
             (cat, award)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
@@ -8,20 +8,20 @@ import Scalaz._
 package object factory {
   // Filter to only the enabled observations by appropriate band.
   def enabledObs(proposal: Proposal): List[Observation] = {
-    val band = extractBand(proposal)
+    // If there is an itac acceptance, then use its band assignment.  Otherwise
+    // just figure we will use the "normal" band 1/2 observations.
+    val band =
+      (for {
+        itac   <- proposal.proposalClass.itac
+        accept <- itac.decision.right.toOption
+      } yield accept.band).getOrElse(1) match {
+        case 3 => Band.BAND_3
+        case _ => Band.BAND_1_2
+      }
     proposal.observations.filter(obs => obs.band == band && obs.enabled)
   }
 
-  // If there is an itac acceptance, then use its band assignment.  Otherwise
-  // just figure we will use the "normal" band 1/2 observations.
-  def extractBand(proposal: Proposal): Band =
-    (for {
-      itac   <- proposal.proposalClass.itac
-      accept <- itac.decision.right.toOption
-    } yield accept.band).getOrElse(1) match {
-      case 3 => Band.BAND_3
-      case _ => Band.BAND_1_2
-    }
+
 
   // Used to calculate the ratio of program time to total time for a proposal for the accepted observations.
   def programTimeRatio(proposal: Proposal): Double = {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
@@ -1,4 +1,38 @@
 package edu.gemini.phase2.skeleton
 
+import edu.gemini.model.p1.immutable.{Band, Observation, Proposal, TimeAmount}
+
+import scalaz._
+import Scalaz._
+
 package object factory {
+  // Filter to only the enabled observations by appropriate band.
+  def enabledObs(proposal: Proposal): List[Observation] = {
+    val band = extractBand(proposal)
+    proposal.observations.filter(obs => obs.band == band && obs.enabled)
+  }
+
+  // If there is an itac acceptance, then use its band assignment.  Otherwise
+  // just figure we will use the "normal" band 1/2 observations.
+  def extractBand(proposal: Proposal): Band =
+    (for {
+      itac   <- proposal.proposalClass.itac
+      accept <- itac.decision.right.toOption
+    } yield accept.band).getOrElse(1) match {
+      case 3 => Band.BAND_3
+      case _ => Band.BAND_1_2
+    }
+
+  // Used to calculate the ratio of program time to total time for a proposal for the accepted observations.
+  def programTimeRatio(proposal: Proposal): Double = {
+    val obs = enabledObs(proposal)
+
+    def timeSum(extract: Observation => Option[TimeAmount]): TimeAmount =
+      TimeAmount.sum(obs.map(extract).flatten)
+
+    val programTime = timeSum(_.progTime)
+    val partnerTime = timeSum(_.partTime)
+    val totalTime = programTime |+| partnerTime
+    totalTime.isEmpty ? 1.0 | (programTime.hours / totalTime.hours)
+  }
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
@@ -6,33 +6,34 @@ import scalaz._
 import Scalaz._
 
 package object factory {
-  // Filter to only the enabled observations by appropriate band.
-  def enabledObs(proposal: Proposal): List[Observation] = {
-    // If there is an itac acceptance, then use its band assignment.  Otherwise
-    // just figure we will use the "normal" band 1/2 observations.
-    val band =
+  implicit class ProposalOps(val proposal: Proposal) extends AnyVal {
+    // Filter to only the enabled observations by appropriate band.
+    def usableObservations: List[Observation] = {
+      // If there is an itac acceptance, then use its band assignment.  Otherwise
+      // just figure we will use the "normal" band 1/2 observations.
+      val band =
       (for {
-        itac   <- proposal.proposalClass.itac
+        itac <- proposal.proposalClass.itac
         accept <- itac.decision.right.toOption
       } yield accept.band).getOrElse(1) match {
         case 3 => Band.BAND_3
         case _ => Band.BAND_1_2
       }
-    proposal.observations.filter(obs => obs.band == band && obs.enabled)
-  }
+      proposal.observations.filter(obs => obs.band == band && obs.enabled)
+    }
 
 
+    // Used to calculate the ratio of program time to total time for a proposal for the accepted observations.
+    def programTimeRatio: Double = {
+      val obs = usableObservations
 
-  // Used to calculate the ratio of program time to total time for a proposal for the accepted observations.
-  def programTimeRatio(proposal: Proposal): Double = {
-    val obs = enabledObs(proposal)
+      def timeSum(extract: Observation => Option[TimeAmount]): TimeAmount =
+        TimeAmount.sum(obs.map(extract).flatten)
 
-    def timeSum(extract: Observation => Option[TimeAmount]): TimeAmount =
-      TimeAmount.sum(obs.map(extract).flatten)
-
-    val programTime = timeSum(_.progTime)
-    val partnerTime = timeSum(_.partTime)
-    val totalTime = programTime |+| partnerTime
-    totalTime.isEmpty ? 1.0 | (programTime.hours / totalTime.hours)
+      val programTime = timeSum(_.progTime)
+      val partnerTime = timeSum(_.partTime)
+      val totalTime = programTime |+| partnerTime
+      totalTime.isEmpty ? 1.0 | (programTime.hours / totalTime.hours)
+    }
   }
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/package.scala
@@ -11,14 +11,14 @@ package object factory {
     def usableObservations: List[Observation] = {
       // If there is an itac acceptance, then use its band assignment.  Otherwise
       // just figure we will use the "normal" band 1/2 observations.
-      val band =
-      (for {
+      val band = (for {
         itac <- proposal.proposalClass.itac
         accept <- itac.decision.right.toOption
       } yield accept.band).getOrElse(1) match {
         case 3 => Band.BAND_3
         case _ => Band.BAND_1_2
       }
+      
       proposal.observations.filter(obs => obs.band == band && obs.enabled)
     }
 


### PR DESCRIPTION
Beforehand, in order to calculate the ratio of program time to total time (for scaling minimum time and awarded time during the skeleton import), we simply summed over all the observations in a proposal.

@cquiroz and @swalker2m pointed out that we should only be doing so for enabled observations in the appropriate band. I have extracted the common shared code out of `Phase1FolderFactory` into the package module that will be used by both, and since this is no longer really a property of a `Proposal` that we should be considering in the P1 model, I moved code from the `Proposal` class that I added here as well.