### PR TITLE
REL-2928: Fixed displayed time precisions as per JIRA notes.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -244,7 +244,9 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         timeLabel.setText(timeStr);
     }
     private static void setTimeLabel(final double time, final JLabel timeLabel) {
-        final String timeStr = time == 0d ? ZERO_TIME_STRING : new HMS(time).toString();
+        final String timeStr = time == 0d ?
+                ZERO_TIME_STRING :
+                new HMS(time).toString(true, false);
         timeLabel.setText(timeStr);
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -161,8 +161,8 @@ public class ProgramForm extends JPanel {
                             new ColumnSpec(ColumnSpec.LEFT, Sizes.dluX(15), FormSpec.NO_GROW),
                             new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(56), FormSpec.NO_GROW),
                             FormFactory.UNRELATED_GAP_COLSPEC,
-                            FormFactory.DEFAULT_COLSPEC,
-                            new ColumnSpec(ColumnSpec.LEFT, Sizes.DLUX11, FormSpec.NO_GROW),
+                            new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(56), FormSpec.NO_GROW),
+                            new ColumnSpec(ColumnSpec.LEFT, Sizes.dluX(15), FormSpec.NO_GROW),
                             new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(58), FormSpec.NO_GROW)
                     },
                     new RowSpec[]{
@@ -207,7 +207,7 @@ public class ProgramForm extends JPanel {
         allocatedTime.setToolTipText("The total program time allocated, in hours:minutes:seconds");
         timePanel.add(allocatedTime, cc.xy(9, 5));
 
-        minimumTimeLabel = new JLabel("Minimum");
+        minimumTimeLabel = new JLabel("Min Program");
         timePanel.add(minimumTimeLabel, cc.xy(11, 3));
         minimumTime = new JLabel("00:00:00");
         minimumTime.setToolTipText("The minimal success time, in hours:minutes:seconds");

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
@@ -18,10 +18,7 @@ import java.util.Map;
 
 final class TimeAcctEditor implements ProgramTypeListener {
     private static final long MS_PER_HOUR = Duration.ofHours(1).toMillis();
-
-    // Used to format values as strings
-    private final static DecimalFormat nf_dec = new DecimalFormat("0.00");
-    private final static DecimalFormat nf_decOpt = new DecimalFormat("0.##");
+    private static final DecimalFormat nf = new DecimalFormat("0.##");
 
     private static Duration toDuration(double hours) {
         return Duration.ofMillis(Math.round(hours * MS_PER_HOUR));
@@ -87,9 +84,9 @@ final class TimeAcctEditor implements ProgramTypeListener {
 
     private void showTotalTime(final TimeAcctAllocation alloc) {
         final TimeAcctAward a = alloc.getSum();
-        ui.getTotalAwardLabel()  .setText(nf_dec.format(a.getTotalHours()));
-        ui.getProgramAwardLabel().setText(nf_dec.format(a.getProgramHours()));
-        ui.getPartnerAwardLabel().setText(nf_dec.format(a.getPartnerHours()));
+        ui.getTotalAwardLabel()  .setText(nf.format(a.getTotalHours()));
+        ui.getProgramAwardLabel().setText(nf.format(a.getProgramHours()));
+        ui.getPartnerAwardLabel().setText(nf.format(a.getPartnerHours()));
     }
 
     private TimeValue getMinimumTime() {
@@ -127,7 +124,7 @@ final class TimeAcctEditor implements ProgramTypeListener {
             ui.getMinimumTimeField().setText("");
         } else {
             minTime = minTime.convertTo(TimeValue.Units.hours);
-            ui.getMinimumTimeField().setText(nf_dec.format(minTime.getTimeAmount())); // REL-434
+            ui.getMinimumTimeField().setText(nf.format(minTime.getTimeAmount())); // REL-434
         }
 
         final TimeAcctAllocation alloc = model.getAllocation();
@@ -136,10 +133,10 @@ final class TimeAcctEditor implements ProgramTypeListener {
         // Show the time for each category.
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
             final double progHours = alloc.getAward(cat).getProgramHours();
-            ui.getProgramAwardField(cat).setText(nf_decOpt.format(progHours)); // REL-434
+            ui.getProgramAwardField(cat).setText(nf.format(progHours)); // REL-434
 
             final double partHours = alloc.getAward(cat).getPartnerHours();
-            ui.getPartnerAwardField(cat).setText(nf_decOpt.format(partHours)); // REL-434
+            ui.getPartnerAwardField(cat).setText(nf.format(partHours)); // REL-434
         }
 
         // Show the percentage for each category.

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
@@ -14,14 +14,14 @@ import java.awt.*;
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 final class TimeAcctEditor implements ProgramTypeListener {
     private static final long MS_PER_HOUR = Duration.ofHours(1).toMillis();
 
     // Used to format values as strings
-    private final static DecimalFormat nf = new DecimalFormat("0.#");
+    private final static DecimalFormat nf_dec = new DecimalFormat("0.00");
+    private final static DecimalFormat nf_decOpt = new DecimalFormat("0.##");
 
     private static Duration toDuration(double hours) {
         return Duration.ofMillis(Math.round(hours * MS_PER_HOUR));
@@ -87,9 +87,9 @@ final class TimeAcctEditor implements ProgramTypeListener {
 
     private void showTotalTime(final TimeAcctAllocation alloc) {
         final TimeAcctAward a = alloc.getSum();
-        ui.getTotalAwardLabel()  .setText(nf.format(a.getTotalHours()));
-        ui.getProgramAwardLabel().setText(nf.format(a.getProgramHours()));
-        ui.getPartnerAwardLabel().setText(nf.format(a.getPartnerHours()));
+        ui.getTotalAwardLabel()  .setText(nf_dec.format(a.getTotalHours()));
+        ui.getProgramAwardLabel().setText(nf_dec.format(a.getProgramHours()));
+        ui.getPartnerAwardLabel().setText(nf_dec.format(a.getPartnerHours()));
     }
 
     private TimeValue getMinimumTime() {
@@ -127,7 +127,7 @@ final class TimeAcctEditor implements ProgramTypeListener {
             ui.getMinimumTimeField().setText("");
         } else {
             minTime = minTime.convertTo(TimeValue.Units.hours);
-            ui.getMinimumTimeField().setText(nf.format(minTime.getTimeAmount())); // REL-434
+            ui.getMinimumTimeField().setText(nf_dec.format(minTime.getTimeAmount())); // REL-434
         }
 
         final TimeAcctAllocation alloc = model.getAllocation();
@@ -136,10 +136,10 @@ final class TimeAcctEditor implements ProgramTypeListener {
         // Show the time for each category.
         for (final TimeAcctCategory cat : TimeAcctCategory.values()) {
             final double progHours = alloc.getAward(cat).getProgramHours();
-            ui.getProgramAwardField(cat).setText(nf.format(progHours)); // REL-434
+            ui.getProgramAwardField(cat).setText(nf_decOpt.format(progHours)); // REL-434
 
             final double partHours = alloc.getAward(cat).getPartnerHours();
-            ui.getPartnerAwardField(cat).setText(nf.format(partHours)); // REL-434
+            ui.getPartnerAwardField(cat).setText(nf_decOpt.format(partHours)); // REL-434
         }
 
         // Show the percentage for each category.

--- a/bundle/jsky.coords/src/main/java/jsky/coords/HMS.java
+++ b/bundle/jsky.coords/src/main/java/jsky/coords/HMS.java
@@ -28,12 +28,20 @@ public class HMS implements Serializable {
     /** set to 1 or -1 */
     private byte sign = 1;
 
-    /** Used to format values as strings. */
-    private static NumberFormat nf = NumberFormat.getInstance(Locale.US);
+    /** Used to format values as strings with decimal places. */
+    private static NumberFormat nf_frac = NumberFormat.getInstance(Locale.US);
 
     static {
-        nf.setMinimumIntegerDigits(2);
-        nf.setMaximumFractionDigits(3);
+        nf_frac.setMinimumIntegerDigits(2);
+        nf_frac.setMaximumFractionDigits(3);
+    }
+
+    /** Used to format values as strings with no fractional part. */
+    private static NumberFormat nf_noFrac = NumberFormat.getInstance(Locale.US);
+
+    static {
+        nf_noFrac.setMinimumIntegerDigits(2);
+        nf_noFrac.setMaximumFractionDigits(0);
     }
 
     /** On the handling of -0: from the javadoc for Double.equals():
@@ -166,21 +174,7 @@ public class HMS implements Serializable {
      * The seconds are formatted with 3 digits of precision.
      */
     public String toString() {
-        String secs = nf.format(sec);
-
-        // sign
-        String signStr;
-        if (sign == -1)
-            signStr = "-";
-        else
-            signStr = "";
-
-        return signStr
-                + nf.format(hours)
-                + ":"
-                + nf.format(min)
-                + ":"
-                + secs;
+        return toString(true);
     }
 
     /**
@@ -188,20 +182,16 @@ public class HMS implements Serializable {
      * or if showSeconds is false, hh:mm.
      */
     public String toString(boolean showSeconds) {
-        if (showSeconds)
-            return toString();
+        return toString(showSeconds, true);
+    }
 
-        // sign
-        String signStr;
-        if (sign == -1)
-            signStr = "-";
-        else
-            signStr = "";
-
-        return signStr
-                + nf.format(hours)
+    public String toString(boolean showSeconds, boolean showFractionalSeconds) {
+        final NumberFormat nf = showFractionalSeconds ? nf_frac : nf_noFrac;
+        return (sign == -1 ? "-1" : "")
+                + nf_noFrac.format(hours)
                 + ":"
-                + nf.format(min);
+                + nf_noFrac.format(min)
+                + (showSeconds ? (":" + nf.format(sec)) : "");
     }
 
     /** Return true if this object has been initialized with a valid value */
@@ -242,50 +232,5 @@ public class HMS implements Serializable {
     @Override
     public int hashCode() {
     	return (int) val;
-    }
-
-    /**
-     * Test cases
-     */
-    public static void main(String[] args) {
-
-        HMS h = new HMS(3, 19, 48.23);
-        System.out.println("HMS(3, 19, 48.23) == " + h + " == " + h.getVal());
-
-        if (!(h.equals(new HMS(h.getVal()))))
-            System.out.println("Equality test failed: " + h + " != " + new HMS(h.getVal()));
-
-        h = new HMS(41, 30, 42.2);
-        System.out.println("41 30 42.2 = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS(-41, 30, 2.2);
-        System.out.println("-41 30 2.2 = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS("-41 30 42.2");
-        System.out.println("-41 30 42.2 = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS("1:01:02.34567");
-        System.out.println("1:01:02.34567 = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS("1:01:02.34567");
-        System.out.println("1:01:02.34567 = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS(-0., 15, 33.3333);
-        System.out.println("-0 15 33.3333 = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS(-0.0001);
-        System.out.println("-0.0001 = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS(121.39583332 / 15.);
-        System.out.println("121.39583332/15. = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS(121.09583332 / 15.);
-        System.out.println("121.09583332/15. = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS(-121.39583332 / 15.);
-        System.out.println("-121.39583332/15. = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
-
-        h = new HMS(-121.09583332 / 15.);
-        System.out.println("-121.09583332/15. = " + h + " = " + h.getVal() + " = " + new HMS(h.getVal()));
     }
 }


### PR DESCRIPTION
Bryan wanted some precision in times displayed to be changed.

This makes the program form display only second precision, and the admin panel display 2 decimals of hour precision for awarded times and min time.

Also, I fixed a UI issue where a column in the time UI was specified incorrectly.