### PR TITLE
REL-1485: OT elevation plot background

### DIFF
--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
@@ -431,10 +431,10 @@ public class ElevationPanel extends JPanel implements PrintableWithDialog, Savea
         // mark the ranges of twilight and darkness
         xyPlot.clearDomainMarkers();
         xyPlot.clearRangeMarkers();
+        addDomainMarker(xyPlot, new Date(_model.getSunSet()),
+                new Date(_model.getSunRise()), TWILIGHT_ALPHA, Color.gray);
         addDomainMarker(xyPlot, new Date(_model.getNauticalTwilightStart()),
-                new Date(_model.getNauticalTwilightEnd()), TWILIGHT_ALPHA, Color.gray);
-        addDomainMarker(xyPlot, new Date(_model.getAstronomicalTwilightStart()),
-                new Date(_model.getAstronomicalTwilightEnd()), DARKNESS_ALPHA, Color.black);
+                new Date(_model.getNauticalTwilightEnd()), DARKNESS_ALPHA, Color.black);
 
         xyPlot.addRangeMarker(new ValueMarker(ElevationPlotModel.getObsThreshold()));
 

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
@@ -57,7 +57,7 @@ public class ElevationPanel extends JPanel implements PrintableWithDialog, Savea
     private static final float DARKNESS_ALPHA = 0.1F;
 
     // Alpha value used to draw twilight area on graph
-    private static final float TWILIGHT_ALPHA = 0.05F;
+    private static final float TWILIGHT_ALPHA = 0.2F;
 
     // This is a required parameter, but we don't want to see the outline
     private static final Stroke DARKNESS_STROKE = new BasicStroke(0.0F);
@@ -78,6 +78,9 @@ public class ElevationPanel extends JPanel implements PrintableWithDialog, Savea
     private static final Color CONSTRAINT_COLOR = new Color(0.0F, 1.0F, 0.0F, 0.5F);
 
     private static final Paint TIMING_WINDOW_PAINT;
+
+    // Color used for daylight
+    private static final Color DAY_COLOR = new Color(0xEE, 0xEE, 0xFF);
 
     static {
         final BufferedImage bi = new BufferedImage(4, 4,  BufferedImage.TYPE_4BYTE_ABGR);
@@ -438,7 +441,7 @@ public class ElevationPanel extends JPanel implements PrintableWithDialog, Savea
 
         xyPlot.addRangeMarker(new ValueMarker(ElevationPlotModel.getObsThreshold()));
 
-        plotCons(xyPlot, _elevationConstraintsMarkerVisible, 2, _model::getConstraintsDataset,   CONSTRAINT_COLOR);
+        plotCons(xyPlot, _elevationConstraintsMarkerVisible,2, _model::getConstraintsDataset, CONSTRAINT_COLOR);
         plotCons(xyPlot, _timingWindowsMarkerVisible, 3, _model::getTimingWindowsDataset, TIMING_WINDOW_PAINT);
     }
 
@@ -519,6 +522,7 @@ public class ElevationPanel extends JPanel implements PrintableWithDialog, Savea
 
         // add a secondary Y axis for airmass or parallactic angle
         _valueAxis2 = new NumberAxis(valueAxisLabel2);
+        plot.setBackgroundPaint(DAY_COLOR);
         plot.setRangeAxis(1, _valueAxis2);
         plot.mapDatasetToRangeAxis(1, 1);
 

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
@@ -590,6 +590,15 @@ public class ElevationPlotModel {
         return cal.getTime();
     }
 
+    /** Return sunrise time in the selected time zone */
+    public Long getSunRise() {
+        return _sunRiseSet.sunrise;
+    }
+
+    /** Return sunset in the selected time zone */
+    public Long getSunSet() {
+        return _sunRiseSet.sunset;
+    }
     /** Return the start time of nautical twilight in the selected time zone */
     public Long getNauticalTwilightStart() {
         return _sunRiseSet.nauticalTwilightStart;

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ObservationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ObservationPanel.java
@@ -210,10 +210,10 @@ public class ObservationPanel extends JPanel implements PrintableWithDialog, Sav
 
             // mark the ranges of twilight and darkness
             plot.clearRangeMarkers();
+            _addDarknessMarker(plot, new Date(_model.getSunSet()),
+                    new Date(_model.getSunRise()), TWILIGHT_ALPHA, Color.gray);
             _addDarknessMarker(plot, new Date(_model.getNauticalTwilightStart()),
-                    new Date(_model.getNauticalTwilightEnd()), TWILIGHT_ALPHA, Color.gray);
-            _addDarknessMarker(plot, new Date(_model.getAstronomicalTwilightStart()),
-                    new Date(_model.getAstronomicalTwilightEnd()), DARKNESS_ALPHA, Color.black);
+                    new Date(_model.getNauticalTwilightEnd()), DARKNESS_ALPHA, Color.black);
 
             // Make sure labels are readable, use scrollbar if needed
             int numTargets = dataset.getColumnCount();


### PR DESCRIPTION
This is an early PR to check I'm going in the right direction. I have to still figure out how to add a legend and some thin lines.

Now the background colors of the elevation plots of the OT go like this:

Light grey: Sunset -> Start Nautical twilight (12°)
Dark grey: Start Nautical twilight (12°) -> End Nautical twilight (12°)
Light grey: End Nautical twilight (12°) -> Sunrise

<img width="1388" alt="elevation_plots" src="https://user-images.githubusercontent.com/215438/27451224-602def0e-575c-11e7-815f-ae8d37bcf4dd.png">