### PR TITLE
Revert "REL-566: ignore acquisition and cal for ToO triggers"

### DIFF
--- a/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/osgi/Activator.scala
+++ b/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/osgi/Activator.scala
@@ -30,6 +30,7 @@ class Activator extends BundleActivator {
 
           // Our TOO service, registered locally as a TooPublisher
           val service = new TooService(odb, site)
+          odb.registerTrigger(TooCondition, service)
           odb.addProgramEventListener(service)
           val props1 = new java.util.Hashtable[String,String]
           val reg1 = ctx.registerService(classOf[TooPublisher].getName, service, props1)
@@ -44,6 +45,7 @@ class Activator extends BundleActivator {
           // Cleanup
           () => {
             odb.removeProgramEventListener(service)
+            odb.unregisterTrigger(TooCondition, service)
             reg1.unregister()
             reg2.unregister()
           }

--- a/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/service/TooCondition.scala
+++ b/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/service/TooCondition.scala
@@ -1,0 +1,38 @@
+package edu.gemini.too.event.service
+
+import edu.gemini.pot.spdb.IDBTriggerCondition
+import edu.gemini.pot.sp.{ISPObservation, SPUtil, SPCompositeChange}
+import edu.gemini.spModel.obs.{ObservationStatus, SPObservation}
+import edu.gemini.spModel.obs.ObsPhase2Status.ON_HOLD
+import edu.gemini.spModel.obs.ObservationStatus.READY
+import edu.gemini.spModel.too.Too
+
+
+/**
+ * Condition that must be met in order to register a ToO event. Namely, an
+ * observation's status must be transitioned from `ON_HOLD` to `READY` and be
+ * a ToO observation.
+ *
+ * This condition is registered with the database such that when it occurs, the
+ * [[edu.gemini.too.event.service.TooService]] is executed to record the event.
+ */
+object TooCondition extends IDBTriggerCondition {
+  private def isDataObjectUpdate(change: SPCompositeChange): Boolean =
+    change.getPropertyName == SPUtil.getDataObjectPropertyName
+
+  private def castIf[T:Manifest](o: Object): Option[T] =
+    for { t <- Option(o) if manifest[T].runtimeClass.isInstance(t) } yield t.asInstanceOf[T]
+
+  private def dataObject(dataObj: Object) = castIf[SPObservation](dataObj)
+  private def observation(change: SPCompositeChange) = castIf[ISPObservation](change.getModifiedNode)
+
+  def triggeredObservation(change: SPCompositeChange): Option[ISPObservation] =
+    if (isDataObjectUpdate(change)) for {
+        obs <- observation(change) if Too.isToo(obs) && ObservationStatus.computeFor(obs) == READY
+        o <- dataObject(change.getOldValue) if o.getPhase2Status == ON_HOLD
+      } yield obs
+    else None
+
+    def matches(change: SPCompositeChange): ISPObservation =
+      triggeredObservation(change).orNull
+}

--- a/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/service/TooService.scala
+++ b/bundle/edu.gemini.too.event/src/main/scala/edu/gemini/too/event/service/TooService.scala
@@ -4,9 +4,8 @@ import edu.gemini.pot.sp._
 import edu.gemini.pot.spdb.{ProgramEvent, ProgramEventListener, IDBTriggerAction, IDBDatabaseService}
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.gemini.obscomp.SPProgram
-import edu.gemini.spModel.obs.{ObsClassService, ObservationStatus, ObsSchedulingReport}
+import edu.gemini.spModel.obs.{ObservationStatus, ObsSchedulingReport}
 import ObservationStatus.{READY, ON_HOLD}
-import edu.gemini.spModel.obsclass.ObsClass.SCIENCE
 import edu.gemini.spModel.too.{Too, TooType}
 import edu.gemini.too.event.api.{TooEvent, TooService => TooServiceApi, TooPublisher, TooTimestamp}
 import edu.gemini.util.security.permission.ProgramPermission
@@ -114,13 +113,7 @@ class TooService(db: IDBDatabaseService, val site: Site, val eventRetentionTime:
       val transitionTrigger = oldOnHold & newReady
       val creationTrigger   = newReady.filterNot(allOldKeys.contains)
 
-      val newlyReadyObsList = obsList(newProg, transitionTrigger ++ creationTrigger)
-      val triggerObsList    = newlyReadyObsList.filter { o =>
-        // REL-566: ignore anything but science observations.
-        ObsClassService.lookupObsClass(o) == SCIENCE
-      }
-
-      trigger(triggerObsList)
+      trigger(obsList(newProg, transitionTrigger ++ creationTrigger))
     }
   }
 


### PR DESCRIPTION
This reverts commit 89cc28476dfff15264300c27678d853fe982c834.

I believed that the second ToO triggering mechanism was no longer used after switching to fetch/store, but I was overlooking scripted ToO triggers which are handled by a servlet.  It is late in the testing cycle so I decided the most prudent thing to do would be to postpone this feature update and return to the same code that was used in 2017A and before.

In other words, the green sections in the diff are just returning to pre-2017B code.