### PR TITLE
REL-3114: Remove constraint on email address suffixes in PIT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ scalaVersion in ThisBuild := "2.11.11"
 
 updateOptions := updateOptions.value.withCachedResolution(true)
 
+cancelable in Global := true
+
 // Note that this is not a standard setting; it's used for building IDEA modules.
 javaVersion in ThisBuild := {
   val expected = "1.8"

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -424,15 +424,17 @@
                                     </fo:block>
                                 </fo:table-cell>
                                 <fo:table-cell>
-                                    <fo:block>
-                                        <xsl:value-of
-                                                select="investigators/pi/phone"/>
-                                        <xsl:text>&#160;</xsl:text>
-                                        <xsl:text>/</xsl:text>
-                                        <xsl:text>&#160;</xsl:text>
-                                        <xsl:value-of
-                                                select="investigators/pi/email"/>
-                                    </fo:block>
+                                    <fo:block-container overflow="hidden">
+                                      <fo:block>
+                                          <xsl:value-of
+                                                  select="investigators/pi/phone"/>
+                                          <xsl:text>&#160;</xsl:text>
+                                          <xsl:text>/</xsl:text>
+                                          <xsl:text>&#160;</xsl:text>
+                                          <xsl:value-of
+                                                  select="investigators/pi/email"/>
+                                      </fo:block>
+                                    </fo:block-container>
                                 </fo:table-cell>
                             </fo:table-row>
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -17,8 +17,8 @@ package object immutable {
 
     // Trim lines, join adjacent lines if non-empty
     def unwrapLines: String = s.lines.map(_.trim).dropWhile(_.isEmpty).map {
-      case s0 if s0.isEmpty => "\n"
-      case s0               => s0 + " "
+      case "" => "\n"
+      case s0 => s"$s0 "
     }.mkString
 
     def trimLines: String = s.lines.map(_.trim).dropWhile(_.isEmpty).mkString("\n")

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -7,7 +7,7 @@ import edu.gemini.model.p1.{ mutable => M }
 package object immutable {
 
   /** Email regex used for validation. */
-  lazy val EmailRegex = "(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$".r
+  lazy val EmailRegex = "(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]*$".r
 
   type Airmass = Double
 
@@ -18,7 +18,7 @@ package object immutable {
     // Trim lines, join adjacent lines if non-empty
     def unwrapLines: String = s.lines.map(_.trim).dropWhile(_.isEmpty).map {
       case s0 if s0.isEmpty => "\n"
-      case s0 => s0 + " "
+      case s0               => s0 + " "
     }.mkString
 
     def trimLines: String = s.lines.map(_.trim).dropWhile(_.isEmpty).mkString("\n")

--- a/bundle/edu.gemini.pit.launcher/build.sbt
+++ b/bundle/edu.gemini.pit.launcher/build.sbt
@@ -6,7 +6,7 @@ name := "edu.gemini.pit.launcher"
 
 version := pitVersion.value.toOsgiVersion
 
-osgiSettings 
+osgiSettings
 
 ocsBundleSettings
 
@@ -17,3 +17,5 @@ OsgiKeys.bundleSymbolicName := name.value
 OsgiKeys.dynamicImportPackage := Seq("")
 
 OsgiKeys.exportPackage := Seq()
+
+fork in run := true

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/PiEditor.scala
@@ -49,7 +49,6 @@ class PiEditor(pi: PrincipalInvestigator, editable:Boolean) extends StdModalEdit
 
   // Validation (optional for now)
   private val validatingControls = Seq(FirstName, LastName, Email, Institution.Name)
-//  override def editorValid = validatingControls.forall(_.valid)
   validatingControls foreach {
     _.reactions += {
       case ValueChanged(_) => validateEditor()
@@ -86,7 +85,6 @@ class PiEditor(pi: PrincipalInvestigator, editable:Boolean) extends StdModalEdit
     }
 
     object Address extends TextArea(ia.address, 6, 30) with SelectOnFocus {
-//      border = null // ?
       peer.addKeyListener(new KeyAdapter {
         override def keyPressed(e:KeyEvent) {
           if (e.getKeyCode == KeyEvent.VK_TAB) {


### PR DESCRIPTION
This PR relaxes the restriction that emails TLDs must be between 2 and 4 characters. The exported PDF now also will behave better for very long email addresses

I added a couple of changes to the build to simplify launching the PIT from sbt rather than IntelliJ