### PR TITLE
REL-3220: NPE on p1-monitor

### DIFF
--- a/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/DirScanner.scala
+++ b/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/DirScanner.scala
@@ -73,6 +73,7 @@ class DirScanner(dir: MonitoredDirectory) {
     var deletedFiles: List[File] = Nil
     var newFiles: List[File] = Nil
 
+    createDirIfNeeded()
     Option(dir.dir.listFiles()) match {
       case Some(list) =>
         list.foreach {


### PR DESCRIPTION
Last minute fix. There can be a race condition that makes the dir be created after update is called