### PR TITLE
REL-3126 Show user-defined SED brightness normalization in ITC output

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/html/HtmlUtil.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/html/HtmlUtil.scala
@@ -26,7 +26,7 @@ object HtmlUtil {
       s" ${sd.norm} ${sd.units.displayValue} ${l.sedSpectrum} in the ${sd.normBand.name} band."
 
     case u: UserDefined =>
-      s" a user defined spectrum with the name: ${u.name}"
+      s" ${sd.norm} ${sd.units.displayValue} user defined spectrum in the ${sd.normBand.name} band with the name: ${u.name}"
 
     case PowerLaw(index) =>
       s" Power Law Spectrum, with an index of $index and ${sd.norm} mag in the ${sd.normBand.name} band."


### PR DESCRIPTION
Modified HtmlUtil.scala to include the SED brightness when a user-defined spectrum is input.