### PR TITLE
Make getCoords always recalculate the coordinates

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/AllocAdapter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/AllocAdapter.java
@@ -28,7 +28,7 @@ public class AllocAdapter implements Adapter<Alloc> {
 		table.put(PROP_HOUR_ANGLE, minMaxMeanHHMMSS(target, Alloc.Circumstance.HOUR_ANGLE, false));
 		table.put(PROP_PARALLACTIC_ANGLE, minMaxMeanParallacticAngle(target, "\u00B0", false));
 		table.put(PROP_LUNAR_RANGE, minMaxMean(target, Alloc.Circumstance.LUNAR_DISTANCE, "\u00B0", false));
-		table.put(PROP_COORDINATES, obs.getRaString(target.getMiddlePoint()) + " " + obs.getDecString(target.getMiddlePoint()));
+		table.put(PROP_COORDINATES, obs.getCoords(target.getMiddlePoint()));
 
 		if (variant != null) {
 			DateFormat df = new SimpleDateFormat("HH:mm");

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -582,16 +582,9 @@ public final class Obs implements Serializable, Comparable<Obs> {
         return (targetEnvironment != null ? targetEnvironment.getAsterism().getRaDegrees(new Some<>(when)).getOrElse(0.0) : 0.0);
 	}
 
-    public String getRaString(Long when) {
-        return (targetEnvironment != null ? targetEnvironment.getAsterism().getRaString(new Some<>(when)).getOrElse("0.0") : "0.0");
-    }
 	public double getDec(Long when) {
         return (targetEnvironment != null ? targetEnvironment.getAsterism().getDecDegrees(new Some<>(when)).getOrElse(0.0) : 0.0);
 	}
-
-    public String getDecString(Long when) {
-        return (targetEnvironment != null ? targetEnvironment.getAsterism().getDecString(new Some<>(when)).getOrElse("0.0") : "0.0");
-    }
 
     public Conds getConditions() {
         return conditions;

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -692,8 +692,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
     }
 
     public WorldCoords getCoords(Long when) {
-        if (coords == null) coords = new WorldCoords(getRa(when), getDec(when));
-        return coords;
+        return new WorldCoords(getRa(when), getDec(when));
     }
 
     public String getInstrumentString() {


### PR DESCRIPTION
This was causing the issue reported by @andrewwstephens. Now the OT and QPT elevation plot are identical:

<img width="798" alt="coords_fix" src="https://user-images.githubusercontent.com/215438/29524673-d0ccb2f2-8666-11e7-9f4d-3875e1a6f98d.png">

(The screenshot from Andy was with Gemini North, but I don't know how to make the QPT switch to the North. In any case that target at that date was also wrong in the QPT for the South before)