### PR TITLE
REL-3153: Obsolete GMOS North R150_G5306

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -108,7 +108,7 @@ package object immutable {
     val B600  = M.GmosNDisperser.B600_G5307
     val R600  = M.GmosNDisperser.R600_G5304
     val R400  = M.GmosNDisperser.R400_G5305
-    val R150  = M.GmosNDisperser.R150_G5306
+    val R150  = M.GmosNDisperser.R150_G5308
   }
 
   type GmosNFilter = M.GmosNFilter
@@ -256,7 +256,7 @@ package object immutable {
     val HStar   = M.GpiObservingMode.H_STAR
     val HLiwa   = M.GpiObservingMode.H_LIWA
     val HDirect = M.GpiObservingMode.DIRECT_H_BAND
-    
+
     def isCoronographMode(mode: GpiObservingMode):Boolean = mode.value.startsWith("Coronograph")
     def isDirectMode(mode: GpiObservingMode):Boolean = mode.value.endsWith("direct")
     def scienceBand(mode: GpiObservingMode):Option[String] = {

--- a/bundle/edu.gemini.model.p1/src/main/xjb/GmosN.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/GmosN.xjb
@@ -23,7 +23,7 @@
                 <jxb:typesafeEnumMember name="R400_G5305"/>
             </jxb:bindings>
             <jxb:bindings node="./xsd:enumeration[@value='R150']">
-                <jxb:typesafeEnumMember name="R150_G5306"/>
+                <jxb:typesafeEnumMember name="R150_G5308"/>
             </jxb:bindings>
         </jxb:bindings>
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -77,7 +77,9 @@ public class GmosNorthType {
         B600_G5307("B600_G5307", "B600", 600),
         R600_G5304("R600_G5304", "R600", 600),
         R400_G5305("R400_G5305", "R400", 400),
-        R150_G5306("R150_G5306", "R150", 150),
+        R150_G5306("R150_G5306", "R150", 150) {
+            @Override public boolean isObsolete() { return true; }
+        },
         R150_G5308("R150_G5308", "R150", 150),
         ;
 


### PR DESCRIPTION
Makes R150_G5306 obsolete to make way for R150_G5308, which should be selected when the PI chooses an R150 filter in the phase 1 proposal.