### PR TITLE
REL-3197: Homogenize SmartGcal Configuration Files

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/Calibration.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/Calibration.java
@@ -7,6 +7,7 @@
 
 package edu.gemini.spModel.gemini.calunit.smartgcal;
 
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.calibration.CalibrationStep;
 
 public interface Calibration extends CalibrationStep {
@@ -18,4 +19,10 @@ public interface Calibration extends CalibrationStep {
 
     /** Repeat count. */
     Integer getObserve();
+
+    /**
+     * Export the Calibration configuration to a list of String suitable for
+     * writing to a configuration file.
+     */
+    ImList<String> export();
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/CalibrationImpl.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/CalibrationImpl.java
@@ -6,6 +6,8 @@
 
 package edu.gemini.spModel.gemini.calunit.smartgcal;
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.CalUnitParams;
 import edu.gemini.spModel.type.SpTypeUtil;
 
@@ -311,5 +313,18 @@ public final class CalibrationImpl implements Calibration {
         if (this.isArc != other.isArc) return false;
         return this.basecals.equals(other.basecals);
 
+    }
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                Integer.toString(observe),
+                filter.sequenceValue(),
+                diffuser.sequenceValue(),
+                DefaultImList.create(lamps).map(l -> l.sequenceValue()).mkString("", ";", ""),
+                shutter.sequenceValue(),
+                Long.toString(Math.round(exposureTime * 1000)),
+                Integer.toString(coadds),
+                DefaultImList.create(basecals).map(b -> b.name()).mkString("", ";", ""));
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/CalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/CalibrationMap.java
@@ -1,9 +1,11 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal;
 
+import edu.gemini.shared.util.immutable.ImList;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Base interface for all calibration maps.
@@ -42,4 +44,9 @@ public interface CalibrationMap extends Serializable {
 
     Version getVersion();
 
+    /**
+     * Export the calibration map to a list of String suitable for writing to a
+     * configuration file.
+     */
+    Stream<ImList<String>> export();
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/CalibrationProvider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/CalibrationProvider.java
@@ -7,8 +7,11 @@
 
 package edu.gemini.spModel.gemini.calunit.smartgcal;
 
+import edu.gemini.shared.util.immutable.ImList;
+
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * A calibration provider allows to lookup the calibrations that are related to a given instrument configuration
@@ -36,6 +39,11 @@ public interface CalibrationProvider extends Serializable {
      * @return
      */
     Version getVersion(Calibration.Type type, String instrument);
+
+    /**
+     * Exports the calibration information in a format suitable for writing.
+     */
+    Stream<ImList<String>> export(Calibration.Type type, String instrument);
 
     /**
      * Gets version information for all calibration tables.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/ConfigurationKey.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/ConfigurationKey.java
@@ -7,6 +7,7 @@
 
 package edu.gemini.spModel.gemini.calunit.smartgcal;
 
+import edu.gemini.shared.util.immutable.ImList;
 
 import java.io.Serializable;
 
@@ -16,4 +17,5 @@ public interface ConfigurationKey extends Serializable {
 
     public interface Values extends Serializable {}
 
+    public ImList<String> export();
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/EmptyCalibrationProvider.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/EmptyCalibrationProvider.java
@@ -1,8 +1,12 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal;
 
+import edu.gemini.shared.util.immutable.ImCollections;
+import edu.gemini.shared.util.immutable.ImList;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * A default/empty calibration provider that always returns no calibration
@@ -21,6 +25,11 @@ public enum EmptyCalibrationProvider implements CalibrationProvider {
     @Override
     public Version getVersion(Calibration.Type type, String instrument) {
         return new Version(0, timestamp);
+    }
+
+    @Override
+    public Stream<ImList<String>> export(Calibration.Type type, String instrument) {
+        return Stream.empty();
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyFlamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyFlamingos2.java
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.keys;
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.ConfigurationKey;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
 
@@ -70,5 +72,14 @@ public class ConfigKeyFlamingos2 implements ConfigurationKey {
     @Override
     public String getInstrumentName() {
         return Flamingos2.SP_TYPE.readableStr;
+    }
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                disperser.sequenceValue(),
+                filter.sequenceValue(),
+                fpUnit.sequenceValue()
+        );
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGmosNorth.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGmosNorth.java
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.keys;
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.gmos.GmosCommonType;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
@@ -64,5 +66,17 @@ public class ConfigKeyGmosNorth extends ConfigKeyGmos {
     @Override
     public String getInstrumentName() {
         return InstGmosNorth.SP_TYPE.readableStr;
+    }
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                disperser.sequenceValue(),
+                filter.sequenceValue(),
+                focalPlaneUnit.sequenceValue(),
+                xBin.sequenceValue(),
+                yBin.sequenceValue(),
+                order.sequenceValue(),
+                gain.sequenceValue());
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGmosSouth.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGmosSouth.java
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.keys;
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.gmos.GmosCommonType;
 import edu.gemini.spModel.gemini.gmos.GmosSouthType;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
@@ -67,4 +69,16 @@ public class ConfigKeyGmosSouth extends ConfigKeyGmos {
         return InstGmosSouth.SP_TYPE.readableStr;
     }
 
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                disperser.sequenceValue(),
+                filter.sequenceValue(),
+                focalPlaneUnit.sequenceValue(),
+                xBin.sequenceValue(),
+                yBin.sequenceValue(),
+                order.sequenceValue(),
+                gain.sequenceValue());
+    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGnirs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGnirs.java
@@ -1,6 +1,8 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.keys;
 
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.ConfigurationKey;
 import edu.gemini.spModel.gemini.calunit.smartgcal.CalibrationProvider;
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams;
@@ -100,4 +102,17 @@ public class ConfigKeyGnirs implements ConfigurationKey {
     public String getInstrumentName() {
         return InstGNIRS.SP_TYPE.readableStr;
     }
+
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                mode.name(),
+                pixelScale.sequenceValue(),
+                disperser.sequenceValue(),
+                crossDispersed.sequenceValue(),
+                slitWidth.sequenceValue(),
+                wellDepth.sequenceValue());
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyGpi.java
@@ -1,6 +1,8 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.keys;
 
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.ConfigurationKey;
 import edu.gemini.spModel.gemini.gpi.Gpi;
 
@@ -64,5 +66,13 @@ public class ConfigKeyGpi implements ConfigurationKey {
     @Override
     public String getInstrumentName() {
         return Gpi.SP_TYPE.readableStr;
+    }
+
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                mode.sequenceValue(),
+                disperser.sequenceValue());
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyNifs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyNifs.java
@@ -1,6 +1,8 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.keys;
 
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.ConfigurationKey;
 import edu.gemini.spModel.gemini.nifs.InstNIFS;
 import edu.gemini.spModel.gemini.nifs.NIFSParams;
@@ -77,5 +79,14 @@ public class ConfigKeyNifs implements ConfigurationKey {
     @Override
     public String getInstrumentName() {
         return InstNIFS.SP_TYPE.readableStr;
+    }
+
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                disperser.sequenceValue(),
+                filter.sequenceValue(),
+                mask.sequenceValue());
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyNiri.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/ConfigKeyNiri.java
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.keys;
 
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.ConfigurationKey;
 import edu.gemini.spModel.gemini.niri.InstNIRI;
 import edu.gemini.spModel.gemini.niri.Niri;
@@ -90,5 +92,16 @@ public class ConfigKeyNiri implements ConfigurationKey {
     @Override
     public String getInstrumentName() {
         return InstNIRI.SP_TYPE.readableStr;
+    }
+
+
+    @Override
+    public ImList<String> export() {
+        return DefaultImList.create(
+                disperser.sequenceValue(),
+                filter.sequenceValue(),
+                mask.sequenceValue(),
+                camera.sequenceValue(),
+                beamSplitter.sequenceValue());
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/WavelengthRange.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/keys/WavelengthRange.java
@@ -95,6 +95,15 @@ public final class WavelengthRange implements Serializable {
      */
     public double getMax() { return this.max; }
 
+    public boolean overlaps(final WavelengthRange that) {
+        return min < that.max && max >= that.min;
+    }
+
+    public boolean contains(double val) {
+        return val >= min && val < max;
+    }
+
+
     @Override
     public String toString() { return "[" + min + "," + max + ")"; }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/BaseCalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/BaseCalibrationMap.java
@@ -1,12 +1,15 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.maps;
 
 
+import edu.gemini.shared.util.immutable.ImCollections;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.*;
 import edu.gemini.spModel.type.DisplayableSpType;
 
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Abstract base class for all calibration maps.
@@ -86,4 +89,8 @@ public abstract class BaseCalibrationMap implements CalibrationMap {
         return CalibrationImpl.Values.values();
     }
 
+    @Override
+    public Stream<ImList<String>> export() {
+        return Stream.empty();
+    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/CentralWavelengthMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/CentralWavelengthMap.java
@@ -86,7 +86,9 @@ public abstract class CentralWavelengthMap extends BaseCalibrationMap {
     }
 
     private static String exportWavelength(double wl) {
-        return Long.toString(Math.round(wl * 1000));
+        // Wavelength stored as a double is problematic.  In some instruments
+        // these are um and in others nm.  Parsing has to be instrument specific.
+        return (wl == Double.MAX_VALUE) ? "MAX" : Long.toString(Math.round(wl * 1000));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/CentralWavelengthMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/CentralWavelengthMap.java
@@ -85,11 +85,19 @@ public abstract class CentralWavelengthMap extends BaseCalibrationMap {
         return rangeSet.findCalibrations(wavelength);
     }
 
-    private static String exportWavelength(double wl) {
+    private String exportWavelength(double wl) {
         // Wavelength stored as a double is problematic.  In some instruments
-        // these are um and in others nm.  Parsing has to be instrument specific.
-        return (wl == Double.MAX_VALUE) ? "MAX" : Long.toString(Math.round(wl * 1000));
+        // these are um and in others nm. We will ask each type of
+        // CentralWavelengthMap to convert its double value to integral
+        // angstroms.
+        return (wl == Double.MAX_VALUE) ? "MAX" : Integer.toString(toAngstroms(wl));
     }
+
+    /**
+     * Convert the given wavelength value in double to an integral angstroms for
+     * export.
+     */
+    protected abstract int toAngstroms(double wl);
 
     /**
      * Export the calibration map to a list of String suitable for writing to a

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/GMOSNCalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/GMOSNCalibrationMap.java
@@ -22,7 +22,7 @@ import java.util.Set;
  * lookups fast and simple. As of April 2012 the GMOS-N and GMOS-S tables have each between 20000 and 40000
  * entries resulting in about 50MB of memory consumption (see UX-1426 for more information).
  */
-public class GMOSNCalibrationMap extends CentralWavelengthMap {
+public final class GMOSNCalibrationMap extends CentralWavelengthMap {
 
     public GMOSNCalibrationMap(Version version) {
         // make gmos-n maps big enough for all entries that it will have to store
@@ -73,5 +73,10 @@ public class GMOSNCalibrationMap extends CentralWavelengthMap {
 
         // return the set of keys we just came up with
         return keys;
+    }
+
+    // GMOS-N central wavelength is stored as nm.
+    protected int toAngstroms(double wl) {
+        return (int) Math.round(wl * 10);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/GMOSSCalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/GMOSSCalibrationMap.java
@@ -22,7 +22,7 @@ import java.util.Set;
  * lookups fast and simple. As of April 2012 the GMOS-N and GMOS-S tables have each between 20000 and 40000
  * entries resulting in about 50MB of memory consumption (see UX-1426 for more information).
  */
-public class GMOSSCalibrationMap extends CentralWavelengthMap {
+public final class GMOSSCalibrationMap extends CentralWavelengthMap {
 
     public GMOSSCalibrationMap(Version version) {
         // make gmos-s maps big enough for all entries that it will have to store
@@ -74,4 +74,10 @@ public class GMOSSCalibrationMap extends CentralWavelengthMap {
         // return the set of keys we just came up with
         return keys;
     }
+
+    // GMOS-S central wavelength is stored as nm.
+    protected int toAngstroms(double wl) {
+        return (int) Math.round(wl * 10);
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/GNIRSCalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/GNIRSCalibrationMap.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 /**
  */
-public class GNIRSCalibrationMap extends CentralWavelengthMap {
+public final class GNIRSCalibrationMap extends CentralWavelengthMap {
 
     public GNIRSCalibrationMap(Version version) {
         super(version);
@@ -59,4 +59,10 @@ public class GNIRSCalibrationMap extends CentralWavelengthMap {
         // return the set of keys we just came up with
         return keys;
     }
+
+    // GNIRS central wavelength is stored as um.
+    protected int toAngstroms(double wl) {
+        return (int) Math.round(wl * 10000);
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/NIFSCalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/NIFSCalibrationMap.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 /**
  */
-public class NIFSCalibrationMap extends CentralWavelengthMap {
+public final class NIFSCalibrationMap extends CentralWavelengthMap {
 
     public NIFSCalibrationMap(Version version) {
         super(version);
@@ -47,5 +47,10 @@ public class NIFSCalibrationMap extends CentralWavelengthMap {
 
         // return the set of keys we just came up with
         return keys;
+    }
+
+    // NIFS central wavelength is stored as um.
+    protected int toAngstroms(double wl) {
+        return (int) Math.round(wl * 10000);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/SimpleCalibrationMap.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/calunit/smartgcal/maps/SimpleCalibrationMap.java
@@ -1,11 +1,13 @@
 package edu.gemini.spModel.gemini.calunit.smartgcal.maps;
 
-
+import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.Calibration;
 import edu.gemini.spModel.gemini.calunit.smartgcal.ConfigurationKey;
 import edu.gemini.spModel.gemini.calunit.smartgcal.Version;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  */
@@ -41,4 +43,15 @@ public abstract class SimpleCalibrationMap extends BaseCalibrationMap {
         return calibrations;
     }
 
+    /**
+     * Export the calibration map to a list of String suitable for writing to a
+     * configuration file.
+     */
+    @Override
+    public Stream<ImList<String>> export() {
+        return map.entrySet().stream().flatMap(me -> {
+            final ImList<String> key = me.getKey().export();
+            return me.getValue().stream().map(cal -> key.append(cal.export()));
+        });
+    }
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/CalImpl.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/CalImpl.scala
@@ -1,5 +1,6 @@
 package edu.gemini.spModel.gemini.seqcomp
 
+import edu.gemini.shared.util.immutable.{ImCollections, ImList}
 import edu.gemini.spModel.gemini.calunit.CalUnitParams.{Diffuser, Filter, Shutter, Lamp}
 import edu.gemini.spModel.gemini.calunit.smartgcal.Calibration
 
@@ -28,4 +29,6 @@ final case class CalImpl(lamps: Set[Lamp],
   def getObserve: JInteger          = observe
   def getExposureTime: JDouble      = exposureTime
   def getCoadds: JInteger           = coadds
+
+  def export: ImList[String]        = ImCollections.emptyList[String]
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/TestCalibrationProvider.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/TestCalibrationProvider.scala
@@ -1,6 +1,9 @@
 package edu.gemini.spModel.gemini.seqcomp
 
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.{CalibrationKey, CalibrationProvider, Calibration}
+
+import java.util.stream.Stream
 
 import scala.collection.JavaConverters._
 
@@ -11,6 +14,9 @@ final class TestCalibrationProvider(cals: List[Calibration]) extends Calibration
 
   def getVersion(calType: Calibration.Type, instrument: java.lang.String) =
     null
+
+  def export(calType: Calibration.Type, instrument: String): Stream[ImList[String]] =
+    Stream.empty[ImList[String]]
 
   def getCalibrations(key: CalibrationKey) =
     cals.asJava

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
@@ -2,6 +2,8 @@ package edu.gemini.shared.util.immutable;
 
 import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Default implementation of the {@link ImList} interface.  This implementation
@@ -336,6 +338,12 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
         }
         return cur;
     }
+
+    @Override
+    public Stream<T> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
+
 
     /**
      * Calls {@link #mkString(String, String, String)} with the arguments

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
@@ -2,6 +2,7 @@ package edu.gemini.shared.util.immutable;
 
 import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * Utility methods for working with immutable collections.
@@ -206,6 +207,11 @@ public class ImCollections {
         @Override
         public <U> U foldRight(final U start, final Function2<? super Object, U, U> op) {
             return start;
+        }
+
+        @Override
+        public Stream<Object> stream() {
+            return Stream.empty();
         }
 
         @Override

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
@@ -2,11 +2,16 @@ package edu.gemini.shared.util.immutable;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * An immutable list interface.
  */
 public interface ImList<T> extends Iterable<T> {
+
+    /** Creates a Stream from the list.
+      */
+    Stream<T> stream();
 
     /**
      * Creates a new ImList that has the same contents as this one, except it

--- a/bundle/edu.gemini.spModel.smartgcal/src/main/java/edu/gemini/spModel/smartgcal/provider/CalibrationProviderImpl.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/main/java/edu/gemini/spModel/smartgcal/provider/CalibrationProviderImpl.java
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.smartgcal.provider;
 
+import edu.gemini.shared.util.immutable.ImCollections;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.smartgcal.*;
 import edu.gemini.spModel.gemini.calunit.smartgcal.keys.CalibrationKeyImpl;
 import edu.gemini.spModel.smartgcal.CalibrationMapFactory;
@@ -13,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * This class will be used to create a singleton to provide access to the smart calibration information
@@ -62,6 +65,12 @@ public class CalibrationProviderImpl implements CalibrationProvider, ActionListe
     @Override
     public Version getVersion(Calibration.Type type, String instrument) {
         return getMap(type, instrument).getVersion();
+    }
+
+    @Override
+    public Stream<ImList<String>> export(Calibration.Type type, String instrument) {
+        final CalibrationMap m = getMap(type, instrument);
+        return (m == null) ? Stream.empty() : m.export();
     }
 
     @Override

--- a/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationKeyTest.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationKeyTest.java
@@ -65,10 +65,10 @@ public class CalibrationKeyTest {
         Assert.assertEquals(ranges[1], rangeSet.findRange(20.0d).getValue());
         Assert.assertEquals(ranges[2], rangeSet.findRange(37.5d).getValue());
 
-        Assert.assertNull(rangeSet.findRange(0.0d).getValue());
-        Assert.assertNull(rangeSet.findRange(40.0d).getValue());
-        Assert.assertNull(rangeSet.findRange(42.0d).getValue());
-        Assert.assertNull(rangeSet.findRange(60.0d).getValue());
+        Assert.assertTrue(rangeSet.findRange(0.0d).isEmpty());
+        Assert.assertTrue(rangeSet.findRange(40.0d).isEmpty());
+        Assert.assertTrue(rangeSet.findRange(42.0d).isEmpty());
+        Assert.assertTrue(rangeSet.findRange(60.0d).isEmpty());
     }
 
     @Test

--- a/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationKeyTest.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationKeyTest.java
@@ -60,15 +60,15 @@ public class CalibrationKeyTest {
             rangeSet.add(range, null);
         }
 
-        Assert.assertEquals(ranges[0], rangeSet.findRange(10.0d));
-        Assert.assertEquals(ranges[0], rangeSet.findRange(15.0d));
-        Assert.assertEquals(ranges[1], rangeSet.findRange(20.0d));
-        Assert.assertEquals(ranges[2], rangeSet.findRange(37.5d));
+        Assert.assertEquals(ranges[0], rangeSet.findRange(10.0d).getValue());
+        Assert.assertEquals(ranges[0], rangeSet.findRange(15.0d).getValue());
+        Assert.assertEquals(ranges[1], rangeSet.findRange(20.0d).getValue());
+        Assert.assertEquals(ranges[2], rangeSet.findRange(37.5d).getValue());
 
-        Assert.assertNull(rangeSet.findRange(0.0d));
-        Assert.assertNull(rangeSet.findRange(40.0d));
-        Assert.assertNull(rangeSet.findRange(42.0d));
-        Assert.assertNull(rangeSet.findRange(60.0d));
+        Assert.assertNull(rangeSet.findRange(0.0d).getValue());
+        Assert.assertNull(rangeSet.findRange(40.0d).getValue());
+        Assert.assertNull(rangeSet.findRange(42.0d).getValue());
+        Assert.assertNull(rangeSet.findRange(60.0d).getValue());
     }
 
     @Test

--- a/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationMapReaderTest.java
+++ b/bundle/edu.gemini.spModel.smartgcal/src/test/java/edu/gemini/spModel/smartgcal/CalibrationMapReaderTest.java
@@ -6,6 +6,8 @@
 
 package edu.gemini.spModel.smartgcal;
 
+import edu.gemini.shared.util.immutable.ImCollections;
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.gemini.calunit.CalUnitParams;
 import edu.gemini.spModel.gemini.calunit.smartgcal.Calibration;
 import edu.gemini.spModel.gemini.calunit.smartgcal.CalibrationMap;
@@ -17,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 public class CalibrationMapReaderTest {
 
@@ -178,6 +181,9 @@ public class CalibrationMapReaderTest {
         public Version getVersion() {
             return new Version(1, new Date());
         }
+
+        @Override
+        public Stream<ImList<String>> export() { return Stream.empty(); }
     }
 
     public static class FakeCalibration implements Calibration {
@@ -241,6 +247,9 @@ public class CalibrationMapReaderTest {
         public Integer getCoadds() {
             return null;
         }
+
+        @Override
+        public ImList<String> export() { return ImCollections.emptyList(); }
     }
 
     public static class FakeKey implements ConfigurationKey {
@@ -273,6 +282,9 @@ public class CalibrationMapReaderTest {
         public String getInstrumentName() {
             return "FAKE";
         }
+
+        @Override
+        public ImList<String> export() { return ImCollections.emptyList(); }
     }
 
 }

--- a/bundle/edu.gemini.spdb.shell/src/main/java/edu/gemini/spdb/shell/osgi/Activator.java
+++ b/bundle/edu.gemini.spdb.shell/src/main/java/edu/gemini/spdb/shell/osgi/Activator.java
@@ -34,6 +34,7 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<IDBD
                 "importXml",
                 "exportXml",
                 "exportOcs3",
+                "exportSmartGcal",
                 "du",
                 "purge",
                 "migrateAltair",


### PR DESCRIPTION
This PR provides an `exportSmartGcal` shell command that writes all SmartGcal lookup table information in a format that is easily ingested into OCS3.  Namely, unlike the existing `.csv`s the files produced by `exportSmartGcal`:

1) Always use the sequence value for each enumerated type (this conveniently matches the existing `String` parsers for OCS2 types in OCS3).

2) Expands wildcards and regular expressions.

3) Is case-sensitive.

4) Exports wavelengths consistently as integral angstroms for all instruments.

5) Exports exposure times consistently as integral milliseconds.

5) Removes arbitrary missing values separating the instrument configuration from the matching calibration data.

The implementation is suboptimal in that it adds `export` methods in the various SmartGcal classes rather than, say, adding this capability via a typeclass.  It seemed like it would be challenging to get at the data to be exported since they are stored in private mutable fields in the various calibration maps.  At any rate, the point of the work being done in OCS3 is to replace all of this SmartGcal infrastructure.