### PR TITLE
REL-3264: workaround horizons service bug

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -42,9 +42,9 @@ object HS2Spec extends Specification with ScalaCheck {
       ))
     }
 
-    "handle single result (Format 2) 1P/Halley pattern" in {
-      runSearch(Search.Comet("halley")) must_== \/-(List(
-        Row(HD.Comet("1P"), "Halley")
+    "handle single result (Format 2) 81P/Wild 2 pattern" in {
+      runSearch(Search.Comet("81P")) must_== \/-(List(
+        Row(HD.Comet("81P"), "Wild 2")
       ))
     }
 


### PR DESCRIPTION
This PR updates a test case that is currently failing due to a problem in JPL's horizons service.  Namely a search for "halley" gives an unexpected error message at the top, which breaks the regular expression that is trying to parse the results. Since the problem appears to be in the server, i don't think we should try to work around it in the parser itself.