### PR TITLE
REL-3151: Format changes to PIT PDF investigator list to reduce unconscious bias

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -30,6 +30,7 @@
     <xsl:param name="partner"/>
     <xsl:param name="title"/>
     <xsl:param name="investigatorsList"/>
+    <xsl:param name="partnerLeadDisplay"/>
 
     <xsl:template match="proposal">
         <fo:root>
@@ -484,11 +485,22 @@
                                                     </xsl:call-template>
                                                 </fo:block>
                                             </fo:table-cell>
-                                            <fo:table-cell>
-                                                <fo:block>
-                                                    <xsl:value-of select="/proposal/investigators/*[@id = $leadSciRef]/lastName"/>
-                                                </fo:block>
-                                            </fo:table-cell>
+                                            <xsl:choose>
+                                                <xsl:when test="$partnerLeadDisplay='default'">
+                                                    <fo:table-cell>
+                                                        <fo:block>
+                                                            <xsl:value-of select="/proposal/investigators/*[@id = $leadSciRef]/lastName"/>
+                                                        </fo:block>
+                                                    </fo:table-cell>
+                                                </xsl:when>
+                                                <xsl:otherwise>
+                                                    <fo:table-cell>
+                                                        <fo:block>
+                                                            -
+                                                        </fo:block>
+                                                    </fo:table-cell>
+                                                </xsl:otherwise>
+                                            </xsl:choose>
                                             <fo:table-cell>
                                                 <fo:block>
                                                     <xsl:value-of select="format-number(request/time, '0.0')"/>

--- a/bundle/edu.gemini.model.p1.pdf/src/main/scala/edu/gemini/model/p1/pdf/P1PDF.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/scala/edu/gemini/model/p1/pdf/P1PDF.scala
@@ -13,6 +13,20 @@ import io.Source
  */
 object P1PDF {
 
+  sealed trait PartnerLeadDisplayOption {
+    def param: String
+  }
+
+  object PartnerLeadDisplayOption {
+    val PartnerLeadParam = "partnerLeadDisplay"
+    case object DefaultDisplay extends PartnerLeadDisplayOption {
+      val param = "default"
+    }
+    case object NoDisplay extends PartnerLeadDisplayOption {
+      val param = "no"
+    }
+  }
+
   sealed trait InvestigatorsListOption {
     def param: String
   }
@@ -30,41 +44,41 @@ object P1PDF {
     }
   }
 
-  sealed case class Template(name: String, location: String, pageSize: PDF.PageSize, investigatorsList: InvestigatorsListOption, params: Map[String, String]) {
+  sealed case class Template(name: String, location: String, pageSize: PDF.PageSize, investigatorsList: InvestigatorsListOption, partnerLead: PartnerLeadDisplayOption, params: Map[String, String]) {
     def value(): String = name
-    val parameters: Map[String, String] = params + (InvestigatorsListOption.InvestigatorsListParam -> investigatorsList.param)
+    val parameters: Map[String, String] = params + (InvestigatorsListOption.InvestigatorsListParam -> investigatorsList.param) + (PartnerLeadDisplayOption.PartnerLeadParam -> partnerLead.param)
   }
 
   object GeminiDefault extends Template(
-    "Gemini Default", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.DefaultList,
+    "Gemini Default", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.DefaultList, PartnerLeadDisplayOption.DefaultDisplay,
     Map("partner"->"gs", "pageLayout" -> "default-us-letter", "title" -> "GEMINI OBSERVATORY"))
 
   object GeminiDefaultNoInvestigatorsList extends Template(
-    "Gemini No CoIs", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.NoList,
+    "Gemini No CoIs", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.NoList, PartnerLeadDisplayOption.NoDisplay,
     Map("partner"->"gs", "pageLayout" -> "default-us-letter", "title" -> "GEMINI OBSERVATORY"))
 
   object GeminiDefaultListAtTheEnd extends Template(
-    "Gemini CoIs at End", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.AtTheEndList,
+    "Gemini CoIs at End", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.AtTheEndList, PartnerLeadDisplayOption.NoDisplay,
     Map("partner"->"gs", "pageLayout" -> "default-us-letter", "title" -> "GEMINI OBSERVATORY"))
 
   object AU extends Template(
-    "Australian NGO", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.AtTheEndList,
+    "Australian NGO", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.AtTheEndList, PartnerLeadDisplayOption.NoDisplay,
     Map("partner"->"au", "pageLayout" -> "default-us-letter", "title" -> "GEMINI OBSERVATORY"))
 
   object CL extends Template(
-    "Chilean NGO", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.DefaultList,
+    "Chilean NGO", "templates/xsl-default.xml", PDF.Letter, InvestigatorsListOption.DefaultList, PartnerLeadDisplayOption.DefaultDisplay,
     Map("partner"->"cl", "pageLayout" -> "default-us-letter", "title" -> "PROPUESTA CONICYT-Gemini"))
 
   object NOAO extends Template(
-    "NOAO",   "templates/xsl-NOAO.xml", PDF.Letter, InvestigatorsListOption.DefaultList,
+    "NOAO",   "templates/xsl-NOAO.xml", PDF.Letter, InvestigatorsListOption.DefaultList, PartnerLeadDisplayOption.DefaultDisplay,
     Map("partner"->"us", "pageLayout" -> "default-us-letter"))
 
   object NOAOListAtTheEnd extends Template(
-    "NOAO CoIs at End",   "templates/xsl-NOAO.xml", PDF.Letter, InvestigatorsListOption.AtTheEndList,
+    "NOAO CoIs at End",   "templates/xsl-NOAO.xml", PDF.Letter, InvestigatorsListOption.AtTheEndList, PartnerLeadDisplayOption.DefaultDisplay,
     Map("partner"->"us", "pageLayout" -> "default-us-letter"))
 
   object NOAONoInvestigatorsList extends Template(
-    "NOAO No CoIs",   "templates/xsl-NOAO.xml", PDF.Letter, InvestigatorsListOption.NoList,
+    "NOAO No CoIs",   "templates/xsl-NOAO.xml", PDF.Letter, InvestigatorsListOption.NoList, PartnerLeadDisplayOption.DefaultDisplay,
     Map("partner"->"us", "pageLayout" -> "default-us-letter"))
 
   /** Gets a list with all templates that are currently available. */
@@ -175,7 +189,7 @@ object P1PDF {
     val home = System.getProperty("user.home")
     val in = new File(s"$home/pitsource.xml")
     val out = new File(s"$home/pittarget.pdf")
-    createFromFile(in, NOAONoInvestigatorsList, out)
+    createFromFile(in, GeminiDefault, out)
 
     val ok = Runtime.getRuntime.exec(Array("open", out.getAbsolutePath)).waitFor
     println("Exec returned " + ok)


### PR DESCRIPTION
Add the option for certain templates to hide the partner lead. The table structure didn't change so we display a `-` instead. Changing the table structure would be complicated as the widths are 
not calculated dynamically

![screenshot 2017-08-22 17 06 42](https://user-images.githubusercontent.com/3615303/29585111-574e1da2-875c-11e7-8824-d175297f8a16.png)
