### PR TITLE
REL-3129: Proprietary Months Issue

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/dataflow/GsaSequenceEditor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/dataflow/GsaSequenceEditor.java
@@ -25,7 +25,7 @@ public enum GsaSequenceEditor {
     }
 
     public void addProprietaryPeriod(IConfig c, GsaAspect gsa, ObsClass obsClass) {
-        final int m = obsClass.shouldChargeProgram() ? gsa.getProprietaryMonths() : 0;
+        final int m = (obsClass.shouldChargeProgram() || gsa.isHeaderPrivate()) ? gsa.getProprietaryMonths() : 0;
         c.putParameter(OBSERVE_CONFIG_NAME, DefaultParameter.getInstance(PROPRIETARY_MONTHS, m));
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatFlatObsCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatFlatObsCB.java
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.ISPSeqComponent;
 import edu.gemini.spModel.config.AbstractSeqComponentCB;
 import edu.gemini.spModel.config2.Config;
 import edu.gemini.spModel.data.config.*;
+import edu.gemini.spModel.dataflow.GsaSequenceEditor;
 import edu.gemini.spModel.gemini.calunit.calibration.CalConfigBuilderUtil;
 import edu.gemini.spModel.gemini.calunit.calibration.CalConfigFactory;
 import edu.gemini.spModel.gemini.calunit.calibration.MutableIndexedCalibrationStep;
@@ -77,6 +78,9 @@ public class SeqRepeatFlatObsCB extends AbstractSeqComponentCB {
         // Now write the configuration for this manual cal into the sequence.
         Config c = CalConfigFactory.complete(mics);
         CalConfigBuilderUtil.updateIConfig(c, config, prevFull);
+
+        final SeqRepeatFlatObs f = (SeqRepeatFlatObs) getDataObject();
+        GsaSequenceEditor.instance.addProprietaryPeriod(config, getSeqComponent().getProgram(), f.getObsClass());
 
         if (SeqRepeatCbOptions.getAddObsCount(_options)) {
             ISysConfig obs = getObsSysConfig(config);

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/dataflow/ProprietaryTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/dataflow/ProprietaryTest.scala
@@ -83,4 +83,13 @@ class ProprietaryTest extends InstrumentSequenceTestBase[Flamingos2, SeqConfigFl
       val gsa = GsaAspect.getDefaultAspect(pt)
       doTest(SPProgramID.toProgramID(pid), PUBLIC, gsa.getProprietaryMonths)
     }
+
+  @Test def testPrivateOverrides(): Unit = {
+    getProgram.update { _.setGsaAspect(new GsaAspect(true, 42, PRIVATE)) }
+    getObserveSeqComp.dataObject = getObserveSeqDataObject <| (_.setObsClass(ObsClass.DAY_CAL))
+
+    // Even though the daycal isn't charged, the private header flag makes it
+    // keep the proprietary period instead of the default of 0 months.
+    doTest(PRIVATE, 42)
+  }
 }


### PR DESCRIPTION
This PR fulfills a new feature request and fixes a bug.  The new feature is that programs marked as having private metadata now will get the specified proprietary months for even non-charged datasets like daycals.  The bug is that manual flat/arcs were missing the proprietary header fields in the sequence.