### PR TITLE
REL-3171: fix TigraTable creation

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/tigratable/TigraTableCreator.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/tigratable/TigraTableCreator.java
@@ -81,15 +81,17 @@ public class TigraTableCreator {
             }
 
             // Create the output file.
-            log.info("writing temp file to " + out.getAbsolutePath());
-            final ServiceReference<VcsService> ref = ctx.getServiceReference(VcsService.class);
-            final VcsService vcs = (ref == null) ? null : ctx.getService(ref);
-            final List<TigraTable> tables = TigraTableFunctor.getTigraTables(SPDB.get(), vcs, user);
-            _writeTables(tables, out);
+            log.info("Writing TigraTable data to " + out.getAbsolutePath());
+            final List<TigraTable> tables = TigraTableData.getOrNull(ctx, user);
+            if (tables == null) {
+                log.severe("Could not find a VcsService. TigraTable data not updated.");
+            } else {
+                _writeTables(tables, out);
 
-            // FTP the results.
-            final FtpProps props = new FtpProps(env);
-            FtpUtil$.MODULE$.sendFile(log, out, props);
+                // FTP the results.
+                final FtpProps props = new FtpProps(env);
+                FtpUtil$.MODULE$.sendFile(log, out, props);
+            }
 
         } else {
             log.warning("Cannot proceed. No current site.");

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/tigratable/TigraTableData.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/tigratable/TigraTableData.scala
@@ -1,0 +1,39 @@
+package edu.gemini.dbTools.tigratable
+
+import edu.gemini.pot.client.SPDB
+import edu.gemini.sp.vcs2.VcsService
+import edu.gemini.util.osgi.SecureServiceFactory
+
+import org.osgi.framework.BundleContext
+import org.osgi.framework.ServiceReference
+
+import java.util.{List => JList, Set => JSet}
+import java.security.Principal
+
+import scala.collection.JavaConverters._
+
+// Logically this utility is part of TigraTableCreator, but we would need to
+// rewrite it in Scala to incorporate the service creation.
+
+object TigraTableData {
+
+  /** Obtains the TigraTable data from the database, assuming a VcsService is
+    * available.
+    *
+    * @return Some(java.util.List[TigraTable]) if a secure VcsService has been
+    *         registered; None otherwise
+    */
+  def get(ctx: BundleContext, user: JSet[Principal]): Option[JList[TigraTable]] =
+    SecureServiceFactory.withSecureService(ctx, classOf[VcsService], user.asScala.toSet, None) { vcs =>
+      TigraTableFunctor.getTigraTables(SPDB.get(), vcs, user)
+    }
+
+  /** Obtains the TigraTable data from the database, assuming a VcsService is
+    * available.  (This version is intended to simplify access from Java.)
+    *
+    * @return a java.util.List[TigraTable] if a secure VcsService has been
+    *         registered; null otherwise
+    */
+  def getOrNull(ctx: BundleContext, user: JSet[Principal]): JList[TigraTable] =
+    get(ctx, user).orNull
+}


### PR DESCRIPTION
This PR updates the way that `TigraTableCreator` obtains a `VcsService`, taking advantage of the new `SecureServiceFactory` utility.  The previous version was failing to find a `VcsService` and therefore failing to update the TigraTable data.