### PR TITLE
REL-3190: Remove Y and J-lo filters for Flamingos 2

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
@@ -21,8 +21,8 @@ object Flamingos2 {
   private def filtersFor(d: Option[Flamingos2Disperser]): List[Flamingos2Filter] = d match {
     case Some(R1200HK) => List(JH, HK)
     case Some(R1200JH) => List(JH)
-    case Some(R3000)   => List(J_LOW, J, H, K_LONG, K_SHORT, K_BLUE, K_RED)
-    case _             => List(Y, J_LOW, J, H, K_LONG, K_SHORT, K_BLUE, K_RED)
+    case Some(R3000)   => List(K_LONG, K_SHORT, K_BLUE, K_RED)
+    case _             => List(J, H, K_LONG, K_SHORT, K_BLUE, K_RED)
   }
 
   private def defaultFilterFor(d: Flamingos2Disperser): Option[Flamingos2Filter] = d match {

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
@@ -21,7 +21,7 @@ object Flamingos2 {
   private def filtersFor(d: Option[Flamingos2Disperser]): List[Flamingos2Filter] = d match {
     case Some(R1200HK) => List(JH, HK)
     case Some(R1200JH) => List(JH)
-    case Some(R3000)   => List(K_LONG, K_SHORT, K_BLUE, K_RED)
+    case Some(R3000)   => List(J, H, K_LONG, K_SHORT, K_BLUE, K_RED)
     case _             => List(J, H, K_LONG, K_SHORT, K_BLUE, K_RED)
   }
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -1,5 +1,10 @@
 Gemini Phase I Schema Changes
 
+# Version 2018.1.1 - 2018B
+##########################
+
+* Hidden filter Y and J-lo for Flamingos2
+
 # Version 2017.2.1 - 2017B
 ##########################
 

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/f2_removedfilters.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/f2_removedfilters.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2017.2.1">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2017" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <flamingos2>
+            <mos id="blueprint-0">
+                <name>Flamingos2 MOS R3K J-lo (1.122 um)</name>
+                <visitor>false</visitor>
+                <filter>J-lo (1.122 um)</filter>
+                <disperser>R3K</disperser>
+                <preimaging>false</preimaging>
+            </mos>
+        </flamingos2>
+        <flamingos2>
+            <imaging id="blueprint-1">
+                <name>Flamingos2 Imaging J-lo (1.122 um)</name>
+                <visitor>false</visitor>
+                <filter>J-lo (1.122 um)</filter>
+            </imaging>
+        </flamingos2>
+        <flamingos2>
+            <imaging id="blueprint-2">
+                <name>Flamingos2 Imaging Y (1.020 um)</name>
+                <visitor>false</visitor>
+                <filter>Y (1.020 um)</filter>
+            </imaging>
+        </flamingos2>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-0"/>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-1"/>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-2"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/Flamingos2Spec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/Flamingos2Spec.scala
@@ -7,13 +7,13 @@ class Flamingos2Spec extends Specification {
   "The Flamingos2 decision tree" should {
     "not include the narrow band filters, REL-1282" in {
       val f2 = new Flamingos2.ImagingFilterNode()
-      f2.choices must have size 8
+      f2.choices must have size 6
       // sanity check
-      f2.choices must contain (Flamingos2Filter.Y)
+      f2.choices must not contain (Flamingos2Filter.Y)
     }
     "include the K-Long filter, REL-2308" in {
       val f2 = new Flamingos2.ImagingFilterNode()
-      f2.choices must have size 8
+      f2.choices must have size 6
       // sanity check
       f2.choices must contain (Flamingos2Filter.K_LONG)
     }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -555,14 +555,18 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       }
     }
     "proposal with F2 R3K+Y longslit must use the filter Y, REL-1282" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_f2_R3K+Y_longslit.xml")))
+      skipped {
+        val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_f2_R3K+Y_longslit.xml")))
 
-      testF2R3KYConversion(xml)
+        testF2R3KYConversion(xml)
+      }
     }
     "proposal with F2 R3K+Y MOS must use the filter Y, REL-1282" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_f2_R3K+Y_mos.xml")))
+      skipped {
+        val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_f2_R3K+Y_mos.xml")))
 
-      testF2R3KYConversion(xml)
+        testF2R3KYConversion(xml)
+      }
     }
     "proposal with F2 K-long filter must use the new name, REL-2565" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_f2_old_longslit.xml")))
@@ -739,6 +743,19 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
         case StepResult(changes, result) =>
           result \\ "request" must \\("time")
           result \\ "request" must not \\ "progTime"
+      }
+    }
+    "F2 proposal with Y or J-lo fiters should remove them, REL-3193" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("f2_removedfilters.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 4
+          result \\ "flamingos2" must not(\\("filter") \> "J-lo (1.122 um)")
+          result \\ "flamingos2" must not(\\("filter") \> "Y (1.020 um)")
+          result \\ "flamingos2" must not(\\("name") \>~ ".*Y (1.020 um).*")
+          result \\ "flamingos2" must not(\\("name") \>~ ".*J-lo (1.122 um).*")
       }
     }
   }


### PR DESCRIPTION
The PIT 2018A won't support these two filters