### PR TITLE
REL-1121: Add GMOS timing overheads

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -26,6 +26,11 @@ public class GmosCommonType {
     }
 
     public interface Disperser extends DisplayableSpType, LoggableSpType, SequenceableSpType {
+
+        public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "disperser");
+
+        public static final double CHANGE_OVERHEAD = 90.0;
+
         boolean isMirror();
         // The dispersers "ruling density" in lines/mm.
         int rulingDensity();
@@ -38,6 +43,11 @@ public class GmosCommonType {
     }
 
     public interface Filter extends DisplayableSpType, LoggableSpType, SequenceableSpType {
+
+        public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "filter");
+
+        public static final double CHANGE_OVERHEAD = 20.0;
+
         boolean isNone();
         String getWavelength();
     }
@@ -49,9 +59,14 @@ public class GmosCommonType {
     }
 
     public interface FPUnit extends DisplayableSpType, LoggableSpType, SequenceableSpType {
+
         // IFU visualisation in TPE
         // The offset from the base position in arcsec
         double IFU_FOV_OFFSET = 30.;
+
+        public static final ItemKey KEY = new ItemKey(INSTRUMENT_KEY, "fpu");
+
+        public static final double CHANGE_OVERHEAD = 60.0;
 
         // The offsets (from the base pos) and dimensions of the IFU FOV (in arcsec)
         Rectangle2D.Double[] IFU_FOV = new Rectangle2D.Double[]{

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -1281,15 +1281,6 @@ public abstract class InstGmosCommon<
     private static final CategorizedTime DHS_WRITE = CategorizedTime.fromSeconds(Category.DHS_WRITE, 10.0);
 
     public CategorizedTimeGroup calc(Config cur, Option<Config> prev) {
-        final ItemKey FPU_KEY = new ItemKey("instrument:fpu");
-        final double FPU_OVERHEAD = 60.0;
-
-        final ItemKey FILTER_KEY = new ItemKey("instrument:filter");
-        final double FILTER_OVERHEAD = 20.0;
-
-        final ItemKey DISPERSER_KEY = new ItemKey("instrument:disperser");
-        final double DISPERSER_OVERHEAD = 90.0;
-
         final Collection<CategorizedTime> times = new ArrayList<>();
 
         double exposureTime = ExposureCalculator.instance.exposureTimeSec(cur);
@@ -1305,14 +1296,20 @@ public abstract class InstGmosCommon<
         }
         times.add(CategorizedTime.fromSeconds(Category.EXPOSURE, exposureTime));
 
-        if (PlannedTime.isUpdated(cur, prev, FPU_KEY)) {
-            times.add(CategorizedTime.fromSeconds(Category.CONFIG_CHANGE, FPU_OVERHEAD, "FPU"));
+        if (PlannedTime.isUpdated(cur, prev, GmosCommonType.FPUnit.KEY)) {
+            times.add(CategorizedTime.fromSeconds(
+                    Category.CONFIG_CHANGE, GmosCommonType.FPUnit.CHANGE_OVERHEAD, "FPU")
+            );
         }
-        if (PlannedTime.isUpdated(cur, prev, FILTER_KEY)) {
-            times.add(CategorizedTime.fromSeconds(Category.CONFIG_CHANGE, FILTER_OVERHEAD, "Filter"));
+        if (PlannedTime.isUpdated(cur, prev, GmosCommonType.Filter.KEY)) {
+            times.add(CategorizedTime.fromSeconds(
+                    Category.CONFIG_CHANGE, GmosCommonType.Filter.CHANGE_OVERHEAD, "Filter")
+            );
         }
-        if (PlannedTime.isUpdated(cur, prev, DISPERSER_KEY)) {
-            times.add(CategorizedTime.fromSeconds(Category.CONFIG_CHANGE, DISPERSER_OVERHEAD, "Disperser"));
+        if (PlannedTime.isUpdated(cur, prev, GmosCommonType.Disperser.KEY)) {
+            times.add(CategorizedTime.fromSeconds(
+                    Category.CONFIG_CHANGE, GmosCommonType.Disperser.CHANGE_OVERHEAD, "Disperser")
+            );
         }
 
         double readoutTime = GmosReadoutTime.getReadoutOverhead(cur, getCustomROIs());

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/plannedtime/GcalStepCalculator.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/plannedtime/GcalStepCalculator.java
@@ -26,7 +26,7 @@ public enum GcalStepCalculator implements StepCalculator {
     private static final CategorizedTime gcalConfigTime(ItemKey key) {
         String name   = key.getName();
         String detail = Character.toUpperCase(name.charAt(0)) + name.substring(1);
-        return CategorizedTime.apply(Category.CONFIG_CHANGE, CONFIG_CHANGE_TIME, detail);
+        return CategorizedTime.apply(Category.CONFIG_CHANGE, CONFIG_CHANGE_TIME, "GCAL " + detail);
     }
 
     private static CategorizedTime scienceFoldMove(Option<Config> prev, boolean isCalStep) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/plannedtime/PlannedTime.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/plannedtime/PlannedTime.java
@@ -222,30 +222,10 @@ public final class PlannedTime implements Serializable {
             return times.hashCode();
         }
 
-        public Pair<Map<Category, CategorizedTime>, Map<Category, ImList<CategorizedTime>>> maxTimes() {
-            Map<Category, CategorizedTime> max = new TreeMap<>();
-            Map<Category, ImList<CategorizedTime>> losers = new TreeMap<>();
-
-            for (CategorizedTime ct : times) {
-                CategorizedTime cur = max.get(ct.category);
-
-                ImList<CategorizedTime> currLosers = losers.get(ct.category);
-                if (currLosers == null) {
-                    losers.put(ct.category, ImCollections.emptyList());
-                }
-
-                if (cur == null) {
-                    max.put(ct.category, ct);
-                } else if (cur.compareTo(ct) < 0) {
-                    max.put(ct.category, ct);
-                    losers.put(ct.category, currLosers.append(cur));
-                }
-                else {
-                    losers.put(ct.category, currLosers.append(ct));
-                }
-            }
-            return new Pair(max, losers);
+        public HashMap<Category, ImList<CategorizedTime>> groupTimes() {
+            return DefaultImList.create(times).groupBy(t -> t.category);
         }
+
         public long totalTime() {
             if (times.size() == 0) return 0;
 

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
@@ -352,12 +352,9 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
         HashMap<K, ImList<T>> m = new HashMap<>();
         for (final T elem : backingList) {
             final K key = f.apply(elem);
-            final ImList<T> val = m.get(key);
-            if (val == null) {
-                m.put(key, create(elem));
-            } else {
-                m.put(key, val.append(elem));
-            }
+            m.put(key, ImOption.apply(m.get(key)).map(
+                    lst -> lst.append(elem)
+            ).getOrElse(() -> create(elem)));
         }
         return m;
     }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
@@ -348,6 +348,21 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
     }
 
     @Override
+    public <K> HashMap<K, ImList<T>> groupBy(Function1<? super T, K> f) {
+        HashMap<K, ImList<T>> m = new HashMap<>();
+        for (final T elem : backingList) {
+            final K key = f.apply(elem);
+            final ImList<T> val = m.get(key);
+            if (val == null) {
+                m.put(key, create(elem));
+            } else {
+                m.put(key, val.append(elem));
+            }
+        }
+        return m;
+    }
+
+    @Override
     public Stream<T> stream() {
         return StreamSupport.stream(spliterator(), false);
     }
@@ -391,4 +406,5 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
         }
         return res;
     }
+
 }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
@@ -4,8 +4,6 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyMap;
-
 /**
  * Utility methods for working with immutable collections.
  */

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyMap;
+
 /**
  * Utility methods for working with immutable collections.
  */
@@ -212,6 +214,11 @@ public class ImCollections {
         @Override
         public <U> U foldRight(final U start, final Function2<? super Object, U, U> op) {
             return start;
+        }
+
+        @Override
+        public <K> HashMap<K, ImList<Object>> groupBy(final Function1<? super Object, K> f) {
+            return new HashMap<>();
         }
 
         @Override

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
@@ -1,6 +1,7 @@
 package edu.gemini.shared.util.immutable;
 
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -429,4 +430,19 @@ public interface ImList<T> extends Iterable<T> {
      * @return the result of combining the elements with the seed value
      */
     <U> U foldRight(U start, Function2<? super T, U, U> op);
+
+    /**
+     * Partitions the elements of this list according to the discriminator function.
+     *
+     * @param f the discriminator function.
+     *
+     * @param <K> the type of the keys returned by the discriminator function.
+     *
+     * @return A HashMap from keys to lists where the following invariant holds:
+     *
+     *         {{{
+     *           (xs groupBy f)(k) = xs filter (x => f(x) == k)
+     *         }}}
+     */
+    <K> HashMap<K, ImList<T>> groupBy(Function1<? super T, K> f);
 }

--- a/bundle/edu.gemini.shared.util/src/test/java/edu/gemini/shared/util/immutable/ImListTest.java
+++ b/bundle/edu.gemini.shared.util/src/test/java/edu/gemini/shared/util/immutable/ImListTest.java
@@ -6,10 +6,7 @@ package edu.gemini.shared.util.immutable;
 
 import junit.framework.TestCase;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Comparator;
+import java.util.*;
 
 /**
  * Test code for immutable lists.
@@ -470,5 +467,26 @@ public class ImListTest extends TestCase {
         assertEquals("cba", create('a', 'b', 'c').foldRight("", op));
         //noinspection unchecked
         assertEquals("", ImCollections.EMPTY_LIST.foldRight("", op));
+    }
+
+    public void testGroupBy() {
+        Function1<Character, Integer> f = new Function1<Character, Integer>() {
+            @Override public Integer apply(Character c) {
+                if (c == 'a') { return 1; }
+                else if (c == 'b') { return 2; }
+                else if (c == 'c') { return 3; }
+                else { return 4; }
+            }
+        };
+
+        HashMap<Integer, ImList<Character>> em = new HashMap<>();
+
+        em.put(1, create('a'));
+        em.put(2, create('b', 'b'));
+        em.put(3, create('c', 'c', 'c'));
+        em.put(4, create('e', 'd'));
+
+        assertEquals(em, create('c', 'a', 'b', 'e', 'b', 'c', 'c', 'd').groupBy(f));
+        assertEquals(new HashMap<>(), ImCollections.EMPTY_LIST.groupBy(f));
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/ObserveTimeLineNode.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/ObserveTimeLineNode.java
@@ -6,6 +6,7 @@
 //
 package jsky.app.ot.editor.seq;
 
+import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime.*;
 import jsky.app.ot.util.OtColor;
@@ -90,20 +91,45 @@ public class ObserveTimeLineNode extends DefaultTimeLineNode {
         } else {
             buf.append("<p align=\"center\"><b>").append(SequenceTabUtil.shortDatasetLabel(plannedTime.sequence.getStep(step))).append("</b></p>");
 
-            buf.append("<table><tr><th>Event</th><th>Sec</th></tr>");
+            buf.append("<table><tr><th colspan=\"2\">Event</th><th colspan=\"2\">Sec</th></tr>");
             Step s = plannedTime.steps.get(step);
-            Map<Category, CategorizedTime> m = s.times.maxTimes();
+            Map<Category, CategorizedTime> m = s.times.maxTimes()._1();
+            Map<Category, ImList<CategorizedTime>> losers = s.times.maxTimes()._2();
             for (Category c : Category.values()) {
                 CategorizedTime ct = m.get(c);
                 if (ct == null) continue;
                 buf.append("<tr>");
-                buf.append("<td>").append(formatCategory(ct)).append("</td>");
+                buf.append("<td colspan=\"3\">").append(formatCategory(ct)).append("</td>");
 
                 String secStr = formatSec(ct.time);
                 buf.append("<td align=\"right\"> ").append(secStr).append("</td>");
                 buf.append("</tr>");
+
+                // Only Config changes have separate actions running in parallel.
+                if (ct.category == Category.CONFIG_CHANGE) {
+                    buf.append("<tr>");
+                    buf.append("<td></td>");
+                    buf.append("<td>").append(formatCategory(ct)).append("</td>");
+
+                    buf.append("<td align=\"right\"> ").append(secStr).append("</td>");
+                    buf.append("<td></td>");
+                    buf.append("</tr>");
+
+                    ImList<CategorizedTime> lcts = losers.get(c);
+                    for (CategorizedTime lct : lcts) {
+                        if (lct == null) continue;
+                        buf.append("<tr>");
+                        buf.append("<td></td>");
+                        buf.append("<td>").append(formatCategory(lct)).append("</td>");
+
+                        String secLosStr = formatSec(lct.time);
+                        buf.append("<td align=\"right\"> ").append(secLosStr).append("</td>");
+                        buf.append("<td></td>");
+                        buf.append("</tr>");
+                    }
+                }
             }
-            buf.append("<tr><td><b>Total</b></td><td align=\"right\"><b>").append(formatSec(s.totalTime())).append("</b></td></tr>");
+            buf.append("<tr><td colspan=\"3\"><strong>Total</strong></td><td align=\"right\"><strong>").append(formatSec(s.totalTime())).append("</strong></td></tr>");
             buf.append("</table>");
         }
         buf.append("</body></html>");

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/ObserveTimeLineNode.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/ObserveTimeLineNode.java
@@ -15,6 +15,7 @@ import jsky.timeline.DefaultTimeLineNode;
 
 import java.awt.*;
 import java.awt.event.MouseEvent;
+import java.util.Comparator;
 import java.util.Map;
 
 import static jsky.app.ot.editor.seq.Keys.DATALABEL_KEY;
@@ -93,13 +94,13 @@ public class ObserveTimeLineNode extends DefaultTimeLineNode {
 
             buf.append("<table><tr><th colspan=\"2\">Event</th><th colspan=\"2\">Sec</th></tr>");
             Step s = plannedTime.steps.get(step);
-            Map<Category, CategorizedTime> m = s.times.maxTimes()._1();
-            Map<Category, ImList<CategorizedTime>> losers = s.times.maxTimes()._2();
+            Map<Category, ImList<CategorizedTime>> m = s.times.groupTimes();
             for (Category c : Category.values()) {
-                CategorizedTime ct = m.get(c);
-                if (ct == null) continue;
+                ImList<CategorizedTime> cts = m.get(c);
+                if (cts == null) continue;
+                CategorizedTime ct = cts.max(Comparator.naturalOrder());
                 buf.append("<tr>");
-                buf.append("<td colspan=\"3\">").append(formatCategory(ct)).append("</td>");
+                buf.append("<td colspan=\"3\">").append(c.display).append("</td>");
 
                 String secStr = formatSec(ct.time);
                 buf.append("<td align=\"right\"> ").append(secStr).append("</td>");
@@ -115,8 +116,10 @@ public class ObserveTimeLineNode extends DefaultTimeLineNode {
                     buf.append("<td></td>");
                     buf.append("</tr>");
 
-                    ImList<CategorizedTime> lcts = losers.get(c);
-                    for (CategorizedTime lct : lcts) {
+                    ImList<CategorizedTime> lcts = m.get(c);
+                    if (lcts == null) continue;
+                    ImList<CategorizedTime> lctst = lcts.sort(Comparator.reverseOrder()).tail();
+                    for (CategorizedTime lct : lctst) {
                         if (lct == null) continue;
                         buf.append("<tr>");
                         buf.append("<td></td>");


### PR DESCRIPTION
Adding the GMOS overheads was the primary goal but most of the changes in this PR are about the tooltip message over the timeline which now shows the configurations that didn't contribute to the maximum timings.

<img width="209" alt="tooltip" src="https://user-images.githubusercontent.com/215438/29943178-de88de56-8e6e-11e7-9904-de8ac5257a29.png">

The code for the tooltip is quite dirty but not I'm not sure how to do it more cleanly in Java.