### PR TITLE
REL-1438: user target types

### DIFF
--- a/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
+++ b/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
@@ -235,7 +235,7 @@ public class AbstractRuleTest {
                         )
                 )
         );
-        TargetEnvironment env = TargetEnvironment.create(sptarget, guide, ImCollections.<SPTarget>emptyList());
+        final TargetEnvironment env = TargetEnvironment.create(sptarget, guide, ImCollections.<UserTarget>emptyList());
 
         target.setTargetEnvironment(env);
         ISPObsComponent targetObsComp = createObsComp(target);
@@ -267,7 +267,7 @@ public class AbstractRuleTest {
                         )
                 )
         );
-        TargetEnvironment env = TargetEnvironment.create(sptarget, guide, ImCollections.<SPTarget>emptyList());
+        final TargetEnvironment env = TargetEnvironment.create(sptarget, guide, ImCollections.<UserTarget>emptyList());
 
         target.setTargetEnvironment(env);
         ISPObsComponent targetObsComp = createObsComp(target);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -45,7 +45,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     // for serialization
     private static final long serialVersionUID = 4L;
 
-    public static final String VERSION = "2017B-1";
+    public static final String VERSION = "2018A-1";
 
     /** This property records the program queue/classical state. */
     public static final String PROGRAM_MODE_PROP = "programMode";

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/UserTarget.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/UserTarget.java
@@ -1,0 +1,70 @@
+package edu.gemini.spModel.target.env;
+
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.spModel.target.SPTarget;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Tuple of a user SPTarget and its type.
+ */
+public final class UserTarget implements Serializable {
+
+    /**
+     * Enumeration of the usages of additional non-guide star targets in a
+     * target environment.
+     */
+    public enum Type {
+        blindOffset("Blind-offset"),
+        offAxis("Off-axis"),
+        tuning("Tuning Star"),
+        other("User");
+
+        public final String displayName;
+
+        private Type(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public static Option<Type> fromString(String s) {
+            return ImOption.fromOptional(
+                    Stream.of(values())
+                            .filter(t -> t.name().equals(s))
+                            .findFirst()
+            );
+        }
+    }
+
+    public final Type type;
+    public final SPTarget target;
+
+    public UserTarget(Type type, SPTarget target) {
+        if (type == null) throw new NullPointerException("type cannot be null");
+        if (target == null) throw new NullPointerException("target cannot be null");
+
+        this.type   = type;
+        this.target = target;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserTarget that = (UserTarget) o;
+        return Objects.equals(type, that.type) &&
+                Objects.equals(target, that.target);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, target);
+    }
+
+    public UserTarget cloneTarget() {
+        return new UserTarget(type, target.clone());
+    }
+}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
@@ -9,6 +9,7 @@ import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideGroup;
 import edu.gemini.spModel.target.env.IndexedGuideGroup;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.UserTarget;
 
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -99,8 +100,8 @@ public final class TargetSelection {
                     res.add(new GuideStarSelection(idx++, g, t));
                 }
             }
-            for (final SPTarget t : env.getUserTargets()) {
-                res.add(new NormalTargetSelection(idx++, t));
+            for (final UserTarget t : env.getUserTargets()) {
+                res.add(new NormalTargetSelection(idx++, t.target));
             }
             return DefaultImList.create(res);
         }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
@@ -139,12 +139,20 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
       arbitrary[GuideEnv].map(ge => GuideEnvironment(ge))
     }
 
+  implicit val arbUserTarget: Arbitrary[UserTarget] =
+    Arbitrary {
+      for {
+        u <- Gen.oneOf(UserTarget.Type.values)
+        t <- arbitrary[SPTarget]
+      } yield new UserTarget(u, t)
+    }
+
   implicit val arbTargetEnvironment: Arbitrary[TargetEnvironment] =
     Arbitrary {
       for {
         b <- arbitrary[SPTarget]
         g <- arbitrary[GuideEnvironment]
-        u <- boundedListOf[SPTarget](3)
+        u <- boundedListOf[UserTarget](3)
       } yield TargetEnvironment.create(b, g, u.asImList)
     }
 

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
@@ -159,6 +159,14 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
     }
 
     @Override
+    public int indexWhere(Function1<? super T, Boolean> p) {
+        for (int i=0; i<backingList.size(); ++i) {
+            if (p.apply(backingList.get(i))) return i;
+        }
+        return -1;
+    }
+
+    @Override
     public boolean isEmpty() {
         return backingList.isEmpty();
     }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
@@ -98,6 +98,11 @@ public class ImCollections {
         }
 
         @Override
+        public int indexWhere(final Function1<? super Object, Boolean> p) {
+            return -1;
+        }
+
+        @Override
         public boolean isEmpty() {
             return true;
         }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
@@ -172,6 +172,15 @@ public interface ImList<T> extends Iterable<T> {
     int indexOf(T o);
 
     /**
+     * Returns the index of the first occurrence which satisfies the predicate.
+     *
+     * @param p the predicate to test the elements against
+     *
+     * @return index of the first matching element, if any; -1 otherwise
+     */
+    int indexWhere(Function1<? super T, Boolean> p);
+
+    /**
      * Returns <code>true</code> if this list contains no elements.
      *
      * @return <code>true</code> if this list contains no elements

--- a/bundle/edu.gemini.shared.util/src/test/java/edu/gemini/shared/util/immutable/ImListTest.java
+++ b/bundle/edu.gemini.shared.util/src/test/java/edu/gemini/shared/util/immutable/ImListTest.java
@@ -304,6 +304,12 @@ public class ImListTest extends TestCase {
         }
     };
 
+    public void testIndexWhere() {
+        assertEquals(-1, create(1, 3, 5, 7).indexWhere(even));
+        assertEquals(0,  create(0, 1, 2, 3).indexWhere(even));
+        assertEquals(3,  create(1, 3, 5, 6).indexWhere(even));
+    }
+
     public void testFind() {
         assertEquals(None.INSTANCE, create(1, 3, 5, 7).find(even));
         assertEquals(new Some<Integer>(0), create(0, 1, 2).find(even));

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/migration/to2009B/SPTargetPosListParser.java
@@ -7,6 +7,7 @@ import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.UserTarget;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 
 import java.util.*;
@@ -33,7 +34,7 @@ enum SPTargetPosListParser {
         TargetEnvironment toTargetEnv() {
             if (base == null) base = new SPTarget();
             final ImList<GuideProbeTargets> glst = DefaultImList.create(guideMap.values());
-            final ImList<SPTarget> ulst = DefaultImList.create(userTargets);
+            final ImList<UserTarget>        ulst = DefaultImList.create(userTargets).map(t -> new UserTarget(UserTarget.Type.other, t));
             return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(glst).setUserTargets(ulst);
         }
     }

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/Migration.scala
@@ -64,6 +64,13 @@ trait Migration {
       ps  <- env.allParamSets if ps.getName == ParamSetBase
     } yield (obs.getParamSet(ParamSetObservation), ps)
 
+  protected def targetEnvs(d: Document): List[ParamSet] =
+    for {
+      obs <- d.findContainers(SPComponentType.OBSERVATION_BASIC)
+      cnt <- obs.findContainers(SPComponentType.TELESCOPE_TARGETENV)
+      env <- cnt.allParamSets if env.getName == ParamSetTargetEnv
+    } yield env
+
   /** (target env paramset, target paramset) paramset pairs **/
   protected def envAndBases(d: Document): List[(ParamSet, ParamSet)] =
     for {

--- a/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2018A/To2018A.scala
+++ b/bundle/edu.gemini.spModel.io/src/main/scala/edu/gemini/spModel/io/impl/migration/to2018A/To2018A.scala
@@ -1,19 +1,13 @@
 package edu.gemini.spModel.io.impl.migration.to2018A
 
 import edu.gemini.pot.sp.SPComponentType
-import edu.gemini.spModel.core.{Coordinates, Ephemeris}
-import edu.gemini.spModel.gemini.gnirs.InstGNIRS
-import edu.gemini.spModel.io.PioSyntax
 import edu.gemini.spModel.io.impl.migration.Migration
 import edu.gemini.spModel.pio.{Container, Document, ParamSet, Pio, Version}
-import edu.gemini.spModel.pio.codec.ParamSetCodec
-import edu.gemini.spModel.pio.codec.CodecSyntax._
+import edu.gemini.spModel.pio.xml.{PioXmlFactory, PioXmlUtil}
+import edu.gemini.spModel.target.SPTargetPio
 import edu.gemini.spModel.target.TargetParamCodecs._
 import edu.gemini.spModel.target.TargetParamSetCodecs._
-import edu.gemini.spModel.pio.xml.{PioXmlFactory, PioXmlUtil}
-import edu.gemini.spModel.pio.{Container, Document, ParamSet, Pio, Version}
-import edu.gemini.spModel.target.SPTargetPio
-import edu.gemini.spModel.target.env.Asterism
+import edu.gemini.spModel.target.env.{Asterism, UserTarget}
 
 import scalaz._
 import Scalaz._
@@ -23,12 +17,17 @@ object To2018A extends Migration {
   val version = Version.`match`("2018A-1")
 
   val conversions: List[Document => Unit] =
-    List(targetToAsterism)
+    List(
+      targetToAsterism,
+      typeUserTargets
+    )
 
   val fact = new PioXmlFactory
 
   // Convert base positions to single-target asterisms
   private def targetToAsterism(d: Document): Unit = {
+
+    import edu.gemini.spModel.pio.codec.CodecSyntax._
 
     // SPTarget paramset to Asterism paramSet
     def convertToAsterism(ps: ParamSet): ParamSet =
@@ -41,4 +40,23 @@ object To2018A extends Migration {
 
   }
 
+  // Convert user targets to give them a type.
+  private def typeUserTargets(d: Document): Unit = {
+
+    import edu.gemini.spModel.io.PioSyntax._
+
+    val ps = for {
+      e <- targetEnvs(d)
+      p <- e.allParamSets.filter(_.getName == "userTargets")
+    } {
+      p.paramSets("spTarget").foreach { t =>
+        p.removeChild(t)
+
+        val ut = fact.createParamSet("userTarget")
+        Pio.addParam(fact, ut, "type", UserTarget.Type.other.name());
+        ut.addParamSet(t)
+        p.addParamSet(ut)
+      }
+    }
+  }
 }

--- a/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2018A/userTargets.xml
+++ b/bundle/edu.gemini.spModel.io/src/test/resources/edu/gemini/spModel/io/impl/migration/to2018A/userTargets.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2017B-1" subtype="basic" key="bc81feda-0591-4f36-9687-485ecd5dd44f" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="true"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="YES"/>
+    </paramset>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="5759db1f-cc1c-4b2e-bdcd-6460641ef6d3" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GMOS-S Observation"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <paramset name="schedulingBlock">
+          <param name="start" value="1509471000000"/>
+          <paramset name="duration">
+            <param name="tag" value="unstated"/>
+          </paramset>
+        </paramset>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="be298695-618d-4757-a7f2-90d5d5554b82" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="ANY"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="aaa45ea6-12ad-4225-9184-b72c1fc2ee22" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="base">
+              <paramset name="target">
+                <param name="name" value="Vega"/>
+                <param name="redshift" value="-6.9E-5"/>
+                <param name="parallax" value="130.23"/>
+                <paramset name="magnitude">
+                  <param name="value" value="0.03"/>
+                  <param name="band" value="U"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="value" value="0.03"/>
+                  <param name="band" value="B"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="value" value="0.03"/>
+                  <param name="band" value="V"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="value" value="0.07"/>
+                  <param name="band" value="R"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="value" value="0.1"/>
+                  <param name="band" value="I"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="value" value="-0.18"/>
+                  <param name="band" value="J"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="value" value="-0.03"/>
+                  <param name="band" value="H"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="magnitude">
+                  <param name="value" value="0.13"/>
+                  <param name="band" value="K"/>
+                  <param name="system" value="Vega"/>
+                </paramset>
+                <paramset name="coordinates">
+                  <param name="ra" value="279.23473478999995"/>
+                  <param name="dec" value="38.783688960000006"/>
+                </paramset>
+                <paramset name="proper-motion">
+                  <param name="delta-ra" value="200.94"/>
+                  <param name="delta-dec" value="286.23"/>
+                  <param name="epoch" value="2000.0"/>
+                </paramset>
+                <param name="tag" value="sidereal"/>
+              </paramset>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="0"/>
+              <paramset name="guideGroup">
+                <param name="tag" value="AutoInitialTag"/>
+              </paramset>
+            </paramset>
+            <paramset name="userTargets">
+              <paramset name="spTarget">
+                <paramset name="target">
+                  <param name="name" value="User1"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="279.29583333333335"/>
+                    <param name="dec" value="38.83027777777778"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
+              </paramset>
+              <paramset name="spTarget">
+                <paramset name="target">
+                  <param name="name" value="User2"/>
+                  <paramset name="coordinates">
+                    <param name="ra" value="279.17499999999995"/>
+                    <param name="dec" value="38.73916666666668"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOSSouth" key="e81dbf5b-b994-4034-ba3a-60687e79a308" name="GMOS-S">
+        <paramset name="GMOS-S" kind="dataObj">
+          <param name="exposureTime" value="300.0"/>
+          <param name="posAngle" value="0"/>
+          <param name="coadds" value="1"/>
+          <param name="adc" value="NONE"/>
+          <param name="ampCount" value="TWELVE"/>
+          <param name="gainChoice" value="LOW"/>
+          <param name="ampReadMode" value="SLOW"/>
+          <param name="detectorManufacturer" value="HAMAMATSU"/>
+          <param name="disperser" value="MIRROR"/>
+          <param name="fpuMode" value="BUILTIN"/>
+          <param name="fpu" value="FPU_NONE"/>
+          <param name="filter" value="NONE"/>
+          <param name="ccdXBinning" value="ONE"/>
+          <param name="ccdYBinning" value="ONE"/>
+          <param name="issPort" value="SIDE_LOOKING"/>
+          <param name="posAngleConstraint" value="FIXED"/>
+          <param name="stageMode" value="FOLLOW_XYZ"/>
+          <param name="dtaXOffset" value="ZERO"/>
+          <param name="builtinROI" value="FULL_FRAME"/>
+          <param name="useNS" value="FALSE"/>
+          <param name="mosPreimaging" value="NO"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="370850e0-ba7f-414d-b724-715dc7386465" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="744348d5-561f-4e62-ae9c-23c898ee8ea0" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="e1960449-89fe-4916-acc2-d263b30d97e6" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+        <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="c3577dc4-4f8a-46a6-8fc1-ed2d7b6a5e7f" name="Observe">
+          <paramset name="Observe" kind="dataObj">
+            <param name="repeatCount" value="1"/>
+            <param name="class" value="SCIENCE"/>
+          </paramset>
+        </container>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="e1960449-89fe-4916-acc2-d263b30d97e6"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="370850e0-ba7f-414d-b724-715dc7386465"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="bc81feda-0591-4f36-9687-485ecd5dd44f"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="744348d5-561f-4e62-ae9c-23c898ee8ea0"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="aaa45ea6-12ad-4225-9184-b72c1fc2ee22"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="26"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e81dbf5b-b994-4034-ba3a-60687e79a308"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="be298695-618d-4757-a7f2-90d5d5554b82"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="5759db1f-cc1c-4b2e-bdcd-6460641ef6d3"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c3577dc4-4f8a-46a6-8fc1-ed2d7b6a5e7f"/>
+      <param name="44d4f9b7-bb72-47fe-8c88-1f93c1e46a87" value="1"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2018A/TargetToAsterismTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2018A/TargetToAsterismTest.scala
@@ -21,7 +21,7 @@ class TargetToAsterismTest extends Specification with MigrationTest {
        .getOrElse(sys.error(s"Couldn't find asterism for observation named '$obsName'."))
   }
 
-  "2017B Asterism Migration" should {
+  "2018A Asterism Migration" should {
 
     "Convert sidereal targets." in withTestProgram2("asterism.xml") {
       _.findAsterism("sidereal") must beLike {

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2018A/UserTargetConversionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2018A/UserTargetConversionTest.scala
@@ -1,0 +1,56 @@
+package edu.gemini.spModel.io.impl.migration.to2018A
+
+import edu.gemini.spModel.core.Angle
+import edu.gemini.spModel.io.impl.migration.MigrationTest
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.UserTarget
+import edu.gemini.shared.util.immutable.ScalaConverters._
+
+import org.specs2.mutable.Specification
+
+class UserTargetConversionTest extends Specification with MigrationTest {
+  import UserTargetConversionTest._
+
+  "2018A User Target Conversion" should {
+
+    "Type user targets as 'other'" in withTestProgram2("userTargets.xml") {
+      _.allObservations.flatMap(_.findTargetObsComp).exists { toc =>
+        val userTargets = toc.getTargetEnvironment.getUserTargets.asScalaList
+        (userTargets.size == 2) && userTargets.zip(List(user1, user2)).forall((matches _).tupled)
+      }
+    }
+  }
+
+}
+
+object UserTargetConversionTest {
+  val user1 = userTarget("User1", "18:37:11.000", "38:49:49.00")
+  val user2 = userTarget("User2", "18:36:42.000", "38:44:21.00")
+
+  private def userTarget(name: String, ra: String, dec: String): UserTarget = {
+    val sp = new SPTarget()
+    sp.setName(name)
+
+    val rad  = Angle.parseHMS(ra).getOrElse(sys.error(s"Could not parse RA: $ra")).toDegrees
+    sp.setRaDegrees(rad)
+
+    val decd = Angle.parseDMS(dec).getOrElse(sys.error(s"Could not parse Dec: $dec")).toDegrees
+    sp.setDecDegrees(decd)
+
+    new UserTarget(UserTarget.Type.other, sp)
+  }
+
+
+  def matches(u0: UserTarget, u1: UserTarget): Boolean = {
+    val when = new edu.gemini.shared.util.immutable.Some(new java.lang.Long(0))
+
+    def same[A](f: UserTarget => A): Boolean = f(u0) == f(u1)
+
+    same(_.`type`                             ) &&
+    same(_.target.getName                     ) &&
+    same(_.target.getRaDegrees(when).getValue ) &&
+    same(_.target.getDecDegrees(when).getValue)
+  }
+
+}

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
@@ -21,7 +21,7 @@ public final class TargetGroupConfig extends ParamSet {
     public static final String TYPE_VALUE="targetgroup";
 
     public static TargetGroupConfig createBaseGroup(final TargetEnvironment env) {
-        final ImList<SPTarget> targets = env.getUserTargets().cons(env.getArbitraryTargetFromAsterism());
+        final ImList<SPTarget> targets = env.getUserTargets().map(u -> u.target).cons(env.getArbitraryTargetFromAsterism());
         return new TargetGroupConfig(TccNames.BASE, targets, ImOption.apply(env.getArbitraryTargetFromAsterism()));
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -5,6 +5,7 @@ import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.UserTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.wdba.glue.api.WdbaGlueException;
 import edu.gemini.spModel.target.env.GuideGroup;
@@ -105,12 +106,13 @@ public class TccFieldConfig extends ParamSet {
 
         // Add the user targets.
         int pos = 1;
-        for (SPTarget user : env.getUserTargets()) {
-            if (isEmpty(user.getName())) {
-                user.setName(TargetConfig.formatName("User", pos));
+        for (UserTarget user : env.getUserTargets()) {
+            final SPTarget t = user.target;
+            if (isEmpty(t.getName())) {
+                t.setName(TargetConfig.formatName("User", pos));
             }
             ++pos;
-            add(new TargetConfig(user));
+            add(new TargetConfig(t));
         }
 
         // Add the "group" for the base position.

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/Flamingos2SupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/Flamingos2SupportTest.java
@@ -11,6 +11,7 @@ import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.UserTarget;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.telescope.IssPort;
@@ -45,7 +46,7 @@ public final class Flamingos2SupportTest extends InstrumentSupportTestBase<Flami
 
     private TargetEnvironment create(final GuideProbe... probes) {
         final ImList<GuideProbeTargets> gtCollection = createGuideTargetsList(probes);
-        final ImList<SPTarget> userTargets = ImCollections.emptyList();
+        final ImList<UserTarget>         userTargets = ImCollections.emptyList();
         return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GsaoiSupportTest.java
@@ -10,6 +10,7 @@ import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.UserTarget;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.telescope.IssPort;
@@ -56,7 +57,7 @@ public final class GsaoiSupportTest extends InstrumentSupportTestBase<Gsaoi> {
 
     private TargetEnvironment create(final GuideProbe... probes) {
         final ImList<GuideProbeTargets> gtCollection = createGuideTargetsList(probes);
-        final ImList<SPTarget> userTargets = ImCollections.emptyList();
+        final ImList<UserTarget>         userTargets = ImCollections.emptyList();
         return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideConfigTest.java
@@ -58,7 +58,7 @@ public final class GuideConfigTest extends TestBase {
 
     private TargetEnvironment create(GuideProbe... probes) {
         final ImList<GuideProbeTargets> gtCollection = createGuideTargetsList(probes);
-        final ImList<SPTarget> userTargets = ImCollections.emptyList();
+        final ImList<UserTarget>         userTargets = ImCollections.emptyList();
         return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GuideGroupTest.java
@@ -14,6 +14,7 @@ import edu.gemini.spModel.target.env.GuideEnvironment;
 import edu.gemini.spModel.target.env.GuideGroup;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.UserTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.env.OptionsListImpl;
 import org.dom4j.Document;
@@ -51,7 +52,7 @@ public final class GuideGroupTest extends TestBase {
 
     private TargetEnvironment create(final GuideProbe... probes) {
         final ImList<GuideProbeTargets> gtCollection = createGuideTargetsList(probes);
-        final ImList<SPTarget> userTargets = ImCollections.emptyList();
+        final ImList<UserTarget>         userTargets = ImCollections.emptyList();
         return TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/TargetGroupTest.java
@@ -83,7 +83,7 @@ public final class TargetGroupTest extends TestBase {
     @Test public void testUnamedBaseAndUser() throws Exception {
         final SPTarget base = new SPTarget(); base.setName("");
         final SPTarget user = new SPTarget(); user.setName("");
-        final ImList<SPTarget> userTargets = ImCollections.singletonList(user);
+        final ImList<UserTarget> userTargets = ImCollections.singletonList(new UserTarget(UserTarget.Type.other, user));
 
         nameMap.putTargetName(base, TccNames.BASE);
         nameMap.putTargetName(user, "User (1)");
@@ -95,7 +95,7 @@ public final class TargetGroupTest extends TestBase {
         final GuideProbeTargets gt = GuideProbeTargets.create(PwfsGuideProbe.pwfs2, targetList);
 
         final ImList<GuideProbeTargets> gtCollection = DefaultImList.create(gt);
-        final ImList<SPTarget> userTargets = ImCollections.emptyList();
+        final ImList<UserTarget> userTargets = ImCollections.emptyList();
 
         final TargetEnvironment env = TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
         testTargetEnvironment(env);
@@ -148,7 +148,7 @@ public final class TargetGroupTest extends TestBase {
         nameMap.putGuiderName(GmosOiwfsGuideProbe.instance, "OIWFS");
 
         final ImList<GuideProbeTargets> gtCollection = DefaultImList.create(gt);
-        final ImList<SPTarget> userTargets = ImCollections.emptyList();
+        final ImList<UserTarget>         userTargets = ImCollections.emptyList();
 
         final TargetEnvironment env = TargetEnvironment.create(base).setAllPrimaryGuideProbeTargets(gtCollection).setUserTargets(userTargets);
         testTargetEnvironment(env);
@@ -422,7 +422,7 @@ public final class TargetGroupTest extends TestBase {
         // Check the base element.
         Element baseGroupElement = getGroupElement(TccNames.BASE, groupElements);
         assertNotNull(baseGroupElement);
-        ImList<SPTarget> targets = env.getUserTargets();
+        ImList<SPTarget> targets = env.getUserTargets().map(u -> u.target);
         targets = targets.cons(env.getArbitraryTargetFromAsterism());
 
         String baseName = nameMap.getTargetName(env.getArbitraryTargetFromAsterism());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -218,14 +218,13 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
      */
     private boolean selectionIsUserTarget() {
         final TargetEnvironment env = getDataObject().getTargetEnvironment();
-        return selectedTarget().exists(t -> env.getUserTargets().contains(t));
+        return selectedTarget().exists(t -> env.isUserPosition(t));
     }
 
     /**
      * Auxiliary method to set the selection to the specified target.
      */
     private void setSelectionToTarget(final SPTarget t) {
-        //_curSelection = ImOption.apply(t).map(Left<SPTarget,IndexedGuideGroup>::new);
         _curSelection = ImOption.apply(t).map(Left::new);
     }
 
@@ -423,9 +422,11 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 updateGuideStarAdders();
             }
 
-            _w.newMenu.add(new JMenuItem("User") {{
-                addActionListener(new AddUserTargetAction(newTOC, _w.positionTable));
-            }});
+            for (UserTarget.Type t : UserTarget.Type.values()) {
+                _w.newMenu.add(new JMenuItem(t.displayName) {{
+                    addActionListener(new AddUserTargetAction(t, newTOC, _w.positionTable));
+                }});
+            }
 
             if (inst.hasGuideProbes()) {
                 _w.newMenu.addSeparator();
@@ -539,13 +540,15 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
 
         // Make a list of PositionTypes that are legal in the current observation context.
         int index = 0;
-        final PositionType[] ptA = new PositionType[2 + guiders.size()];
+        final PositionType[] ptA = new PositionType[1 + guiders.size() + UserTarget.Type.values().length];
         ptA[index++] = BasePositionType.instance;
         for (GuideProbe guider : guidersList) {
             final boolean guiderNotIllegal = !guider.equals(illegal);
             ptA[index++] = new GuidePositionType(guider, guiderNotIllegal, _w.positionTable);
         }
-        ptA[index] = UserPositionType.instance;
+        for (UserTarget.Type t : UserTarget.Type.values()) {
+            ptA[index++] = new UserPositionType(t);
+        }
 
         _w.tag.removeActionListener(_tagListener);
         _w.tag.setModel(new DefaultComboBoxModel<>(ptA));
@@ -629,14 +632,18 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
     }
 
     private static class AddUserTargetAction extends AddAction {
-        AddUserTargetAction(final TargetObsComp obsComp, final TelescopePosTableWidget positionTable) {
+        private final UserTarget.Type userTargetType;
+
+        AddUserTargetAction(final UserTarget.Type utt, final TargetObsComp obsComp, final TelescopePosTableWidget positionTable) {
             super(obsComp, positionTable);
+            userTargetType = utt;
         }
 
         @Override public void actionPerformed(final ActionEvent actionEvent) {
             final TargetEnvironment env = obsComp.getTargetEnvironment();
             final SPTarget target = new SPTarget();
-            final TargetEnvironment newEnv = env.setUserTargets(env.getUserTargets().append(target));
+            final UserTarget   ut = new UserTarget(userTargetType, target);
+            final TargetEnvironment newEnv = env.setUserTargets(env.getUserTargets().append(ut));
             obsComp.setTargetEnvironment(newEnv);
             positionTable.selectTarget(target);
         }
@@ -886,9 +893,18 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                     groups.add(group);
                 }
 
-                final TargetEnvironment newEnv = duplicated ?
-                        env.setGuideEnvironment(env.getGuideEnvironment().setOptions(DefaultImList.create(groups))) :
-                        env.setUserTargets(env.getUserTargets().append(newTarget));
+                final TargetEnvironment newEnv;
+
+                if (duplicated) {
+                    newEnv = env.setGuideEnvironment(env.getGuideEnvironment().setOptions(DefaultImList.create(groups)));
+                } else {
+                    // Wasn't a guide star so check which user target needs to
+                    // be copied.
+                    final ImList<UserTarget> us = env.getUserTargets();
+                    newEnv = us.find(u -> u.target.equals(target)).map(u ->
+                        env.setUserTargets(us.append(new UserTarget(u.type, newTarget)))
+                    ).getOrElse(env);
+                }
                 dataObject.setTargetEnvironment(newEnv);
             });
         } else {
@@ -1029,8 +1045,8 @@ enum BasePositionType implements PositionType {
 
         final SPTarget base = env.getArbitraryTargetFromAsterism();
 
-        final GuideEnvironment genv = env.getGuideEnvironment();
-        final ImList<SPTarget> user = env.getUserTargets().append(base);
+        final GuideEnvironment   genv = env.getGuideEnvironment();
+        final ImList<UserTarget> user = env.getUserTargets().append(new UserTarget(UserTarget.Type.other, base));
 
         final TargetEnvironment newEnv = TargetEnvironment.create(target, genv, user);
         obsComp.setTargetEnvironment(newEnv);
@@ -1045,7 +1061,7 @@ enum BasePositionType implements PositionType {
     }
 }
 
-class GuidePositionType implements PositionType {
+final class GuidePositionType implements PositionType {
     private final GuideProbe guider;
     private final boolean available;
     private final TelescopePosTableWidget positionTable;
@@ -1104,8 +1120,12 @@ class GuidePositionType implements PositionType {
     }
 }
 
-enum UserPositionType implements PositionType {
-    instance;
+final class UserPositionType implements PositionType {
+    final UserTarget.Type userTargetType;
+
+    UserPositionType(UserTarget.Type t) {
+        this.userTargetType = t;
+    }
 
     @Override public boolean isAvailable() {
         return true;
@@ -1116,15 +1136,18 @@ enum UserPositionType implements PositionType {
         if (isMember(env, target)) return;
         env = env.removeTarget(target);
 
-        final TargetEnvironment newEnv = env.setUserTargets(env.getUserTargets().append(target));
-        obsComp.setTargetEnvironment(newEnv);
+        obsComp.setTargetEnvironment(
+            env.setUserTargets(
+                env.getUserTargets().append(new UserTarget(userTargetType, target))
+            )
+        );
     }
 
     @Override public boolean isMember(final TargetEnvironment env, final SPTarget target) {
-        return env.getUserTargets().contains(target);
+        return env.getUserTargets().find(u -> u.type == userTargetType && u.target.equals(target)).isDefined();
     }
 
     @Override public String toString() {
-        return TargetEnvironment.USER_NAME;
+        return userTargetType.displayName;
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -206,9 +206,9 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
         }
 
         static final class UserTargetRow extends NonBaseTargetRow {
-            UserTargetRow(final int index, final SPTarget target, final Option<Coordinates> baseCoords,
+            UserTargetRow(final int index, final UserTarget u, final Option<Coordinates> baseCoords,
                           final Option<Long> when) {
-                super(true, String.format("%s (%d)", TargetEnvironment.USER_NAME, index), target, baseCoords, when);
+                super(true, String.format("%s (%d)", u.type.displayName, index), u.target, baseCoords, when);
             }
 
             @Override public boolean movable() { return false; }
@@ -302,9 +302,9 @@ final class TelescopePosTableWidget extends JTable implements TelescopePosWatche
 
             // Add the user positions.
             env.getUserTargets().zipWithIndex().foreach(tup -> {
-                final SPTarget target = tup._1();
-                final int index = tup._2() + 1;
-                tmpRows.add(new UserTargetRow(index, target, baseCoords, when));
+                final UserTarget t = tup._1();
+                final int    index = tup._2() + 1;
+                tmpRows.add(new UserTargetRow(index, t, baseCoords, when));
             });
 
             return tmpRows;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/AgsStrategyPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/AgsStrategyPanel.java
@@ -30,35 +30,44 @@ public final class AgsStrategyPanel extends AgsSelectorControl {
 
     public void setAgsOptions(final AgsContext opts) {
         // clear current strategies from gui
-        pan.remove(label);
+        pan.removeAll();
         for (JRadioButton button : buttons) {
-            pan.remove(button);
             buttonGroup.remove(button);
         }
         buttons.clear();
 
         if (opts.nonEmpty()) {
-            pan.add(label);
+            pan.add(createRow(0, label));
 
             final boolean usingDefault = opts.usingDefault();
+
+            final int indent = 5;
 
             if (opts.defaultStrategy.isDefined()) {
                 final JRadioButton button = mkButton(opts.defaultStrategy.getValue(), true);
                 buttons.add(button);
-                pan.add(button);
+                pan.add(createRow(indent, button));
                 button.setSelected(usingDefault);
             }
 
             for (final AgsStrategy s : opts.validStrategies) {
                 final JRadioButton button = mkButton(s, false);
                 buttons.add(button);
-                pan.add(button);
+                pan.add(createRow(indent, button));
                 button.setSelected(!usingDefault && opts.strategyOverride.exists(sel -> sel == s));
             }
         }
 
         pan.revalidate();
         pan.repaint();
+    }
+
+    private static Box createRow(int indent, JComponent cmp) {
+        final Box b = Box.createHorizontalBox();
+        b.add(Box.createHorizontalStrut(indent));
+        b.add(cmp);
+        b.add(Box.createHorizontalGlue());
+        return b;
     }
 
     private JRadioButton mkButton(final AgsStrategy s, final boolean isDefault) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeFeatureManager.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeFeatureManager.java
@@ -24,12 +24,10 @@ final class TpeFeatureManager {
     private static class TpeFeatureData {
         final TpeImageFeature feature;  // The image feature itself
         final JToggleButton button;     // The button used to toggle it
-        final Option<Component> key;    // Key used to explain the feature
 
-        public TpeFeatureData(TpeImageFeature feature, JToggleButton button, Option<Component> key) {
+        public TpeFeatureData(TpeImageFeature feature, JToggleButton button) {
             this.feature = feature;
             this.button = button;
-            this.key = key;
         }
     }
 
@@ -90,17 +88,9 @@ final class TpeFeatureManager {
             Preferences.set(prefName, selected);
         });
 
-        final Option<Component> keyPanel = tif.getKey().isEmpty() ? None.instance() :
-                                             new Some<>(TpeToolBar.createKeyPanel(tif.getKey().getValue()));
-
-        _featureMap.put(name, new TpeFeatureData(tif, btn, keyPanel));
+        _featureMap.put(name, new TpeFeatureData(tif, btn));
 
         _tpeToolBar.addViewItem(btn, tif.getCategory());
-        if (keyPanel.isDefined()) {
-            final Component comp = keyPanel.getValue();
-            comp.setVisible(false);
-            _tpeToolBar.addViewItem(comp, tif.getCategory());
-        }
     }
 
     public void updateAvailableOptions(final Collection<TpeImageFeature> feats, final TpeContext ctx) {
@@ -157,9 +147,6 @@ final class TpeFeatureManager {
         TpeFeatureData tfd = _featureMap.get(tif.getName());
         if (available != tfd.button.isVisible()) {
             tfd.button.setVisible(available);
-            if (!tfd.key.isEmpty()) {
-                tfd.key.getValue().setVisible(available);
-            }
         }
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -11,6 +11,7 @@ import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.*;
 import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.TargetEnvironment;
+import edu.gemini.spModel.target.env.UserTarget;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.offset.OffsetPosBase;
 import edu.gemini.spModel.telescope.PosAngleConstraint;
@@ -1046,8 +1047,9 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
                 if (stats.getRow().size() > 0 && stats.getRow().elementAt(0) != null) {
                     newTarget.setName(stats.getRow().elementAt(0).toString());
                 }
-                TargetEnvironment te = obsComp.getTargetEnvironment().setUserTargets(obsComp.getTargetEnvironment().getUserTargets().append(newTarget));
-                obsComp.setTargetEnvironment(te);
+                final UserTarget         newUserTarget  = new UserTarget(UserTarget.Type.other, newTarget);
+                final ImList<UserTarget> newUserTargets = obsComp.getTargetEnvironment().getUserTargets().append(newUserTarget);
+                obsComp.setTargetEnvironment(obsComp.getTargetEnvironment().setUserTargets(newUserTargets));
                 getContext().targets().commit();
             }
         } else {


### PR DESCRIPTION
The target environment currently has a list of `SPTarget` "user" targets.  This update creates a `UserTarget` tuple that pairs a `UserTarget.Type` with an `SPTarget` to give it a meaning.  We don't do anything with this meaning yet but it is still useful because it clearly indicates the purpose of each user target.  The new types are "Blind Offset", "Off Axis", "Tuning Star" and "Other" (which renders as the familiar old "User").  We need a catchall like "Other" if for no other reason to convert existing programs.

A large part of this update went into reformatting the tool buttons that appear to the left of the image in the TPE.  Since there are now more options for creating targets, they needed to be rearranged into two columns.