### PR TITLE
update spModel core libs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,18 +11,18 @@ pitVersion in ThisBuild := OcsVersion("2017B", false, 2, 1, 0)
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.11.11"
 
 updateOptions := updateOptions.value.withCachedResolution(true)
 
 // Note that this is not a standard setting; it's used for building IDEA modules.
 javaVersion in ThisBuild := {
-  val expected = "1.8" 
+  val expected = "1.8"
   val actual   = sys.props("java.version")
   if (!actual.startsWith(expected))
     println(s"""
       |***
-      |***                   INCORRECT JAVA RUNTIME VERSION 
+      |***                   INCORRECT JAVA RUNTIME VERSION
       |***
       |***  The build expects version $expected, but you are running $actual.
       |***  Change the VM you're using to run sbt to avoid confusion and strange behavior.
@@ -46,8 +46,8 @@ scalacOptions in ThisBuild ++= Seq(
   "-Xlint:-stars-align",
   "-Yno-adapted-args"
   // "-Ywarn-dead-code"        // N.B. doesn't work well with bottom
-  // "-Ywarn-numeric-widen",   
-  // "-Ywarn-value-discard"   
+  // "-Ywarn-numeric-widen",
+  // "-Ywarn-value-discard"
 )
 
 javacOptions in ThisBuild ++= Seq(
@@ -56,17 +56,17 @@ javacOptions in ThisBuild ++= Seq(
   "-Xlint:all,-serial,-path,-deprecation,-unchecked,-fallthrough" // TOOD: turn all on except maybe -serial and -path
 )
 
-val specs2Version = "3.7"
+val specs2Version = "3.8.9"
 
 // Use managed dependencies for tests; everyone gets JUnit, ScalaCheck, and Specs2
 libraryDependencies in ThisBuild ++= Seq(
   "junit"           % "junit"                % "4.11"        % "test",
   "com.novocode"    % "junit-interface"      % "0.9"         % "test",
-  "org.scalacheck" %% "scalacheck"           % "1.12.5"      % "test",
+  "org.scalacheck" %% "scalacheck"           % "1.12.6"      % "test",
   "org.specs2"     %% "specs2-core"          % specs2Version % "test",
   "org.specs2"     %% "specs2-scalacheck"    % specs2Version % "test",
   "org.specs2"     %% "specs2-matcher-extra" % specs2Version % "test",
-  "org.scalatest"  %% "scalatest"            % "3.0.0-M15"   % "test"
+  "org.scalatest"  %% "scalatest"            % "3.0.1"       % "test"
 )
 
 // Required for specs2

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/image/ImageSearchQuerySpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/image/ImageSearchQuerySpec.scala
@@ -44,19 +44,19 @@ class ImageSearchQuerySpec extends FlatSpec with Matchers with PropertyChecks wi
       forAll { (t: TestCase) =>
         val c1 = t.c.copy(ra = t.c.ra.offset(t.delta))
         ImageSearchQuery(t.catalog, t.c, t.size, None).isNearby(ImageSearchQuery(t.catalog, c1, t.size, None)) shouldBe true
-      }(implicitly[PropertyCheckConfiguration], testCase(Angle.zero, ImageSearchQuery.maxDistance), implicitly[Shrink[TestCase]], implicitly[CheckerAsserting[Assertion]])
+      }(implicitly[PropertyCheckConfiguration], testCase(Angle.zero, ImageSearchQuery.maxDistance), implicitly[Shrink[TestCase]], implicitly[CheckerAsserting[Assertion]], implicitly, implicitly)
     }
     it should "be nearby close coordinates in dec" in {
       forAll { (t: TestCase) =>
         val c1 = t.c.copy(dec = t.c.dec.offset(t.delta)._1)
         ImageSearchQuery(t.catalog, t.c, t.size, None).isNearby(ImageSearchQuery(t.catalog, c1, t.size, None)) shouldBe true
-      }(implicitly[PropertyCheckConfiguration], testCase(Angle.zero, ImageSearchQuery.maxDistance), implicitly[Shrink[TestCase]], implicitly[CheckerAsserting[Assertion]])
+      }(implicitly[PropertyCheckConfiguration], testCase(Angle.zero, ImageSearchQuery.maxDistance), implicitly[Shrink[TestCase]], implicitly[CheckerAsserting[Assertion]], implicitly, implicitly)
     }
     it should "be symmetric" in {
       forAll { (t: TestCase) =>
         val c1 = t.c.copy(dec = t.c.dec.offset(t.delta)._1)
         ImageSearchQuery(t.catalog, t.c, t.size, None).isNearby(ImageSearchQuery(t.catalog, c1, t.size, None)) shouldBe ImageSearchQuery(t.catalog, c1, t.size, None).isNearby(ImageSearchQuery(t.catalog, t.c, t.size, None))
-      }(implicitly[PropertyCheckConfiguration], testCase(Angle.zero, Angle.fromDegrees(359.99)), implicitly[Shrink[TestCase]], implicitly[CheckerAsserting[Assertion]])
+      }(implicitly[PropertyCheckConfiguration], testCase(Angle.zero, Angle.fromDegrees(359.99)), implicitly[Shrink[TestCase]], implicitly[CheckerAsserting[Assertion]], implicitly, implicitly)
     }
     it should "work near zero" in {
       // Special case when the diff is very close to zero but negative

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -19,7 +19,7 @@ import edu.gemini.pit.model.{AppPreferences, Model}
 import edu.gemini.pit.catalog.NotFound
 import edu.gemini.pit.catalog.Error
 
-import scalaz._
+import scalaz.{ Band => _, _ }
 import Scalaz._
 
 object ProblemRobot {
@@ -343,7 +343,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       case f: FastTurnaroundProgramClass => f.tooOption.some
       case _                             => None
     }
-    
+
     private val band3RapidToO = for {
       o  <- p.observations
       to <- proposalToO(p.proposalClass)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListModel.scala
@@ -1,7 +1,7 @@
 package edu.gemini.pit.ui.view.obs
 
 import edu.gemini.model.p1.immutable._
-import scalaz._
+import scalaz.{ Band => _, _ }
 import Scalaz._
 
 import scala.language.existentials
@@ -22,7 +22,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
    * should be indented.
    */
   lazy val elems = {
-    
+
     // Sort the observations, turn them into ObsElems, and expand the list
     val es = visible.sortBy(_.toString).map(ObsElem(_))
     expand(es)
@@ -144,7 +144,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
     (this /: source._2.map((source._1, _)))(_.pasteOne(_, target))
   }
 
-  
+
   // When you paste, the target might be valid, invalid, or missing altogether. These are all legal.
   def pasteOne(source:(ObsListModel, ObsListElem), target:Option[ObsGroup[_]]):ObsListModel = {
 
@@ -158,7 +158,7 @@ case class ObsListModel(all:List[Observation], band:Band, gs:(ObsListGrouping[_]
     def clear(o:Observation) = (o.copy() /: toClear)((o, g) => g.clear(o))
 
     val os = os0.map(clear)
-    
+
     target match {
       case None                  => this ++ os.map(_.copy(band = band))
       case Some(t) if !droppable => this ++ os.map(_.copy(band = band))

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -10,7 +10,7 @@ import javax.swing.TransferHandler._
 
 import scala.swing._
 import scalaz.Scalaz._
-import scalaz._
+import scalaz.{ Band => _, _ }
 import javax.swing.{Action => _, _}
 
 import edu.gemini.gsa.client.api.GsaParams

--- a/bundle/edu.gemini.spModel.core/build.sbt
+++ b/bundle/edu.gemini.spModel.core/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
   "org.scalaz" %% "scalaz-core" % ScalaZVersion,
   "org.scalaz" %% "scalaz-effect" % ScalaZVersion,
-  "com.squants"  %% "squants"  % "0.6.2"
+  "com.squants"  %% "squants"  % "0.6.3"
   )
 
 osgiSettings
@@ -27,7 +27,7 @@ OsgiKeys.dynamicImportPackage := Seq("")
 OsgiKeys.exportPackage := Seq(
   "edu.gemini.spModel.core",
   "edu.gemini.spModel.core.osgi")
-        
+
 sourceGenerators in Compile += Def.task {
   val ocsVer = ocsVersion.value
   val outDir = (sourceManaged in Compile).value / "edu" / "gemini" / "spModel" / "core"
@@ -41,11 +41,10 @@ initialCommands := "import edu.gemini.spModel.core._, scalaz._, Scalaz._"
 
 scalacOptions in (Compile, doc) ++= Seq(
   "-groups",
-  "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath, 
-  "-doc-source-url", "https://github.com/gemini-hlws/ocs/master€{FILE_PATH}.scala" 
+  "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath,
+  "-doc-source-url", "https://github.com/gemini-hlws/ocs/master€{FILE_PATH}.scala"
 )
 
 publishArtifact in (ThisBuild, packageSrc) := true
 
 publishMavenStyle in ThisBuild := true
-

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeSystem.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeSystem.scala
@@ -1,6 +1,6 @@
 package edu.gemini.spModel.core
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scalaz.Equal
 
 /** Unit that can represent an integrated brightness or a uniform surface brightness per area. */
@@ -49,7 +49,7 @@ object MagnitudeSystem {
     Equal.equalA
 
   // ===== LEGACY JAVA SUPPORT =====
-  val allForOTAsJava = new java.util.Vector[MagnitudeSystem](allForOT)
+  val allForOTAsJava = new java.util.Vector[MagnitudeSystem](allForOT.asJava)
   val Default = default // default is a reserved key word in Java!
 
 }
@@ -68,4 +68,3 @@ object SurfaceBrightness {
     Equal.equalA
 
 }
-

--- a/project/OcsBuild.scala
+++ b/project/OcsBuild.scala
@@ -2,14 +2,14 @@
 import sbt._
 import Keys._
 
-object OcsBuild extends Build 
+object OcsBuild extends Build
   with OcsBundle      // bundle project definitions
   with OcsBundleSettings // bundle project definitions
   with OcsApp         // application project definitions
   with OcsAppSettings // settings for app projects
   with OcsKey         // ocs-provided keys
 {
-  val ScalaZVersion = "7.2.2"
+  val ScalaZVersion = "7.2.13"
 
   override lazy val settings = super.settings ++
     Seq(

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,7 @@
 
 // Dependencies for the build itself.
 
-val ScalaZVersion = "7.2.2"
+val ScalaZVersion = "7.2.13"
 
 libraryDependencies ++= Seq(
   "org.ow2.asm" % "asm" % "4.0",


### PR DESCRIPTION
This updates the `spModel.core` dependencies to versions that have 2.12 artifacts available, which we need in order to move compile it to 2.12 for Gem. There were a handful of compile errors that are fixed here. After this change you can say

    sbt ++2.12.2 bundle_edu_gemini_spModel_core/packageBin

to create a jarfile for core compiled with 2.12