### PR TITLE
REL-2838 Make PWFS2 p2checker agree with the PWFS2 AGS

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/pwfs/PwfsRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/pwfs/PwfsRule.java
@@ -45,14 +45,13 @@ public class PwfsRule implements IRule {
                 try {
                     pwfs.checkBoundaries(primary, ctx).foreach(bs -> {
                         switch (bs) {
-                            case inside:
+                            case vignetting:
                                 problems.addWarning(PREFIX + "WARN", "The " + pwfs.getKey() + WARN, targetNode);
                                 break;
-                            case innerBoundary:
+                            case inRange:
                                 // OK, this is where it should be: between inner and outer limits
                                 break;
-                            case outerBoundary:
-                            case outside:
+                            case outOfRange:
                                 problems.addError(PREFIX + "ERROR", "The " + pwfs.getKey() + ERROR, targetNode);
                                 break;
                         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -306,7 +306,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
             // check positions against corrected outer patrol field bounds
             return getCorrectedPatrolField(ctx).map(pf -> {
                 final BoundaryPosition bp = pf.checkBoundaries(coords, baseCoordinates, positionAngle, sciencePositions);
-                if (bp != BoundaryPosition.inside) {
+                if ((bp != BoundaryPosition.inside) && (bp != BoundaryPosition.innerBoundary)) {
                     return BoundaryPosition.outside;
                 }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsProbeRangeArea.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsProbeRangeArea.java
@@ -1,0 +1,5 @@
+package edu.gemini.spModel.target.obsComp;
+/**
+   * Enumeration of possible results when checking boundaries for PWFS2.
+   */
+  public enum PwfsProbeRangeArea{inRange, outOfRange, vignetting}


### PR DESCRIPTION
It turns out the PWFS2 p2checker was ruling out the guide stars that where between the inner limit and the inner boundary which should have been picked, as the AGS is already doing.

We also introduced an enumeration class for the results of the PWFS2 p2checker so that it's easier to understand.