### PR TITLE
REL-3151: Format changes to PIT PDF investigator list to reduce unconscious bias

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -89,7 +89,7 @@
                   </xsl:call-template>
                 </xsl:when>
                 <xsl:when test="$investigatorsList = 'atTheEnd'">
-                    <xsl:call-template name="investigators-list">
+                    <xsl:call-template name="investigators-list-unbiased">
                         <xsl:with-param name="proposal-id" select="$proposal-id"/>
                         <xsl:with-param name="section" select="3"/>
                     </xsl:call-template>
@@ -1081,6 +1081,170 @@
 
     </xsl:template>
 
+    <xsl:template name="investigators-list-unbiased">
+        <xsl:param name="proposal-id"/>
+        <xsl:param name="section"/>
+
+        <!-- BEGIN investigator information -->
+        <fo:page-sequence master-reference="investigators">
+            <!-- BEGIN header -->
+            <fo:static-content
+                    flow-name="xsl-region-before"
+                    font-family="Times"
+                    font-size="10pt">
+                <fo:table table-layout="fixed">
+                    <fo:table-column column-width="8cm"/>
+                    <fo:table-column column-width="3cm"/>
+                    <fo:table-column column-width="5cm"/>
+                    <fo:table-body>
+                        <fo:table-row>
+                            <fo:table-cell>
+                                <fo:block font-style="italic">
+                                    <xsl:variable name="receiptDate" select="/proposal/proposalClass/ngo[partner=$this-partner]/receipt/timestamp"/>
+                                    <fo:inline><xsl:value-of select="$obs-name"/> Proposal, received <xsl:value-of select="substring($receiptDate, 0, 11)"/></fo:inline>
+                                </fo:block>
+                            </fo:table-cell>
+                            <fo:table-cell>
+                                <fo:block font-style="italic">
+                                    Section <xsl:value-of select="$section"/> Page <fo:page-number/>
+                                </fo:block>
+                            </fo:table-cell>
+                            <fo:table-cell border="0.5pt solid black" text-align="center">
+                                <fo:block font-weight="bold" font-size="12pt">
+                                    <xsl:value-of select="$proposal-id"/>
+                                </fo:block>
+                            </fo:table-cell>
+                        </fo:table-row>
+                    </fo:table-body>
+                </fo:table>
+            </fo:static-content>
+            <!-- END header -->
+
+            <!-- BEGIN second page body -->
+            <!-- The main body is called "xsl-region-body". -->
+            <fo:flow flow-name="xsl-region-body"
+                     font-family="Times"
+                     font-size="12pt">
+
+                <!-- BEGIN title -->
+                <fo:block font-weight="bold" font-size="18pt">
+                    Investigator Information
+                </fo:block>
+                <!-- END title -->
+
+                <!-- BEGIN PI -->
+                <fo:table table-layout="fixed" space-before="12pt"
+                          space-after="8pt">
+                    <fo:table-column column-width="6cm"/>
+                    <fo:table-column column-width="2cm"/>
+                    <fo:table-column column-width="8cm"/>
+                    <fo:table-body>
+                        <fo:table-row>
+                            <fo:table-cell>
+                                <fo:block>
+                                    <fo:inline font-weight="bold">Investigator:</fo:inline>
+                                </fo:block>
+                            </fo:table-cell>
+                            <fo:table-cell>
+                                <fo:block>
+                                    <fo:inline font-weight="bold">Status:</fo:inline>
+                                </fo:block>
+                            </fo:table-cell>
+                            <fo:table-cell>
+                                <fo:block>
+                                    <fo:inline font-weight="bold">Affiliation:</fo:inline>
+                                </fo:block>
+                            </fo:table-cell>
+                        </fo:table-row>
+                    <xsl:for-each select="investigators/pi | investigators/coi">
+                        <xsl:sort select="lastName"/>
+                        <fo:table-row>
+                            <fo:table-cell>
+                                <fo:block>
+                                    <xsl:value-of select="substring(firstName, 1, 1)"/>.&#160;<xsl:value-of select="lastName"/>
+                                </fo:block>
+                            </fo:table-cell>
+                            <fo:table-cell>
+                                <fo:block>
+                                    <xsl:variable name="status" select="status"/>
+                                    <xsl:if test="$status = 'Grad Thesis'">T</xsl:if>
+                                    <xsl:if test="$status = 'PhD'">P</xsl:if>
+                                    <xsl:if test="$status = 'Grad No Thesis'">G</xsl:if>
+                                    <xsl:if test="$status = 'Other'">O</xsl:if>
+                                </fo:block>
+                            </fo:table-cell>
+                            <fo:table-cell>
+                                <fo:block>
+                                    <xsl:value-of select="address/institution"/>
+                                    <xsl:value-of select="institution"/>
+                                </fo:block>
+                            </fo:table-cell>
+                        </fo:table-row>
+                    </xsl:for-each>
+                    </fo:table-body>
+                </fo:table>
+                <!-- END PI -->
+
+                <!-- This is how you create a horizontal rule. -->
+                <fo:block text-align="center" space-after="8pt">
+                    <fo:leader leader-length="11.5cm"
+                               leader-pattern="rule"
+                               alignment-baseline="middle"
+                               rule-thickness="0.5pt" color="black"/>
+                </fo:block>
+
+                <!-- BEGIN Reviewer -->
+                <xsl:for-each select="proposalClass/fastTurnaround[@reviewer]">
+                    <fo:table table-layout="fixed" space-after="0pt">
+                        <fo:table-column column-width="6cm"/>
+                        <fo:table-column column-width="2cm"/>
+                        <fo:table-column column-width="8cm"/>
+                        <fo:table-body>
+                            <fo:table-row>
+                                <fo:table-cell>
+                                    <fo:block>
+                                        <fo:inline font-weight="bold">Reviewer:</fo:inline>
+                                        <xsl:text>&#160;</xsl:text>
+                                        <xsl:call-template name="investigator-name">
+                                            <xsl:with-param name="id" select="@reviewer"/>
+                                        </xsl:call-template>
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                        </fo:table-body>
+                    </fo:table>
+                </xsl:for-each>
+                <!-- END Reviewer -->
+
+                <!-- BEGIN Mentor -->
+                <xsl:for-each select="proposalClass/fastTurnaround[@mentor]">
+                    <fo:table table-layout="fixed" space-after="10pt">
+                        <fo:table-column column-width="6cm"/>
+                        <fo:table-column column-width="2cm"/>
+                        <fo:table-column column-width="8cm"/>
+                        <fo:table-body>
+                            <fo:table-row>
+                                <fo:table-cell>
+                                    <fo:block>
+                                        <fo:inline font-weight="bold">Mentor:</fo:inline>
+                                        <xsl:text>&#160;</xsl:text>
+                                        <xsl:call-template name="investigator-name">
+                                            <xsl:with-param name="id" select="@mentor"/>
+                                        </xsl:call-template>
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                        </fo:table-body>
+                    </fo:table>
+                </xsl:for-each>
+                <!-- END Mentor -->
+
+            </fo:flow>
+        <!-- END investgator information -->
+        </fo:page-sequence>
+        <!-- END second page body -->
+
+    </xsl:template>
     <!-- Creates a section heading and description text -->
     <xsl:template name="styled-section-header">
         <xsl:param name="section-name"/>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -1364,7 +1364,6 @@
                                     <fo:inline font-weight="bold">&#160;(thesis)</fo:inline>
                                 </xsl:if>
                                 <xsl:if test="status != 'Grad Thesis'">
-                                    <fo:inline font-weight="bold">&#160;(thesis)</fo:inline>
                                     <xsl:value-of select="status"/>
                                 </xsl:if>
                             </fo:block>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -1145,7 +1145,7 @@
                                          alignment-baseline="middle"
                                          rule-thickness="0.5pt" color="black"/>
                           </fo:block>
-                          <xsl:call-template name="investigators-list">
+                          <xsl:call-template name="investigators-list-no-bias">
                           </xsl:call-template>
 
                           <fo:block text-align="center" space-after="6pt">
@@ -1312,6 +1312,71 @@
         </fo:table>
     </xsl:template>
 
+    <!-- Displays the list of the investigators in no bias mode-->
+    <xsl:template name="investigators-list-no-bias">
+        <fo:block space-before="8pt">
+            <fo:inline font-weight="bold">
+                Investigator Information
+            </fo:inline>
+        </fo:block>
+
+        <fo:table table-layout="fixed" space-before="6pt" space-after="12pt" font-size="10pt">
+            <fo:table-column column-width="50%"/>
+            <fo:table-column column-width="25%"/>
+            <fo:table-column column-width="25%"/>
+            <fo:table-body>
+                <fo:table-row>
+                    <fo:table-cell background-color="{$hdrColor}">
+                        <fo:block text-align="center" font-weight="bold">Investigator</fo:block>
+                    </fo:table-cell>
+                    <fo:table-cell background-color="{$hdrColor}"
+                                   border-left-style="solid" border-color="black" border-width="0.5pt">
+                        <fo:block text-align="center" font-weight="bold">Status</fo:block>
+                    </fo:table-cell>
+                    <fo:table-cell background-color="{$hdrColor}"
+                                   border-left-style="solid" border-color="black" border-width="0.5pt">
+                        <fo:block text-align="center" font-weight="bold">Affiliation</fo:block>
+                    </fo:table-cell>
+                </fo:table-row>
+
+                <fo:table-row>
+                    <fo:table-cell number-columns-spanned="3" border-bottom-style="solid"
+                                   border-color="black" border-width="0.25pt">
+                        <fo:block>
+                        </fo:block>
+                    </fo:table-cell>
+                </fo:table-row>
+
+                <xsl:for-each select="investigators/pi | investigators/coi">
+                    <xsl:sort select="lastName"/>
+                    <fo:table-row>
+                        <fo:table-cell border-bottom-style="solid"
+                                       border-color="black" border-width="0.25pt">
+                            <fo:block>
+                                <xsl:value-of select="substring(firstName, 1, 1)"/>.&#160;<xsl:value-of select="lastName"/>
+                            </fo:block>
+                        </fo:table-cell>
+
+                        <fo:table-cell border-bottom-style="solid"
+                                       border-color="black" border-width="0.25pt">
+                            <fo:block>
+                                <xsl:value-of select="status"/>
+                            </fo:block>
+                        </fo:table-cell>
+
+                        <fo:table-cell border-bottom-style="solid"
+                                       border-color="black" border-width="0.25pt">
+                            <fo:block>
+                                <xsl:value-of select="address/institution"/>
+                                <xsl:value-of select="institution"/>
+                            </fo:block>
+                        </fo:table-cell>
+                    </fo:table-row>
+                </xsl:for-each>
+            </fo:table-body>
+        </fo:table>
+    </xsl:template>
+    
     <!-- Creates a table with observation detail information -->
     <xsl:template name="observation-details-table">
         <xsl:param name="nodes"/>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -1322,8 +1322,8 @@
 
         <fo:table table-layout="fixed" space-before="6pt" space-after="12pt" font-size="10pt">
             <fo:table-column column-width="50%"/>
-            <fo:table-column column-width="25%"/>
-            <fo:table-column column-width="25%"/>
+            <fo:table-column column-width="15%"/>
+            <fo:table-column column-width="35%"/>
             <fo:table-body>
                 <fo:table-row>
                     <fo:table-cell background-color="{$hdrColor}">
@@ -1360,7 +1360,13 @@
                         <fo:table-cell border-bottom-style="solid"
                                        border-color="black" border-width="0.25pt">
                             <fo:block>
-                                <xsl:value-of select="status"/>
+                                <xsl:if test="status = 'Grad Thesis'">
+                                    <fo:inline font-weight="bold">&#160;(thesis)</fo:inline>
+                                </xsl:if>
+                                <xsl:if test="status != 'Grad Thesis'">
+                                    <fo:inline font-weight="bold">&#160;(thesis)</fo:inline>
+                                    <xsl:value-of select="status"/>
+                                </xsl:if>
                             </fo:block>
                         </fo:table-cell>
 
@@ -1376,7 +1382,7 @@
             </fo:table-body>
         </fo:table>
     </xsl:template>
-    
+
     <!-- Creates a table with observation detail information -->
     <xsl:template name="observation-details-table">
         <xsl:param name="nodes"/>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/scala/edu/gemini/model/p1/pdf/P1PDF.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/scala/edu/gemini/model/p1/pdf/P1PDF.scala
@@ -170,7 +170,7 @@ object P1PDF {
     val home = System.getProperty("user.home")
     val in = new File(s"$home/pitsource.xml")
     val out = new File(s"$home/pittarget.pdf")
-    createFromFile(in, NOAONoInvestigatorsList, out)
+    createFromFile(in, GeminiDefaultListAtTheEnd, out)
 
     val ok = Runtime.getRuntime.exec(Array("open", out.getAbsolutePath)).waitFor
     println("Exec returned " + ok)

--- a/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
@@ -270,7 +270,7 @@ class P1TemplatesSpec extends Specification with XmlMatchers {
       val proposalXml = XML.loadString(result)
 
       // Show the principal
-      proposalXml must (\\("block") \ "inline" \>~ "Principal Investigator:")
+      proposalXml must (\\("block") \>~ """P..Investigator""")
     }
 
   }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -333,7 +333,7 @@ case object SemesterConverter2015BTo2016A extends SemesterConverter {
 case object SemesterConverter2015ATo2015B extends SemesterConverter {
   val gracesReadModeTransformer: TransformFunction = {
     case p @ <graces>{ns @ _*}</graces> if (p \\ "readMode").isEmpty =>
-      StepResult(s"Graces missing Read mode assigned to Fast.", <graces>ns: _*<readMode>Fast (Gain=1.6e/ADU, Read noise=4.7e)</readMode></graces>).successNel
+      StepResult(s"Graces missing Read mode assigned to Fast.", <graces>{ns}<readMode>Fast (Gain=1.6e/ADU, Read noise=4.7e)</readMode></graces>).successNel
   }
 
   val gracesFiberTransformer: TransformFunction = {

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -55,7 +55,7 @@ object UpConverter {
   def convert(node: XMLNode):Result = node match {
     case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text == Proposal.currentSchemaVersion =>
       StepResult(Nil, node).successNel[String]
-    case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text == "2017.2.1"                    =>
+    case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text.matches("2017.2.[12]")           =>
       from2017B.concatenate.convert(node)
     case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text == "2017.1.1"                    =>
       from2017A.concatenate.convert(node)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -331,6 +331,11 @@ case object SemesterConverter2015BTo2016A extends SemesterConverter {
  * This converter will upgrade to 2015B
  */
 case object SemesterConverter2015ATo2015B extends SemesterConverter {
+  val gracesReadModeTransformer: TransformFunction = {
+    case p @ <graces>{ns @ _*}</graces> if (p \\ "readMode").isEmpty =>
+      StepResult(s"Graces missing Read mode assigned to Fast.", <graces>ns: _*<readMode>Fast (Gain=1.6e/ADU, Read noise=4.7e)</readMode></graces>).successNel
+  }
+
   val gracesFiberTransformer: TransformFunction = {
     case p @ <graces>{ns @ _*}</graces> if (p \\ "fiberMode").nonEmpty =>
       val fiberMode = (p \\ "fiberMode").text
@@ -353,7 +358,7 @@ case object SemesterConverter2015ATo2015B extends SemesterConverter {
       StepResult(s"Graces Fiber mode $fiberMode updated to ${transformFiberMode(fiberMode)}.", <graces>{GracesFiberMode.transform(ns)}</graces>).successNel
   }
 
-  val transformers = List(gracesFiberTransformer)
+  val transformers = List(gracesFiberTransformer, gracesReadModeTransformer)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -694,11 +694,12 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           result \\ "graces" must \\("fiberMode") \> "2 fibers (target+sky, R~40k)"
           result \\ "graces" must \\("name") \> "Graces 2 fibers (target+sky, R~40k)"
           result \\ "graces" must \\("fiberMode") \> "1 fiber (target only, R~67.5k)"
           result \\ "graces" must \\("name") \> "Graces 1 fiber (target only, R~67.5k)"
+          result \\ "graces" must \\("readMode") \> "Fast (Gain=1.6e/ADU, Read noise=4.7e)"
       }
     }
     "proposal with NIRI blueprints should remove unavailable filters, REL-2390" in {

--- a/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/config/P1MonitorConfig.scala
+++ b/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/config/P1MonitorConfig.scala
@@ -101,10 +101,13 @@ class P1MonitorConfig(ctx: BundleContext) {
   }
 
   private def toTemplate(s: String): P1PDF.Template = s match {
-    case "au" => P1PDF.AU
-    case "cl" => P1PDF.CL
-    case "us" => P1PDF.NOAO
-    case _    => P1PDF.GeminiDefaultListAtTheEnd
+    case "ar" | "br" | "kr" | "uh" => P1PDF.GeminiDefault
+    case "cfh" | "subaru" | "keck" => P1PDF.GeminiDefault
+    case "au"                      => P1PDF.AU
+    case "cl"                      => P1PDF.CL
+    case "us"                      => P1PDF.NOAO
+    case "ca"                      => P1PDF.GeminiDefaultListAtTheEnd
+    case _                         => P1PDF.GeminiDefaultListAtTheEnd
   }
 
   def getDirectories: Traversable[MonitoredDirectory] = map.values

--- a/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/config/P1MonitorConfig.scala
+++ b/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/config/P1MonitorConfig.scala
@@ -93,7 +93,7 @@ class P1MonitorConfig(ctx: BundleContext) {
         val to = (elementContent(_type, TO_TAG) ++ global_to).map(new InternetAddress(_))
         val cc = (elementContent(_type, CC_TAG) ++ global_cc).map(new InternetAddress(_))
         val bcc = (elementContent(_type, BCC_TAG) ++ global_bcc).map(new InternetAddress(_))
-        val template = (elementContent(_type, TEMPLATE_TAG) ++ global_bcc).headOption.map(toTemplate)
+        val template = elementContent(_type, TEMPLATE_TAG).headOption.orElse(Some(name)).map(toTemplate)
         (name, MonitoredDirectory(name, rootDir.head, username, group, to, cc, bcc, template.getOrElse(P1PDF.GeminiDefault)))
       }
     }


### PR DESCRIPTION
This are more updates to get an unbiased view of the investigators list. It creates a new table that doesn't show the investigator's name or whether they are principal or co-investigators

This also includes a fix on an upconversion of certain graces proposals bug