### PR TITLE
Updated settings for release candidate

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -38,7 +38,7 @@ def common(pv: Version) = AppConfig(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",
     "org.osgi.framework.startlevel.beginning" -> "100",
     "org.osgi.framework.bootdelegation"       -> "*",
-    "edu.gemini.pit.test"                     -> "true",
+    "edu.gemini.pit.test"                     -> "false",
     "edu.gemini.ags.host"                     -> "gnauxodb.gemini.edu",
     "edu.gemini.ags.port"                     -> "8443"
   ),
@@ -89,5 +89,3 @@ def windows(pv: Version) = AppConfig(
     "org.osgi.framework.storage" -> "${user.home}/AppData/Local/edu.gemini.PIT/felix-cache"
   )
 ) extending List(common(pv))
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization in Global := "edu.gemini.ocs"
 
 ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2018A", true, 1, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2018A", false, 1, 1, 0)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion


### PR DESCRIPTION
This will be used for the first PIT release targeting the real backends and will be the basis of a new branch for the pit 2018 release