### PR TITLE
REL-3086: Configure the P1 monitor to handle CFHT proposals

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Partners.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Partners.scala
@@ -7,18 +7,18 @@ import scalaz.{-\/, Equal, \/, \/-}
 object Partners {
 
   val name = Map[Any, String](
-    NgoPartner.AR -> "Argentina",
-    NgoPartner.AU -> "Australia",
-    NgoPartner.BR -> "Brazil",
-    NgoPartner.CA -> "Canada",
-    NgoPartner.CL -> "Chile",
-    NgoPartner.KR -> "Republic of Korea",
-    NgoPartner.US -> "United States",
-    NgoPartner.UH -> "University of Hawaii",
-    ExchangePartner.CFHT -> Site.CFHT.name,
-    ExchangePartner.KECK -> Site.Keck.name,
+    NgoPartner.AR          -> "Argentina",
+    NgoPartner.AU          -> "Australia",
+    NgoPartner.BR          -> "Brazil",
+    NgoPartner.CA          -> "Canada",
+    NgoPartner.CL          -> "Chile",
+    NgoPartner.KR          -> "Republic of Korea",
+    NgoPartner.US          -> "United States",
+    NgoPartner.UH          -> "University of Hawaii",
+    ExchangePartner.CFH    -> Site.CFH.name,
+    ExchangePartner.KECK   -> Site.Keck.name,
     ExchangePartner.SUBARU -> Site.Subaru.name,
-    LargeProgramPartner -> "Large Program"
+    LargeProgramPartner    -> "Large Program"
   )
 
   // REL-2248 Contains a list of partners that are not allowed on joint proposals

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Site.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Site.scala
@@ -42,9 +42,9 @@ object Site {
     override def isExchange = true
   }
 
-  case object CFHT extends Site {
+  case object CFH extends Site {
     def name = "CFH Observatory"
-    def abbreviation = "CFHT"
+    def abbreviation = "CFH"
     override def isExchange = true
   }
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -63,7 +63,7 @@ package object immutable {
   object ExchangePartner extends EnumObject[M.ExchangePartner] {
     final val KECK   = M.ExchangePartner.KECK
     final val SUBARU = M.ExchangePartner.SUBARU
-    final val CFHT   = M.ExchangePartner.CFHT
+    final val CFH    = M.ExchangePartner.CFH
   }
 
   // Singleton used to represent a Large Program "Partner"

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -150,7 +150,12 @@ case object SemesterConverter2017BTo2018A extends SemesterConverter {
       }
       StepResult(s"The unavailable Flamingos2 filters $jLoFilter and $yFilter have been removed from the proposal.", <flamingos2>{yjLoFilterTransformer.transform(ns)}</flamingos2>).successNel
   }
-  override val transformers = List(removeF2YJloFilters)
+
+  val renameCFH: TransformFunction = {
+    case p @ <partner>cfht</partner> =>
+      StepResult("Renamed CFHT partner to CFH", <partner>cfh</partner>).successNel
+  }
+  override val transformers = List(removeF2YJloFilters, renameCFH)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/visibility/TargetVisibilityCalc.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/visibility/TargetVisibilityCalc.scala
@@ -33,7 +33,7 @@ object TargetVisibilityCalc {
     case GS     => GS
     case Keck   => GN
     case Subaru => GN
-    case CFHT   => GN
+    case CFH    => GN
   }
 
   private def visibility(key: Key, coords: Coordinates): TargetVisibility = {

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -5,6 +5,7 @@ Gemini Phase I Schema Changes
 
 * Hidden filter Y and J-lo for Flamingos2
 * Added Subaru Intensive Program proposal class
+* Renamed CFHT references to CFH
 
 # Version 2017.2.1 - 2017B
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Submission.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Submission.xsd
@@ -209,7 +209,7 @@
         <xsd:restriction base="xsd:token">
             <xsd:enumeration value="keck"/>
             <xsd:enumeration value="subaru"/>
-            <xsd:enumeration value="cfht"/>
+            <xsd:enumeration value="cfh"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2018A.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2018A.xml
@@ -140,7 +140,7 @@
         </translation>
         <translation>
             <from>cfh</from>
-            <to>CFHT</to>
+            <to>CFH</to>
         </translation>
         <translation>
             <from>kr</from>

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2018A.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2018A.xml
@@ -37,7 +37,7 @@
 
     <type name="SIP">
         <dir>/home/software/test_proposals/subaru_intensive_program/proposals/2018A</dir>
-        <to>cquiroz@gemini.edu</to>
+        <to>pitlp@gemini.edu</to>
     </type>
 
     <type name="ar">

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -41,7 +41,7 @@ object SpProgramFactory {
   )
 
   private val EXC_TIME_ACCT = Map(
-    CFHT   -> TimeAcctCategory.CFH,
+    CFH    -> TimeAcctCategory.CFH,
     SUBARU -> TimeAcctCategory.JP,
     KECK   -> TimeAcctCategory.XCHK
   )

--- a/bundle/edu.gemini.pit/src/main/java/edu/gemini/pit/ui/util/SharedIcons.java
+++ b/bundle/edu.gemini.pit/src/main/java/edu/gemini/pit/ui/util/SharedIcons.java
@@ -43,7 +43,7 @@ public interface SharedIcons {
     Icon FLAG_AU = new SharedIcon("au.png");
     Icon FLAG_BR = new SharedIcon("br.png");
     Icon FLAG_CA = new SharedIcon("ca.png");
-    Icon FLAG_CFHT = new SharedIcon("cfht.png");
+    Icon FLAG_CFH = new SharedIcon("cfht.png");
     Icon FLAG_CL = new SharedIcon("cl.png");
     Icon FLAG_KR = new SharedIcon("kr.png");
     Icon FLAG_GEMINI = new SharedIcon("gemini.png");

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/BlueprintEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/BlueprintEditor.scala
@@ -33,7 +33,7 @@ object BlueprintEditor {
       case e: ExchangeProposalClass       => e.partner match {
         case ExchangePartner.KECK   => Site.Keck
         case ExchangePartner.SUBARU => Site.Subaru
-        case ExchangePartner.CFHT   => Site.CFHT // Shouldn't happen
+        case ExchangePartner.CFH    => Site.CFH // Shouldn't happen
       }
       case s: SubaruIntensiveProgramClass => Site.Subaru
       case _                              => Site.GN // or GS; same thing

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/PartnerView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/PartnerView.scala
@@ -68,7 +68,7 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
   // An enum for submission type, so we can filter the partner/exchange list
   object PartnerType extends Enumeration {
     val GeminiPartner  = Value("Gemini Partner Request")
-    val ExchangeCFHT   = Value("Exchange Request (CFH PIs)")
+    val ExchangeCFH    = Value("Exchange Request (CFH PIs)")
     val ExchangeKeck   = Value("Exchange Request (Keck PIs)")
     val ExchangeSubaru = Value("Exchange Request (Japanese PIs)")
   }
@@ -177,7 +177,7 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
     }
 
     // Site combo
-    object siteCombo extends ComboBox(ExchangePartner.values.filterNot(_ == ExchangePartner.CFHT)) with Bound[Proposal, ProposalClass] with TextRenderer[ExchangePartner] {
+    object siteCombo extends ComboBox(ExchangePartner.values.filterNot(_ == ExchangePartner.CFH)) with Bound[Proposal, ProposalClass] with TextRenderer[ExchangePartner] {
 
       val lens = Proposal.proposalClass
 
@@ -910,9 +910,9 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
 
       // We have local state for all alternatives
       var localGemini:List[NgoSubmission] = Nil
-      var localKeck = ExchangeSubmission(SubmissionRequest.empty, None, ExchangePartner.KECK, InvestigatorRef.empty)
+      var localKeck   = ExchangeSubmission(SubmissionRequest.empty, None, ExchangePartner.KECK, InvestigatorRef.empty)
       var localSubaru = ExchangeSubmission(SubmissionRequest.empty, None, ExchangePartner.SUBARU, InvestigatorRef.empty)
-      var localCFHT = ExchangeSubmission(SubmissionRequest.empty, None, ExchangePartner.CFHT, InvestigatorRef.empty)
+      var localCFH    = ExchangeSubmission(SubmissionRequest.empty, None, ExchangePartner.CFH, InvestigatorRef.empty)
 
       override def refresh(m:Option[ProposalClass]) {
         // Enabled?
@@ -930,11 +930,11 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
           case QueueProposalClass(_, _, _, Left(ngos), _, _)                                       => localGemini = ngos
           case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.KECK    => localKeck = e
           case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.SUBARU  => localSubaru = e
-          case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.CFHT    => localCFHT = e
+          case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.CFH     => localCFH = e
           case ClassicalProposalClass(_, _, _, Left(ngos), _)                                      => localGemini = ngos
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.KECK   => localKeck = e
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.SUBARU => localSubaru = e
-          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFHT   => localCFHT= e
+          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFH    => localCFH= e
           case e: ExchangeProposalClass                                                            => localGemini = e.subs
           case _                                                                                   => // ignore
         }
@@ -944,11 +944,11 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
           case QueueProposalClass(_, _, _, Left(_), _, _)                                          => GeminiPartner
           case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.KECK    => ExchangeKeck
           case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.SUBARU  => ExchangeSubaru
-          case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.CFHT    => ExchangeCFHT
+          case QueueProposalClass(_, _, _, Right(e), _, _) if e.partner == ExchangePartner.CFH     => ExchangeCFH
           case ClassicalProposalClass(_, _, _, Left(_), _)                                         => GeminiPartner
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.KECK   => ExchangeKeck
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.SUBARU => ExchangeSubaru
-          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFHT   => ExchangeCFHT
+          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFH    => ExchangeCFH
           case _: ExchangeProposalClass                                                            => GeminiPartner
           case _: SpecialProposalClass                                                             => GeminiPartner
           case _: LargeProgramClass                                                                => GeminiPartner
@@ -967,14 +967,14 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
                 case GeminiPartner  => q.copy(subs = Left(localGemini))
                 case ExchangeKeck   => q.copy(subs = Right(localKeck))
                 case ExchangeSubaru => q.copy(subs = Right(localSubaru))
-                case ExchangeCFHT   => q.copy(subs = Right(localCFHT))
+                case ExchangeCFH    => q.copy(subs = Right(localCFH))
               }
             case c:ClassicalProposalClass =>
               selection.item match {
                 case GeminiPartner  => c.copy(subs = Left(localGemini))
                 case ExchangeKeck   => c.copy(subs = Right(localKeck))
                 case ExchangeSubaru => c.copy(subs = Right(localSubaru))
-                case ExchangeCFHT   => c.copy(subs = Right(localCFHT))
+                case ExchangeCFH    => c.copy(subs = Right(localCFH))
               }
             case e:ExchangeProposalClass  =>
               selection.item match {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/Partners.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/Partners.scala
@@ -7,18 +7,18 @@ import javax.swing.Icon
 
 object PartnersFlags {
   val flag = Map[Any, Icon](
-    NgoPartner.AR -> SharedIcons.FLAG_AR,
-    NgoPartner.AU -> SharedIcons.FLAG_AU,
-    NgoPartner.BR -> SharedIcons.FLAG_BR,
-    NgoPartner.CA -> SharedIcons.FLAG_CA,
-    NgoPartner.CL -> SharedIcons.FLAG_CL,
-    NgoPartner.KR -> SharedIcons.FLAG_KR,
-    NgoPartner.US -> SharedIcons.FLAG_US,
-    NgoPartner.UH -> SharedIcons.FLAG_UH,
-    ExchangePartner.CFHT -> SharedIcons.FLAG_CFHT,
-    ExchangePartner.KECK -> SharedIcons.FLAG_KECK,
+    NgoPartner.AR          -> SharedIcons.FLAG_AR,
+    NgoPartner.AU          -> SharedIcons.FLAG_AU,
+    NgoPartner.BR          -> SharedIcons.FLAG_BR,
+    NgoPartner.CA          -> SharedIcons.FLAG_CA,
+    NgoPartner.CL          -> SharedIcons.FLAG_CL,
+    NgoPartner.KR          -> SharedIcons.FLAG_KR,
+    NgoPartner.US          -> SharedIcons.FLAG_US,
+    NgoPartner.UH          -> SharedIcons.FLAG_UH,
+    ExchangePartner.CFH    -> SharedIcons.FLAG_CFH,
+    ExchangePartner.KECK   -> SharedIcons.FLAG_KECK,
     ExchangePartner.SUBARU -> SharedIcons.FLAG_JP,
-    LargeProgramPartner -> SharedIcons.FLAG_GEMINI
+    LargeProgramPartner    -> SharedIcons.FLAG_GEMINI
   ).map {
     case (p, i) => (p,
       new Icon {


### PR DESCRIPTION
For historical reasons the PIT has mixed the usage of CFHT and CFH to refer to the Canada-France-Hawaii Telescope

This PR fixes this unifying it to use always CFH and it also enables the p1-monitor to handle CFH properly