### PR TITLE
Add Smart Gcal Updating to Seqexec Client

### DIFF
--- a/bundle/edu.gemini.seqexec.odb/src/main/scala/edu/gemini/seqexec/odb/SeqExecService.scala
+++ b/bundle/edu.gemini.seqexec.odb/src/main/scala/edu/gemini/seqexec/odb/SeqExecService.scala
@@ -8,9 +8,7 @@ import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
 import edu.gemini.spModel.config2.ConfigSequence
 import edu.gemini.spModel.core.Peer
-import edu.gemini.spModel.gemini.calunit.smartgcal.CalibrationProvider
 import edu.gemini.spModel.io.SpImportService
-import edu.gemini.spModel.seqcomp.SeqRepeatCbOptions
 import java.io.{BufferedReader, InputStreamReader, StringReader}
 import java.net.{HttpURLConnection, URL}
 import java.net.HttpURLConnection.{HTTP_NOT_FOUND, HTTP_OK}
@@ -85,11 +83,9 @@ object SeqExecService {
       }
     }
 
-  private def extractSequence(obs: ISPObservation, smartGcal: CalibrationProvider): TrySeq[ConfigSequence] =
+  private def extractSequence(obs: ISPObservation): TrySeq[ConfigSequence] =
     catchingAll {
-      val options = new java.util.HashMap[String, Object]
-      SeqRepeatCbOptions.setCalibrationProvider(options, smartGcal)
-      ConfigBridge.extractSequence(obs, options, IDENTITY_MAP, true)
+      ConfigBridge.extractSequence(obs, null, IDENTITY_MAP, true)
     }
 
   /** Constructs a SeqExecService that works with a servlet running in the ODB.
@@ -97,7 +93,7 @@ object SeqExecService {
     * observation XML (wrapped in a program shell suitable for importing). The
     * XML is then parsed and the sequence is extracted.
     */
-  def client(peer: Peer, smartGcal: CalibrationProvider): SeqExecService =
+  def client(peer: Peer): SeqExecService =
     new SeqExecService {
       override def sequence(oid: SPObservationID): TrySeq[ConfigSequence] =
         for {
@@ -105,7 +101,7 @@ object SeqExecService {
           c <- open(u)
           x <- read(c, oid)
           o <- parse(x)
-          s <- extractSequence(o, smartGcal)
+          s <- extractSequence(o)
         } yield s
     }
 }

--- a/bundle/edu.gemini.seqexec.odb/src/main/scala/edu/gemini/seqexec/odb/SmartGcal.scala
+++ b/bundle/edu.gemini.seqexec.odb/src/main/scala/edu/gemini/seqexec/odb/SmartGcal.scala
@@ -1,7 +1,7 @@
 package edu.gemini.seqexec.odb
 
 import edu.gemini.spModel.core.Peer
-import edu.gemini.spModel.gemini.calunit.smartgcal.{CalibrationProvider, CalibrationRepository}
+import edu.gemini.spModel.gemini.calunit.smartgcal.{CalibrationProviderHolder, CalibrationProvider, CalibrationRepository}
 import edu.gemini.spModel.smartgcal.UpdatableCalibrationRepository
 import edu.gemini.spModel.smartgcal.provider.CalibrationProviderImpl
 import edu.gemini.spModel.smartgcal.repository.{CalibrationUpdater, CalibrationFileCache, CalibrationRemoteRepository}
@@ -10,13 +10,13 @@ import java.nio.file.Path
 import java.time.Duration
 
 object SmartGcal {
-  def initialize(peer: Peer, dir: Path): TrySeq[CalibrationProvider] =
+  def initialize(peer: Peer, dir: Path): TrySeq[Unit] =
     catchingAll {
       val service    = new CalibrationRemoteRepository(peer.host, peer.port)
       val cachedRepo = new CalibrationFileCache(dir.toFile)
       val provider   = new CalibrationProviderImpl(cachedRepo)
+      CalibrationProviderHolder.setProvider(provider)
       CalibrationUpdater.instance.addListener(provider)
       CalibrationUpdater.instance.start(cachedRepo, service, Duration.ofHours(1).toMillis)
-      provider
     }
 }

--- a/bundle/edu.gemini.seqexec.odb/src/main/scala/edu/gemini/seqexec/odb/SmartGcal.scala
+++ b/bundle/edu.gemini.seqexec.odb/src/main/scala/edu/gemini/seqexec/odb/SmartGcal.scala
@@ -1,0 +1,22 @@
+package edu.gemini.seqexec.odb
+
+import edu.gemini.spModel.core.Peer
+import edu.gemini.spModel.gemini.calunit.smartgcal.{CalibrationProvider, CalibrationRepository}
+import edu.gemini.spModel.smartgcal.UpdatableCalibrationRepository
+import edu.gemini.spModel.smartgcal.provider.CalibrationProviderImpl
+import edu.gemini.spModel.smartgcal.repository.{CalibrationUpdater, CalibrationFileCache, CalibrationRemoteRepository}
+
+import java.nio.file.Path
+import java.time.Duration
+
+object SmartGcal {
+  def initialize(peer: Peer, dir: Path): TrySeq[CalibrationProvider] =
+    catchingAll {
+      val service    = new CalibrationRemoteRepository(peer.host, peer.port)
+      val cachedRepo = new CalibrationFileCache(dir.toFile)
+      val provider   = new CalibrationProviderImpl(cachedRepo)
+      CalibrationUpdater.instance.addListener(provider)
+      CalibrationUpdater.instance.start(cachedRepo, service, Duration.ofHours(1).toMillis)
+      provider
+    }
+}

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/Flamingos2_ARC.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/Flamingos2_ARC.csv
@@ -1,1 +1,68 @@
-0,2013/04/30 00:00:00 HST# F2_ARC.csv#,,,,,,,,,,,,#,2013 Apr 30,,,,,,,,,,,#,,,,,,,,,,,,#,Recommended GCAL configurations and Exp. Times for F2 calibrations:,,,,,,,,,,,#,"Spectroscopic Arcs:  JH1200, HK1200, R3000",,,,,,,,,,,#,,,,,,,,,,,,#,Note the following:,,,,,,,,,,,#,,,,,,,,,,,,#,"All Arcs are taken with GCALlamp=Ar, GCALfilter=NIR balance, GCALdiffuser=IR",,,,,,,,,,,#,The choice of filter within F2 is considered because they sort orders,,,,,,,,,,,#,"The Read Mode is Bright Object, Readout mode Science",,,,,,,,,,,#,,,,,,,,,,,,#,,,,,,,,,,,,#,,,,,,,,,,,,#  Instrument Configuration from OT,,,,,,GCAL configuration from OT,,,,,,Disperser,Filter,Focal Plane Unit,,/=>/,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal#,,,,,,,,,,,,R=1200 (J + H) grism,JH (spectroscopic),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,NightR=1200 (J + H) grism,JH (spectroscopic),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,NightR=1200 (J + H) grism,JH (spectroscopic),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,NightR=1200 (J + H) grism,JH (spectroscopic),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,NightR=1200 (J + H) grism,JH (spectroscopic),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,8,1,NightR=1200 (J + H) grism,JH (spectroscopic),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,8,1,Night#,,,,,,,,,,,,R=1200 (H + K) grism,HK (spectroscopic),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,90,1,NightR=1200 (H + K) grism,HK (spectroscopic),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,90,1,NightR=1200 (H + K) grism,HK (spectroscopic),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,90,1,NightR=1200 (H + K) grism,HK (spectroscopic),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,40,1,NightR=1200 (H + K) grism,HK (spectroscopic),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,40,1,NightR=1200 (H + K) grism,HK (spectroscopic),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,40,1,Night#,,,,,,,,,,,,R=3000 (J or H or K) grism,J-low (1.15 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,NightR=3000 (J or H or K) grism,J-low (1.15 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,NightR=3000 (J or H or K) grism,J-low (1.15 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,NightR=3000 (J or H or K) grism,J-low (1.15 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,NightR=3000 (J or H or K) grism,J-low (1.15 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,NightR=3000 (J or H or K) grism,J-low (1.15 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night#,,,,,,,,,,,,R=3000 (J or H or K) grism,J (1.25 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,NightR=3000 (J or H or K) grism,J (1.25 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,NightR=3000 (J or H or K) grism,J (1.25 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,NightR=3000 (J or H or K) grism,J (1.25 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,NightR=3000 (J or H or K) grism,J (1.25 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,NightR=3000 (J or H or K) grism,J (1.25 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night#,,,,,,,,,,,,R=3000 (J or H or K) grism,H (1.65 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,NightR=3000 (J or H or K) grism,H (1.65 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,NightR=3000 (J or H or K) grism,H (1.65 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,NightR=3000 (J or H or K) grism,H (1.65 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,NightR=3000 (J or H or K) grism,H (1.65 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,NightR=3000 (J or H or K) grism,H (1.65 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night#,,,,,,,,,,,,R=3000 (J or H or K) grism,K-short (2.15 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,NightR=3000 (J or H or K) grism,K-short (2.15 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,NightR=3000 (J or H or K) grism,K-short (2.15 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,NightR=3000 (J or H or K) grism,K-short (2.15 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,NightR=3000 (J or H or K) grism,K-short (2.15 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,NightR=3000 (J or H or K) grism,K-short (2.15 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night#,,,,,,,,,,,,
+361,2016/02/10 11:50:08 HST
+# F2_ARC.csv,,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,2016 Feb 10,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,Recommended GCAL configurations and Exp. Times for F2 calibrations:,,,,,,,,,,,,
+#,"Spectroscopic Arcs:  JH1200, HK1200, R3000",,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,Note the following:,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,"All Arcs are taken with GCALlamp=Ar, GCALfilter=NIR balance, GCALdiffuser=IR",,,,,,,,,,,,
+#,The choice of filter within F2 is considered because they sort orders,,,,,,,,,,,,
+#,"The Read Mode is Bright Object, Readout mode Science",,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#  Instrument Configuration from OT,,,,,,GCAL configuration from OT,,,,,,,
+Disperser,Filter,Focal Plane Unit,,/=>/,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
+#,,,,,,,,,,,,,
+R=1200 (J + H) grism,JH (spectroscopic),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,8,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,8,1,Night
+#,,,,,,,,,,,,,
+R=1200 (H + K) grism,HK (spectroscopic),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,90,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,90,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,90,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,40,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,40,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,40,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,J-low (1.15 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,J (1.25 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,60,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,30,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,15,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,H (1.65 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,K-short (2.15 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,K-long (2.20 um),1-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),2-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),3-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,180,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),4-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),6-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),8-pix longslit,,,,1,NIR balance,IR,Ar arc,Closed,80,1,Night
+#,,,,,,,,,,,,,

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/Flamingos2_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/Flamingos2_FLAT.csv
@@ -1,1 +1,89 @@
-0,2013/04/30 00:00:00 HST# F2_FLAT.csv#,,,,,,,,,,,,#,2013 Apr 30,,,,,,,,,,,#,,,,,,,,,,,,#,Recommended GCAL configurations and Exp. Times for F2 calibrations:,,,,,,,,,,,#,IR lamp,,,,,,,,,,,#,,,,,,,,,,,,#,Note the following:,,,,,,,,,,,#,,,,,,,,,,,,#,"All Flats are taken with GCALlamp=IR grey body-high, GCALdiffuser=IR",,,,,,,,,,,#,The choice of filter within F2 is considered because they sort orders,,,,,,,,,,,#,"The Read Mode is Bright Object, Readout mode Science",,,,,,,,,,,#,,,,,,,,,,,,#,,,,,,,,,,,,#,,,,,,,,,,,,#  Instrument Configuration from OT,,,,,,,GCAL configuration from OT,,,,,Disperser,Filter,Focal Plane Unit,,/=>/,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal#,,,,,,,,,,,,None,Y (1.02 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Open,20,1,DayNone,Y (1.02 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Closed,20,1,DayNone,J-low (1.15 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Open,3,1,DayNone,J-low (1.15 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Closed,3,1,DayNone,J (1.25 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Open,60,1,DayNone,J (1.25 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Closed,60,1,DayNone,H (1.65 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Open,3,1,DayNone,H (1.65 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Closed,3,1,DayNone,K-short (2.15 um),Imaging (none),,,,6,ND2.0,IR,IR grey body - high,Closed,6,1,DayNone,JH (spectroscopic),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Open,2,1,DayNone,JH (spectroscopic),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Closed,2,1,DayNone,HK (spectroscopic),Imaging (none),,,,6,ND2.0,IR,IR grey body - high,Closed,2,1,Day#,,,,,,,,,,,,#,,,,,,,,,,,,R=1200 (J + H) grism,JH (spectroscopic),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,15,1,DayR=1200 (J + H) grism,JH (spectroscopic),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,8,1,DayR=1200 (J + H) grism,JH (spectroscopic),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,5,1,DayR=1200 (J + H) grism,JH (spectroscopic),4-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,4,1,DayR=1200 (J + H) grism,JH (spectroscopic),6-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,3,1,DayR=1200 (J + H) grism,JH (spectroscopic),8-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,2,1,Day#,,,,,,,,,,,,R=1200 (H + K) grism,HK (spectroscopic),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,8,1,DayR=1200 (H + K) grism,HK (spectroscopic),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,4,1,DayR=1200 (H + K) grism,HK (spectroscopic),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,3,1,DayR=1200 (H + K) grism,HK (spectroscopic),4-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,80,1,DayR=1200 (H + K) grism,HK (spectroscopic),6-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,50,1,DayR=1200 (H + K) grism,HK (spectroscopic),8-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,40,1,Day#,,,,,,,,,,,,R=3000 (J or H or K) grism,J-low (1.15 um),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,30,1,DayR=3000 (J or H or K) grism,J-low (1.15 um),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,16,1,DayR=3000 (J or H or K) grism,J-low (1.15 um),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,10,1,DayR=3000 (J or H or K) grism,J-low (1.15 um),4-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,8,1,DayR=3000 (J or H or K) grism,J-low (1.15 um),6-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,6,1,DayR=3000 (J or H or K) grism,J-low (1.15 um),8-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,4,1,Day#,,,,,,,,,,,,R=3000 (J or H or K) grism,J (1.25 um),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,30,1,DayR=3000 (J or H or K) grism,J (1.25 um),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,16,1,DayR=3000 (J or H or K) grism,J (1.25 um),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,10,1,DayR=3000 (J or H or K) grism,J (1.25 um),4-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,8,1,DayR=3000 (J or H or K) grism,J (1.25 um),6-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,6,1,DayR=3000 (J or H or K) grism,J (1.25 um),8-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,4,1,Day#,,,,,,,,,,,,R=3000 (J or H or K) grism,H (1.65 um),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,16,1,DayR=3000 (J or H or K) grism,H (1.65 um),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,8,1,DayR=3000 (J or H or K) grism,H (1.65 um),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,6,1,DayR=3000 (J or H or K) grism,H (1.65 um),4-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,160,1,DayR=3000 (J or H or K) grism,H (1.65 um),6-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,100,1,DayR=3000 (J or H or K) grism,H (1.65 um),8-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,80,1,Day#,,,,,,,,,,,,R=3000 (J or H or K) grism,K-short (2.15 um),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,16,1,DayR=3000 (J or H or K) grism,K-short (2.15 um),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,8,1,DayR=3000 (J or H or K) grism,K-short (2.15 um),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,6,1,DayR=3000 (J or H or K) grism,K-short (2.15 um),4-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,160,1,DayR=3000 (J or H or K) grism,K-short (2.15 um),6-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,100,1,DayR=3000 (J or H or K) grism,K-short (2.15 um),8-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,80,1,Day#,,,,,,,,,,,,
+363,2016/04/03 13:13:50 HST
+# F2_FLAT.csv,,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,2016 Feb 10,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,Recommended GCAL configurations and Exp. Times for F2 calibrations:,,,,,,,,,,,,
+#,IR lamp,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,Note the following:,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,"All Flats are taken with GCALlamp=IR grey body-high, GCALdiffuser=IR",,,,,,,,,,,,
+#,The choice of filter within F2 is considered because they sort orders,,,,,,,,,,,,
+#,"The Read Mode is Bright Object, Readout mode Science",,,,,,,,,,,,
+#, Added the 'R=3000 grism  + Y filter. Also made edits based on M. Schirmer checks done in July 2013. 082113,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+#  Instrument Configuration from OT,,,,,,,GCAL configuration from OT,,,,,,
+Disperser,Filter,Focal Plane Unit,,/=>/,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
+#,,,,,,,,,,,,,
+None,Y (1.02 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Open,20,1,Day
+None,Y (1.02 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Closed,20,1,Day
+None,J-low (1.15 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Open,4,1,Day
+None,J-low (1.15 um),Imaging (none),,,,6,ND4.0,IR,IR grey body - high,Closed,4,1,Day
+None,J (1.25 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Open,60,1,Day
+None,J (1.25 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Closed,60,1,Day
+None,H (1.65 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Open,3,1,Day
+None,H (1.65 um),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Closed,3,1,Day
+None,K-short (2.15 um),Imaging (none),,,,6,ND2.0,IR,IR grey body - high,Closed,3,1,Day
+None,JH (spectroscopic),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Open,2,1,Day
+None,JH (spectroscopic),Imaging (none),,,,6,ND4-5,IR,IR grey body - high,Closed,2,1,Day
+None,HK (spectroscopic),Imaging (none),,,,6,ND2.0,IR,IR grey body - high,Closed,2,1,Day
+#,,,,,,,,,,,,,
+#,,,,,,,,,,,,,
+R=1200 (J + H) grism,JH (spectroscopic),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,20,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,8,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,5,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),4-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,4,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),6-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,3,1,Night
+R=1200 (J + H) grism,JH (spectroscopic),8-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,3,1,Night
+#,,,,,,,,,,,,,
+R=1200 (H + K) grism,HK (spectroscopic),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,10,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,4,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,3,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),4-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,80,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),6-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,60,1,Night
+R=1200 (H + K) grism,HK (spectroscopic),8-pix longslit,,,,1,ND4-5,IR,IR grey body - high,Open,40,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,J-low (1.15 um),1-pix longslit,,,,1,none,IR,IR grey body - high,Open,50,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),2-pix longslit,,,,1,none,IR,IR grey body - high,Open,25,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),3-pix longslit,,,,1,none,IR,IR grey body - high,Open,15,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),4-pix longslit,,,,1,none,IR,IR grey body - high,Open,12,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),6-pix longslit,,,,1,none,IR,IR grey body - high,Open,8,1,Night
+R=3000 (J or H or K) grism,J-low (1.15 um),8-pix longslit,,,,1,none,IR,IR grey body - high,Open,6,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,J (1.25 um),1-pix longslit,,,,1,none,IR,IR grey body - high,Open,10,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),2-pix longslit,,,,1,none,IR,IR grey body - high,Open,5,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),3-pix longslit,,,,1,ND1.0,IR,IR grey body - high,Open,25,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),4-pix longslit,,,,1,ND1.0,IR,IR grey body - high,Open,20,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),6-pix longslit,,,,1,ND1.0,IR,IR grey body - high,Open,12,1,Night
+R=3000 (J or H or K) grism,J (1.25 um),8-pix longslit,,,,1,ND1.0,IR,IR grey body - high,Open,10,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,H (1.65 um),1-pix longslit,,,,1,ND1.0,IR,IR grey body - high,Open,6,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,50,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,40,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),4-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,25,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),6-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,20,1,Night
+R=3000 (J or H or K) grism,H (1.65 um),8-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,15,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,K-short (2.15 um),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,32,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,16,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,12,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),4-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,9,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),6-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,6,1,Night
+R=3000 (J or H or K) grism,K-short (2.15 um),8-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,4,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,Y (1.02 um),1-pix longslit,,,,1,none,IR,IR grey body - high,Open,80,1,Night
+R=3000 (J or H or K) grism,Y (1.02 um),2-pix longslit,,,,1,none,IR,IR grey body - high,Open,50,1,Night
+R=3000 (J or H or K) grism,Y (1.02 um),3-pix longslit,,,,1,none,IR,IR grey body - high,Open,30,1,Night
+R=3000 (J or H or K) grism,Y (1.02 um),4-pix longslit,,,,1,none,IR,IR grey body - high,Open,20,1,Night
+R=3000 (J or H or K) grism,Y (1.02 um),6-pix longslit,,,,1,none,IR,IR grey body - high,Open,15,1,Night
+R=3000 (J or H or K) grism,Y (1.02 um),8-pix longslit,,,,1,none,IR,IR grey body - high,Open,12,1,Night
+#,,,,,,,,,,,,,
+R=3000 (J or H or K) grism,K-long (2.20 um),1-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,32,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),2-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,16,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),3-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,12,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),4-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,9,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),6-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,6,1,Night
+R=3000 (J or H or K) grism,K-long (2.20 um),8-pix longslit,,,,1,ND2.0,IR,IR grey body - high,Open,4,1,Night
+#,,,,,,,,,,,,,

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-N_ARC.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-N_ARC.csv
@@ -1,21 +1,49 @@
-149,2011/11/28 00:16:04 HST
+415,2017/04/25 12:29:53 HST
 #0,,,,,,,,,,,,,,,,,,
+#,,V "JS, 2017apr17 IFU2 GMOS-N Hamamatsu update complete for all gratings (R600 is copy of B600); IFUR needs to be verified",,,,,,,,,,,,,,,
+#,,V ,"KC, 2017apr12 LS complete for all gratings",,,,,,,,,,,,,,,
+#
+#,,V "KC, 2017feb23 starting values from GMOS-S Hamamatsu",,,,,,,,,,,,,,,
+#
+#,,V 1.12,"KC, 2014nov19",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,New values for Hamamatsu CCDs updated for B600 IFU, R831 ,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.11,"KC, 2014sep19",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,New values for Hamamatsu CCDs updated for B600, R600 (excluding IFU),,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.10,"KC, 2014jul23",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,New values for Hamamatsu CCDs updated for B1200, R400, R150,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.9,"GG, 2011jan24",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,added order-blocking filters support for remaining gratings,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.8,"GG, 2011jan12",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,added order-blocking filters support forn R831 ,,,,,,,,,,,,,,,,
+#,,version renumbered for cosistency with OT,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
 #,,V 1.7,"GG, 2011nov28",,,,,,,,,,,,,,,
 #,,changes:,,,,,,,,,,,,,,,,
-#,,"all slits supported (Longslit, NS, MOS)",,,,,,,,,,,,,,,,
+#,,"all slits supported (Longslit, NS, MOS); Bug fixes",,,,,,,,,,,,,,,,
 #,,,,,,,,,,,,,,,,,,
-#,,V 1.22,"GG, 2011nov21",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,bug fixes,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.2,"GG, 2011nov03",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,added grating+filter combinations,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.1,"GG, 2011oct14",,,,,,,,,,,,,,,
+#,,V 1.5,"GG, 2011oct13",,,,,,,,,,,,,,,
 #,,changes:,,,,,,,,,,,,,,,,
 #,,Any filter ($.*) for IFU,,,,,,,,,,,,,,,,
 #,,"Used regular expressions for Longslit and N and S, and IFU ",,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.44,,,,,,,,,,,,,,,,
+#,,"GG, 2011Sep15",,,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,Filled Calibration Basecal column,,,,,,,,,,,,,,,,
+#,,Used Longslit.* and N and S *  for FPU,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.3,,,,,,,,,,,,,,,,
+#,,"GG, 2011Ago17",,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
 #,,,,,,,,,,,,,,,,,,
 #,,Recommended GCAL configurations and Exp. Times for GMOS calibrations:,,,,,,,,,,,,,,,,
 #,,Spectroscopic Arcs:  R150 R400 B600 R600 R831 B1200,,,,,,,,,,,,,,,,
@@ -36,411 +64,689 @@
 Disperser,Filter,Focal Plane Unit,Xbin,Ybin,Central Wavelength,Order ,Gain,,/=>/,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
 ,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,1,1,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,2,1,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,1,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,2,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,4,1,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,1,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,4,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,2,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
-R150_G5306,$.*one|.*G.*,$.*arcsec.*,4,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,2,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,2,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R150_G5306,$.*,IFU *,1,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
-R150_G5306,$.*,IFU *,2,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
-R150_G5306,$.*,IFU *,4,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-# ,,,,,,,,,,,,,,,,,,Day
-#,,,,,,,,,,,,,,,,,,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,1,1,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,2,1,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,1,2,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,2,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,4,1,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,1,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,4,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,2,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R400_G5305,$.*one|.*G.*,$.*arcsec.*,4,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R400_G5305,$.*,IFU *,1,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
-R400_G5305,$.*,IFU *,2,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
-R400_G5305,$.*,IFU *,4,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+$R150.*,$.*,IFU *,1,1,350-1200,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$R150.*,$.*,IFU *,2,1,350-1200,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+$R150.*,$.*,IFU *,4,1,350-1200,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,70,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,none,$.*arcsec.*,1,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
-B600_G5307,none,$.*arcsec.*,2,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5307,none,$.*arcsec.*,1,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5307,none,$.*arcsec.*,2,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,4,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,1,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,4,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-B600_G5307,none,$.*arcsec.*,2,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-B600_G5307,none,$.*arcsec.*,4,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350-425,1,Low,,,,1,        None,Visible,CuAr arc,Closed,70,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,425-515,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350-515,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,$.*,IFU *,1,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-B600_G5307,$.*,IFU *,2,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-B600_G5307,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+$R400.*,$.*,IFU *,1,1,350-510,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+$R400.*,$.*,IFU *,2,1,350-510,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+$R400.*,$.*,IFU *,4,1,350-510,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,none,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-B600_G5307,none,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5307,none,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5307,none,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5307,none,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5307,none,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5307,none,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-B600_G5307,none,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-B600_G5307,none,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,11,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,11,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,515-575,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,$.*,IFU *,1,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
-B600_G5307,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5307,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$R400.*,$.*,IFU *,1,1,510-715,1,Low,,,,1,         None,Visible,CuAr arc,Closed,45,1,Day
+$R400.*,$.*,IFU *,1,1,510-715,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+$R400.*,$.*,IFU *,2,1,510-715,1,Low,,,,1,         None,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*,IFU *,2,1,510-715,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R400.*,$.*,IFU *,4,1,510-715,1,Low,,,,1,         None,Visible,CuAr arc,Closed,11,1,Day
+$R400.*,$.*,IFU *,4,1,510-715,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,8,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,none,$.*arcsec.*,1,1,610 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
-B600_G5307,none,$.*arcsec.*,2,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,1,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,2,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,4,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,1,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,4,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-B600_G5307,none,$.*arcsec.*,2,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-B600_G5307,none,$.*arcsec.*,4,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+$R400.*,$.*,IFU *,1,1,715-850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+$R400.*,$.*,IFU *,2,1,715-850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R400.*,$.*,IFU *,4,1,715-850,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,8,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,$.*,IFU *,1,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5307,$.*,IFU *,2,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
-B600_G5307,$.*,IFU *,4,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
-# ,,,,,,,,,,,,,,,,,,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,575-650,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+##,,,,,,,,,,,,,,,,,,Day
+$R400.*,$.*,IFU *,1,1,850-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R400.*,$.*,IFU *,2,1,850-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+$R400.*,$.*,IFU *,4,1,850-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5304,none,$.*arcsec.*,1,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
-R600_G5304,none,$.*arcsec.*,2,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5304,none,$.*arcsec.*,1,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5304,none,$.*arcsec.*,2,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,4,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,1,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,4,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-R600_G5304,none,$.*arcsec.*,2,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-R600_G5304,none,$.*arcsec.*,4,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R600_G5304,$.*,IFU *,1,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R600_G5304,$.*,IFU *,2,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R600_G5304,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R600_G5304,none,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-R600_G5304,none,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5304,none,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5304,none,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5304,none,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5304,none,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5304,none,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R600_G5304,none,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R600_G5304,none,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R600_G5304,$.*,IFU *,1,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
-R600_G5304,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5304,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R600_G5304,none,$.*arcsec.*,1,1,610 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
-R600_G5304,none,$.*arcsec.*,2,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,1,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,2,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,4,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,1,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,4,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R600_G5304,none,$.*arcsec.*,2,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R600_G5304,none,$.*arcsec.*,4,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R600_G5304,$.*,IFU *,1,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5304,$.*,IFU *,2,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
-R600_G5304,$.*,IFU *,4,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-#,,,,,,,,,,,,,,,,,,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,none,$.*arcsec.*,1,1,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
-R831_G5302,none,$.*arcsec.*,2,1,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5302,none,$.*arcsec.*,1,2,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5302,none,$.*arcsec.*,2,2,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5302,none,$.*arcsec.*,4,1,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5302,none,$.*arcsec.*,1,4,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5302,none,$.*arcsec.*,4,2,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5302,none,$.*arcsec.*,2,4,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5302,none,$.*arcsec.*,4,4,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,$.*,IFU *,1,1,400 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
-R831_G5302,$.*,IFU *,2,1,400 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R831_G5302,$.*,IFU *,4,1,400 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,none,$.*arcsec.*,1,1,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5302,none,$.*arcsec.*,2,1,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-R831_G5302,none,$.*arcsec.*,1,2,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-R831_G5302,none,$.*arcsec.*,2,2,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5302,none,$.*arcsec.*,4,1,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5302,none,$.*arcsec.*,1,4,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5302,none,$.*arcsec.*,4,2,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R831_G5302,none,$.*arcsec.*,2,4,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R831_G5302,none,$.*arcsec.*,4,4,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,$.*,IFU *,1,1,590 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
-R831_G5302,$.*,IFU *,2,1,590 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,45,1,Day
-R831_G5302,$.*,IFU *,4,1,590 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,none,$.*arcsec.*,1,1,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5302,none,$.*arcsec.*,2,1,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5302,none,$.*arcsec.*,1,2,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5302,none,$.*arcsec.*,2,2,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5302,none,$.*arcsec.*,4,1,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5302,none,$.*arcsec.*,1,4,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5302,none,$.*arcsec.*,4,2,650 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R831_G5302,none,$.*arcsec.*,2,4,650 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R831_G5302,none,$.*arcsec.*,4,4,650 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,$.*,IFU *,1,1,650 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5302,$.*,IFU *,2,1,650 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
-R831_G5302,$.*,IFU *,4,1,650 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
-# ,,,,,,,,,,,,,,,,,,Day
-#,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,none,$.*arcsec.*,1,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
-B1200_G5301,none,$.*arcsec.*,2,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5301,none,$.*arcsec.*,1,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5301,none,$.*arcsec.*,2,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,4,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,1,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,4,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5301,none,$.*arcsec.*,2,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5301,none,$.*arcsec.*,4,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,$.*,IFU *,1,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B1200_G5301,$.*,IFU *,2,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B1200_G5301,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,none,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B1200_G5301,none,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5301,none,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5301,none,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5301,none,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5301,none,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5301,none,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B1200_G5301,none,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B1200_G5301,none,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,$.*,IFU *,1,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-B1200_G5301,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-B1200_G5301,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,none,$.*arcsec.*,1,1,610 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
-B1200_G5301,none,$.*arcsec.*,2,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,1,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,2,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,4,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,1,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,4,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5301,none,$.*arcsec.*,2,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5301,none,$.*arcsec.*,4,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,$.*,IFU *,1,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5301,$.*,IFU *,2,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-B1200_G5301,$.*,IFU *,4,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R150_G5306,none,$.*arcsec.*,1,1,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R150_G5306,none,$.*arcsec.*,2,1,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R150_G5306,none,$.*arcsec.*,1,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R150_G5306,none,$.*arcsec.*,2,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R150_G5306,none,$.*arcsec.*,4,1,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R150_G5306,none,$.*arcsec.*,1,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R150_G5306,none,$.*arcsec.*,4,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5306,none,$.*arcsec.*,2,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5306,none,$.*arcsec.*,4,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R150_G5306,$.*,IFU *,1,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
-R150_G5306,$.*,IFU *,2,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
-R150_G5306,$.*,IFU *,4,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,44,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,11,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,11,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,11,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,650-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,3,1,Day
+###,,,,,,,,,,,,,,,,,,Day
+$R400.*,$.*,IFU *,1,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R400.*,$.*,IFU *,2,1,950-1200,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$R400.*,$.*,IFU *,4,1,950-1200,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,24,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-R400_G5305,none,$.*arcsec.*,1,1,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R400_G5305,none,$.*arcsec.*,2,1,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R400_G5305,none,$.*arcsec.*,1,2,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R400_G5305,none,$.*arcsec.*,2,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R400_G5305,none,$.*arcsec.*,4,1,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R400_G5305,none,$.*arcsec.*,1,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R400_G5305,none,$.*arcsec.*,4,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R400_G5305,none,$.*arcsec.*,2,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R400_G5305,none,$.*arcsec.*,4,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R400_G5305,$.*,IFU *,1,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
-R400_G5305,$.*,IFU *,2,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
-R400_G5305,$.*,IFU *,4,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+$B600.*,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$B600.*,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$B600.*,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B600.*,$.*,IFU *,2,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$B600.*,$.*,IFU *,4,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$B600.*,$.*,IFU *,2,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,2,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B600.*,$.*,IFU *,4,1,800 - 860,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+$B600.*,$.*,IFU *,2,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B600.*,$.*,IFU *,4,1,860 - 1000,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,2,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B600.*,$.*,IFU *,4,1,1000 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+# ,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$R600.*,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$R600.*,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$R600.*,$.*,IFU *,2,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$R600.*,$.*,IFU *,4,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$R600.*,$.*,IFU *,2,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R600.*,$.*,IFU *,4,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R600.*,$.*,IFU *,2,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R600.*,$.*,IFU *,4,1,800 - 860,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+$R600.*,$.*,IFU *,2,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R600.*,$.*,IFU *,4,1,860 - 1000,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R600.*,$.*,IFU *,2,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R600.*,$.*,IFU *,4,1,1000 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,350 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
+$R831.*,$.*,IFU *,2,1,350 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+$R831.*,$.*,IFU *,4,1,350 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,625 - 825,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,590 - 630,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+$R831.*,$.*,IFU *,2,1,590 - 630,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
+$R831.*,$.*,IFU *,4,1,590 - 630,1,Low,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,630 - 695,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$R831.*,$.*,IFU *,2,1,630 - 695,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$R831.*,$.*,IFU *,4,1,630 - 695,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,825 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,2,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,695 - 850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+$R831.*,$.*,IFU *,2,1,695 - 850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+$R831.*,$.*,IFU *,4,1,695 - 850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,850 - 900,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+$R831.*,$.*,IFU *,2,1,850 - 900,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R831.*,$.*,IFU *,4,1,850 - 900,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,900 - 1050,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R831.*,$.*,IFU *,2,1,900 - 1050,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$R831.*,$.*,IFU *,4,1,900 - 1050,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,1050 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$R831.*,$.*,IFU *,2,1,1050 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$R831.*,$.*,IFU *,4,1,1050 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+# ,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+$B1200.*,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+$B1200.*,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,616 - 660,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,616 - 660,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,616 - 660,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,616 - 660,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,616 - 660,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,616 - 660,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,555 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+$B1200.*,$.*,IFU *,2,1,555 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$B1200.*,$.*,IFU *,4,1,555 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,650 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B1200.*,$.*,IFU *,2,1,650 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$B1200.*,$.*,IFU *,4,1,650 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,800 - 1050,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+$B1200.*,$.*,IFU *,2,1,800 - 1050,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B1200.*,$.*,IFU *,4,1,800 - 1050,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,1050 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*,IFU *,2,1,1050 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B1200.*,$.*,IFU *,4,1,1050 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R150.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R150.*,$.*,IFU *,1,1,350 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$R150.*,$.*,IFU *,2,1,350 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$R150.*,$.*,IFU *,4,1,350 - 1200,1,High,,,,1,         GMOS balance,Visible,CuAr arc,Closed,140,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,none,$.*arcsec.*,1,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
-B600_G5307,none,$.*arcsec.*,2,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5307,none,$.*arcsec.*,1,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5307,none,$.*arcsec.*,2,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,4,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,1,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,4,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,2,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,4,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350-425,1,High,,,,1,        None,Visible,CuAr arc,Closed,170,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,425-515,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,320,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,320,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350-515,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,$.*,IFU *,1,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B600_G5307,$.*,IFU *,2,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B600_G5307,$.*,IFU *,4,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$R400.*,$.*,IFU *,1,1,350-510,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$R400.*,$.*,IFU *,2,1,350-510,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+$R400.*,$.*,IFU *,4,1,350-510,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,none,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5307,none,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B600_G5307,none,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B600_G5307,none,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5307,none,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5307,none,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5307,none,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5307,none,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5307,none,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,44,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,44,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,44,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,515-575,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,$.*,IFU *,1,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-B600_G5307,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-B600_G5307,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,none,$.*arcsec.*,1,1,610 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
-B600_G5307,none,$.*arcsec.*,2,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B600_G5307,none,$.*arcsec.*,1,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B600_G5307,none,$.*arcsec.*,2,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,4,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,1,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5307,none,$.*arcsec.*,4,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,2,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5307,none,$.*arcsec.*,4,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R400.*,$.*,IFU *,1,1,510-715,1,High,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
+$R400.*,$.*,IFU *,1,1,510-715,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+$R400.*,$.*,IFU *,2,1,510-715,1,High,,,,1,         None,Visible,CuAr arc,Closed,44,1,Day
+$R400.*,$.*,IFU *,2,1,510-715,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R400.*,$.*,IFU *,4,1,510-715,1,High,,,,1,         None,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*,IFU *,4,1,510-715,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,16,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5307,$.*,IFU *,1,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5307,$.*,IFU *,2,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5307,$.*,IFU *,4,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+$R400.*,$.*,IFU *,1,1,715-850,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+$R400.*,$.*,IFU *,2,1,715-850,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R400.*,$.*,IFU *,4,1,715-850,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,575-650,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+##,,,,,,,,,,,,,,,,,,Day
+$R400.*,$.*,IFU *,1,1,850-950,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R400.*,$.*,IFU *,2,1,850-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+$R400.*,$.*,IFU *,4,1,850-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,88,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,44,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,44,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R400.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,650-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+###,,,,,,,,,,,,,,,,,,Day
+$R400.*,$.*,IFU *,1,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R400.*,$.*,IFU *,2,1,950-1200,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$R400.*,$.*,IFU *,4,1,950-1200,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+#,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5304,none,$.*arcsec.*,1,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
-R600_G5304,none,$.*arcsec.*,2,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5304,none,$.*arcsec.*,1,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5304,none,$.*arcsec.*,2,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,4,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,1,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,4,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,2,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,4,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5304,$.*,IFU *,1,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-R600_G5304,$.*,IFU *,2,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-R600_G5304,$.*,IFU *,4,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$B600.*,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$B600.*,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$B600.*,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5304,none,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5304,none,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R600_G5304,none,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R600_G5304,none,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5304,none,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5304,none,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5304,none,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5304,none,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5304,none,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,320,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5304,$.*,IFU *,1,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R600_G5304,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-R600_G5304,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+$B600.*,$.*,IFU *,1,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$B600.*,$.*,IFU *,2,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B600.*,$.*,IFU *,4,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5304,none,$.*arcsec.*,1,1,610 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
-R600_G5304,none,$.*arcsec.*,2,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-R600_G5304,none,$.*arcsec.*,1,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-R600_G5304,none,$.*arcsec.*,2,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,4,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,1,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5304,none,$.*arcsec.*,4,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,2,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5304,none,$.*arcsec.*,4,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,140,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5304,$.*,IFU *,1,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5304,$.*,IFU *,2,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5304,$.*,IFU *,4,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+$B600.*,$.*,IFU *,1,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+$B600.*,$.*,IFU *,2,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$B600.*,$.*,IFU *,4,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
 #,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
 #,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$B600.*,$.*,IFU *,2,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,800 - 860,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,32,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5302,none,$.*arcsec.*,1,1,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,360,1,Day
-R831_G5302,none,$.*arcsec.*,2,1,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
-R831_G5302,none,$.*arcsec.*,1,2,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
-R831_G5302,none,$.*arcsec.*,2,2,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5302,none,$.*arcsec.*,4,1,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5302,none,$.*arcsec.*,1,4,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5302,none,$.*arcsec.*,4,2,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5302,none,$.*arcsec.*,2,4,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5302,none,$.*arcsec.*,4,4,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+$B600.*,$.*,IFU *,1,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+$B600.*,$.*,IFU *,2,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,860 - 1000,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,24,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5302,$.*,IFU *,1,1,400 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,600,1,Day
-R831_G5302,$.*,IFU *,2,1,400 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-R831_G5302,$.*,IFU *,4,1,400 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,none,$.*arcsec.*,1,1,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5302,none,$.*arcsec.*,2,1,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5302,none,$.*arcsec.*,1,2,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5302,none,$.*arcsec.*,2,2,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R831_G5302,none,$.*arcsec.*,4,1,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R831_G5302,none,$.*arcsec.*,1,4,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R831_G5302,none,$.*arcsec.*,4,2,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5302,none,$.*arcsec.*,2,4,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5302,none,$.*arcsec.*,4,4,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,$.*,IFU *,1,1,590 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R831_G5302,$.*,IFU *,2,1,590 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
-R831_G5302,$.*,IFU *,4,1,590 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,none,$.*arcsec.*,1,1,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R831_G5302,none,$.*arcsec.*,2,1,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5302,none,$.*arcsec.*,1,2,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5302,none,$.*arcsec.*,2,2,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5302,none,$.*arcsec.*,4,1,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5302,none,$.*arcsec.*,1,4,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5302,none,$.*arcsec.*,4,2,650 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R831_G5302,none,$.*arcsec.*,2,4,650 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R831_G5302,none,$.*arcsec.*,4,4,650 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R831_G5302,$.*,IFU *,1,1,650 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5302,$.*,IFU *,2,1,650 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5302,$.*,IFU *,4,1,650 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+$B600.*,$.*,IFU *,1,1,1000 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$B600.*,$.*,IFU *,2,1,1000 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,1000 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,none,$.*arcsec.*,1,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
-B1200_G5301,none,$.*arcsec.*,2,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-B1200_G5301,none,$.*arcsec.*,1,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-B1200_G5301,none,$.*arcsec.*,2,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,4,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,1,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,4,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,2,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,4,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,$.*,IFU *,1,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
-B1200_G5301,$.*,IFU *,2,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
-B1200_G5301,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$R600.*,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$R600.*,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$R600.*,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,none,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5301,none,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,32,1,Day
-B1200_G5301,none,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,32,1,Day
-B1200_G5301,none,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5301,none,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5301,none,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5301,none,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5301,none,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5301,none,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,320,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,$.*,IFU *,1,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B1200_G5301,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
-B1200_G5301,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+$R600.*,$.*,IFU *,1,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$R600.*,$.*,IFU *,2,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$R600.*,$.*,IFU *,4,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,none,$.*arcsec.*,1,1,610 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
-B1200_G5301,none,$.*arcsec.*,2,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
-B1200_G5301,none,$.*arcsec.*,1,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
-B1200_G5301,none,$.*arcsec.*,2,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,4,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,1,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5301,none,$.*arcsec.*,4,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,2,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5301,none,$.*arcsec.*,4,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,140,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5301,$.*,IFU *,1,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-B1200_G5301,$.*,IFU *,2,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5301,$.*,IFU *,4,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,32,1,Day
-#,,,,,,,,,,,,,,,,,,
+$R600.*,$.*,IFU *,1,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+$R600.*,$.*,IFU *,2,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$R600.*,$.*,IFU *,4,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$R600.*,$.*,IFU *,2,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R600.*,$.*,IFU *,4,1,800 - 860,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+$R600.*,$.*,IFU *,2,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R600.*,$.*,IFU *,4,1,860 - 1000,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R600.*,$.*,IFU *,1,1,1000 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$R600.*,$.*,IFU *,2,1,1000 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R600.*,$.*,IFU *,4,1,1000 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,360,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,350 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,600,1,Day
+$R831.*,$.*,IFU *,2,1,350 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+$R831.*,$.*,IFU *,4,1,350 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,48,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,48,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,625 - 825,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,590 - 630,1,High,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
+$R831.*,$.*,IFU *,2,1,590 - 630,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+$R831.*,$.*,IFU *,4,1,590 - 630,1,High,,,,1,         None,Visible,CuAr arc,Closed,80,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,630 - 695,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+$R831.*,$.*,IFU *,2,1,630 - 695,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$R831.*,$.*,IFU *,4,1,630 - 695,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$R831.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,825 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,695 - 850,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+$R831.*,$.*,IFU *,2,1,695 - 850,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+$R831.*,$.*,IFU *,4,1,695 - 850,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,850 - 900,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+$R831.*,$.*,IFU *,2,1,850 - 900,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$R831.*,$.*,IFU *,4,1,850 - 900,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,900 - 1050,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+$R831.*,$.*,IFU *,2,1,900 - 1050,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$R831.*,$.*,IFU *,4,1,900 - 1050,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$R831.*,$.*,IFU *,1,1,1050 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+$R831.*,$.*,IFU *,2,1,1050 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$R831.*,$.*,IFU *,4,1,1050 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+# ,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
+$B1200.*,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
+$B1200.*,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,616 - 660,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,616 - 660,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,616 - 660,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,616 - 660,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,616 - 660,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,616 - 660,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,555 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
+$B1200.*,$.*,IFU *,2,1,555 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$B1200.*,$.*,IFU *,4,1,555 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,200,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,650 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*,IFU *,2,1,650 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B1200.*,$.*,IFU *,4,1,650 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+$B1200.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,800 - 1050,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+$B1200.*,$.*,IFU *,2,1,800 - 1050,1,High,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+$B1200.*,$.*,IFU *,4,1,800 - 1050,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B1200.*,$.*,IFU *,1,1,1050 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+$B1200.*,$.*,IFU *,2,1,1050 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$B1200.*,$.*,IFU *,4,1,1050 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-N_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-N_FLAT.csv
@@ -1,6119 +1,3545 @@
-149,2011/11/28 00:16:04 HST
-#0,,,,,,,,,,,,,,,,,,
-#,,V 1.84,"GG, 2011nov21",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,"added/fixed mask image cal, bug fixes",,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.80,"GG, 2011nov03",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,added grating+filter combinations,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,GMOS-N_FLAT,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,"V 1.71 - GG, 2011oct14",,,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,"use of common expressions for longslit and longslit Nand S, and $IFU.* - size of table reduced to half",,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,"V 1.6 - GG, 2011oct13",,,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,"SmartGCal Flats only as Nighttime calibrations. If for some reason we want a daytime GCALflat, configure this separately.",,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.5,,,,,,,,,,,,,,,,
-#,,"GG, 2011sep15",,,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,Filled  Calibration Basecal column,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.4,,,,,,,,,,,,,,,,
-#,,"GG, 2011sep01",,,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,Added explicitly N & S $.*s  - size is now ~6400 rows,,,,,,,,,,,,,,,,
-#,,Some components names fixed by FN,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,Recommended GCAL configurations and Exp. Times for GMOS-N calibrations:,,,,,,,,,,,,,,,,
-#,,Quartz Halogen flats,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,Note the following:,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,The choice of filter within GMOS  is not considered except for $IFU.* 2 Slits configurations,,,,,,,,,,,,,,,,
-#,,The Readout is Slow and the Gain is Low and the three best amps were used for GCALflats,,,,,,,,,,,,,,,,
-#,,The GMOS -N and GMOS -S detector controllers only support integer exposure times,,,,,,,,,,,,,,,,
-#,,The B600_G5307 is not yet complete for 2.0 and 5.0 arcsec slits (use the values for R400_G5305 or consult your Gemini contact scientist),,,,,,,,,,,,,,,,
-#,,"For High gain, use 2x the exposure time from Low gain",,,,,,,,,,,,,,,,
-#,,Some alternative configurations rows are commented out (notably for R150_G5306),,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
+416,2017/06/02 15:27:43 HST
+# GMOS_FLAT
+#
+# V , KC 2017apr13 for Hamamatsus, Updated all R150 B600 R831 B1200 R400 and B600 IFU and LS flats
+# V , KC 2017apr13 for Hamamatsus, Only B1200 IFUR still needed
+# V , KC 2017mar25 for Hamamatsus, Updated R150 and B600 IFU and LS flats
+# V , KC 2017feb23 for Hamamatsus, starting with GMOS-S Ham values
+#
+# V 357, KR 2015august25
+#
+# update for 15B-Q-51 (R831 780 IFU-R 1x1)
+# update for 15B-Q-32 (B600 850 IFU-R 1x1)
+# update for 15A-Q-99 (B600 532 1.5arcsec 4x4)
+# update for 15B-Q-62 (R400 0.75arcsec 4x4) 
+# update for 15A-Q-17 (R400 0.75arcsec) 
+# update for 14A-Q-2 (R400 1.0arcsec) 
+# update for 15A-Q-200 (R400 0.75arcsec) and 15A-Q-201 (R150 1.0arcsec)
+# update for R400 15A-Q-13 (R150 2.0arcsec) and 15A-Q-30 (R400 840nm 0.5 arcsec)
+# another few updates to R400 to support 14B-LP-4 and also 15A-Q-13
+# third quick update to R400 1.0arcsec to support queue
+# second quick update to R831 0.5arcsec to support queue
+# quick update to R400 IFU-R to support queue
+#
+# this is a copy of GMOS-N flat version 240, starting point for Hamamatsu CCDs
+# Site dependent instrument specifications removed.
+#
+# For GMOS-N comment out configurations using filters u_G.{4}, Lya395_G.{4}, and RG670_G.{4}.
+# For GMOS-S comment out configurations using filters DS920_G.{4}
+#
+# SmartGCal Flats only as Nighttime calibrations. If for some reason we want a daytime GCALflat, configure this separately.
+#
+# Recommended GCAL configurations and Exp. Times for GMOS calibrations
+# Quartz Halogen flats
+#
+# Note the following
+# The choice of filter within GMOS is not considered except for $IFU.* 2 Slits configurations
+# The Readout is Slow and the Gain is Low
+# The GMOS -N and GMOS -S detector controllers only support integer exposure times
+# For High gain, use 2x the exposure time from Low gain
+#
+# Low Gain Configurations
+#
 #  Instrument Configuration from OT,,,,,,,,,,,,GCAL configuration,,,,,,
 Disperser,Filter,Focal Plane Unit,Xbin,Ybin,Central Wavelength,Order,Gain ,,,/=>/,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
-Mirror,r_G0303,none,1,1,Any ,*,Low,,,,5,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
-Mirror,r_G0303,none,1,1,Any ,*,Low,,,,5,ND4-5,IR,Quartz Halogen,Closed,4,1,Day
-Mirror,i_G0302,none,1,1,Any ,*,Low,,,,5,none,IR,IR grey body - low,Open,5,1,Day
-Mirror,z_G0304,none,1,1,Any ,*,Low,,,,5,ND1.0,IR,IR grey body - high,Open,10,1,Day
-Mirror,r_G0303,none,2,2,Any ,*,Low,,,,5,ND4-5,IR,Quartz Halogen,Closed,15,1,Day
-Mirror,i_G0302,none,2,2,Any ,*,Low,,,,5,ND1.0,IR,IR grey body - high,Open,10,1,Day
-Mirror,z_G0304,none,2,2,Any ,*,Low,,,,5,ND3.0,IR,IR grey body - high,Open,15,1,Day
-Mirror,g_G0301,none,2,2,Any ,*,Low,,,,5,ND4.0,IR,Quartz Halogen,Closed,20,1,Day
-#,,,,,,,,,,,,,,,,,,
-$.*irror,r_G0303,*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
-#,,,,,,,,,,,,,,,,,,
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 1000,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 1000,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,100,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,1,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
-R150_G5306,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,38,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 1000,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5306,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5306,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,44,1,Night
-R150_G5306,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,22,1,Night
-R150_G5306,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,11,1,Night
-R150_G5306,GG455_G0305,$IFU.* 2 Slits,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R150_G5306,GG455_G0305,$IFU.* 2 Slits,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R150_G5306,GG455_G0305,$IFU.* 2 Slits,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+#
+Mirror,$u_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+# Mirror,$RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Ha_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$HaC_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$DS920_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$SII_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$OIII_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$OIIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$HeII_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$HeIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+# Mirror,$Lya395_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+# Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$GG455_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$OG515_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$RG610_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+# Mirror,$RG780_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$CaT_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Ha_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$HaC_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$DS920_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$SII_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OIII_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$OIIIC_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$HeII_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$HeIIC_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+# Mirror,$Lya395_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+# Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+#
+# Imaging with IFU in the beam
+#
+Mirror,$u_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$r_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Z_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Y_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$GG455_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$OG515_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$RG610_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+# Mirror,$RG780_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$CaT_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Ha_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$HaC_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$DS920_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$SII_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OIII_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$OIIIC_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeII_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeIIC_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+# Mirror,$Lya395_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+# Mirror,$i_G.{4} [+] RG780_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+#
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+# $R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,50,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,50,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,25,1,Night
+# $R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,100,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Night
+# $R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,15,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,15,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,7,1,Night
+#$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,38,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R150.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R150.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
 #,,,,,,,,,,,,,,,,,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,2,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,4,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 1.50 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,2,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,4,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 2.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,2,1,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,1,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,2,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,4,1,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,1,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,2,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,4,2,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 5.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.75 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.50 arcsec,4,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$.* 0.25 arcsec,4,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5305,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R400_G5305,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5305,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-R400_G5305,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-R400_G5305,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,23,1,Night
-R400_G5305,g_G0301,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R400_G5305,g_G0301,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R400_G5305,g_G0301,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R400_G5305,r_G0303,$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
-R400_G5305,r_G0303,$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
-R400_G5305,r_G0303,$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
-R400_G5305,i_G0302,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5305,i_G0302,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5305,i_G0302,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-R400_G5305,z_G0304,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5305,z_G0304,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5305,z_G0304,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,650 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,650 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,650 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,650 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,650 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,650 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,700 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,700 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,700 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,415 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,700 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night 
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625 - 725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625 - 725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,415 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,550 - 625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625 - 725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,700 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,650 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,650 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,650 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,415 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,415 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,550 - 650,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,550 - 650,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,650 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,415 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,650 - 730,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,730 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Night
+#$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,700 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,625 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,625 - 675,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,625 - 675,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,675 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,675 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,415 - 480,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night  
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,415 - 480,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,415 - 480,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,480 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,480 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,480 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,550 - 625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night  
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,550 - 625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,550 - 625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625 - 675,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625 - 675,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625 - 675,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,675 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,675 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,675 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,415 - 450,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,415 - 450,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,550 - 625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,550 - 625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625 - 675,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625 - 675,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,675 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,675 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300 - 450,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450 - 480,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,480 - 550,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,550 - 625,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625 - 675,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,675 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,10,1,Night
+#$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,700 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,625 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,625 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,625 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,625 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,625 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,625 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,625 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,625 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,550 - 625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,625 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,700 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,625 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,625 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,625 - 675,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,650 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,625 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,625 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,550 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,625 - 675,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,300 - 425,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,425 - 475,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,475 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,300 - 425,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,425 - 475,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,475 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,300 - 425,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,425 - 475,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,475 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,625 - 675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,675 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,1,1,400 - 425,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,1,1,425 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,2,1,400 - 425,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,2,1,425 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,4,1,400 - 425,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,4,1,425 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,1,1,706 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,2,1,706 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,4,1,706 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,1,1,848 - 1100,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,2,1,848 - 1100,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,4,1,848 - 1100,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,1,1,830 - 925,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,2,1,830 - 925,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,4,1,830 - 925,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,1,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,2,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,4,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 500-650 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 650 - 750 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,7,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 500-650 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 650 - 750 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,420 - 500,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,500 - 650,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,220,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-B600_G5307,g_G0301,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B600_G5307,g_G0301,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5307,g_G0301,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-B600_G5307,r_G0303,$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5307,r_G0303,$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5307,r_G0303,$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-B600_G5307,i_G0302,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,i_G0302,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,i_G0302,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,z_G0304,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,z_G0304,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,z_G0304,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,675-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,775-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,500-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-425,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,425-500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,500-535,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,500-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,500-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,625-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,625-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400-530,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-375,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,375-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,475-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,475-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,475-525,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,540 - 730,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,730 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,350 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,525 - 610,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,610 - 750,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,750 - 890,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,g_G0301,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5304,g_G0301,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5304,g_G0301,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R600_G5304,r_G0303,$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-R600_G5304,r_G0303,$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R600_G5304,r_G0303,$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-R600_G5304,i_G0302,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,i_G0302,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5304,i_G0302,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5304,z_G0304,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,z_G0304,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,z_G0304,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,675-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,775-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,500-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-425,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,425-500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,500-535,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,500-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,500-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,625-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,625-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400-530,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-375,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,375-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,475-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,475-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,475-525,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,565 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,565 - 620,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,620 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,450 - 515,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,450 - 515,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,515 - 580,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,515 - 580,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,580 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,580 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,450 - 515,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,515 - 580,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,580 - 600,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,600 - 665,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,665 - 770,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,770 - 840,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,840 - 950,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,850 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,850 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,g_G0301 + GG455_G0305,$IFU.* 2 Slits,1,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5302,g_G0301 + GG455_G0305,$IFU.* 2 Slits,2,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5302,g_G0301 + GG455_G0305,$IFU.* 2 Slits,4,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R831_G5302,r_G0303 + RG610_G0307,$IFU.* 2 Slits,1,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5302,r_G0303 + RG610_G0307,$IFU.* 2 Slits,2,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5302,r_G0303 + RG610_G0307,$IFU.* 2 Slits,4,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R831_G5302,i_G0302 + CaT_G0309,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,i_G0302 + CaT_G0309,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,i_G0302 + CaT_G0309,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,z_G0304 + CaT_G0309,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,z_G0304 + CaT_G0309,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,z_G0304 + CaT_G0309,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,350 - 390,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,390 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,525 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,415 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,525 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,950 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,525 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,650 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,650 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,650 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,850 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,415 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,415 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,415 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,415 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,415 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,415 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625 - 725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,350 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,350 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525 - 625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625 - 725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625 - 725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,350 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525 - 625,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625 - 725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,950 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,350 - 525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,525 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,850 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,850 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,415 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,550 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,625 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,775 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,68,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,775 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,34,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,775 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,1,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,2,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,4,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,210,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,170,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,85,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,55,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,42,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,850 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,g_G0301 + OG515_G0306,$IFU.* 2 Slits,1,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,g_G0301 + OG515_G0306,$IFU.* 2 Slits,2,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5301,g_G0301 + OG515_G0306,$IFU.* 2 Slits,4,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,810 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,810 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,810 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,810 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,810 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,810 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,810 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,810 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,750 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,810 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,810 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,810 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,810 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,810 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,810 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,810 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,810 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,810 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,550 - 810,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,810 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,550 - 660,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,660 - 830,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,830 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,550 - 660,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,660 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,750 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,350 - 490,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,490 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,350 - 490,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,350 - 490,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,490 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,490 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,350 - 490,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,350 - 490,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,350 - 490,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,490 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,490 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,490 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,815 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,815 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,815 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,350 - 490,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,350 - 490,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,490 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,490 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,550 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,550 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,675 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,350 - 490,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,490 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,550 - 675,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,675 - 750,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,750 - 815,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,815 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,850 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,450 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+#$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,815 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+#$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,815 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,1,1,450 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,55,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,2,1,450 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,27,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,4,1,450 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,14,1,Night
+#
+# High Gain Configurations
+#
+# Mirror,$r.{6},none,1,1,Any ,0,High,,,,5,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+# Mirror,$r.{6},none,1,1,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,8,1,Day
+# Mirror,$i.{6},none,1,1,Any ,0,High,,,,5,none,IR,IR grey body - low,Open,10,1,Day
+# Mirror,$z.{6},none,1,1,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
+# Mirror,$r.{6},none,2,2,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,30,1,Day
+# Mirror,$i.{6},none,2,2,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
+# Mirror,$z.{6},none,2,2,Any ,0,High,,,,5,ND3.0,IR,IR grey body - high,Open,30,1,Day
+# Mirror,$g.*,none,2,2,Any ,0,High,,,,5,ND4.0,IR,Quartz Halogen,Closed,40,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+# Mirror,$RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Ha_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$HaC_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$DS920_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$SII_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OIII_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$OIIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeII_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+# Mirror,$Lya395_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+# Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$u_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$g_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$r_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$i_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$z_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$Z_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$Y_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$GG455_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OG515_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$RG610_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+# Mirror,$RG780_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$CaT_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$Ha_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$HaC_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$DS920_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$SII_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$OIII_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$OIIIC_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$HeII_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$HeIIC_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+# Mirror,$Lya395_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$g_G.{4} [+] GG455.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4} [+] OG515.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$r_G.{4} [+] RG610.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+# Mirror,$i_G.{4} [+] RG780.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4} [+] CaT.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4} [+] CaT.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4.0,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4.0,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
 #,,,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-Mirror,r_G0303,none,1,1,Any ,0,High,,,,5,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
-Mirror,r_G0303,none,1,1,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,8,1,Day
-Mirror,i_G0302,none,1,1,Any ,0,High,,,,5,none,IR,IR grey body - low,Open,10,1,Day
-Mirror,z_G0304,none,1,1,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
-Mirror,r_G0303,none,2,2,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,30,1,Day
-Mirror,i_G0302,none,2,2,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
-Mirror,z_G0304,none,2,2,Any ,0,High,,,,5,ND3.0,IR,IR grey body - high,Open,30,1,Day
-Mirror,g_G0301,none,2,2,Any ,0,High,,,,5,ND4.0,IR,Quartz Halogen,Closed,40,1,Day
-#,,,,,,,,,,,,,,,,,,
-Mirror,r_G0303,$.*,1,1,Any ,0,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
-#,,,,,,,,,,,,,,,,,,
-R150_G5306,none,$.* 1.00 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,none,$.* 1.00 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.00 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 1.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 1.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 1.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-# R150_G5306,none,$.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-R150_G5306,none,$.* 1.50 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 1.50 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.50 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.50 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.50 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.50 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 1.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5306,none,$.* 1.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
-# R150_G5306,none,$.* 1.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
-R150_G5306,none,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5306,none,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-R150_G5306,none,$.* 2.00 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 2.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 2.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 2.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 2.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 2.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 2.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 2.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-# R150_G5306,none,$.* 2.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-# R150_G5306,none,$.* 2.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-R150_G5306,none,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5306,none,$.* 5.00 arcsec,1,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 5.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 5.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 5.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 5.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 5.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-# R150_G5306,none,$.* 5.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-# R150_G5306,none,$.* 5.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-# R150_G5306,none,$.* 5.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-R150_G5306,none,$.* 5.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 5.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5306,none,$.* 5.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5306,none,$.* 5.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5306,none,$.* 5.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,76,1,Night
-R150_G5306,none,$.* 0.75 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R150_G5306,none,$.* 0.75 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 0.75 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 0.75 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.75 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.75 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.75 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.75 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5306,none,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
-R150_G5306,none,$.* 0.50 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5306,none,$.* 0.50 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,none,$.* 0.50 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,none,$.* 0.50 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.50 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.50 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 0.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$.* 0.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.25 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R150_G5306,none,$.* 0.25 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5306,none,$.* 0.25 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5306,none,$.* 0.25 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,none,$.* 0.25 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,none,$.* 0.25 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5306,none,$.* 0.25 arcsec,2,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.25 arcsec,4,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5306,none,$.* 0.25 arcsec,4,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5306,none,$IFU.* Right Slit .*,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,88,1,Night
-R150_G5306,none,$IFU.* Right Slit .*,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,44,1,Night
-R150_G5306,none,$IFU.* Right Slit .*,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,22,1,Night
-R150_G5306,GG455_G0305,$IFU.* 2 Slits,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R150_G5306,GG455_G0305,$IFU.* 2 Slits,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R150_G5306,GG455_G0305,$IFU.* 2 Slits,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R150.*,none,$.* 1.00 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.00 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 1.00 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 1.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,none,$.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
+$R150.*,none,$.* 1.50 arcsec,1,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 1.50 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 1.50 arcsec,2,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.50 arcsec,4,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.50 arcsec,1,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,none,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
+$R150.*,none,$.* 2.00 arcsec,1,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 2.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 2.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 2.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,50,1,Night
+# $R150.*,none,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+$R150.*,none,$.* 5.00 arcsec,1,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 5.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 5.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 5.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 5.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 5.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 5.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$R150.*,none,$.* 5.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$R150.*,none,$.* 5.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,15,1,Night
+#$R150.*,none,$.* 5.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,15,1,Night
+$R150.*,none,$.* 0.75 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 0.75 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 0.75 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 0.75 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,none,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
+$R150.*,none,$.* 0.50 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.50 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.50 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.50 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 0.50 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 0.50 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,none,$.* 0.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R150.*,none,$.* 0.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.25 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.25 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.25 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.25 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.25 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.25 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.25 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R150.*,none,$.* 0.25 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R150.*,none,$.* 0.25 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$IFU.* Right Slit .*,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R150.*,none,$IFU.* Right Slit .*,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R150.*,none,$IFU.* Right Slit .*,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
 #,,,,,,,,,,,,,,,,,1,Night
-R400_G5305,none,$.* 1.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,none,$.* 1.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 1.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 1.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 1.00 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 1.00 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 1.00 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.00 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.00 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.00 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.00 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.00 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.00 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.00 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.00 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.00 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.00 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 1.50 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5305,none,$.* 1.50 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 1.50 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 1.50 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.50 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.50 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,2,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.50 arcsec,4,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.50 arcsec,2,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.50 arcsec,4,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 1.50 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 1.50 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 2.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 2.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 2.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 2.00 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 2.00 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 2.00 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,2,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 2.00 arcsec,4,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 2.00 arcsec,2,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,4,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 2.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,2,1,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,1,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,2,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,4,1,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,1,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,2,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,4,1,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,1,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,2,4,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,4,2,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,2,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,4,2,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 5.00 arcsec,4,4,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 5.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 0.75 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
-R400_G5305,none,$.* 0.75 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R400_G5305,none,$.* 0.75 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 0.75 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 0.75 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5305,none,$.* 0.75 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5305,none,$.* 0.75 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.75 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.75 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.75 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.75 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.75 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.75 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 0.75 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 0.75 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 0.75 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 0.75 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.75 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.50 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5305,none,$.* 0.50 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5305,none,$.* 0.50 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,none,$.* 0.50 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,none,$.* 0.50 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 0.50 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 0.50 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 0.50 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 0.50 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 0.50 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.50 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.50 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.50 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.50 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.50 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.50 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.50 arcsec,4,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 0.50 arcsec,4,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5305,none,$.* 0.25 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R400_G5305,none,$.* 0.25 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R400_G5305,none,$.* 0.25 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5305,none,$.* 0.25 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5305,none,$.* 0.25 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5305,none,$.* 0.25 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5305,none,$.* 0.25 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,none,$.* 0.25 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,none,$.* 0.25 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5305,none,$.* 0.25 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 0.25 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 0.25 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5305,none,$.* 0.25 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 0.25 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5305,none,$.* 0.25 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.25 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5305,none,$.* 0.25 arcsec,4,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$.* 0.25 arcsec,4,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5305,none,$IFU.* Right Slit .*,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R400_G5305,none,$IFU.* Right Slit .*,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-R400_G5305,none,$IFU.* Right Slit .*,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5305,none,$IFU.* Right Slit .*,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R400_G5305,none,$IFU.* Right Slit .*,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5305,none,$IFU.* Right Slit .*,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,46,1,Night
-R400_G5305,g_G0301,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R400_G5305,g_G0301,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R400_G5305,g_G0301,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R400_G5305,r_G0303,$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
-R400_G5305,r_G0303,$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
-R400_G5305,r_G0303,$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
-R400_G5305,i_G0302,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R400_G5305,i_G0302,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5305,i_G0302,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5305,z_G0304,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R400_G5305,z_G0304,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5305,z_G0304,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,650 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,650 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,650 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,650 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,650 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,650 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,415 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,550 - 650,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,700 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625 - 725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625 - 725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,415 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,550 - 625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625 - 725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,700 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,650 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,650 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,650 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,415 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,415 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,550 - 650,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,550 - 650,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,650 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,415 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,550 - 650,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,650 - 730,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,730 - 1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+#$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,700 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,625 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,625 - 675,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,625 - 675,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,675 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,675 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,415 - 480,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,415 - 480,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,415 - 480,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,480 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,480 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,480 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,550 - 625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,550 - 625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,550 - 625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625 - 675,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625 - 675,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625 - 675,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,675 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,675 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,675 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,415 - 450,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,415 - 450,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,550 - 625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,550 - 625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625 - 675,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625 - 675,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,675 - 1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,675 - 1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300 - 450,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450 - 480,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,480 - 550,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,550 - 625,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625 - 675,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,675 - 1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Night
+#$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,700 - 1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,625 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,625 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,625 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,625 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,625 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,625 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,625 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,625 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,550 - 625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,625 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,700 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,625 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,625 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,625 - 675,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,650 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,625 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,625 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,550 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,625 - 675,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,300 - 425,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,425 - 475,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,475 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,300 - 425,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,425 - 475,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,475 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,300 - 425,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,425 - 475,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,475 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,625 - 675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,675 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,1,1,400 - 425,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,1,1,425 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,2,1,400 - 425,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,260,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,2,1,425 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,4,1,400 - 425,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,4,1,425 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,1,1,706 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,2,1,706 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,4,1,706 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,1,1,848 - 1100,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,2,1,848 - 1100,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,4,1,848 - 1100,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,1,1,830 - 925,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,2,1,830 - 925,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,4,1,830 - 925,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,1,1,780 - 933,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,2,1,780 - 933,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,4,1,780 - 933,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 1.00 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.00 arcsec,2,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 500-650 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 650 - 750 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.00 arcsec,4,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 1.50 arcsec,2,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 500-650 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 650 - 750 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 1.50 arcsec,4,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 2.00 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 2.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,420 - 500,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,500 - 650,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,650 - 750,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,750 - 850,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 5.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.75 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.75 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.50 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.50 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.50 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.25 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5307,none,$.* 0.25 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,none,$.* 0.25 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,440,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,1,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,none,$IFU.* Right Slit .*,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5307,g_G0301,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-B600_G5307,g_G0301,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B600_G5307,g_G0301,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5307,r_G0303,$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B600_G5307,r_G0303,$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5307,r_G0303,$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5307,i_G0302,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5307,i_G0302,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5307,i_G0302,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5307,z_G0304,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5307,z_G0304,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5307,z_G0304,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,104,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,36,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,675-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,775-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,500-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-425,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,425-500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,500-535,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,500-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,500-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,625-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,625-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400-530,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-375,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,375-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,475-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,475-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,475-525,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,260,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,540 - 730,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,730 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 1.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 2.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,350 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,525 - 610,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,610 - 750,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,750 - 890,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,890 - 950,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 5.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.75 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,2,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$.* 0.25 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5304,g_G0301,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R600_G5304,g_G0301,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5304,g_G0301,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5304,r_G0303,$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-R600_G5304,r_G0303,$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-R600_G5304,r_G0303,$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R600_G5304,i_G0302,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5304,i_G0302,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5304,i_G0302,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5304,z_G0304,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5304,z_G0304,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5304,z_G0304,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,104,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,36,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,675-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,775-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+#$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,500-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-425,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,425-500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,500-535,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,500-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,500-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,625-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,625-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400-530,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-375,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,375-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,475-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,475-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,475-525,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,60,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,260,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,565 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 1.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,565 - 620,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,620 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 2.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,450 - 515,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,450 - 515,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,515 - 580,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,515 - 580,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,580 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,580 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,450 - 515,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,515 - 580,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,580 - 600,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,600 - 665,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,665 - 770,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,770 - 840,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,840 - 950,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 5.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,144,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,850 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5302,none,$.* 0.75 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.75 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,850 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.50 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 0.50 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,448,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,256,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,2,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.25 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5302,none,$.* 0.25 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5302,none,$.* 0.25 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,g_G0301 + GG455_G0305,$IFU.* 2 Slits,1,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R831_G5302,g_G0301 + GG455_G0305,$IFU.* 2 Slits,2,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5302,g_G0301 + GG455_G0305,$IFU.* 2 Slits,4,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5302,r_G0303 + RG610_G0307,$IFU.* 2 Slits,1,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R831_G5302,r_G0303 + RG610_G0307,$IFU.* 2 Slits,2,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5302,r_G0303 + RG610_G0307,$IFU.* 2 Slits,4,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5302,i_G0302 + CaT_G0309,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,i_G0302 + CaT_G0309,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,i_G0302 + CaT_G0309,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5302,z_G0304 + CaT_G0309,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5302,z_G0304 + CaT_G0309,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5302,z_G0304 + CaT_G0309,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,350 - 390,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,390 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,525 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,415 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,525 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,525 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,650 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,650 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,650 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,415 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,415 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,415 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,415 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,415 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,415 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625 - 725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,350 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,350 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525 - 625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625 - 725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625 - 725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,350 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525 - 625,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625 - 725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725 - 1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,350 - 525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,525 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,415 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,550 - 625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,625 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,775 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,136,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,775 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,68,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,775 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,1,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,2,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,4,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,420,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,340,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,170,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,110,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,84,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
 #,,,,,,,,,,,,,,,,,,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.00 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 1.50 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 2.00 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 5.00 arcsec,4,4,850 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.75 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.50 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,256,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,2,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5301,none,$.* 0.25 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,2,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5301,none,$IFU.* Right Slit .*,4,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5301,g_G0301 + OG515_G0306,$IFU.* 2 Slits,1,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-B1200_G5301,g_G0301 + OG515_G0306,$IFU.* 2 Slits,2,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5301,g_G0301 + OG515_G0306,$IFU.* 2 Slits,4,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,810 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,810 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,810 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,810 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,810 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,810 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,810 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,810 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,750 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,810 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,810 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,810 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,810 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,810 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,810 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,810 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,810 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,810 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,550 - 810,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,810 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,550 - 660,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,660 - 830,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,830 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,550 - 660,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,660 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,750 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,350 - 490,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,490 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,350 - 490,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,350 - 490,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,490 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,490 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,350 - 490,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,350 - 490,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,350 - 490,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,490 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,490 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,490 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,815 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,815 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,815 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,350 - 490,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,28,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,350 - 490,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,28,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,490 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,490 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,550 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,550 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,675 - 1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,350 - 490,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,490 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,550 - 675,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,675 - 750,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,750 - 815,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,815 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,450 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,815 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,256,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,815 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,550 - 815,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,815 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,550 - 815,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,815 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,1,1,450 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,110,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,2,1,450 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,54,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,4,1,450 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,28,1,Night
 #,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-S_ARC.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-S_ARC.csv
@@ -1,5 +1,26 @@
-149,2011/11/28 00:16:04 HST
+336,2014/11/19 18:13:01 HST
 #0,,,,,,,,,,,,,,,,,,
+#,,V 1.12,"KC, 2014nov19",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,New values for Hamamatsu CCDs updated for B600 IFU, R831 ,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.11,"KC, 2014sep19",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,New values for Hamamatsu CCDs updated for B600, R600 (excluding IFU),,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.10,"KC, 2014jul23",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,New values for Hamamatsu CCDs updated for B1200, R400, R150,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.9,"GG, 2011jan24",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,added order-blocking filters support for remaining gratings,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
+#,,V 1.8,"GG, 2011jan12",,,,,,,,,,,,,,,
+#,,changes:,,,,,,,,,,,,,,,,
+#,,added order-blocking filters support forn R831 ,,,,,,,,,,,,,,,,
+#,,version renumbered for cosistency with OT,,,,,,,,,,,,,,,,
+#,,,,,,,,,,,,,,,,,,
 #,,V 1.7,"GG, 2011nov28",,,,,,,,,,,,,,,
 #,,changes:,,,,,,,,,,,,,,,,
 #,,"all slits supported (Longslit, NS, MOS); Bug fixes",,,,,,,,,,,,,,,,
@@ -38,410 +59,675 @@
 Disperser,Filter,Focal Plane Unit,Xbin,Ybin,Central Wavelength,Order ,Gain,,/=>/,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
 ,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,1,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,1,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,1,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,2,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,1,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,1,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,2,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,2,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,1,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,4,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,2,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,4,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,4,350-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R150_G5326,$.*,IFU *,1,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
-R150_G5326,$.*,IFU *,2,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
-R150_G5326,$.*,IFU *,4,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-# ,,,,,,,,,,,,,,,,,,Day
-#,,,,,,,,,,,,,,,,,,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,400-950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,400-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
-#,,,,,,,,,,,,,,,,,,Day
-R400_G5325,$.*,IFU *,1,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
-R400_G5325,$.*,IFU *,2,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
-R400_G5325,$.*,IFU *,4,1,400-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+R150_G5326,$.*,IFU *,1,1,350-1200,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+R150_G5326,$.*,IFU *,2,1,350-1200,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+R150_G5326,$.*,IFU *,4,1,350-1200,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,90,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,none,$.*arcsec.*,1,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
-B600_G5323,none,$.*arcsec.*,2,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5323,none,$.*arcsec.*,1,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5323,none,$.*arcsec.*,2,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,4,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,1,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,4,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-B600_G5323,none,$.*arcsec.*,2,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-B600_G5323,none,$.*arcsec.*,4,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,350-500,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,350-500,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,$.*,IFU *,1,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-B600_G5323,$.*,IFU *,2,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-B600_G5323,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*,IFU *,1,1,350-510,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*,IFU *,2,1,350-510,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*,IFU *,4,1,350-510,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,none,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-B600_G5323,none,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5323,none,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5323,none,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5323,none,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5323,none,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5323,none,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-B600_G5323,none,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-B600_G5323,none,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,500-670,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,11,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,510-750,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,1,1,510-750,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
+R400_G5325,$.*,IFU *,2,1,510-750,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,2,1,510-750,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*,IFU *,4,1,510-750,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+R400_G5325,$.*,IFU *,4,1,510-750,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,750-850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,2,1,750-850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,4,1,750-850,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,64,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,670-950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+##,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,850-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,2,1,850-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+R400_G5325,$.*,IFU *,4,1,850-950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,64,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,950-1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,1,1,Day
+###,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+R400_G5325,$.*,IFU *,1,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,2,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,2,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+R400_G5325,$.*,IFU *,4,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,4,1,950-1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+# ,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B600_G5323,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+B600_G5323,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+B600_G5323,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 B600_G5323,$.*,IFU *,1,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
-B600_G5323,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5323,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,45,1,Day
+B600_G5323,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,23,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,none,$.*arcsec.*,1,1,610 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
-B600_G5323,none,$.*arcsec.*,2,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,1,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,2,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,4,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,1,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,4,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-B600_G5323,none,$.*arcsec.*,2,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-B600_G5323,none,$.*arcsec.*,4,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,$.*,IFU *,1,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5323,$.*,IFU *,2,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
-B600_G5323,$.*,IFU *,4,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+B600_G5323,$.*,IFU *,1,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*,IFU *,2,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+B600_G5323,$.*,IFU *,4,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,800 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,800 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,800 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B600_G5323,$.*,IFU *,1,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+B600_G5323,$.*,IFU *,2,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+B600_G5323,$.*,IFU *,4,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,none,$.*arcsec.*,1,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
-R600_G5324,none,$.*arcsec.*,2,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5324,none,$.*arcsec.*,1,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5324,none,$.*arcsec.*,2,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,4,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,1,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,4,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-R600_G5324,none,$.*arcsec.*,2,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
-R600_G5324,none,$.*arcsec.*,4,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,$.*,IFU *,1,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R600_G5324,$.*,IFU *,2,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R600_G5324,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+R600_G5324,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+R600_G5324,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+R600_G5324,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,none,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-R600_G5324,none,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5324,none,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5324,none,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5324,none,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5324,none,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5324,none,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R600_G5324,none,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R600_G5324,none,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 R600_G5324,$.*,IFU *,1,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
-R600_G5324,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5324,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,45,1,Day
+R600_G5324,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,23,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,none,$.*arcsec.*,1,1,610 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
-R600_G5324,none,$.*arcsec.*,2,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,1,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,2,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,4,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,1,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,4,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R600_G5324,none,$.*arcsec.*,2,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R600_G5324,none,$.*arcsec.*,4,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,610 - 800,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,$.*,IFU *,1,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5324,$.*,IFU *,2,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
-R600_G5324,$.*,IFU *,4,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+R600_G5324,$.*,IFU *,1,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*,IFU *,2,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+R600_G5324,$.*,IFU *,4,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,800 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,800 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,800 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,800 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R600_G5324,$.*,IFU *,1,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+R600_G5324,$.*,IFU *,2,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+R600_G5324,$.*,IFU *,4,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,none,$.*arcsec.*,1,1,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
-R831_G5322,none,$.*arcsec.*,2,1,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5322,none,$.*arcsec.*,1,2,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5322,none,$.*arcsec.*,2,2,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5322,none,$.*arcsec.*,4,1,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5322,none,$.*arcsec.*,1,4,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5322,none,$.*arcsec.*,4,2,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5322,none,$.*arcsec.*,2,4,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5322,none,$.*arcsec.*,4,4,400 - 590,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 595,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,$.*,IFU *,1,1,400 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
-R831_G5322,$.*,IFU *,2,1,400 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R831_G5322,$.*,IFU *,4,1,400 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+R831_G5322,$.*,IFU *,1,1,350 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
+R831_G5322,$.*,IFU *,2,1,350 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+R831_G5322,$.*,IFU *,4,1,350 - 590,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,none,$.*arcsec.*,1,1,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5322,none,$.*arcsec.*,2,1,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-R831_G5322,none,$.*arcsec.*,1,2,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,15,1,Day
-R831_G5322,none,$.*arcsec.*,2,2,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5322,none,$.*arcsec.*,4,1,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5322,none,$.*arcsec.*,1,4,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5322,none,$.*arcsec.*,4,2,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R831_G5322,none,$.*arcsec.*,2,4,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R831_G5322,none,$.*arcsec.*,4,4,590 - 650,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,45,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,595 - 625,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,625 - 675,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,9,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 R831_G5322,$.*,IFU *,1,1,590 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
 R831_G5322,$.*,IFU *,2,1,590 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,45,1,Day
 R831_G5322,$.*,IFU *,4,1,590 - 650,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,none,$.*arcsec.*,1,1,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5322,none,$.*arcsec.*,2,1,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5322,none,$.*arcsec.*,1,2,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5322,none,$.*arcsec.*,2,2,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5322,none,$.*arcsec.*,4,1,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5322,none,$.*arcsec.*,1,4,650 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
-R831_G5322,none,$.*arcsec.*,4,2,650 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R831_G5322,none,$.*arcsec.*,2,4,650 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
-R831_G5322,none,$.*arcsec.*,4,4,650 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,675 - 780,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,675 - 780,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,675 - 780,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,675 - 780,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,675 - 780,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,675 - 780,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,675 - 780,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,675 - 780,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,675 - 780,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,$.*,IFU *,1,1,650 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5322,$.*,IFU *,2,1,650 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
-R831_G5322,$.*,IFU *,4,1,650 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,780 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,780 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,780 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,780 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,780 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,780 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,780 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,780 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,780 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R831_G5322,$.*,IFU *,1,1,650 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R831_G5322,$.*,IFU *,2,1,650 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R831_G5322,$.*,IFU *,4,1,650 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,none,$.*arcsec.*,1,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
-B1200_G5321,none,$.*arcsec.*,2,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5321,none,$.*arcsec.*,1,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5321,none,$.*arcsec.*,2,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,4,1,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,1,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,4,2,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5321,none,$.*arcsec.*,2,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5321,none,$.*arcsec.*,4,4,400 - 555,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 616,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,$.*,IFU *,1,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B1200_G5321,$.*,IFU *,2,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B1200_G5321,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+B1200_G5321,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+B1200_G5321,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+B1200_G5321,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,none,$.*arcsec.*,1,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B1200_G5321,none,$.*arcsec.*,2,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5321,none,$.*arcsec.*,1,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5321,none,$.*arcsec.*,2,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5321,none,$.*arcsec.*,4,1,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5321,none,$.*arcsec.*,1,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5321,none,$.*arcsec.*,4,2,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B1200_G5321,none,$.*arcsec.*,2,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B1200_G5321,none,$.*arcsec.*,4,4,555 - 610,1,Low,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,616 - 660,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 B1200_G5321,$.*,IFU *,1,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
 B1200_G5321,$.*,IFU *,2,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
 B1200_G5321,$.*,IFU *,4,1,555 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,none,$.*arcsec.*,1,1,610 - 950,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
-B1200_G5321,none,$.*arcsec.*,2,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,1,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,2,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,4,1,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,1,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,4,2,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5321,none,$.*arcsec.*,2,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B1200_G5321,none,$.*arcsec.*,4,4,610 - 950,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,5,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,3,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,660 - 760,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,660 - 760,1,Low,,,,1,        None,Visible,CuAr arc,Closed,1,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,$.*,IFU *,1,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5321,$.*,IFU *,2,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-B1200_G5321,$.*,IFU *,4,1,610 - 950,1,Low,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+B1200_G5321,$.*,IFU *,1,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+B1200_G5321,$.*,IFU *,2,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+B1200_G5321,$.*,IFU *,4,1,610 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,1,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,1,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,1,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
-R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,760 - 1200,1,Low,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,760 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R150_G5326,$.*,IFU *,1,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
-R150_G5326,$.*,IFU *,2,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
-R150_G5326,$.*,IFU *,4,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+B1200_G5321,$.*,IFU *,1,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*,IFU *,2,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*,IFU *,4,1,800 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+#,,,,,,,,,,,,,,,,,,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+R150_G5326,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R150_G5326,$.*,IFU *,1,1,350 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+R150_G5326,$.*,IFU *,2,1,350 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+R150_G5326,$.*,IFU *,4,1,350 - 1200,1,High,,,,1,         GMOS balance,Visible,CuAr arc,Closed,180,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,400 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
-R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,400 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,350-500,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,240,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,240,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,350-500,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R400_G5325,$.*,IFU *,1,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
-R400_G5325,$.*,IFU *,2,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
-R400_G5325,$.*,IFU *,4,1,400 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,1,1,350-510,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+R400_G5325,$.*,IFU *,2,1,350-510,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*,IFU *,4,1,350-510,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,360,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,500-670,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,22,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,510-750,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+R400_G5325,$.*,IFU *,1,1,510-750,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+R400_G5325,$.*,IFU *,2,1,510-750,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,2,1,510-750,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+R400_G5325,$.*,IFU *,4,1,510-750,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,4,1,510-750,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,750-850,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+R400_G5325,$.*,IFU *,2,1,750-850,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,4,1,750-850,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,128,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,64,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,64,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,670-950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,850-950,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,2,1,850-950,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,4,1,850-950,1,High,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,128,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,64,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,64,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,2,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,2,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,1,4,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,2,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,2,4,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,950-1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+R400_G5325,$.*one|.*G.*,$.*arcsec.*,4,4,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+##,,,,,,,,,,,,,,,,,,Day
+R400_G5325,$.*,IFU *,1,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,80,1,Day
+R400_G5325,$.*,IFU *,1,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,2,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+R400_G5325,$.*,IFU *,2,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+R400_G5325,$.*,IFU *,4,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R400_G5325,$.*,IFU *,4,1,950-1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,none,$.*arcsec.*,1,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
-B600_G5323,none,$.*arcsec.*,2,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5323,none,$.*arcsec.*,1,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5323,none,$.*arcsec.*,2,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,4,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,1,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,4,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,2,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,4,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,$.*,IFU *,1,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B600_G5323,$.*,IFU *,2,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-B600_G5323,$.*,IFU *,4,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+B600_G5323,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+B600_G5323,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+B600_G5323,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,none,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5323,none,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B600_G5323,none,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B600_G5323,none,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5323,none,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5323,none,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B600_G5323,none,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5323,none,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-B600_G5323,none,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 B600_G5323,$.*,IFU *,1,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-B600_G5323,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-B600_G5323,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+B600_G5323,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
+B600_G5323,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,45,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,none,$.*arcsec.*,1,1,610 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
-B600_G5323,none,$.*arcsec.*,2,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B600_G5323,none,$.*arcsec.*,1,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B600_G5323,none,$.*arcsec.*,2,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,4,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,1,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B600_G5323,none,$.*arcsec.*,4,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,2,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-B600_G5323,none,$.*arcsec.*,4,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,610 - 800,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B600_G5323,$.*,IFU *,1,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B600_G5323,$.*,IFU *,2,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-B600_G5323,$.*,IFU *,4,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+B600_G5323,$.*,IFU *,1,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+B600_G5323,$.*,IFU *,2,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*,IFU *,4,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,1,800 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,1,800 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,2,800 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,2,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,1,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,1,4,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,2,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,2,4,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+B600_G5323,$.*one|.*G.*,$.*arcsec.*,4,4,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B600_G5323,$.*,IFU *,1,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,28,1,Day
+B600_G5323,$.*,IFU *,2,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+B600_G5323,$.*,IFU *,4,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,none,$.*arcsec.*,1,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
-R600_G5324,none,$.*arcsec.*,2,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5324,none,$.*arcsec.*,1,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5324,none,$.*arcsec.*,2,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,4,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,1,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,4,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,2,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,4,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,$.*,IFU *,1,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-R600_G5324,$.*,IFU *,2,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-R600_G5324,$.*,IFU *,4,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+R600_G5324,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+R600_G5324,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+R600_G5324,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,none,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5324,none,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R600_G5324,none,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R600_G5324,none,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5324,none,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5324,none,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R600_G5324,none,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5324,none,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R600_G5324,none,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 R600_G5324,$.*,IFU *,1,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
-R600_G5324,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-R600_G5324,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+R600_G5324,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
+R600_G5324,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,45,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,none,$.*arcsec.*,1,1,610 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
-R600_G5324,none,$.*arcsec.*,2,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-R600_G5324,none,$.*arcsec.*,1,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-R600_G5324,none,$.*arcsec.*,2,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,4,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,1,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-R600_G5324,none,$.*arcsec.*,4,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,2,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R600_G5324,none,$.*arcsec.*,4,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,610 - 800,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,610 - 800,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R600_G5324,$.*,IFU *,1,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-R600_G5324,$.*,IFU *,2,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R600_G5324,$.*,IFU *,4,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+R600_G5324,$.*,IFU *,1,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+R600_G5324,$.*,IFU *,2,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*,IFU *,4,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,1,800 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,1,800 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,2,800 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,2,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,1,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,1,4,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,60,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,2,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,2,4,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
+R600_G5324,$.*one|.*G.*,$.*arcsec.*,4,4,800 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,15,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R600_G5324,$.*,IFU *,1,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,28,1,Day
+R600_G5324,$.*,IFU *,2,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+R600_G5324,$.*,IFU *,4,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,none,$.*arcsec.*,1,1,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,360,1,Day
-R831_G5322,none,$.*arcsec.*,2,1,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
-R831_G5322,none,$.*arcsec.*,1,2,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
-R831_G5322,none,$.*arcsec.*,2,2,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5322,none,$.*arcsec.*,4,1,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5322,none,$.*arcsec.*,1,4,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-R831_G5322,none,$.*arcsec.*,4,2,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5322,none,$.*arcsec.*,2,4,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5322,none,$.*arcsec.*,4,4,400 - 590,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,360,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,240,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 595,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,$.*,IFU *,1,1,400 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,600,1,Day
-R831_G5322,$.*,IFU *,2,1,400 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
-R831_G5322,$.*,IFU *,4,1,400 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+R831_G5322,$.*,IFU *,1,1,350 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,600,1,Day
+R831_G5322,$.*,IFU *,2,1,350 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+R831_G5322,$.*,IFU *,4,1,350 - 590,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,none,$.*arcsec.*,1,1,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5322,none,$.*arcsec.*,2,1,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5322,none,$.*arcsec.*,1,2,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5322,none,$.*arcsec.*,2,2,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R831_G5322,none,$.*arcsec.*,4,1,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R831_G5322,none,$.*arcsec.*,1,4,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-R831_G5322,none,$.*arcsec.*,4,2,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5322,none,$.*arcsec.*,2,4,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-R831_G5322,none,$.*arcsec.*,4,4,590 - 650,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,48,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,48,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,595 - 625,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,240,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,140,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,140,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,625 - 675,1,High,,,,1,      GMOS balance,Visible,CuAr arc,Closed,18,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 R831_G5322,$.*,IFU *,1,1,590 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
 R831_G5322,$.*,IFU *,2,1,590 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,90,1,Day
 R831_G5322,$.*,IFU *,4,1,590 - 650,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,none,$.*arcsec.*,1,1,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
-R831_G5322,none,$.*arcsec.*,2,1,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5322,none,$.*arcsec.*,1,2,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5322,none,$.*arcsec.*,2,2,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5322,none,$.*arcsec.*,4,1,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5322,none,$.*arcsec.*,1,4,650 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
-R831_G5322,none,$.*arcsec.*,4,2,650 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R831_G5322,none,$.*arcsec.*,2,4,650 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-R831_G5322,none,$.*arcsec.*,4,4,650 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,675 - 780,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,675 - 780,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,675 - 780,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,675 - 780,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,675 - 780,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,675 - 780,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,675 - 780,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,675 - 780,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,675 - 780,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-R831_G5322,$.*,IFU *,1,1,650 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-R831_G5322,$.*,IFU *,2,1,650 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
-R831_G5322,$.*,IFU *,4,1,650 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,16,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,1,780 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,1,780 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,2,780 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,2,780 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,1,780 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,1,4,780 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,2,780 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,2,4,780 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+R831_G5322,$.*one|.*G.*,$.*arcsec.*,4,4,780 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+R831_G5322,$.*,IFU *,1,1,650 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+R831_G5322,$.*,IFU *,2,1,650 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+R831_G5322,$.*,IFU *,4,1,650 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,none,$.*arcsec.*,1,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
-B1200_G5321,none,$.*arcsec.*,2,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-B1200_G5321,none,$.*arcsec.*,1,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
-B1200_G5321,none,$.*arcsec.*,2,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,4,1,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,1,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,4,2,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,2,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,4,4,400 - 555,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,120,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,350 - 616,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,$.*,IFU *,1,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
-B1200_G5321,$.*,IFU *,2,1,400 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
-B1200_G5321,$.*,IFU *,4,1,400 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+B1200_G5321,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
+B1200_G5321,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,720,1,Day
+B1200_G5321,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,none,$.*arcsec.*,1,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5321,none,$.*arcsec.*,2,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,32,1,Day
-B1200_G5321,none,$.*arcsec.*,1,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,32,1,Day
-B1200_G5321,none,$.*arcsec.*,2,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5321,none,$.*arcsec.*,4,1,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5321,none,$.*arcsec.*,1,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,16,1,Day
-B1200_G5321,none,$.*arcsec.*,4,2,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5321,none,$.*arcsec.*,2,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
-B1200_G5321,none,$.*arcsec.*,4,4,555 - 610,1,High,,,,1,        None,Visible,CuAr arc,Closed,4,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,160,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,616 - 660,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 B1200_G5321,$.*,IFU *,1,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
 B1200_G5321,$.*,IFU *,2,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
 B1200_G5321,$.*,IFU *,4,1,555 - 610,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,none,$.*arcsec.*,1,1,610 - 950,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
-B1200_G5321,none,$.*arcsec.*,2,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
-B1200_G5321,none,$.*arcsec.*,1,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
-B1200_G5321,none,$.*arcsec.*,2,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,4,1,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,1,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-B1200_G5321,none,$.*arcsec.*,4,2,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,2,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-B1200_G5321,none,$.*arcsec.*,4,4,610 - 950,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,10,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,660 - 760,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,660 - 760,1,High,,,,1,        None,Visible,CuAr arc,Closed,2,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-B1200_G5321,$.*,IFU *,1,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
-B1200_G5321,$.*,IFU *,2,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
-B1200_G5321,$.*,IFU *,4,1,610 - 950,1,High,,,,1,         None,Visible,CuAr arc,Closed,32,1,Day
+B1200_G5321,$.*,IFU *,1,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
+B1200_G5321,$.*,IFU *,2,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,60,1,Day
+B1200_G5321,$.*,IFU *,4,1,610 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,1,760 - 1200,1,High,,,,1,        None,Visible,CuAr arc,Closed,8,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,1,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,2,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,2,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,1,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,1,4,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,2,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,2,4,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*one|.*G.*,$.*arcsec.*,4,4,760 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+B1200_G5321,$.*,IFU *,1,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,40,1,Day
+B1200_G5321,$.*,IFU *,2,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,20,1,Day
+B1200_G5321,$.*,IFU *,4,1,800 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-S_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GMOS-S_FLAT.csv
@@ -1,3737 +1,3676 @@
-149,2011/11/28 00:16:04 HST
-#0,,,,,,,,,,,,,,,,,,
-#,,V 1.83,"GG, 2011nov28",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,Bug fixes,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.81,"GG, 2011nov16",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,Mask imaging fixed,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.80,"GG, 2011nov03",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,added grating+filter combinations,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.79,"GG, 2011oct13",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,"use of common expressions for longslit and longslit Nand S, and IFU - size of table reduced to half",,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.6,"GG, 2011oct07",,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,"SmartGCal Flats only as Nighttime calibrations. If for some reason we want a daytime GCALflat, configure this separately.",,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.5,,,,,,,,,,,,,,,,
-#,,"GG, 2011sep14",,,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,Filled  Calibration Basecal column,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,V 1.4,,,,,,,,,,,,,,,,
-#,,"GG, 2011sep01",,,,,,,,,,,,,,,,
-#,,changes:,,,,,,,,,,,,,,,,
-#,,Added explicitly N & S $.*s  - size is now ~6400 rows,,,,,,,,,,,,,,,,
-#,,Some components names fixed by FN,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,v1.3 changes:,,,,,,,,,,,,,,,,
-#,,GCAL_South_2011aug17.1.3,,,,,,,,,,,,,,,,
-#,,- Size ~ 3700 rows,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,v1.1 changes:,,,,,,,,,,,,,,,,
-#,,#NAME?,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,Recommended GCAL configurations and Exp. Times for GMOS-S calibrations:,,,,,,,,,,,,,,,,
-#,,Quartz Halogen flats ,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,Note the following:,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-#,,The choice of filter within GMOS is not considered except for $IFU.*-2 configurations,,,,,,,,,,,,,,,,
-#,,The Readout is Slow and the Gain is Low and the three best amps were used for GCALflats,,,,,,,,,,,,,,,,
-#,,The GMOS-N and GMOS-S detector controllers only support integer exposure times,,,,,,,,,,,,,,,,
-#,,The B600 is not yet complete for 2.0 and 5.0  arcsec slits (use the values for R400 or consult your Gemini contact scientist),,,,,,,,,,,,,,,,
-#,,For High gain the exposure time is twice the exposure time from Low gain,,,,,,,,,,,,,,,,
-#,,Some alternative configurations rows are commented out (notably for R150_G5326),,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
+357,2015/08/24 22:37:41 HST
+# GMOS_FLAT
+# V 357, KR 2015august25
+#
+# update for 15B-Q-51 (R831 780 IFU-R 1x1)
+# update for 15B-Q-32 (B600 850 IFU-R 1x1)
+# update for 15A-Q-99 (B600 532 1.5arcsec 4x4)
+# update for 15B-Q-62 (R400 0.75arcsec 4x4) 
+# update for 15A-Q-17 (R400 0.75arcsec) 
+# update for 14A-Q-2 (R400 1.0arcsec) 
+# update for 15A-Q-200 (R400 0.75arcsec) and 15A-Q-201 (R150 1.0arcsec)
+# update for R400 15A-Q-13 (R150 2.0arcsec) and 15A-Q-30 (R400 840nm 0.5 arcsec)
+# another few updates to R400 to support 14B-LP-4 and also 15A-Q-13
+# third quick update to R400 1.0arcsec to support queue
+# second quick update to R831 0.5arcsec to support queue
+# quick update to R400 IFU-R to support queue
+#
+# this is a copy of GMOS-N flat version 240, starting point for Hamamatsu CCDs
+# Site dependent instrument specifications removed.
+#
+# For GMOS-N comment out configurations using filters u_G.{4}, Lya395_G.{4}, and RG670_G.{4}.
+# For GMOS-S comment out configurations using filters DS920_G.{4}
+#
+# SmartGCal Flats only as Nighttime calibrations. If for some reason we want a daytime GCALflat, configure this separately.
+#
+# Recommended GCAL configurations and Exp. Times for GMOS calibrations
+# Quartz Halogen flats
+#
+# Note the following
+# The choice of filter within GMOS is not considered except for $IFU.* 2 Slits configurations
+# The Readout is Slow and the Gain is Low
+# The GMOS -N and GMOS -S detector controllers only support integer exposure times
+# For High gain, use 2x the exposure time from Low gain
+#
+# Low Gain Configurations
+#
 #  Instrument Configuration from OT,,,,,,,,,,,,GCAL configuration,,,,,,
 Disperser,Filter,Focal Plane Unit,Xbin,Ybin,Central Wavelength,Order,Gain ,,,/=>/,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
-Mirror,r_G0326,none,1,1,Any ,0,Low,,,,5,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
-Mirror,r_G0326,none,1,1,Any ,0,Low,,,,5,ND4-5,IR,Quartz Halogen,Closed,4,1,Day
-Mirror,i_G0327,none,1,1,Any ,0,Low,,,,5,none,IR,IR grey body - low,Open,5,1,Day
-Mirror,z_G0328,none,1,1,Any ,0,Low,,,,5,ND1.0,IR,IR grey body - high,Open,10,1,Day
-Mirror,r_G0326,none,2,2,Any ,0,Low,,,,5,ND4-5,IR,Quartz Halogen,Closed,15,1,Day
-Mirror,i_G0327,none,2,2,Any ,0,Low,,,,5,ND1.0,IR,IR grey body - high,Open,10,1,Day
-Mirror,z_G0328,none,2,2,Any ,0,Low,,,,5,ND3.0,IR,IR grey body - high,Open,15,1,Day
-Mirror,g_G0325,none,2,2,Any ,0,Low,,,,5,ND4.0,IR,Quartz Halogen,Closed,20,1,Day
-Mirror,u_G0332,none,2,2,Any ,0,Low,,,,5,ND4.0,IR,Quartz Halogen,Closed,20,1,Day
+#
+Mirror,$u_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Ha_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$HaC_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+# Mirror,$DS920_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$SII_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$OIII_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$OIIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$HeII_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$HeIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$Lya395_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$GG455_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$OG515_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$RG610_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$RG780_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$CaT_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Ha_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$HaC_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+# Mirror,$DS920_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$SII_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OIII_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$OIIIC_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$HeII_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$HeIIC_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$Lya395_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
+#
+# Imaging with IFU in the beam
+#
+Mirror,$u_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$r_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Z_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Y_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$GG455_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$OG515_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$RG610_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$RG780_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$CaT_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Ha_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$HaC_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+# Mirror,$DS920_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$SII_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OIII_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$OIIIC_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeII_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeIIC_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$Lya395_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] RG780_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+#
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300 - 1200,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300 - 1200,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
+# $R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
+$R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,100,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+# $R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+$R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+# $R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+# $R150.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
+# $R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
+$R150.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,38,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300 - 1200,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+# $R150.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300 - 1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R150.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,44,1,Night
+$R150.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,22,1,Night
+$R150.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,11,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,1,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,2,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+#,,,,,,,,,,,,,,,,,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,590 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,590 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,590 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,590 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,590 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,590 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,450 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,625 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,850 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,450 - 625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,625 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2*,850 - 1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,650 - 740,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,650 - 740,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,650 - 740,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,740 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,740 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,740 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,38,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,19,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R400.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,1,1,706 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,2,1,706 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R400.*,$i.{6},$IFU.* 2 Slits,4,1,706 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,1,1,848 - 1100,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,2,1,848 - 1100,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$z.{6},$IFU.* 2 Slits,4,1,848 - 1100,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,1,1,830 - 925,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,2,1,830 - 925,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$Z.{6},$IFU.* 2 Slits,4,1,830 - 925,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,1,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,2,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$R400.*,$CaT.*,$IFU.* 2 Slits,4,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,800-1200,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,500-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,500-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,500-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-425,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,425-500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,500-535,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,13,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,500-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,500-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,500-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,500-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,500-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400-530,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-375,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,375-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400-800,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400-545,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400-545,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400-545,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,545-700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,545-700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,545-700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,700-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,700-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,700-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,475-750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,475-750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,750-1200,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,750-1200,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,475-625,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,220,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,750 - 800,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,800 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,750 - 800,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,800 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,750 - 800,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,800 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,540 - 730,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,730 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,350 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525 - 610,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,610 - 750,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,750 - 890,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,210,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,105,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,53,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,565 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,565 - 620,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,620 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450 - 515,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450 - 515,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,515 - 580,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,515 - 580,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,580 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,580 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450 - 515,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,515 - 580,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,580 - 600,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,600 - 665,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,665 - 770,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,770 - 840,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,840 - 950,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,850 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,565 - 740,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,565 - 740,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,565 - 740,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,740 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,740 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,740 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,850 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,850 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,5,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,850 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,850 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,1,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,2,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,4,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,1,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,2,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,4,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$z.{6},$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,850 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,1,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,2,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,4,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
+#
+# High Gain Configurations
+#
+# Mirror,$r.{6},none,1,1,Any ,0,High,,,,5,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+# Mirror,$r.{6},none,1,1,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,8,1,Day
+# Mirror,$i.{6},none,1,1,Any ,0,High,,,,5,none,IR,IR grey body - low,Open,10,1,Day
+# Mirror,$z.{6},none,1,1,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
+# Mirror,$r.{6},none,2,2,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,30,1,Day
+# Mirror,$i.{6},none,2,2,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
+# Mirror,$z.{6},none,2,2,Any ,0,High,,,,5,ND3.0,IR,IR grey body - high,Open,30,1,Day
+# Mirror,$g.*,none,2,2,Any ,0,High,,,,5,ND4.0,IR,Quartz Halogen,Closed,40,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$Ha_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$HaC_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+# Mirror,$DS920_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$SII_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OIII_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$OIIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeII_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$HeIIC_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$Lya395_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$g_G.{4} [+] GG455_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4} [+] OG515_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$u_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$g_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$r_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$i_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$z_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$Z_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$Y_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$GG455_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$OG515_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$RG610_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$RG780_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$CaT_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
+Mirror,$Ha_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$HaC_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+# Mirror,$DS920_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$SII_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$OIII_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$OIIIC_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$HeII_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$HeIIC_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$Lya395_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Day
+Mirror,$Hartmann[AB]_G.{4} [+] r_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,8,1,Day
+Mirror,$g_G.{4} [+] GG455.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$g_G.{4} [+] OG515.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$r_G.{4} [+] RG610.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4} [+] RG780.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$i_G.{4} [+] CaT.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$z_G.{4} [+] CaT.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4.0,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$g_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4.0,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$r_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$i_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$z_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$Z_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
+Mirror,$Y_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
 #,,,,,,,,,,,,,,,,,,
-Mirror,r_G0326,none,1,1,Any ,0,High,,,,5,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
-Mirror,r_G0326,none,1,1,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,8,1,Day
-Mirror,i_G0327,none,1,1,Any ,0,High,,,,5,none,IR,IR grey body - low,Open,10,1,Day
-Mirror,z_G0328,none,1,1,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
-Mirror,r_G0326,none,2,2,Any ,0,High,,,,5,ND4-5,IR,Quartz Halogen,Closed,30,1,Day
-Mirror,i_G0327,none,2,2,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
-Mirror,z_G0328,none,2,2,Any ,0,High,,,,5,ND3.0,IR,IR grey body - high,Open,30,1,Day
-Mirror,g_G0325,none,2,2,Any ,0,High,,,,5,ND4.0,IR,Quartz Halogen,Closed,40,1,Day
-Mirror,u_G0332,none,2,2,Any ,0,High,,,,5,ND4.0,IR,Quartz Halogen,Closed,40,1,Day
-,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,
+$R150.*,none,$.* 1.00 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,none,$.* 1.00 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.00 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+# $R150.*,none,$.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
+$R150.*,none,$.* 1.50 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 1.50 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 1.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,none,$.* 1.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
+# $R150.*,none,$.* 1.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
+$R150.*,none,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,none,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
+$R150.*,none,$.* 2.00 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 2.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 2.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 2.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 2.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+# $R150.*,none,$.* 2.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
+# $R150.*,none,$.* 2.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
+$R150.*,none,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,none,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+$R150.*,none,$.* 5.00 arcsec,1,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 5.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 5.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 5.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 5.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 5.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+# $R150.*,none,$.* 5.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
+# $R150.*,none,$.* 5.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
+# $R150.*,none,$.* 5.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
+$R150.*,none,$.* 5.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 5.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,none,$.* 5.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+# $R150.*,none,$.* 5.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
+$R150.*,none,$.* 5.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,76,1,Night
+$R150.*,none,$.* 0.75 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R150.*,none,$.* 0.75 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.75 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.75 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+# $R150.*,none,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
+$R150.*,none,$.* 0.50 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R150.*,none,$.* 0.50 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,none,$.* 0.50 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,none,$.* 0.50 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.50 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.50 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$.* 0.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.25 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R150.*,none,$.* 0.25 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R150.*,none,$.* 0.25 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R150.*,none,$.* 0.25 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,none,$.* 0.25 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,none,$.* 0.25 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R150.*,none,$.* 0.25 arcsec,2,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.25 arcsec,4,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R150.*,none,$.* 0.25 arcsec,4,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R150.*,none,$IFU.* Right Slit .*,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,88,1,Night
+$R150.*,none,$IFU.* Right Slit .*,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,44,1,Night
+$R150.*,none,$IFU.* Right Slit .*,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,22,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R150.*,$GG455.*,$IFU.* 2 Slits,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+#,,,,,,,,,,,,,,,,,1,Night
+$R400.*,none,$.* 1.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,none,$.* 1.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 1.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 1.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 1.00 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 1.00 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 1.00 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.00 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.00 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.00 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.00 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.00 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.00 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.00 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.00 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.00 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.00 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 1.50 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,none,$.* 1.50 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 1.50 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 1.50 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.50 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.50 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,2,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.50 arcsec,4,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.50 arcsec,2,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.50 arcsec,4,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 1.50 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 1.50 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 2.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 2.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 2.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 2.00 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 2.00 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 2.00 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,2,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 2.00 arcsec,4,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 2.00 arcsec,2,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,4,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 2.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,2,1,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,1,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,2,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,4,1,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,1,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,2,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,4,1,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,1,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,2,4,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,4,2,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,2,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,4,2,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 5.00 arcsec,4,4,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 5.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 0.75 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$R400.*,none,$.* 0.75 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R400.*,none,$.* 0.75 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 0.75 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 0.75 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,none,$.* 0.75 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R400.*,none,$.* 0.75 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.75 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.75 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.75 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.75 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.75 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.75 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 0.75 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 0.75 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 0.75 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 0.75 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.75 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.50 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,none,$.* 0.50 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R400.*,none,$.* 0.50 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,none,$.* 0.50 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,none,$.* 0.50 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 0.50 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 0.50 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 0.50 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 0.50 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 0.50 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.50 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.50 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.50 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.50 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.50 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.50 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.50 arcsec,4,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 0.50 arcsec,4,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,none,$.* 0.25 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R400.*,none,$.* 0.25 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R400.*,none,$.* 0.25 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,none,$.* 0.25 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R400.*,none,$.* 0.25 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R400.*,none,$.* 0.25 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R400.*,none,$.* 0.25 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,none,$.* 0.25 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,none,$.* 0.25 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R400.*,none,$.* 0.25 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 0.25 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 0.25 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R400.*,none,$.* 0.25 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 0.25 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R400.*,none,$.* 0.25 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.25 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R400.*,none,$.* 0.25 arcsec,4,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$.* 0.25 arcsec,4,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R400.*,none,$IFU.* Right Slit .*,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R400.*,none,$IFU.* Right Slit .*,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R400.*,none,$IFU.* Right Slit .*,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,none,$IFU.* Right Slit .*,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R400.*,none,$IFU.* Right Slit .*,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,none,$IFU.* Right Slit .*,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,46,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R400.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$R400.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$R400.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R400.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$R400.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R400.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R400.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$B600.*,none,$.* 1.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 1.00 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.00 arcsec,2,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,4, 500-650 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,4, 650 - 750 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.00 arcsec,4,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 1.50 arcsec,2,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,4, 500-650 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,4, 650 - 750 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 1.50 arcsec,4,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 2.00 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 2.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,2,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,1,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,1,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,1,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,2,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,4,420 - 500,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,4,500 - 650,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,4,650 - 750,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,4,750 - 850,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 5.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.75 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.75 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 0.50 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.50 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.50 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,none,$.* 0.25 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,none,$.* 0.25 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,none,$.* 0.25 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,none,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,440,1,Night
+$B600.*,none,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
+$B600.*,none,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$B600.*,none,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$B600.*,none,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$IFU.* Right Slit .*,1,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,none,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B600.*,none,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$B600.*,none,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,none,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,none,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,none,$IFU.* Right Slit .*,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B600.*,none,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B600.*,none,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B600.*,none,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,none,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,none,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,none,$IFU.* Right Slit .*,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$R600.*,none,$.* 1.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,4,540 - 730,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,4,730 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 1.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 2.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,4,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 2.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,2,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,1,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,4,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,2,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,1,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,2,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,4,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,2,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,2,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,4,350 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,4,525 - 610,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,4,610 - 750,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,4,750 - 890,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,4,890 - 950,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 5.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.75 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.50 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,2,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,2,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,2,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.25 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$.* 0.25 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R600.*,none,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R600.*,none,$IFU.* Right Slit .*,1,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R600.*,none,$IFU.* Right Slit .*,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
+$R600.*,none,$IFU.* Right Slit .*,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,none,$IFU.* Right Slit .*,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,none,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R600.*,none,$IFU.* Right Slit .*,2,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R600.*,none,$IFU.* Right Slit .*,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R600.*,none,$IFU.* Right Slit .*,2,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,none,$IFU.* Right Slit .*,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,none,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R600.*,none,$IFU.* Right Slit .*,4,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R600.*,none,$IFU.* Right Slit .*,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R600.*,none,$IFU.* Right Slit .*,4,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,none,$IFU.* Right Slit .*,4,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$R600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$R600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,565 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,565 - 620,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,620 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450 - 515,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450 - 515,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,515 - 580,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,515 - 580,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,580 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,580 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450 - 515,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,515 - 580,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,580 - 600,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,600 - 665,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,665 - 770,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,770 - 840,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,840 - 950,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,144,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,850 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,850 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,448,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,256,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$R831.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,1,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,2,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$R831.*,$g.* GG455.*,$IFU.* 2 Slits,4,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,1,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,2,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$R831.*,$r.* RG610.*,$IFU.* 2 Slits,4,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$i.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$R831.*,$z.* CaT.*,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+#,,,,,,,,,,,,,,,,,,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.00 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 1.50 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 2.00 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 5.00 arcsec,4,4,850 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.75 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.50 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,256,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,2,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$.* 0.25 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,32,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,2,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
+$B1200.*,$None|GG455_G.*|OG515_G.*|RG610_G.*|RG780_G.*,$IFU.* Right Slit .*,4,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,1,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,2,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
+$B1200.*,$g.* OG515.*,$IFU.* 2 Slits,4,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
 #,,,,,,,,,,,,,,,,,,
-Mirror,r_G0326,$.*,1,1,Any ,0,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
-Mirror,r_G0326,*,1,1,Any ,0,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
-#,,,,,,,,,,,,,,,,,,
-R150_G5326,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 1000,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 1000,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,100,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,75,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,38,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 1000,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 1000,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,44,1,Night
-R150_G5326,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,22,1,Night
-R150_G5326,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,11,1,Night
-R150_G5326,GG455_G0329,$IFU.* 2 Slits,1,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R150_G5326,GG455_G0329,$IFU.* 2 Slits,2,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R150_G5326,GG455_G0329,$IFU.* 2 Slits,4,1,400 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-,,,,,,,,,,,,,,,,,,
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-# R150_G5326,$.*one|.*G.*, $.* 1.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
-R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,200,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,300,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,150,1,Night
-R150_G5326,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,76,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-# R150_G5326,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 1000,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,400,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R150_G5326,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R150_G5326,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,88,1,Night
-R150_G5326,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,44,1,Night
-R150_G5326,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,22,1,Night
-R150_G5326,GG455_G0329,$IFU.* 2 Slits,1,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R150_G5326,GG455_G0329,$IFU.* 2 Slits,2,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R150_G5326,GG455_G0329,$IFU.* 2 Slits,4,1,400 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-,,,,,,,,,,,,,,,,,,
-#,,,,,,,,,,,,,,,,,,
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,1,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,2,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,1,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,2,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400 - 700,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,4,700 - 1000,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,2,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,4,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,400 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,700 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,23,1,Night
-R400_G5325,g_G0325,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R400_G5325,g_G0325,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R400_G5325,g_G0325,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R400_G5325,r_G0326,$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
-R400_G5325,r_G0326,$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
-R400_G5325,r_G0326,$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
-R400_G5325,i_G0327,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5325,i_G0327,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5325,i_G0327,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-R400_G5325,z_G0328,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5325,z_G0328,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5325,z_G0328,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-#,,,,,,,,,,,,,,,,,,
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*, $.* 1.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,2,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 1.50 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,2,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 2.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,1,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,2,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,1,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,1,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,2,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,2,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400 - 700,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 5.00 arcsec,4,4,700 - 1000,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,4,400 - 700,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.75 arcsec,4,4,700 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.50 arcsec,4,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,1,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,2,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,2,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$.* 0.25 arcsec,4,4,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,400 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5325,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,700 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,46,1,Night
-R400_G5325,g_G0325,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R400_G5325,g_G0325,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R400_G5325,g_G0325,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R400_G5325,r_G0326,$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
-R400_G5325,r_G0326,$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
-R400_G5325,r_G0326,$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
-R400_G5325,i_G0327,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R400_G5325,i_G0327,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5325,i_G0327,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R400_G5325,z_G0328,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R400_G5325,z_G0328,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R400_G5325,z_G0328,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-#,,,,,,,,,,,,,,,,,,
-B600_G5323,none, $.* 1.00 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 500-650 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 650 - 750 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,7,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 500-650 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 650 - 750 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 500-650 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 650 - 750 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 750 - 850 ,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 850 - 1050 ,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,420 - 500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,500 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,350 - 420,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,420 - 500,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,500 - 650,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,220,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-B600_G5323,g_G0325,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B600_G5323,g_G0325,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5323,g_G0325,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-B600_G5323,r_G0326,$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5323,r_G0326,$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5323,r_G0326,$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-B600_G5323,i_G0327,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,i_G0327,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,i_G0327,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,z_G0328,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,z_G0328,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,z_G0328,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none, $.* 1.00 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none, $.* 1.00 arcsec,2,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 500-650 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 650 - 750 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none, $.* 1.00 arcsec,4,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 1.50 arcsec,2,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 500-650 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 650 - 750 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 1.50 arcsec,4,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 500-650 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 650 - 750 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 750 - 850 ,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,2, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,1, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,1,4, 850 - 1050 ,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 2.00 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 2.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,420 - 500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,500 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,350 - 420,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,420 - 500,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,500 - 650,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,650 - 750,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,750 - 850,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 5.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.75 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.75 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.50 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.50 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.50 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.25 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B600_G5323,none,$.* 0.25 arcsec,2,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,none,$.* 0.25 arcsec,4,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,440,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,1,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,none,$IFU.* Right Slit .*,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5323,g_G0325,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-B600_G5323,g_G0325,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B600_G5323,g_G0325,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B600_G5323,r_G0326,$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B600_G5323,r_G0326,$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B600_G5323,r_G0326,$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B600_G5323,i_G0327,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B600_G5323,i_G0327,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B600_G5323,i_G0327,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B600_G5323,z_G0328,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
-B600_G5323,z_G0328,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B600_G5323,z_G0328,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,540 - 730,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,730 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,540 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,525 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,750 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,350 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,415 - 525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,525 - 610,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,610 - 750,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,750 - 890,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,890 - 950,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,415 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,795 - 890,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,890 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,450 - 540,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,540 - 795,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,795 - 890,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,g_G0325,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5324,g_G0325,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5324,g_G0325,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R600_G5324,r_G0326,$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-R600_G5324,r_G0326,$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R600_G5324,r_G0326,$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-R600_G5324,i_G0327,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,i_G0327,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-R600_G5324,i_G0327,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R600_G5324,z_G0328,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,z_G0328,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,z_G0328,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none, $.* 1.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,540 - 730,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,730 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 1.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 2.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,540 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,525 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,750 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,350 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,415 - 525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,525 - 610,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,610 - 750,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,750 - 890,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,890 - 950,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 5.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.75 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,2,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,1,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,2,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,415 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,795 - 890,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,890 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$.* 0.25 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,450 - 540,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,540 - 795,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,795 - 890,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R600_G5324,g_G0325,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R600_G5324,g_G0325,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R600_G5324,g_G0325,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R600_G5324,r_G0326,$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-R600_G5324,r_G0326,$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-R600_G5324,r_G0326,$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-R600_G5324,i_G0327,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-R600_G5324,i_G0327,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-R600_G5324,i_G0327,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R600_G5324,z_G0328,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R600_G5324,z_G0328,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R600_G5324,z_G0328,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-#,,,,,,,,,,,,,,,,,,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,350 - 415,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,415 - 565,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,565 - 790,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,790 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,415 - 565,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,415 - 565,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,565 - 790,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,565 - 790,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,790 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,790 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,565 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,850 - 950,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,565 - 620,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,620 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,620 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,450 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,450 - 515,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,450 - 515,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,515 - 580,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,515 - 580,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,580 - 650,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,580 - 650,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,850 - 950,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,850 - 950,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,950 - 1050,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,950 - 1050,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,450 - 515,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,515 - 580,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,580 - 600,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,600 - 665,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,665 - 770,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,770 - 840,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,840 - 950,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,950 - 1050,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,850 - 1050,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,9,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,415 - 565,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,565 - 790,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,790 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,850 - 950,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,950 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,850 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,350 - 415,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,415 - 565,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,565 - 790,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,790 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,850 - 1050,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,890 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,g_G0325 + GG455_G0329,$IFU.* 2 Slits,1,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5322,g_G0325 + GG455_G0329,$IFU.* 2 Slits,2,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5322,g_G0325 + GG455_G0329,$IFU.* 2 Slits,4,1,400 - 600,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-R831_G5322,r_G0326 + RG610_G0331,$IFU.* 2 Slits,1,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5322,r_G0326 + RG610_G0331,$IFU.* 2 Slits,2,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5322,r_G0326 + RG610_G0331,$IFU.* 2 Slits,4,1,550 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-R831_G5322,i_G0327 + CaT_G0333,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,i_G0327 + CaT_G0333,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,i_G0327 + CaT_G0333,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,z_G0328 + CaT_G0333,$IFU.* 2 Slits,1,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,z_G0328 + CaT_G0333,$IFU.* 2 Slits,2,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,z_G0328 + CaT_G0333,$IFU.* 2 Slits,4,1,750 - 950,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-#,,,,,,,,,,,,,,,,,,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,350 - 415,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,415 - 565,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,565 - 790,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,790 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none, $.* 1.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,415 - 565,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,415 - 565,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,565 - 790,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,565 - 790,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,790 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,790 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 1.50 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,565 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 1.50 arcsec,4,4,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,850 - 950,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,565 - 620,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,620 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,620 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 2.00 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,450 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,450 - 515,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,450 - 515,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,515 - 580,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,515 - 580,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,580 - 650,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,580 - 650,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,850 - 950,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,850 - 950,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,2,4,950 - 1050,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,2,950 - 1050,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,450 - 515,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,515 - 580,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,580 - 600,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,600 - 665,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,665 - 770,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,770 - 840,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,840 - 950,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 5.00 arcsec,4,4,950 - 1050,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,144,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,2,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,1,4,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,1,850 - 1050,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-R831_G5322,none,$.* 0.75 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,415 - 565,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,565 - 790,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,790 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.75 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,850 - 950,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,1,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,2,950 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.50 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.50 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.50 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,448,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,256,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,224,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,1,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,2,850 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,112,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,1,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.25 arcsec,1,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,128,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,56,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-R831_G5322,none,$.* 0.25 arcsec,2,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,2,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,350 - 415,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,28,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,415 - 565,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,565 - 790,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,790 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-R831_G5322,none,$.* 0.25 arcsec,4,4,850 - 1050,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,1,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,2,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,890 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,none,$IFU.* Right Slit .*,4,1,950 - 1050,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,g_G0325 + GG455_G0329,$IFU.* 2 Slits,1,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-R831_G5322,g_G0325 + GG455_G0329,$IFU.* 2 Slits,2,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-R831_G5322,g_G0325 + GG455_G0329,$IFU.* 2 Slits,4,1,400 - 600,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-R831_G5322,r_G0326 + RG610_G0331,$IFU.* 2 Slits,1,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,480,1,Night
-R831_G5322,r_G0326 + RG610_G0331,$IFU.* 2 Slits,2,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
-R831_G5322,r_G0326 + RG610_G0331,$IFU.* 2 Slits,4,1,550 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-R831_G5322,i_G0327 + CaT_G0333,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,i_G0327 + CaT_G0333,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,i_G0327 + CaT_G0333,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-R831_G5322,z_G0328 + CaT_G0333,$IFU.* 2 Slits,1,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-R831_G5322,z_G0328 + CaT_G0333,$IFU.* 2 Slits,2,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-R831_G5322,z_G0328 + CaT_G0333,$IFU.* 2 Slits,4,1,750 - 950,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-#,,,,,,,,,,,,,,,,,,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,22,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,42,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,17,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,17,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,450 - 550,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,550 - 650,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,350 - 450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,450 - 550,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,550 - 650,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,650 - 750,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,7,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,850 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,18,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,23,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,23,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,750 - 850,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,1,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,650 - 750,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,750 - 850,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,850 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,210,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,650 - 750,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,180,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,350 - 450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,450 - 550,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,550 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,650 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,750 - 850,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,3,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,850 - 1000,1,Low,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,g_G0325 + GG455_G0329,$IFU.* 2 Slits,1,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5321,g_G0325 + GG455_G0329,$IFU.* 2 Slits,2,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-B1200_G5321,g_G0325 + GG455_G0329,$IFU.* 2 Slits,4,1,450 - 750,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,75,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-#,,,,,,,,,,,,,,,,,,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none, $.* 1.00 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,44,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,84,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 1.50 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 2.00 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,34,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,34,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,450 - 550,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,550 - 650,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,350 - 450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,450 - 550,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,550 - 650,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,650 - 750,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,14,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 5.00 arcsec,4,4,850 - 1000,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,72,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,36,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,46,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,46,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.75 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,750 - 850,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.50 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,256,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,192,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,128,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,4,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,2,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,2,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,1,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,1,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,2,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,2,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,650 - 750,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,750 - 850,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
-B1200_G5321,none,$.* 0.25 arcsec,4,4,850 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,800,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,640,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,720,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,720,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,24,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,1,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,32,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,420,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,320,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,650 - 750,1,High,,,,1,none,Visible,Quartz Halogen,Closed,360,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,12,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,2,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,16,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,350 - 450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,450 - 550,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,160,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,550 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,650 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,750 - 850,1,High,,,,1,none,Visible,Quartz Halogen,Closed,6,1,Night
-B1200_G5321,none,$IFU.* Right Slit .*,4,1,850 - 1000,1,High,,,,1,none,Visible,Quartz Halogen,Closed,8,1,Night
-B1200_G5321,g_G0325 + GG455_G0329,$IFU.* 2 Slits,1,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,600,1,Night
-B1200_G5321,g_G0325 + GG455_G0329,$IFU.* 2 Slits,2,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,300,1,Night
-B1200_G5321,g_G0325 + GG455_G0329,$IFU.* 2 Slits,4,1,450 - 750,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,150,1,Night
-#,,,,,,,,,,,,,,,,,,Night
-#,,,,,,,,,,,,,,,,,,Night

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GNIRS_ARC.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GNIRS_ARC.csv
@@ -1,267 +1,277 @@
-149,2011/11/28 00:16:04 HST
-"Mode","Pixel Scale","Disperser","Cross Dispersed","Central Wavelength","Focal Plane Unit","Well Depth","Calibration Lamps","Calibration Shutter","Calibration Filter","Calibration Diffuser","Calibration Observe","Calibration Exposure Time","Calibration Coadds","Calibration Basecal"
+257,2013/07/12 16:46:59 HST
+#,,V 257,"MLB, 2013jul12 added config for 13B-Q-91",,,,,,,,,,,
+Mode,Pixel Scale,Disperser,Cross Dispersed,Central Wavelength,Focal Plane Unit,Well Depth,Calibration Lamps,Calibration Shutter,Calibration Filter,Calibration Diffuser,Calibration Observe,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
 ,,,,,,,,,,,,,,
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.03 - 1.06","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,20,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.03 - 1.06","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,16,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.03 - 1.06","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,14,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.03 - 1.06","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,14,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.03 - 1.06","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,11,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.03 - 1.06","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,11,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.03 - 1.06","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.06 - 1.17","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.06 - 1.17","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,26,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.06 - 1.17","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,23,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.06 - 1.17","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,20,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.06 - 1.17","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,18,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.06 - 1.17","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,17,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.06 - 1.17","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.21 - 1.25","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,24,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.21 - 1.25","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,20,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.21 - 1.25","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,16,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.21 - 1.25","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.21 - 1.25","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,9,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.21 - 1.25","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.21 - 1.25","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.25 - 1.28","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,24,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.25 - 1.28","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,24,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.25 - 1.28","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.25 - 1.28","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.25 - 1.28","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,9,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.25 - 1.28","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.25 - 1.28","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.28 - 1.32","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.28 - 1.32","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,7,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.28 - 1.32","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.28 - 1.32","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,5.5,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.28 - 1.32","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.28 - 1.32","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,4.5,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.28 - 1.32","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,4,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.32 - 1.36","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.32 - 1.36","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,4,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.32 - 1.36","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,3,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.32 - 1.36","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,2,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.32 - 1.36","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,3.5,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.32 - 1.36","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,3.3,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.32 - 1.36","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,3,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.49 - 1.54","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.49 - 1.54","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,53,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.49 - 1.54","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.49 - 1.54","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,38,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.49 - 1.54","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.49 - 1.54","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.49 - 1.54","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.54 - 1.63","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,100,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.54 - 1.63","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,90,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.54 - 1.63","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,75,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.54 - 1.63","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.54 - 1.63","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.54 - 1.63","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.54 - 1.63","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.63 - 1.68","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,100,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.63 - 1.68","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,75,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.63 - 1.68","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.63 - 1.68","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.63 - 1.68","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.63 - 1.68","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.63 - 1.68","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.68 - 1.73","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.68 - 1.73","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.68 - 1.73","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,8.5,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.68 - 1.73","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,7.5,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.68 - 1.73","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.68 - 1.73","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.68 - 1.73","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.73 - 1.78","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,100,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.73 - 1.78","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,90,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.73 - 1.78","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,75,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.73 - 1.78","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.73 - 1.78","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.73 - 1.78","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.73 - 1.78","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.97 - 2.04","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,100,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.97 - 2.04","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,85,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.97 - 2.04","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,70,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.97 - 2.04","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,55,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.97 - 2.04","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.97 - 2.04","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","1.97 - 2.04","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.04 - 2.10","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.04 - 2.10","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.04 - 2.10","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,55,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.04 - 2.10","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,50,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.04 - 2.10","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.04 - 2.10","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.04 - 2.10","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.10 - 2.16","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.10 - 2.16","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,55,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.10 - 2.16","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,50,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.10 - 2.16","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,45,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.10 - 2.16","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.10 - 2.16","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.10 - 2.16","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.16 - 2.23","0.10 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.16 - 2.23","0.15 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.16 - 2.23","0.20 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.16 - 2.23","0.30 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.16 - 2.23","0.45 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.16 - 2.23","0.675 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","No","2.16 - 2.23","1.0 arcsec","Shallow","Ar arc+Xe arc","Closed","none","IR",2,40,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.03 - 1.17","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.03 - 1.17","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.03 - 1.17","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.03 - 1.17","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.03 - 1.17","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.03 - 1.17","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.03 - 1.17","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.17 - 1.30","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.17 - 1.30","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.17 - 1.30","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.17 - 1.30","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,7,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.17 - 1.30","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.17 - 1.30","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.17 - 1.30","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.30 - 1.37","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.30 - 1.37","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,7.5,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.30 - 1.37","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,7,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.30 - 1.37","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,6,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.30 - 1.37","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.30 - 1.37","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.30 - 1.37","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.49 - 1.66","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.49 - 1.66","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.49 - 1.66","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.49 - 1.66","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,25,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.49 - 1.66","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,20,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.49 - 1.66","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,20,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.49 - 1.66","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,20,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.66 - 1.82","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.66 - 1.82","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.66 - 1.82","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.66 - 1.82","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.66 - 1.82","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.66 - 1.82","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.66 - 1.82","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,8,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.91 - 2.35","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.91 - 2.35","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.91 - 2.35","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.91 - 2.35","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.91 - 2.35","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.91 - 2.35","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","1.91 - 2.35","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","2.35 - 2.49","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,120,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","2.35 - 2.49","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,115,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","2.35 - 2.49","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,105,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","2.35 - 2.49","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,95,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","2.35 - 2.49","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,90,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","2.35 - 2.49","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,85,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","No","2.35 - 2.49","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,75,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.03 - 1.12","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,1.5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.03 - 1.12","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,1.5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.03 - 1.12","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.03 - 1.12","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.12 - 1.17","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,4.5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.12 - 1.17","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,3.5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.12 - 1.17","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,2.5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.12 - 1.17","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,1.5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.17 - 1.28","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.17 - 1.28","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.17 - 1.28","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.17 - 1.28","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.28 - 1.37","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.2,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.28 - 1.37","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.2,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.28 - 1.37","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.2,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.28 - 1.37","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.2,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.49 - 1.63","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,3,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.49 - 1.63","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,2.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.49 - 1.63","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,2.3,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.49 - 1.63","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,2,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.63 - 1.77","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.63 - 1.77","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.63 - 1.77","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.63 - 1.77","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.91 - 2.10","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.91 - 2.10","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.91 - 2.10","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","1.91 - 2.10","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.10 - 2.29","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.10 - 2.29","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.10 - 2.29","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.10 - 2.29","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.29 - 2.48","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,13,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.29 - 2.48","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,12,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.29 - 2.48","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,11,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","No","2.29 - 2.48","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","LXD","0.9 - 2.56","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","LXD","0.9 - 2.56","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,3,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","LXD","0.9 - 2.56","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,3,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","LXD","0.9 - 2.56","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,3,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","LXD","0.9 - 2.56","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,3,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","LXD","0.9 - 2.56","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","SXD","0.9 - 2.56","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","LXD","0.9 - 2.56","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","LXD","0.9 - 2.56","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","LXD","0.9 - 2.56","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,4,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","LXD","0.9 - 2.56","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,4,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","LXD","0.9 - 2.56","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,4,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","LXD","0.9 - 2.56","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,4,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","LXD","0.9 - 2.56","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.05""/pix","111 l/mm grating","LXD","0.9 - 2.56","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,10,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","LXD","0.9 - 2.56","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","LXD","0.9 - 2.56","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","LXD","0.9 - 2.56","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","LXD","0.9 - 2.56","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","LXD","0.9 - 2.56","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","LXD","0.9 - 2.56","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","32 l/mm grating","LXD","0.9 - 2.56","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","SXD","0.9 - 2.56","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","SXD","0.9 - 2.56","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","SXD","0.9 - 2.56","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","111 l/mm grating","SXD","0.9 - 2.56","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","SXD","0.9 - 2.56","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,10,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","SXD","0.9 - 2.56","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,10,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","SXD","0.9 - 2.56","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","SXD","0.9 - 2.56","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.03 - 1.17","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.03 - 1.17","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.03 - 1.17","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.03 - 1.17","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.17 - 1.37","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.17 - 1.37","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.17 - 1.37","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.17 - 1.37","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,0.6,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.47 - 1.80","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.47 - 1.80","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.47 - 1.80","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.47 - 1.80","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,1,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.91 - 2.49","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.91 - 2.49","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.91 - 2.49","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.15""/pix","32 l/mm grating","No","1.91 - 2.49","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,5,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.03 - 1.17","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.03 - 1.17","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.03 - 1.17","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.03 - 1.17","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.03 - 1.17","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.03 - 1.17","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.03 - 1.17","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,30,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.17 - 1.37","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.17 - 1.37","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.17 - 1.37","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.17 - 1.37","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.17 - 1.37","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.17 - 1.37","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.17 - 1.37","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.47 - 1.80","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.47 - 1.80","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.47 - 1.80","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.47 - 1.80","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.47 - 1.80","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.47 - 1.80","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.47 - 1.80","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,15,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.91 - 2.49","0.30 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.91 - 2.49","0.675 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.91 - 2.49","1.0 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.91 - 2.49","0.45 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.91 - 2.49","0.20 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.91 - 2.49","0.15 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
-"Spectroscopy","0.05""/pix","10 l/mm grating","No","1.91 - 2.49","0.10 arcsec","Shallow","Ar arc","Closed","none","IR",2,60,1,"Night"
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.06,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,20,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.06,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,16,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.06,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,14,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.06,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,14,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.06,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,11,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.06,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,11,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.06,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.06 - 1.17,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.06 - 1.17,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,26,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.06 - 1.17,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,23,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.06 - 1.17,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,20,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.06 - 1.17,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,18,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.06 - 1.17,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,17,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.06 - 1.17,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,24,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,20,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,16,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,9,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,24,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,24,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,9,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.32,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.32,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,7,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.32,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.32,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,5.5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.32,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.32,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,4.5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.32,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.32 - 1.36,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.32 - 1.36,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.32 - 1.36,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.32 - 1.36,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.32 - 1.36,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,3.5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.32 - 1.36,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,3.3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.32 - 1.36,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.54,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.54,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,53,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.54,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.54,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,38,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.54,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.54,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.54,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.54 - 1.63,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,100,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.54 - 1.63,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,90,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.54 - 1.63,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,75,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.54 - 1.63,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.54 - 1.63,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.54 - 1.63,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.54 - 1.63,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.63 - 1.68,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,100,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.63 - 1.68,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,75,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.63 - 1.68,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.63 - 1.68,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.63 - 1.68,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.63 - 1.68,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.63 - 1.68,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.68 - 1.73,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.68 - 1.73,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.68 - 1.73,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,8.5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.68 - 1.73,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,7.5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.68 - 1.73,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.68 - 1.73,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.68 - 1.73,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.73 - 1.78,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,100,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.73 - 1.78,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,90,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.73 - 1.78,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,75,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.73 - 1.78,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.73 - 1.78,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.73 - 1.78,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.73 - 1.78,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,100,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,85,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,70,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,55,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,55,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,50,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,55,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,50,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,45,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.16 - 2.23,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.16 - 2.23,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.16 - 2.23,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.16 - 2.23,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.16 - 2.23,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.16 - 2.23,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.16 - 2.23,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,40,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.31,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,80,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.31,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,80,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.31,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,80,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.31,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,80,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.31,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.31,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.31,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.31 - 2.40,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.31 - 2.40,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.31 - 2.40,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.31 - 2.40,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.31 - 2.40,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,180,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.31 - 2.40,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,180,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.31 - 2.40,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,180,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.40 - 2.49,0.10 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.40 - 2.49,0.15 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.40 - 2.49,0.20 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.40 - 2.49,0.30 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,200,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.40 - 2.49,0.45 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,180,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.40 - 2.49,0.675 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,180,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.40 - 2.49,1.0 arcsec,Shallow,Ar arc+Xe arc,Closed,none,IR,2,180,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,25,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,20,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,20,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,20,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.35,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.35,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.35,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.35,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.35,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.35,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.35,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.35 - 2.49,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,120,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.35 - 2.49,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,115,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.35 - 2.49,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,105,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.35 - 2.49,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,95,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.35 - 2.49,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,90,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.35 - 2.49,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,85,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.35 - 2.49,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,75,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,1.5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,1.5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,4.5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,3.5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,2.5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,1.5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.28,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.28,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.28,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.28,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.28 - 1.37,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.2,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.28 - 1.37,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.2,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.28 - 1.37,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.2,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.28 - 1.37,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.2,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.63,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.63,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,2.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.63,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,2.3,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.63,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,2,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.63 - 1.77,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.63 - 1.77,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.63 - 1.77,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.63 - 1.77,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.91 - 2.10,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.91 - 2.10,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.91 - 2.10,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.91 - 2.10,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.10 - 2.29,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.10 - 2.29,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.10 - 2.29,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.10 - 2.29,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.29 - 2.48,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,13,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.29 - 2.48,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,12,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.29 - 2.48,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,11,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,2.29 - 2.48,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,10,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,SXD,1.47 - 1.80,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,4,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.8,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,10,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,10,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.8,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,1,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.91 - 2.49,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.91 - 2.49,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.91 - 2.49,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.91 - 2.49,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,30,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,15,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.30 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.675 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,1.0 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.45 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.20 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.15 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.10 arcsec,Shallow,Ar arc,Closed,none,IR,2,60,1,Night

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GNIRS_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GNIRS_FLAT.csv
@@ -1,53 +1,144 @@
-149,2011/11/28 00:16:04 HST
+321,2014/08/06 10:23:38 HST
+#,,V 256,"MLB, 2013Jul12",,Changes:,added config for 13AQ28-110 AND 13B-Q-91
+# "REM, 2014Jul17",,Changes:,"edited IR Texp for SB+SXD+32, 0.45"" slit from 8 sec to 7 sec"
+# 2014 Aug 6, astephens, modified 0.15"/pix 32 l/mm 1.47-1.80 1.0" slit exposure time from 0.24s to 0.38s
+#
 Mode,Pixel Scale,Disperser,Cross Dispersed,Central Wavelength,Focal Plane Unit,Well Depth,Calibration Lamps,Calibration Shutter,Calibration Filter,Calibration Diffuser,Calibration Observe,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,3.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.3,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.6,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.7,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3.2,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.65,3,Day
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,4,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,3,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,3,3,Day
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.8,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,2,3,Day
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.7,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.2,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.7,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.7,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.8,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.2,3,Day
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.6,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.2,3,Day
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,6,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,3.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,2.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,1.8,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,1.2,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,0.8,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,0.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1,3,Day
+Imaging,"0.05""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Open,none,IR,10,2.5,1,Night
+Imaging,"0.05""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Closed,none,IR,10,2.5,1,Night
+Imaging,"0.05""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Open,ND1.0,IR,10,2.5,1,Night
+Imaging,"0.05""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Closed,ND1.0,IR,10,2.5,1,Night
+Imaging,"0.05""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Open,ND2.0,IR,10,1.5,1,Night
+Imaging,"0.05""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Closed,ND2.0,IR,10,1.5,1,Night
+Imaging,"0.05""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Open,ND4-5,IR,8,8,1,Night
+Imaging,"0.05""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Closed,ND4-5,IR,8,8,1,Night
+Imaging,"0.15""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Open,ND1.0,IR,8,2.5,1,Night
+Imaging,"0.15""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Closed,ND1.0,IR,8,2.5,1,Night
+Imaging,"0.15""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Open,ND4.0,IR,8,1.5,1,Night
+Imaging,"0.15""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Closed,ND4.0,IR,8,1.5,1,Night
+Imaging,"0.15""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Open,ND4-5,IR,6,12,1,Night
+Imaging,"0.15""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Closed,ND4-5,IR,6,12,1,Night
+Imaging,"0.15""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Open,ND4-5,IR,10,1,1,Night
+Imaging,"0.15""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Closed,ND4-5,IR,10,1,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,5,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,8,10,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,20,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,8,1.7,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,7.5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,3,1.3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,2.1,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.44,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3.6,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,20,7.2,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,6,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,20,8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,12,3,Day
+Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,8,13.2,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,4.8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,2.16,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.44,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,2.94,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,8.7,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,16.8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,9.24,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,12,3,Day
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3.6,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.56,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.08,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,2.28,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,5.4,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,13.8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,7.8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,12,3,Day
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.32,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,0.9,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,2.1,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,4.74,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,7.2,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,8.28,3,Day
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.10 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,10,11.4,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.30 arcsec,Shallow,IR grey body - high,Open,none,IR,6,0.7,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.675 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,0.8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,1.0 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,0.5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.45 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,1.18,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.20 arcsec,Shallow,IR grey body - high,Open ,ND1.0,IR,6,2.7,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.10 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,6.7,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.15 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,3.7,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,5,2,Day
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.10 arcsec,Deep,IR grey body - high,Open,none,IR,8,2,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.15 arcsec,Deep,IR grey body - high,Open,none,IR,10,1.3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.20 arcsec,Deep,IR grey body - high,Open,none,IR,10,1,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.30 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.6,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.45,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.2,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,pinhole 0.1,Deep,IR grey body - high,Open,none,IR,3,2,1,Day
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,5,3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,8,1.7,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,3,1.3,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,20,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,8,10,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,7.5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,5,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,20,8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,20,7.2,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,6,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3.6,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,2.1,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.8,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.44,1,Night
+Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,12,3,Day
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,4.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.76,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.92,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.84,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,5.4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3.84,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.03 - 1.17,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.98,3,Day
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,4.8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,3.6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,5.4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4.8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.17 - 1.21,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,3.6,3,Day
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4.8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3.6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.16,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.21 - 1.25,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,2.4,3,Day
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,2.04,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.44,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.84,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4.8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3.24,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.16,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.25 - 1.28,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.44,3,Day
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.8,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.72,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3.6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.28 - 1.36,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.44,3,Day
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,7.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,4.2,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,3,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,2.16,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,1.44,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,0.96,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,0.6,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.49 - 1.78,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.2,3,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.91 - 1.97,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,6,50,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.91 - 1.97,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,6,40,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.91 - 1.97,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,6,25,1,Night
@@ -57,8 +148,6 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.91 - 1.97,0.675 arcsec,Shallow,I
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.91 - 1.97,1.0 arcsec,Shallow,IR grey body - high,Open,none,IR,6,5,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.91 - 1.97,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,45,1,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.04,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,90,1,Day
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,60,1,Day
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,45,1,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.29,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,6,35,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.29,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,6,20,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.29,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,6,15,1,Night
@@ -66,6 +155,8 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.29,0.30 arcsec,Shallow,IR
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.29,0.45 arcsec,Shallow,IR grey body - high,Open,none,IR,6,7,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.29,0.675 arcsec,Shallow,IR grey body - high,Open,none,IR,6,4,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,1.97 - 2.29,1.0 arcsec,Shallow,IR grey body - high,Open,none,IR,6,2.5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.04 - 2.10,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,60,1,Day
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.10 - 2.16,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,45,1,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.23 - 2.29,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,45,1,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.29 - 2.41,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,6,35,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.29 - 2.41,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,6,20,1,Night
@@ -90,6 +181,7 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.80 - 3.08,0.30 arcsec,Deep,IR gr
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.80 - 3.08,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,4,10,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.80 - 3.08,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,4,7,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.80 - 3.08,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,4,4,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.80 - 3.65,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,200,2,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.08 - 3.18,0.10 arcsec,Deep,IR grey body - high,Open,none,IR,4,28,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.08 - 3.18,0.15 arcsec,Deep,IR grey body - high,Open,none,IR,4,23,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.08 - 3.18,0.20 arcsec,Deep,IR grey body - high,Open,none,IR,4,18,1,Night
@@ -132,7 +224,6 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.56 - 3.65,0.30 arcsec,Deep,IR gr
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.56 - 3.65,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,4,6,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.56 - 3.65,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,4,3.5,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.56 - 3.65,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,4,1.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,2.80 - 3.65,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,200,2,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.75,0.10 arcsec,Deep,IR grey body - high,Open,none,IR,4,18,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.75,0.15 arcsec,Deep,IR grey body - high,Open,none,IR,4,14,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.75,0.20 arcsec,Deep,IR grey body - high,Open,none,IR,4,10,1,Night
@@ -140,6 +231,7 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.75,0.30 arcsec,Deep,IR gr
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.75,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,4,5,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.75,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,4,3,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.75,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,4,1.5,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.94,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,150,2,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.75 - 3.84,0.10 arcsec,Deep,IR grey body - high,Open ,none,IR,4,18,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.75 - 3.84,0.15 arcsec,Deep,IR grey body - high,Open ,none,IR,4,13,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.75 - 3.84,0.20 arcsec,Deep,IR grey body - high,Open ,none,IR,4,9,1,Night
@@ -154,7 +246,6 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.84 - 3.94,0.30 arcsec,Deep,IR gr
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.84 - 3.94,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,4,5,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.84 - 3.94,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,4,3,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.84 - 3.94,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,4,1.5,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.65 - 3.94,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,150,2,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.03,0.10 arcsec,Deep,IR grey body - high,Open,none,IR,4,18,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.03,0.15 arcsec,Deep,IR grey body - high,Open,none,IR,4,14,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.03,0.20 arcsec,Deep,IR grey body - high,Open,none,IR,4,10,1,Night
@@ -162,6 +253,7 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.03,0.30 arcsec,Deep,IR gr
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.03,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,4,5,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.03,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,4,3,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.03,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,4,1.75,1,Night
+Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.22,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,120,2,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.03 - 4.12,0.10 arcsec,Deep,IR grey body - high,Open ,none,IR,4,18,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.03 - 4.12,0.15 arcsec,Deep,IR grey body - high,Open ,none,IR,4,13,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.03 - 4.12,0.20 arcsec,Deep,IR grey body - high,Open ,none,IR,4,9,1,Night
@@ -176,7 +268,6 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.12 - 4.22,0.30 arcsec,Deep,IR gr
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.12 - 4.22,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,4,5,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.12 - 4.22,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,4,3,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.12 - 4.22,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,4,1.75,1,Night
-Spectroscopy,"0.05""/pix",111 l/mm grating,No,3.94 - 4.22,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,120,2,Day
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.40 - 4.97,0.10 arcsec,Deep,IR grey body - high,Closed,none,IR,10,20,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.40 - 4.97,0.15 arcsec,Deep,IR grey body - high,Closed,none,IR,10,12,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,4.40 - 4.97,0.20 arcsec,Deep,IR grey body - high,Closed,none,IR,10,8,1,Night
@@ -201,39 +292,56 @@ Spectroscopy,"0.05""/pix",111 l/mm grating,No,5.36 - 5.55,0.45 arcsec,Deep,IR gr
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,5.36 - 5.55,0.675 arcsec,Deep,IR grey body - high,Closed,none,IR,10,1,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,5.36 - 5.55,1.0 arcsec,Deep,IR grey body - high,Closed,none,IR,10,0.6,1,Night
 Spectroscopy,"0.05""/pix",111 l/mm grating,No,5.36 - 5.55,pinhole 0.3,Deep,IR grey body - high,Closed,NIR balance,IR,5,1.5,1,Day
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.5,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.9,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.6,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.7,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.8,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.2,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,pinhole 0.1,Shallow,Quartz Halogen,Closed,ND1.0,IR,1,3,3,Day
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.9,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.6,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.5,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.7,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.1,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.75,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,4.5,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,pinhole 0.1,Shallow,Quartz Halogen,Closed,ND1.0,IR,1,1,3,Day
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.9,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.7,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.5,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.8,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.2,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.8,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,4.5,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,pinhole 0.1,Shallow,Quartz Halogen,Closed,ND1.0,IR,1,2,3,Day
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.65,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.4,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.3,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.2,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.45,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.3,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.2,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1,3,Day
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.5,3,Day
+Spectroscopy,"0.05""/pix",32 l/mm grating,SXD,1.49 - 1.82,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,4,8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,SXD,1.49 - 1.82,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,8,4,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,3,15,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,3,60,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,30,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open,none,IR,5,3.25,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,4,7,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,3,50,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,7,5,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,5,0.96,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,10.8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,4.8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,14.4,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,28.8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,7.2,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,21.6,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,36,2,Day
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.08,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.72,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,4.8,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3.24,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.16,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.44,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.03 - 1.17,pinhole 0.1,Shallow,Quartz Halogen,Closed,ND1.0,IR,1,3.6,3,Day
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.08,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.72,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.04,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.32,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.9,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,5.4,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.17 - 1.30,pinhole 0.1,Shallow,Quartz Halogen,Closed,ND1.0,IR,1,1.2,3,Day
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,1.08,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.84,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,3,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,2.16,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,1.44,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.96,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,5.4,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.30 - 1.37,pinhole 0.1,Shallow,Quartz Halogen,Closed,ND1.0,IR,1,2.4,3,Day
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.66,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.2,3,Day
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.78,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.15 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.48,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.20 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.36,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.30 arcsec,Shallow,Quartz Halogen,Closed,none,IR,10,0.24,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.54,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.36,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.49 - 1.82,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND1.0,IR,10,0.24,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.66 - 1.82,pinhole 0.1,Shallow,Quartz Halogen,Closed,none,IR,1,1.8,3,Day
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.49,0.10 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,35,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.49,0.15 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,17,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,1.91 - 2.49,0.20 arcsec,Shallow,IR grey body - high,Open ,ND1.0,IR,6,12.5,1,Night
@@ -249,6 +357,7 @@ Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.80 - 3.13,0.30 arcsec,Deep,IR gre
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.80 - 3.13,0.45 arcsec,Deep,IR grey body - high,Open ,none,IR,4,4,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.80 - 3.13,0.675 arcsec,Deep,IR grey body - high,Open ,none,IR,4,3,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.80 - 3.13,1.0 arcsec,Deep,IR grey body - high,Open ,none,IR,4,2.2,1,Night
+Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.80 - 4.13,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,30,2,Day
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,3.13 - 3.46,0.10 arcsec,Deep,IR grey body - high,Open,none,IR,4,10,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,3.13 - 3.46,0.15 arcsec,Deep,IR grey body - high,Open,none,IR,4,7,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,3.13 - 3.46,0.20 arcsec,Deep,IR grey body - high,Open,none,IR,4,6,1,Night
@@ -270,7 +379,6 @@ Spectroscopy,"0.05""/pix",32 l/mm grating,No,3.80 - 4.13,0.30 arcsec,Deep,IR gre
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,3.80 - 4.13,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,4,1.5,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,3.80 - 4.13,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,4,1,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,3.80 - 4.13,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,4,0.4,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,No,2.80 - 4.13,pinhole 0.1,Deep,IR grey body - high,Closed,none,IR,1,30,2,Day
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,4.40 - 5.06,0.10 arcsec,Deep,IR grey body - high,Closed,none,IR,10,3,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,4.40 - 5.06,0.15 arcsec,Deep,IR grey body - high,Closed,none,IR,10,2.2,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,4.40 - 5.06,0.20 arcsec,Deep,IR grey body - high,Closed,none,IR,10,1.6,1,Night
@@ -287,27 +395,27 @@ Spectroscopy,"0.05""/pix",32 l/mm grating,No,5.06 - 5.72,0.45 arcsec,Deep,IR gre
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,5.06 - 5.72,0.675 arcsec,Deep,IR grey body - high,Closed,none,IR,10,0.35,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,5.06 - 5.72,1.0 arcsec,Deep,IR grey body - high,Closed,none,IR,10,0.3,1,Night
 Spectroscopy,"0.05""/pix",32 l/mm grating,No,5.06 - 5.72,pinhole 0.3,Deep,IR grey body - high,Closed,NIR balance,IR,5,1.2,1,Day
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,10,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,6,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,4.5,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,3,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,15,1,Day
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,10,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,7,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,5,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,3,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,28,1,Day
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,7.5,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,4.5,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,3,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,2,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,10,1,Day
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,1.6,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,1,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,0.7,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,0.5,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.63,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,3,1,Day
-Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.63 - 1.77,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,2,1,Day
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,12,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,7.2,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,5.4,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,3.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.03 - 1.12,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,18,1,Day
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,12,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,8.4,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,3.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.12 - 1.17,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,33.6,1,Day
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,12,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,5.4,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,3.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,2.4,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.17 - 1.37,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,12,1,Day
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.63,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,3.6,1,Day
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,1.92,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,1.2,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,0.84,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.49 - 1.77,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,10,0.6,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.63 - 1.77,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,2.4,1,Day
 Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.91 - 2.49,0.30 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,20,1,Night
 Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.91 - 2.49,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,8,12,1,Night
 Spectroscopy,"0.15""/pix",111 l/mm grating,No,1.91 - 2.49,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,10,1,Night
@@ -347,21 +455,30 @@ Spectroscopy,"0.15""/pix",111 l/mm grating,No,4.98 - 5.55,0.30 arcsec,Deep,IR gr
 Spectroscopy,"0.15""/pix",111 l/mm grating,No,4.98 - 5.55,0.45 arcsec,Deep,IR grey body - high,Closed,ND4-5,IR,1,0.2,1,Night
 Spectroscopy,"0.15""/pix",111 l/mm grating,No,4.98 - 5.55,0.675 arcsec,Deep,IR grey body - high,Closed,ND4-5,IR,1,0.2,1,Night
 Spectroscopy,"0.15""/pix",111 l/mm grating,No,4.98 - 5.55,pinhole 0.3,Deep,IR grey body - high,Closed,NIR balance,IR,1,0.2,1,Day
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,2,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,1.2,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,4,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,2.5,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,6,1,Day
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,1.5,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.8,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,3,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,1.8,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,5,1,Day
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.3,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.2,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.8,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.45,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,1,1,Day
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,15,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,10,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open ,none,IR,4,1,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,20,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,2.4,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.5,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3,1,Night
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,4,4.8,1,Day
+Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,8,4.8,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,2.4,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,1.44,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,4.8,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,3,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.03 - 1.17,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,7.2,1,Day
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,1.8,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.96,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,3.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,2.16,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.17 - 1.37,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,2,6,1,Day
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.675 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.36,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,1.0 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.38,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.30 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.96,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,0.45 arcsec,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,0.54,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.47 - 1.80,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,3,1.2,1,Day
 Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.91 - 2.49,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,5,3,1,Night
 Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.91 - 2.49,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,5,2,1,Night
 Spectroscopy,"0.15""/pix",32 l/mm grating,No,1.91 - 2.49,0.30 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,5,7,1,Night
@@ -372,109 +489,14 @@ Spectroscopy,"0.15""/pix",32 l/mm grating,No,2.8 - 4.2,1.0 arcsec,Deep,IR grey b
 Spectroscopy,"0.15""/pix",32 l/mm grating,No,2.8 - 4.2,0.45 arcsec,Deep,IR grey body - high,Closed,none,IR,10,1.2,1,Night
 Spectroscopy,"0.15""/pix",32 l/mm grating,No,2.8 - 4.2,0.30 arcsec,Deep,IR grey body - high,Closed,none,IR,10,1.8,1,Night
 Spectroscopy,"0.15""/pix",32 l/mm grating,No,2.8 - 4.2,pinhole 0.3,Deep,IR grey body - high,Closed,none,IR,3,2,1,Day
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,15,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,2,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,10,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.25,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open ,none,IR,4,1,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,8,4,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,20,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,2.5,1,Night
-Spectroscopy,"0.15""/pix",111 l/mm grating,SXD,0.9 - 2.56,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,4,4,1,Day
 Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,5,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,0.7,1,Night
 Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,10,3.25,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,0.5,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.15 arcsec,Shallow,IR grey body - high,Open ,NIR balance,IR,6,15,1,Night
 Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open ,NIR balance,IR,6,12,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,10,1.5,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open ,NIR balance,IR,10,8,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1,1,Night
-Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,1,1,Day
-Imaging,"0.15""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Open,ND1.0,IR,8,2.5,1,Night
-Imaging,"0.15""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Closed,ND1.0,IR,8,2.5,1,Night
-Imaging,"0.15""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Open,ND4.0,IR,8,1.5,1,Night
-Imaging,"0.15""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Closed,ND4.0,IR,8,1.5,1,Night
-Imaging,"0.15""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Open,ND4-5,IR,6,12,1,Night
-Imaging,"0.15""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Closed,ND4-5,IR,6,12,1,Night
-Imaging,"0.15""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Open,ND4-5,IR,10,1,1,Night
-Imaging,"0.15""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Closed,ND4-5,IR,10,1,1,Night
-Imaging,"0.05""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Open,none,IR,10,2.5,1,Night
-Imaging,"0.05""/pix",*,*,1.03 - 1.17,*,Shallow,IR grey body - high,Closed,none,IR,10,2.5,1,Night
-Imaging,"0.05""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Open,ND1.0,IR,10,2.5,1,Night
-Imaging,"0.05""/pix",*,*,1.17 - 1.37,*,Shallow,IR grey body - high,Closed,ND1.0,IR,10,2.5,1,Night
-Imaging,"0.05""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Open,ND2.0,IR,10,1.5,1,Night
-Imaging,"0.05""/pix",*,*,1.47 - 1.80,*,Shallow,IR grey body - high,Closed,ND2.0,IR,10,1.5,1,Night
-Imaging,"0.05""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Open,ND4-5,IR,8,8,1,Night
-Imaging,"0.05""/pix",*,*,1.91 - 2.49,*,Shallow,IR grey body - high,Closed,ND4-5,IR,8,8,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,5,3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,8,11,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,8,10,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,1.75,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.2,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,20,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,8,1.7,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,20,6,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,6,7.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,3,1.3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,3,1.3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,SXD,0.9 - 2.56,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,8,5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,LXD,0.9 - 2.56,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,10,3,Day
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,IR grey body - high,Open,none,IR,3,15,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.10 arcsec,Shallow,Quartz Halogen,Closed,none,IR,5,0.8,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,3,60,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,9,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,4,30,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,4,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,IR grey body - high,Open,none,IR,5,3.25,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,12,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,IR grey body - high,Open,none,IR,4,7,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,24,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,IR grey body - high,Open,NIR balance,IR,3,50,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,6,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,IR grey body - high,Open,none,IR,7,5,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,5,18,1,Night
-Spectroscopy,"0.05""/pix",32 l/mm grating,LXD,0.9 - 2.56,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,30,2,Day
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,4,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.8,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.2,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,2.45,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,7.25,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,14,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,7.7,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.03 - 1.17,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,10,3,Day
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,0.9,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.9,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,4.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.10 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,11.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,6.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.17 - 1.37,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,10,3,Day
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.30 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,2.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.1,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,0.75,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.75,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.20 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,3.95,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.10 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,10,9.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,0.15 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,6,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.47 - 1.80,pinhole 0.1,Shallow,Quartz Halogen,Closed,NIR balance,IR,1,6.9,3,Day
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.30 arcsec,Shallow,IR grey body - high,Open,none,IR,6,0.7,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.675 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,0.8,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,1.0 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,0.5,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.45 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,1.18,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.20 arcsec,Shallow,IR grey body - high,Open ,ND1.0,IR,6,2.7,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.10 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,6.7,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,0.15 arcsec,Shallow,IR grey body - high,Open,ND1.0,IR,6,3.7,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,1.91 - 2.49,pinhole 0.1,Shallow,IR grey body - high,Open,none,IR,1,5,2,Day
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.10 arcsec,Deep,IR grey body - high,Open,none,IR,8,2,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.15 arcsec,Deep,IR grey body - high,Open,none,IR,10,1.3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.20 arcsec,Deep,IR grey body - high,Open,none,IR,10,1,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.30 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.6,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.45 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.45,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,0.675 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.3,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,1.0 arcsec,Deep,IR grey body - high,Open,none,IR,10,0.2,1,Night
-Spectroscopy,"0.05""/pix",10 l/mm grating,No,2.8 - 4.2,pinhole 0.1,Deep,IR grey body - high,Open,none,IR,3,2,1,Day
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,IR grey body - high,Open ,NIR balance,IR,10,7,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.675 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,0.84,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,1.0 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,0.6,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.45 arcsec,Shallow,Quartz Halogen,Closed,ND2.0,IR,10,1.2,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,pinhole 0.3,Shallow,Quartz Halogen,Closed,NIR balance,IR,5,1.2,3,Day
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.15 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,10,2,1,Night
+Spectroscopy,"0.15""/pix",32 l/mm grating,SXD,0.9 - 2.56,0.30 arcsec,Shallow,Quartz Halogen ,Closed,ND2.0,IR,10,1.8,1,Night

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GPI_ARC.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GPI_ARC.csv
@@ -1,21 +1,7 @@
-1,2013/10/04 12:00:00 HST
+343,2015/01/14 16:10:29 HST
 #,GPI ARC Calibrations,,,,,,,,,
 ,,,,,,,,,,
 Mode,Disperser,,Calibration Lamps,Calibration Shutter,Calibration Filter,Calibration Diffuser,Calibration Observe,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
-Coronograph Y-band,Prism,,Ar arc,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph J-band,Prism,,Ar arc,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph H-band,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph K1-band,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph K2-band,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-H_LIWA,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-H_star,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask Y,Prism,,Ar arc,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask J,Prism,,Ar arc,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask J,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask K1,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask K2,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-Y direct,Prism,,Ar arc,Open,ND4-5,IR,1,1.5,1,Night
-J direct,Prism,,Ar arc,Open,ND4-5,IR,1,1.5,1,Night
-H direct,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-K1 direct,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
-K2 direct,Prism,,Ar arc+Xe arc,Open,ND4-5,IR,1,1.5,1,Night
+$.*K1.*,$[Pp]rism,,Ar arc,Open,none,IR,5,300,1,Day
+$.*K2.*,$[Pp]rism,,Ar arc,Open,none,IR,9,300,1,Day
+$[^K]*,$[Pp]rism,,Ar arc,Open,none,IR,1,30,2,Day

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GPI_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/GPI_FLAT.csv
@@ -1,38 +1,4 @@
-1,2013/10/04 12:00:00 HST
+273,2013/11/06 09:03:23 HST
 #,GPI Flat Calibrations,,,,,,,,,
 ,,,,,,,,,,
 Mode,Disperser,,Calibration Lamps,Calibration Shutter,Calibration Filter,Calibration Diffuser,Calibration Observe,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
-Coronograph Y-band,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph J-band,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph H-band,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph K1-band,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph K2-band,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-H_LIWA,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-H_star,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask Y,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask J,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask H,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask K1,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask K2,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Y direct,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-J direct,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-H direct,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-K1 direct,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-K2 direct,Prism,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph Y-band,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph J-band,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph H-band,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph K1-band,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Coronograph K2-band,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-H_LIWA,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-H_star,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask Y,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask J,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask H,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask K1,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Non Redundant Mask K2,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-Y direct,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-J direct,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-H direct,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-K1 direct,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night
-K2 direct,Wollaston,,IR grey body - high,Open,ND4-5,IR,1,1.5,1,Night

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIFS_ARC.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIFS_ARC.csv
@@ -1,22 +1,25 @@
-149,2011/11/28 00:16:04 HST
-#,NIFS GCAL Calibration Configurations:,,,,,,,,,,,
-#,,,,,,,,,,,,
-#,"V 1.3 - GG, 2011oct15",,,,,,,,,,,
-#,"changes: added �same as disperser"" option to filter",,,,,,,,,,,
-#,,,,,,,,,,,,
-#,"V 1.1 - GG, 2011sep18",,,,,,,,,,,
-#,,,,,,,,,,,,
-#,"For a daytime Calibration set at each wavelength, take: 1) Lamps on flats, 2) Lamps off flats, 3) Ar arcc dAr arcks, 4) Ronchi calibration masks, 5) CleAr arc Ar arcray frame (CleAr arc Ar arcray is to get rid of image persistence from the Ronchi mask frames).  NOTE: Observations Ar arce defined in that order to minimize the number of FPU moves in NIFS and increase the efficiency.",,,,,,,,,,,
-#,Ar arccs for NIFS observations should ALWAYS be taken with the science at night!  (not as daytime calibs).,,,,,,,,,,,
-#,"The Filter and Central Wavelength should be matched to the science observations, as these can be customized by the PI.",,,,,,,,,,,
-#,"If the science observation is made with an occullting disk, this should also be used for the flat fields. This is an uncommon mode.",,,,,,,,,,,
-#,PAr arcameters that should be matched to the science Ar arce indicated in dAr arck orange:,,,,,,,,,,,
-#,,,,,,,,,,,,
+217,2012/02/22 10:43:45 HST
+#,NIFS GCAL Calibration Configurations:
+#,
+#,"V 1.4 - RMcD, 2012feb22"
+#,Changes: Changed disperser name from 'K grating' to '$K.*' to accommodate K_short and K_long grating names
+#,
+#,"V 1.3 - GG, 2011oct15"
+#,"changes: added ï¿½same as disperser"" option to filter"
+#,
+#,"V 1.1 - GG, 2011sep18"
+#,
+#,"For a daytime Calibration set at each wavelength, take: 1) Lamps on flats, 2) Lamps off flats, 3) Ar arcc dAr arcks, 4) Ronchi calibration masks, 5) CleAr arc Ar arcray frame (CleAr arc Ar arcray is to get rid of image persistence from the Ronchi mask frames).  NOTE: Observations Ar arce defined in that order to minimize the number of FPU moves in NIFS and increase the efficiency."
+#,Ar arccs for NIFS observations should ALWAYS be taken with the science at night!  (not as daytime calibs).
+#,"The Filter and Central Wavelength should be matched to the science observations, as these can be customized by the PI."
+#,"If the science observation is made with an occullting disk, this should also be used for the flat fields. This is an uncommon mode."
+#,PAr arcameters that should be matched to the science Ar arce indicated in dAr arck orange:
+#,
 # NIFS,,,,,# GCAL,,,,,,,
 Disperser,Filter,Focal Plane Mask,Central Wavelength,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
 #,,,,,,,,,,,,
 # K band,,,,,,,,,,,,
-K grating,$HK Filter|Same as Disperser,Clear,2.00 - 2.41,,1,none,IR,Ar arc+Xe arc,closed,30,1,Night
+$K.*,$HK Filter|Same as Disperser,Clear,2.00 - 2.41,,1,none,IR,Ar arc+Xe arc,closed,30,1,Night
 #,,,,,,,,,,,,
 # H band,,,,,,,,,,,,
 H grating,$.*H.* Filter|Same as Disperser,Clear,1.49 - 1.78,,1,none,IR,Ar arc,closed,10,1,Night

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIRI_FLAT.csv
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/resources/resources/smartgcal/calibrations/NIRI_FLAT.csv
@@ -1,13 +1,33 @@
-149,2011/11/28 00:16:04 HST
-#,NIRI_Flat.csv,,,,,,,,,,,,
-#,,,,,,,,,,,,,
-#,2011 Oct 23,GG: initial import,,,,,,,,,,,
-#,2011 Nov 08,GG: add SAME to beam splitter,,,,,,,,,,,
-#,2011 Nov 16,AS: sort according to camera & filter,,,,,,,,,,,
-#,2011 Nov 17,AS: fix quartz lamp off flats,,,,,,,,,,,
-#,,,,,,,,,,,,,
+359,2015/09/15 12:51:07 HST
+# NIRI_Flat.csv
+#
+# 2011 Oct 23, GG: initial import
+# 2011 Nov 08, GG: add SAME to beam splitter
+# 2011 Nov 16, AS: sort according to camera & filter
+# 2011 Nov 17, AS: fix quartz lamp off flats
+# 2012 Jul 13, AS: increase f/32 J-band exptime from 3.5s to 4s
+# 2013 Jul 11, AS: add f/14 Kcont 2.272
+# 2013 Sep 02, AS: add f/32 Kcont 2.272
+# 2014 Apr 02, AS:
+#    f/6 Y increased from 6.0s to 7.0s
+#    f/6 J increased from 1.2s to 1.4s
+#    f/6 H increased from 35s to 42s
+#    f/32 J increased from 4s to 5.2s
+#    f/32 Jcon(1207) increased from 4.2s to 5.0s
+#    f/32 H2v=1-0S1 increased from 4.0s to 5.0s
+#    f/32 Kcon(209) increased from 3.5s to 5.0s
+# 2014 Aug 29, AS:
+#    f/6  CO 2-0 (bh) increased from 1.5s to 1.8s
+#    f/14 H2(2-1) increased from 1.0s to 1.1s
+#    f/14 CO(2-0) added with ND4 and 1.1s
+#    f/32 H2(2-1) increased from 2.5s to 3.5s
+#    f/32 CO(2-0) added with ND3 and 3.8s
+#    Remove hydrocarbon entries
+# 2014 Nov 26, AS: add f/14 J-continuum (1.122 um)
+# 2014 Nov 26, AS: increase f/14 Y from 28s to 32s
+#
 Disperser,Filter,Focal Plane Mask,Camera,Beam Splitter,,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
-#,,,,,,,,,,,,,
+#
 none,[FeII] ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,7,1,Day
 none,[FeII] ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,7,1,Day
 #none,Br(alpha),imaging,f/6 ,$f/6|same.*,,10,N/A,N/A,N/A,Closed,N/A,1,Day
@@ -22,10 +42,10 @@ none,CH4(long) ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Clo
 none,CH4(long) ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,1.2,1,Day
 none,CH4(short),imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,2,1,Day
 none,CH4(short),imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,2,1,Day
-none,CO 2-0 (bh) ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,1.5,1,Day
-none,CO 2-0 (bh) ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,1.5,1,Day
-none,H ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Closed,35,1,Day
-none,H ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Open,35,1,Day
+none, CO 2-0 (bh), imaging, f/6, $f/6|same.*, , 10, ND2.0, IR, IR grey body - high, Closed, 1.8, 1, Day
+none, CO 2-0 (bh), imaging, f/6, $f/6|same.*, , 10, ND2.0, IR, IR grey body - high, Open,   1.8, 1, Day
+none,H ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Closed, 42, 1,Day
+none,H ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Open,   42, 1,Day
 none,H-continuum(1.57) ,imaging,f/6 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed,1.9,1,Day
 none,H-continuum(1.57) ,imaging,f/6 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,1.9,1,Day
 none,H2 1-0 S(1) ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,1.7,1,Day
@@ -40,10 +60,10 @@ none,HeI ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,16,
 none,HeI ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,16,1,Day
 none,HeI (2p2s) ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,2,1,Day
 none,HeI (2p2s) ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,2,1,Day
-none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,0.8,1,Day
-none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,0.8,1,Day
-none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,1.2,1,Day
-none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,1.2,1,Day
+#none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,0.8,1,Day
+#none,hydrocarbon ,imaging,f/6 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,0.8,1,Day
+none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,1.4, 1,Day
+none,J ,imaging,f/6 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,  1.4, 1,Day
 none,J-continuum (1.065 um) ,imaging,f/6,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,30,1,Day
 none,J-continuum (1.065 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,30,1,Day
 none,J-continuum (1.122 um) ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,12,1,Day
@@ -62,9 +82,9 @@ none,K(short) ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Clos
 none,K(short) ,imaging,f/6 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Open,5.5,1,Day
 none,Pa(beta),imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,0.8,1,Day
 none,Pa(beta),imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,0.8,1,Day
-none,Y ,imaging,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,6,1,Day
-none,Y,imaging ,f/6 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,6,1,Day
-#,,,,,,,,,,,,,
+none, Y, imaging, f/6, $f/6|same.*,, 10, none, IR, IR grey body - high, Closed, 7.0, 1, Day
+none, Y, imaging, f/6, $f/6|same.*,, 10, none, IR, IR grey body - high, Open,   7.0, 1, Day
+#
 none,[FeII] ,imaging,f/14 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed,5.5,1,Day
 none,[FeII] ,imaging,f/14 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,5.5,1,Day
 #none,Br(alpha),imaging,f/14 ,$f/6|same.*,,10,N/A,N/A,N/A,Closed,N/A,1,Day
@@ -79,16 +99,16 @@ none,CH4(long) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Cl
 none,CH4(long) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Open,1.8,1,Day
 none,CH4(short),imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Closed,3,1,Day
 none,CH4(short),imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Open,3,1,Day
-#none,CO 2-0 (bh) ,imaging,f/14 ,$f/6|same.*,,10,unknown,unknown,unknown,Closed,unknown,1,Day
-#none,CO 2-0 (bh) ,imaging,f/14 ,$f/6|same.*,,10,unknown,unknown,unknown,Open,unknown,1,Day
+none, CO 2-0 (bh), imaging, f/14, $f/6|same.*, , 10, ND4.0, IR, IR grey body - high, Closed, 1.1, 1, Day
+none, CO 2-0 (bh), imaging, f/14, $f/6|same.*, , 10, ND4.0, IR, IR grey body - high, Open,   1.1, 1, Day
 none,H ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,3,1,Day
 none,H ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,3,1,Day
 none,H-continuum(1.57) ,imaging,f/14 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,3.5,1,Day
 none,H-continuum(1.57) ,imaging,f/14 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,3.5,1,Day
 none,H2 1-0 S(1) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Closed,1.5,1,Day
 none,H2 1-0 S(1) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Open,1.5,1,Day
-none,H2 2-1 S(1) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Closed,1,1,Day
-none,H2 2-1 S(1) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Open,1,1,Day
+none, H2 2-1 S(1), imaging, f/14, $f/6|same.*, , 10, ND4.0, IR, IR grey body - high, Closed, 1.1, 1, Day
+none, H2 2-1 S(1), imaging, f/14, $f/6|same.*, , 10, ND4.0, IR, IR grey body - high, Open,   1.1, 1, Day
 none,H2O ice (2.045) ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,1.6,1,Day
 none,H2O ice (2.045) ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,1.6,1,Day
 none,H2O ice (3.050) ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,3.5,1,Day
@@ -97,27 +117,31 @@ none,HeI ,imaging,f/14 ,$f/6|same.*,,10,ND4.0,IR ,Quartz Halogen,Closed,3.5,1,Da
 none,HeI ,imaging,f/14 ,$f/6|same.*,,10,ND4.0,IR ,Quartz Halogen,Open,3.5,1,Day
 none,HeI (2p2s) ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,12,1,Day
 none,HeI (2p2s) ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,12,1,Day
-none,hydrocarbon ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4.2,1,Day
-none,hydrocarbon ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,4.2,1,Day
+#none,hydrocarbon ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4.2,1,Day
+#none,hydrocarbon ,imaging,f/14 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,4.2,1,Day
 none,J ,imaging,f/14 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,8,1,Day
 none,J ,imaging,f/14 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,8,1,Day
 #none,J-continuum (1.065 um) ,imaging,f/14 ,$f/6|same.*,,10,unknown,unknown,unknown,Closed,unknown,1,Day
 #none,J-continuum (1.065 um) ,imaging,f/14 ,$f/6|same.*,,10,unknown,unknown,unknown,Open,unknown,1,Day
+none, J-continuum (1.122 um), imaging, f/14, $f/6|same.*,, 10, ND2.0, IR, IR grey body - high, Closed, 2.1, 1, Day
+none, J-continuum (1.122 um), imaging, f/14, $f/6|same.*,, 10, ND2.0, IR, Quartz Halogen,      Open,   2.1, 1, Day
 none,J-continuum(1.207) ,imaging,f/14 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,5,1,Day
 none,J-continuum(1.207) ,imaging,f/14 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,5,1,Day
 none,K ,imaging,f/14 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Closed,27,1,Day
 none,K ,imaging,f/14 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Open,27,1,Day
 none,K-continuum(2.09) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Closed,1.8,1,Day
 none,K-continuum(2.09) ,imaging,f/14 ,$f/6|same.*,,10,ND4.0 ,IR ,IR grey body - high ,Open,1.8,1,Day
+none,K-continuum(2.27),imaging,f/14,$f/6|same.*,,10,NIR Balance,IR,IR grey body - high,Closed,3.4,1,Day
+none,K-continuum(2.27),imaging,f/14,$f/6|same.*,,10,NIR Balance,IR,IR grey body - high,Open,3.4,1,Day
 none,K(prime) ,imaging,f/14 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Closed,35,1,Day
 none,K(prime) ,imaging,f/14 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Open,35,1,Day
 none,K(short) ,imaging,f/14 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Closed,35,1,Day
 none,K(short) ,imaging,f/14 ,$f/6|same.*,,10,ND4-5 ,IR ,IR grey body - high ,Open,35,1,Day
 none,Pa(beta),imaging,f/14 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,6,1,Day
 none,Pa(beta),imaging,f/14 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,6,1,Day
-none,Y ,imaging,f/14 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,28,1,Day
-none,Y ,imaging,f/14 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,28,1,Day
-#,,,,,,,,,,,,,
+none, Y, imaging, f/14, $f/6|same.*,, 10, none, IR, IR grey body - high, Closed, 32, 1, Day
+none, Y, imaging, f/14, $f/6|same.*,, 10, none, IR, IR grey body - high, Open,   32, 1, Day
+#
 none,[FeII] ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,3,1,Day
 none,[FeII] ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,3,1,Day
 #none,Br(alpha),imaging,f/32 ,$f/6|same.*,,10,N/A,N/A,N/A,Closed,N/A,1,Day
@@ -132,16 +156,16 @@ none,CH4(long) ,imaging,f/32 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Cl
 none,CH4(long) ,imaging,f/32 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,2.2,1,Day
 none,CH4(short),imaging,f/32 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,3.4,1,Day
 none,CH4(short),imaging,f/32 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,3.4,1,Day
-#none,CO 2-0 (bh) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Closed,unknown,1,Day
-#none,CO 2-0 (bh) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Open,unknown,1,Day
+none,CO 2-0 (bh), imaging, f/32, $f/6|same.*, , 10, ND3.0, IR, IR grey body - high, Closed, 3.8, 1, Day
+none,CO 2-0 (bh), imaging, f/32, $f/6|same.*, , 10, ND3.0, IR, IR grey body - high, Open,   3.8, 1, Day
 none,H ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed,2.2,1,Day
 none,H ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,2.2,1,Day
 none,H-continuum(1.57) ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,5.4,1,Day
 none,H-continuum(1.57) ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,5.4,1,Day
-none,H2 1-0 S(1) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed,4,1,Day
-none,H2 1-0 S(1) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,4,1,Day
-none,H2 2-1 S(1) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed,2.5,1,Day
-none,H2 2-1 S(1) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,2.5,1,Day
+none,H2 1-0 S(1) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed, 5.0, 1,Day
+none,H2 1-0 S(1) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,   5.0, 1,Day
+none, H2 2-1 S(1), imaging, f/32, $f/6|same.*, , 10, ND3.0, IR, IR grey body - high, Closed, 3.5, 1, Day
+none, H2 2-1 S(1), imaging, f/32, $f/6|same.*, , 10, ND3.0, IR, IR grey body - high, Open,   3.5, 1, Day
 none,H2O ice (2.045) ,imaging,f/32 ,$f/6|same.*,,10,NIR Balance ,IR ,IR grey body - high ,Closed,3,1,Day
 none,H2O ice (2.045) ,imaging,f/32 ,$f/6|same.*,,10,NIR Balance ,IR ,IR grey body - high ,Open,3,1,Day
 none,H2O ice (3.050) ,imaging,f/32 ,$f/6|same.*,,10,GMOS Balance,IR ,IR grey body - high ,Closed,1.5,1,Day
@@ -150,20 +174,22 @@ none,HeI ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,7
 none,HeI ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,7.5,1,Day
 none,HeI (2p2s) ,imaging,f/32 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Closed,2.3,1,Day
 none,HeI (2p2s) ,imaging,f/32 ,$f/6|same.*,,10,ND1.0 ,IR ,IR grey body - high ,Open,2.3,1,Day
-none,hydrocarbon ,imaging,f/32 ,$f/6|same.*,,10,GMOS Balance,IR ,IR grey body - high ,Closed,4.2,1,Day
-none,hydrocarbon ,imaging,f/32 ,$f/6|same.*,,10,GMOS Balance,IR ,IR grey body - high ,Open,4.2,1,Day
-none,J ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Closed,3.5,1,Day
-none,J ,imaging,f/32 ,$f/6|same.*,,10,none ,IR ,IR grey body - high ,Open,3.5,1,Day
+#none,hydrocarbon ,imaging,f/32 ,$f/6|same.*,,10,GMOS Balance,IR ,IR grey body - high ,Closed,4.2,1,Day
+#none,hydrocarbon ,imaging,f/32 ,$f/6|same.*,,10,GMOS Balance,IR ,IR grey body - high ,Open,4.2,1,Day
+none, J, imaging, f/32, $f/6|same.*,, 10, none, IR, IR grey body - high, Closed, 5.2, 1, Day
+none, J, imaging, f/32, $f/6|same.*,, 10, none, IR, IR grey body - high, Open,   5.2, 1, Day
 #none,J-continuum (1.065 um) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Closed,unknown,1,Day
 #none,J-continuum (1.065 um) ,imaging,f/32 ,$f/6|same.*,,10,unknown,unknown,unknown,Open,unknown,1,Day
 none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,9,1,Day
 none,J-continuum (1.122 um) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,9,1,Day
-none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4.2,1,Day
-none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen,Open,4.2,1,Day
+none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed, 5.0, 1,Day
+none,J-continuum(1.207) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,Quartz Halogen, Open,        5.0, 1,Day
 none,K ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4,1,Day
 none,K ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,4,1,Day
-none,K-continuum(2.09) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed,3.5,1,Day
-none,K-continuum(2.09) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,3.5,1,Day
+none,K-continuum(2.09) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Closed, 5.0, 1,Day
+none,K-continuum(2.09) ,imaging,f/32 ,$f/6|same.*,,10,ND3.0 ,IR ,IR grey body - high ,Open,   5.0, 1,Day
+none,K-continuum(2.27),imaging,f/32,$f/6|same.*,,10,ND3.0,IR,IR grey body - high,Closed,3.0,1,Day
+none,K-continuum(2.27),imaging,f/32,$f/6|same.*,,10,ND3.0,IR,IR grey body - high,Open,3.0,1,Day
 none,K(prime) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,3.6,1,Day
 none,K(prime) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Open,3.6,1,Day
 none,K(short) ,imaging,f/32 ,$f/6|same.*,,10,ND2.0 ,IR ,IR grey body - high ,Closed,4,1,Day

--- a/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/provider/ProviderTest.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/provider/ProviderTest.java
@@ -106,9 +106,9 @@ public class ProviderTest {
         Assert.assertEquals(2, calibrations.size());
         //  check number 1
         Assert.assertEquals(CalUnitParams.Shutter.CLOSED,       calibrations.get(0).getShutter());
-        Assert.assertEquals(CalUnitParams.Filter.ND_30,         calibrations.get(0).getFilter());
+        Assert.assertEquals(CalUnitParams.Filter.ND_20,         calibrations.get(0).getFilter());
         Assert.assertEquals(CalUnitParams.Diffuser.VISIBLE,     calibrations.get(0).getDiffuser());
-        Assert.assertEquals(12,                                 calibrations.get(0).getExposureTime(), 0.01);
+        Assert.assertEquals(4,                                  calibrations.get(0).getExposureTime(), 0.01);
         Assert.assertEquals(new Integer(1),                     calibrations.get(0).getCoadds());
         Assert.assertTrue(calibrations.get(0).isFlat());
         //  check number 2

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -242,6 +242,7 @@ trait OcsBundle {
       bundle_edu_gemini_spModel_core,
       bundle_edu_gemini_spModel_io,
       bundle_edu_gemini_spModel_pio,
+      bundle_edu_gemini_spModel_smartgcal,
       bundle_jsky_coords,
       bundle_jsky_util
     )


### PR DESCRIPTION
In the previous REL-3189 (#1283), I updated the seqexec client to retrieve observation XML in order to relieve the dependency on binary serialization and make it possible to compile the seqexec with Scala 2.12. The seqexec client now expands the sequence in its own process instead of directly receiving it from the database.

What I failed to take into account though is that sequence expansion requires smart gcal lookup tables. This PR addresses that oversight.  I wasn't sure how this will be incorporated into the seqexec though, so feel free to update this as necessary.  As it stands there is a `SmartGcal.initialize()` function that has to be called to get a `CalibrationProvider`, which is needed by the `SeqExecService` client.  You pass the Gemini South ODB peer (always GS) and a directory where it can store smart gcal configuration .csv files.  Reading the config files can take a few seconds so you might want to do this in a separate thread.

I also took advantage of the opportunity to update the pre-packaged .csv files which are used until the first update from the repository takes place.  That's probably a bad idea but that's how smart gcal works and I didn't want to dive into it, especially since smart gcal has been completely redone in `gem`.