### PR TITLE
REL-3187: reinterpret well depth pcode

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDsl2.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDsl2.scala
@@ -37,6 +37,9 @@ trait TemplateDsl2[I <: SPInstObsComp] { gi:GroupInitializer[_] =>
   private var includes:Map[ObsLocation, Seq[Int]] = Map.empty
   private var noteIncludes:Map[NoteLocation, Seq[String]] = Map.empty
 
+  def curIncludes(loc: ObsLocation): Seq[Int] =
+    includes.getOrElse(loc, Seq.empty)
+
   def notes = noteIncludes.values.toList.flatten
   def baselineFolder = includes.get(BaseCal).getOrElse(Nil)
   def targetGroup = includes.get(TargetGroup).getOrElse(Nil)


### PR DESCRIPTION
A new pseudocode instruction made it seem like several new observations should be included to a template, but I believe this was a misinterpretation on my part

```
 SET Well depth == Deep for {5}-{14},{22}
```

I've reimplemented the instruction here to set the well depth only for those listed observations that are otherwise already included.