### PR TITLE
quiet down the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_script:
 script:
   - sudo chmod +x /usr/local/bin/sbt
   - sbt -q -J-Djava.util.logging.config.file=logging.properties -J-Dedu.gemini.ocs.build.ping ++$TRAVIS_SCALA_VERSION test:compile test
+  - sbt -q -J-Djava.util.logging.config.file=logging.properties -J-Dedu.gemini.ocs.build.ping ++2.12.2 bundle_edu_gemini_spModel_core/test
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ before_script:
     fi
 script:
   - sudo chmod +x /usr/local/bin/sbt
-  - sbt ++$TRAVIS_SCALA_VERSION test:compile test
+  - sbt -q -J-Djava.util.logging.config.file=logging.properties ++$TRAVIS_SCALA_VERSION test:compile test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
 sudo: true
+
 language: scala
+
 scala:
-- 2.11.8
+- 2.11.11
+
 jdk:
 - oraclejdk8
+
 addons:
   apt:
     packages:
     - oracle-java8-installer
+
 env:
   global:
   - secure: "RdZfbzf5Oja9oVLCvl7Ej+j9DpRPM4OFZ3pP+TYPqQ1DVfrhA2W2AjpYt8QVXeagVCFbJu48Og/sImkoQnkgh8+/7IGPnX29weEFsHZhf8FA1E7Gf1o1HU5YhJuCOsNOR9xG+1tRHR/+gKOwP1VyGugUhrSwNOuYGOr6yQ1JYfU="
   - secure: "ezhPWkY6EjHsQnqRSEghdsmkzbeB4tBiekfNTH+5E6TmO9qiplasJELa8Bqvpmnl7nCjFFn1BrFBsdxCRyApIiPxxV8KAE3w1whmNGsYdYvNFJo9xqs0BG5CEDIqnT78LstSJVFFKwytLB8Fus1dN17LbV/80+iIx1iJkoSVc7k="
+
 notifications:
   email: true
   hipchat:
@@ -19,6 +25,7 @@ notifications:
     secure: K6uZJoVfjQtjh+l+pbKl+abdqYdbAEwF1nVlMRQL4iLaxGYNEIqiHQTC65j8qQ+Z1dHLMpLzWtg1YJTOahvoWzKk3b94ZXb44MfTZZRo9K7RdAP+5tKYCIjB+FsLOj+fiMBu/OL3ztJbznwNP7uNgg9uy/Xtr4LuHJbZU8EEYC/kt/MYoyfjW43oh9NQpF9Eg0JarjIs7f/01BLrXLIAhN0nnhW+g+N/CcT73Cvz5HQeVvD6Aiam0rqyBWOKadR0fzZkNsFj9+77VBbeEqoGpFpMeklIIGh+cAhH8paVVWDXuUJcjU5LJ1joZiMbCEo76GzmaJ6zp0YSxRjII2oB8TXBhYhq4sBUOGynbiqee5DPxZ9gLBPqJBTUPP/9LqEzAWJtZm7HPDXYb+fmccpVwwXR4uRfphV34pXERE0B6u1dFtiSCGTKyDVQLhNdSBD/m1GGmyjbMA6OV78eFuFkJ5pdTUxlr3xz3W5BZXkr24zm+ugrk0A7QVQ3gcXjL0SsECMw3FJXz4hl90Wwqr1+bxSenz7JaY173adAD0d7T7JVOzGIP3WSdCeklEXzOPJTxVBF0lQ3tgzB3WUyW6rRBe+xc0Hu9c7v6CWrJybFtZvGSWocLpq3dIUckQlcDI8elNbJptaM3n79BkwknX4kCGVCBRWCdXOzNQDkMIpnfaw=
     notify: true
     format: '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}'
+
 before_script:
   - sudo apt-get update && sudo apt-get install oracle-java8-installer
   - echo $TRAVIS_SECURE_ENV_VARS
@@ -30,6 +37,22 @@ before_script:
   - if [ $TRAVIS_SECURE_ENV_VARS == false ]; then
       cp $TRAVIS_BUILD_DIR/project/OcsCredentials.scala.template $TRAVIS_BUILD_DIR/project/OcsCredentials.scala;
     fi
+
 script:
   - sudo chmod +x /usr/local/bin/sbt
-  - sbt -q -J-Djava.util.logging.config.file=logging.properties ++$TRAVIS_SCALA_VERSION test:compile test
+  - sbt -q -J-Djava.util.logging.config.file=logging.properties -J-Dedu.gemini.ocs.build.ping ++$TRAVIS_SCALA_VERSION test:compile test
+
+cache:
+  directories:
+  - $HOME/.sbt/0.13/dependency
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2/cache
+  - $HOME/.nvm
+
+before_cache:
+  - du -h -d 1 $HOME/.ivy2/cache
+  - du -h -d 2 $HOME/.sbt/
+  - find $HOME/.sbt -name "*.lock" -type f -delete
+
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -13,6 +13,8 @@ import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.telescope.PosAngleConstraint._
 import edu.gemini.shared.util.immutable.ScalaConverters._
 
+import java.util.logging.Logger
+
 import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -26,6 +28,8 @@ import Scalaz._
  */
 case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyParams, backend: VoTableBackend = ConeSearchBackend) extends AgsStrategy {
   import SingleProbeStrategy._
+
+  private val LOGGER = Logger.getLogger(classOf[SingleProbeStrategy].getName)
 
   override def magnitudes(ctx: ObsContext, mt: MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =
     params.magnitudeCalc(withCorrectedSite(ctx), mt).toList.map(params.guideProbe -> _)
@@ -82,9 +86,8 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
 
   protected [ags] def select(ctx: ObsContext, mt: MagnitudeTable, candidates: List[SiderealTarget]): Option[AgsStrategy.Selection] = {
 
-    // Temporary for Andy's tests.
     def feedback(feedback: => String): Unit =
-      println(s"AGS $feedback")
+      LOGGER.info(s"AGS $feedback")
 
     def selectMinVigetting(vprobe: VProbe, allValid: List[(ObsContext, List[SiderealTarget])]): Option[AgsStrategy.Selection] = {
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -27,6 +27,8 @@ import edu.gemini.spModel.target.env.TargetEnvironment
 import edu.gemini.spModel.telescope.IssPort
 import jsky.coords.WorldCoords
 
+import java.util.logging.Logger
+
 import scala.concurrent.duration._
 
 import org.specs2.mutable.SpecificationLike
@@ -41,6 +43,9 @@ import Scalaz._
  * See OT-27
  */
 class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with TargetsHelper {
+
+  private val LOGGER = Logger.getLogger(classOf[GemsResultsAnalyzerSpec].getName)
+
   class TestGemsVoTableCatalog(file: String) extends GemsVoTableCatalog {
     override val backend = TestVoTableBackend(file)
   }
@@ -60,12 +65,12 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       results should have size expectedResults
 
       results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
+        LOGGER.info("Result #" + i)
+        LOGGER.info(" Criteria:" + r.criterion)
+        LOGGER.info(" Results size:" + r.results.size)
       }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      LOGGER.info("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 247
 
       val result = gemsGuideStars.head
@@ -121,12 +126,12 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       results should have size expectedResults
 
       results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
+        LOGGER.info("Result #" + i)
+        LOGGER.info(" Criteria:" + r.criterion)
+        LOGGER.info(" Results size:" + r.results.size)
       }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      LOGGER.info("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 135
 
       val result = gemsGuideStars.head
@@ -182,12 +187,12 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       results should have size expectedResults
 
       results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
+        LOGGER.info("Result #" + i)
+        LOGGER.info(" Criteria:" + r.criterion)
+        LOGGER.info(" Results size:" + r.results.size)
       }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      LOGGER.info("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 98
 
       val result = gemsGuideStars.head
@@ -243,12 +248,12 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       results should have size expectedResults
 
       results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
+        LOGGER.info("Result #" + i)
+        LOGGER.info(" Criteria:" + r.criterion)
+        LOGGER.info(" Results size:" + r.results.size)
       }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      LOGGER.info("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 54
 
       val result = gemsGuideStars.head
@@ -360,6 +365,6 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
   def progress(s: Strehl, count: Int, total: Int, usable: Boolean): Boolean = true
 
   def setProgressTitle(s: String) {
-    System.out.println(s)
+    LOGGER.info(s)
   }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemGroup.java
@@ -5,12 +5,14 @@ import edu.gemini.pot.sp.*;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.ListIterator;
+import java.util.logging.Logger;
 
 /**
  * This class provides an in-memory, non-persistent implementation of the
  * ISPGroup remote interface.
  */
 public final class MemGroup extends MemAbstractContainer implements ISPGroup {
+    private static final Logger LOG = Logger.getLogger(MemGroup.class.getName());
     private final MemProgram _program;
 
     // The list of observation components
@@ -143,7 +145,7 @@ public final class MemGroup extends MemAbstractContainer implements ISPGroup {
         try {
             int index = _compList.indexOf(node);
             if (index == -1) {
-                System.out.println("Component was not located and can't be removed.");
+                LOG.warning("Component was not located and can't be removed.");
                 return;
             }
             List<ISPObsComponent> oldCopy = new ArrayList<>(_compList);
@@ -276,4 +278,3 @@ public final class MemGroup extends MemAbstractContainer implements ISPGroup {
 
     @Override public MemProgram getProgram() { return _program; }
 }
-

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObservation.java
@@ -252,7 +252,7 @@ public final class MemObservation extends MemAbstractContainer implements ISPObs
         try {
             int index = _compList.indexOf(node);
             if (index == -1) {
-                System.out.println("Component was not located and can't be removed.");
+                LOG.warning("Component was not located and can't be removed.");
                 return;
             }
             List<ISPObsComponent> oldCopy = new ArrayList<>(_compList);
@@ -362,4 +362,3 @@ public final class MemObservation extends MemAbstractContainer implements ISPObs
     }
 
 }
-

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemProgram.java
@@ -6,12 +6,14 @@ import edu.gemini.shared.util.VersionVector;
 import edu.gemini.spModel.core.SPProgramID;
 
 import java.util.*;
+import java.util.logging.Logger;
 
 /**
  * This class provides an in-memory, non-persistent implementation of the
  * ISPProgram remote interface.
  */
 public final class MemProgram extends MemAbstractContainer implements ISPProgram {
+  private static final Logger LOG = Logger.getLogger(MemProgram.class.getName());
 
     /**
      * Creates a new empty program with the given key and program id.
@@ -242,7 +244,7 @@ public final class MemProgram extends MemAbstractContainer implements ISPProgram
         try {
             int index = _compList.indexOf(node);
             if (index == -1) {
-                System.out.println("Component was not located and can't be removed.");
+                LOG.warning("Component was not located and can't be removed.");
                 return;
             }
             List<ISPObsComponent> oldCopy = new ArrayList<>(_compList);
@@ -479,4 +481,3 @@ public final class MemProgram extends MemAbstractContainer implements ISPProgram
 
     @Override public MemProgram getProgram() { return this; }
 }
-

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemSeqComponent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemSeqComponent.java
@@ -6,12 +6,14 @@ import edu.gemini.pot.sp.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.logging.Logger;
 
 /**
  * This class implements an in-memory, non-persistent
  * <code>ISPSeqComponent</code> object.
  */
 public final class MemSeqComponent extends MemAbstractContainer implements ISPSeqComponent {
+    private static final Logger LOG = Logger.getLogger(MemSeqComponent.class.getName());
 
     private final MemProgram _program;
     private final SPComponentType _type;
@@ -128,7 +130,7 @@ public final class MemSeqComponent extends MemAbstractContainer implements ISPSe
         try {
             int index = _compList.indexOf(node);
             if (index == -1) {
-                //System.out.println("Component was not located and can't be removed.");
+                LOG.warning("Component was not located and can't be removed.");
                 return;
             }
             List<ISPSeqComponent> oldCopy = new ArrayList<>(_compList);
@@ -191,4 +193,3 @@ public final class MemSeqComponent extends MemAbstractContainer implements ISPSe
 
     @Override public MemProgram getProgram() { return _program; }
 }
-

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/VignettingCalculator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/VignettingCalculator.scala
@@ -7,6 +7,7 @@ import edu.gemini.spModel.inst.FeatureGeometry.approximateArea
 import edu.gemini.spModel.obs.context.ObsContext
 
 import java.awt.geom.Area
+import java.util.logging.Logger
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -15,6 +16,9 @@ import scalaz._
 import Scalaz._
 
 sealed trait VignettingCalculator {
+
+  private val LOGGER = Logger.getLogger(classOf[VignettingCalculator].getName)
+
   /** Calculates the percentage of the science area that is obscured by the
     * probe arm when tracking the given guide star candidate.  The return value
     * is therefore always [0, 1] where 0 is no vignetting and 1 is completely
@@ -60,7 +64,7 @@ sealed trait VignettingCalculator {
           val vignetting = calc(f(a))
           if (curMin.forall(_._2 > vignetting)) {
             curMin.foreach { case (t,d) =>
-              println(f"AGS rejecting ${formatCoordinates(f(t))}. Vignettes ${d*100}%.2f%%.")
+              LOGGER.info(f"AGS rejecting ${formatCoordinates(f(t))}. Vignettes ${d*100}%.2f%%.")
             }
             val newMin = Some((a, vignetting))
             if (vignetting == 0.0) newMin else go(as, newMin)

--- a/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/keychain/KeyChain.scala
+++ b/bundle/edu.gemini.util.security/src/main/scala/edu/gemini/util/security/auth/keychain/KeyChain.scala
@@ -180,7 +180,6 @@ abstract class KeyChain(kCell: KeyChain.KCell, pCell: KeyChain.PCell, lCell: Key
       l <- kernel.map(_.selection.map(_._2.get._1)) ||| Action(None)
       s <- Action(subject.getPrincipals <| (_.clear))
       _ <- l.traverseU(p => Action(s.add(p)))
-      _ <- IO.putStrLn("---\n" + subject).liftIO[Action]
       _ <- notifyListeners
     } yield ()
 
@@ -298,7 +297,6 @@ abstract class PersistentKeyChain(
     for {
       _ <- super.commit(k)
       _ <- kCell.get >>= (s => o.put(s).liftIO[Action])
-      _ <- IO.putStrLn("Committed keychain.").liftIO[Action]
     } yield ()
 
 }
@@ -458,6 +456,3 @@ object KeyChain {
     } yield ()
 
 }
-
-
-

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,59 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= SEVERE
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+com.xyz.foo.level = SEVERE

--- a/project/OcsBuild.scala
+++ b/project/OcsBuild.scala
@@ -19,4 +19,19 @@ object OcsBuild extends Build
       (ocsLibraryBundles    in ThisBuild) := ((baseDirectory in LocalRootProject).value / "lib" / "bundle").listFiles.filter(_.getName.endsWith(".jar")).toList
     )
 
+  // When running quiet builds it's important for there to be *some* output, otherwise Travis will
+  // time us out. By defining a system property we can turn on a periodic ping.
+  if (sys.props.isDefinedAt("edu.gemini.ocs.build.ping")) {
+    println("*** Keep-alive ping requested. The build will say PING! every minute or so.")
+    import java.util.{ Timer, TimerTask }
+    val t = new Timer("pinger", true)
+    t.scheduleAtFixedRate(new TimerTask {
+      var count = 0
+      def run() {
+        count += 1
+        println(s"*** PING! Minutes elapsed: rougly $count")
+      }
+    }, 1000 * 60, 1000 * 60)
+  }
+
 }


### PR DESCRIPTION
This sets up the Travis build to run `sbt -q` with a custom logging config that only reports errors. (I verified that you do in fact see compile/test failures). I turned most of the `println`s that were in test output (I couldn't find all of them) into logger messages, so you still see them in a normal build and when running, but not in the CI log.

The CI log for this build should demonstrate silence. We'll see.

I also turned on caching which should speed things up a tiny bit. We'll see.