### PR TITLE
REL-3155: CHFT time modifications remove TAC acceptance in PIT

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Itac.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Itac.scala
@@ -5,19 +5,20 @@ import edu.gemini.model.p1.{mutable => M}
 object Itac {
   def apply(m: M.Itac): Itac =
     Itac(
-      (Option(m.getAccept) map { ma => ItacAccept(ma) }).toRight(ItacReject),
+      (Option(m.getAccept) map { ma => Right(ItacAccept(ma)) }).orElse(Option(m.getReject).map(_ => Left[ItacReject, ItacAccept](ItacReject))),
       Option(m.getNgoauthority),
       Option(m.getComment)
     )
 }
 
 // Placeholder for now...
-case class Itac(decision: Either[ItacReject, ItacAccept], ngoAuthority: Option[NgoPartner], comment: Option[String]) {
+case class Itac(decision: Option[Either[ItacReject, ItacAccept]], ngoAuthority: Option[NgoPartner], comment: Option[String]) {
   def mutable = {
     val m = Factory.createItac
     decision match {
-      case Left(_)  => m.setReject(ItacReject.mutable)
-      case Right(a) => m.setAccept(a.mutable)
+      case Some(Left(_))  => m.setReject(ItacReject.mutable)
+      case Some(Right(a)) => m.setAccept(a.mutable)
+      case _              =>
     }
     comment foreach { m.setComment _ }
     ngoAuthority foreach { m.setNgoauthority _ }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -94,7 +94,7 @@ object Phase1FolderFactory {
   private def band(proposal: Proposal): Band =
     (for {
       itac   <- proposal.proposalClass.itac
-      accept <- itac.decision.right.toOption
+      accept <- itac.decision.flatMap(_.right.toOption)
     } yield accept.band).getOrElse(1) match {
       case 3 => Band.BAND_3
       case _ => Band.BAND_1_2

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonServlet.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonServlet.scala
@@ -144,7 +144,7 @@ final class SkeletonServlet(odb: IDBDatabaseService, templateFactory: TemplateFa
   private def readItacGeminiId(p: Proposal): Option[StandardProgramId] =
     for {
       i <- p.proposalClass.itac
-      s <- i.decision.right.map(_.programId).right.toOption
+      s <- i.decision.flatMap(_.right.map(_.programId).right.toOption)
       p <- ProgramId.parseStandardId(s)
     } yield p
 


### PR DESCRIPTION
This is a subtle bug on the way the phase1 ITAC entry was modeled. This change includes the possibility that the value hasn't been set rather than defaulting to reject solving the bug indicated on REL-3155