### PR TITLE
REL-3254: add a new time accounting category

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctCategory.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/timeacct/TimeAcctCategory.java
@@ -22,6 +22,7 @@ public enum TimeAcctCategory implements Serializable {
         GT("Guaranteed Time"),
         JP("Subaru"),
         LP("Large Program"),
+        LTP("Limited-term Participant"),
         SV("System Verification"),
         UH("University of Hawaii"),
         UK("United Kingdom"),


### PR DESCRIPTION
Adds Limited-term Participant as requested.  Reports, PIO, OT admin etc. all work off the `TimeAcctCategory` enum so nothing else needs to be changed.  As noted in the Jira Task, this category isn't available in Phase I so the PIT and ITAC and skeleton creation code are all unchanged as well.