### PR TITLE
REL-1438: add tag to TCC config

### DIFF
--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -47,7 +47,7 @@ public final class TargetConfig extends ParamSet {
         return String.format("%s (%d)", tag, position);
     }
 
-    public TargetConfig(final SPTarget spt) throws WdbaGlueException {
+    public TargetConfig(final SPTarget spt, final String tag) throws WdbaGlueException {
         super(spt.getName());
         final Target t = spt.getTarget();
 
@@ -61,7 +61,7 @@ public final class TargetConfig extends ParamSet {
         // Parameters
         putParameter(TccNames.OBJNAME,    t.name());
         putParameter(TccNames.BRIGHTNESS, "");
-        putParameter(TccNames.TAG,        "");
+        putParameter(TccNames.TAG,        tag);
         putParameter(TccNames.SYSTEM,     "J2000");
         putParameter(TccNames.C1,         cs.ra().toAngle().formatHMS());
         putParameter(TccNames.C2,         cs.dec().formatDMS());

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -102,7 +102,7 @@ public class TccFieldConfig extends ParamSet {
         if (isEmpty(base.getName())) {
             base.setName(TccNames.BASE);
         }
-        add(new TargetConfig(base));
+        add(new TargetConfig(base, TccNames.BASE));
 
         // Add the user targets.
         int pos = 1;
@@ -112,7 +112,7 @@ public class TccFieldConfig extends ParamSet {
                 t.setName(TargetConfig.formatName("User", pos));
             }
             ++pos;
-            add(new TargetConfig(t));
+            add(new TargetConfig(t, user.type.displayName));
         }
 
         // Add the "group" for the base position.
@@ -135,7 +135,7 @@ public class TccFieldConfig extends ParamSet {
             if (isEmpty(target.getName())) {
                 target.setName(TargetConfig.formatName(tag, pos));
             }
-            add(new TargetConfig(target));
+            add(new TargetConfig(target, tag));
             ++pos;
         }
 


### PR DESCRIPTION
This is a small update to populate the `tag` parameter of TCC target elements.  I'm not sure why we were passing an empty String here, but we have the available information.  @jluhrs can you confirm that this will be okay?

Ideally there should be an associated test case but the TCC XML and dom4j APIs are difficult to use.  After a few hours trying to get a reasonable test, I decided that a visual inspection of the output was probably sufficient.