### PR TITLE
REL-3251: Fix parsing of F2 and Michelle engineering enums

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2017B", false, 1, 1, 3)
+ocsVersion in ThisBuild := OcsVersion("2017B", false, 1, 1, 4)
 
 pitVersion in ThisBuild := OcsVersion("2017B", false, 2, 1, 0)
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -525,12 +525,8 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         public String sequenceValue() { return name(); }
         public String toString() { return displayValue; }
 
-        public static WindowCover valueOf(String name, WindowCover nvalue) {
-            return SpTypeUtil.oldValueOf(WindowCover.class, name, nvalue);
-        }
-
-        public static Option<WindowCover> valueOf(String name, Option<WindowCover> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<WindowCover> valueOf(String tag, Option<WindowCover> def) {
+            return SpTypeUtil.optionValueOf(WindowCover.class, tag).orElse(def);
         }
     }
 
@@ -552,10 +548,6 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         public static Decker valueOf(String name, Decker nvalue) {
             return SpTypeUtil.oldValueOf(Decker.class, name, nvalue);
         }
-
-        public static Option<Decker> valueOf(String name, Option<Decker> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
-        }
     }
 
     public enum ReadoutMode implements StandardSpType {
@@ -572,12 +564,8 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         public String sequenceValue() { return name(); }
         public String toString() { return displayValue; }
 
-        public static ReadoutMode valueOf(String name, ReadoutMode nvalue) {
-            return SpTypeUtil.oldValueOf(ReadoutMode.class, name, nvalue);
-        }
-
-        public static Option<ReadoutMode> valueOf(String name, Option<ReadoutMode> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<ReadoutMode> valueOf(String tag, Option<ReadoutMode> def) {
+            return SpTypeUtil.optionValueOf(ReadoutMode.class, tag).orElse(def);
         }
     }
 
@@ -609,12 +597,8 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         public String toString() { return displayValue(); }
         public int getCount() { return reads; }
 
-        public static Reads valueOf(String name, Reads nvalue) {
-            return SpTypeUtil.oldValueOf(Reads.class, name, nvalue);
-        }
-
-        public static Option<Reads> valueOf(String name, Option<Reads> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<Reads> valueOf(String tag, Option<Reads> def) {
+            return SpTypeUtil.optionValueOf(Reads.class, tag).orElse(def);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/MichelleParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/MichelleParams.java
@@ -40,12 +40,8 @@ public final class MichelleParams {
             return displayValue;
         }
 
-        public static ChopMode valueOf(String name, ChopMode nvalue) {
-            return SpTypeUtil.oldValueOf(ChopMode.class, name, nvalue);
-        }
-
-        public static Option<ChopMode> valueOf(String name, Option<ChopMode> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<ChopMode> valueOf(String tag, Option<ChopMode> def) {
+            return SpTypeUtil.optionValueOf(ChopMode.class, tag).orElse(def);
         }
     }
 
@@ -74,12 +70,8 @@ public final class MichelleParams {
             return displayValue;
         }
 
-        public static ChopWaveform valueOf(String name, ChopWaveform nvalue) {
-            return SpTypeUtil.oldValueOf(ChopWaveform.class, name, nvalue);
-        }
-
-        public static Option<ChopWaveform> valueOf(String name, Option<ChopWaveform> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<ChopWaveform> valueOf(String tag, Option<ChopWaveform> def) {
+            return SpTypeUtil.optionValueOf(ChopWaveform.class, tag).orElse(def);
         }
     }
 
@@ -107,12 +99,8 @@ public final class MichelleParams {
             return displayValue;
         }
 
-        public static DisperserOrder valueOf(String name, DisperserOrder nvalue) {
-            return SpTypeUtil.oldValueOf(DisperserOrder.class, name, nvalue);
-        }
-
-        public static Option<DisperserOrder> valueOf(String name, Option<DisperserOrder> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<DisperserOrder> valueOf(String tag, Option<DisperserOrder> def) {
+            return SpTypeUtil.optionValueOf(DisperserOrder.class, tag).orElse(def);
         }
     }
 
@@ -269,12 +257,8 @@ public final class MichelleParams {
         public String displayValue() { return displayValue; }
         public String toString() { return displayValue; }
 
-        public static Position valueOf(String name, Position nvalue) {
-            return SpTypeUtil.oldValueOf(Position.class, name, nvalue);
-        }
-
-        public static Option<Position> valueOf(String name, Option<Position> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<Position> valueOf(String tag, Option<Position> def) {
+            return SpTypeUtil.optionValueOf(Position.class, tag).orElse(def);
         }
     }
 
@@ -328,12 +312,8 @@ public final class MichelleParams {
             return displayValue;
         }
 
-        public static EngMask valueOf(String name, EngMask nvalue) {
-            return SpTypeUtil.oldValueOf(EngMask.class, name, nvalue);
-        }
-
-        public static Option<EngMask> valueOf(String name, Option<EngMask> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<EngMask> valueOf(String tag, Option<EngMask> def) {
+            return SpTypeUtil.optionValueOf(EngMask.class, tag).orElse(def);
         }
     }
 
@@ -491,12 +471,8 @@ public final class MichelleParams {
             return displayValue;
         }
 
-        public static FilterWheelA valueOf(String name, FilterWheelA nvalue) {
-            return SpTypeUtil.oldValueOf(FilterWheelA.class, name, nvalue);
-        }
-
-        public static Option<FilterWheelA> valueOf(String name, Option<FilterWheelA> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<FilterWheelA> valueOf(String tag, Option<FilterWheelA> def) {
+            return SpTypeUtil.optionValueOf(FilterWheelA.class, tag).orElse(def);
         }
     }
 
@@ -542,12 +518,8 @@ public final class MichelleParams {
             return displayValue;
         }
 
-        public static FilterWheelB valueOf(String name, FilterWheelB nvalue) {
-            return SpTypeUtil.oldValueOf(FilterWheelB.class, name, nvalue);
-        }
-
-        public static Option<FilterWheelB> valueOf(String name, Option<FilterWheelB> nvalue) {
-            return nvalue.map(def -> valueOf(name, def));
+        public static Option<FilterWheelB> valueOf(String tag, Option<FilterWheelB> def) {
+            return SpTypeUtil.optionValueOf(FilterWheelB.class, tag).orElse(def);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/type/SpTypeUtil.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/type/SpTypeUtil.java
@@ -1,5 +1,8 @@
 package edu.gemini.spModel.type;
 
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -105,6 +108,19 @@ public final class SpTypeUtil {
             LOG.fine("Could not find '" + name + "' in class: " + c.getName());
         }
         return res;
+    }
+
+    /**
+     * Converts an enum tag to an enum value using <code>Enum.valueOf()</code>,
+     * wrapping the result in an <code>Option</code> where failure produces a
+     * <code>None</code> rather than an exception.
+     *
+     * @param c class of the enum type
+     * @param tag tag of the enum value
+     * @param <T> enumeration type
+     */
+    public static <T extends Enum<T>> Option<T> optionValueOf(Class<T> c, String tag) {
+        return ImOption.apply(noExceptionValueOf(c, tag));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/EnumTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/EnumTest.scala
@@ -1,0 +1,44 @@
+package edu.gemini.spModel.gemini
+
+import edu.gemini.shared.util.immutable.{ None => GNone, Option => GOption, Some => GSome }
+import edu.gemini.shared.util.immutable.ScalaConverters._
+
+import org.junit.Assert._
+
+sealed class EnumTest[T <: Enum[T]](e: Class[T], valueOf: (String, GOption[T]) => GOption[T]) {
+
+  def testValid(defValue: GOption[T]): Unit =
+    e.getEnumConstants.foreach { t =>
+      assertEquals(s"valueOf ${t.name} failed", new GSome(t), valueOf(t.name, defValue))
+    }
+
+  def testValidNone(): Unit =
+    testValid(GNone.instance[T])
+
+  def testValidSome(): Unit = {
+    testValid(e.getEnumConstants.headOption.asGeminiOpt)
+  }
+
+  def testInvalid(defValue: GOption[T]): Unit =
+    e.getEnumConstants.map(t => s"_${t.name}").foreach { tag =>
+      assertEquals(s"valueOf $tag should return $defValue", defValue, valueOf(tag, defValue))
+    }
+
+  def testInvalidNone(): Unit =
+    testInvalid(GNone.instance[T])
+
+  def testInvalidSome(): Unit =
+    testInvalid(e.getEnumConstants.headOption.asGeminiOpt)
+
+  def testAll(): Unit = {
+    testValidNone
+    testValidSome
+    testInvalidNone
+    testInvalidSome
+  }
+}
+
+object EnumTest {
+  def test[T <: Enum[T]](e: Class[T], valueOf: (String, GOption[T]) => GOption[T]): Unit =
+    new EnumTest(e, valueOf).testAll
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/flamingos2/F2EnumsTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/flamingos2/F2EnumsTest.scala
@@ -1,0 +1,20 @@
+package edu.gemini.spModel.gemini.flamingos2
+
+import edu.gemini.spModel.gemini.EnumTest
+
+import edu.gemini.spModel.gemini.flamingos2.Flamingos2._
+
+import org.junit.Test
+
+class F2EnumsTest {
+
+  @Test def testWindowCover(): Unit =
+    EnumTest.test(classOf[WindowCover], WindowCover.valueOf)
+
+  @Test def testReadoutMode(): Unit =
+    EnumTest.test(classOf[ReadoutMode], ReadoutMode.valueOf)
+
+  @Test def testReads(): Unit =
+    EnumTest.test(classOf[Reads], Reads.valueOf)
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/michelle/MichelleEnumsTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/michelle/MichelleEnumsTest.scala
@@ -1,0 +1,32 @@
+package edu.gemini.spModel.gemini.michelle
+
+import edu.gemini.spModel.gemini.EnumTest
+
+import edu.gemini.spModel.gemini.michelle.MichelleParams._
+
+import org.junit.Test
+
+class MichelleEnumsTest {
+
+  @Test def testChopMode(): Unit =
+    EnumTest.test(classOf[ChopMode], ChopMode.valueOf)
+
+  @Test def testChopWaveform(): Unit =
+    EnumTest.test(classOf[ChopWaveform], ChopWaveform.valueOf)
+
+  @Test def testDispersrOrder(): Unit =
+    EnumTest.test(classOf[DisperserOrder], DisperserOrder.valueOf)
+
+  @Test def testPosition(): Unit =
+    EnumTest.test(classOf[Position], Position.valueOf)
+
+  @Test def testEngMask(): Unit =
+    EnumTest.test(classOf[EngMask], EngMask.valueOf)
+
+  @Test def testFilterWheelA(): Unit =
+    EnumTest.test(classOf[FilterWheelA], FilterWheelA.valueOf)
+
+  @Test def testFilterWheelB(): Unit =
+    EnumTest.test(classOf[FilterWheelB], FilterWheelB.valueOf)
+
+}


### PR DESCRIPTION
This PR corrects an issue with parsing of F2 and Michelle engineering enums that resulted in data loss.  In particular, when reading an optional enum tag from XML, we make the call:

```java
        v = Pio.getValue(paramSet, WINDOW_COVER_PROP.getName());
        if (v != null) setWindowCover(WindowCover.valueOf(v, getWindowCover()));
```

where the value of `getWindowCover()`, intended to be used as the default value in case `v` is not readable, is usually `None` when initializing a program.  Then in the `WindowCover` parser we would inexplicably map the default value to the actual lookup of `v` resulting in `None`.

