### PR TITLE
REL-1485: Removed times from elevation titles and fixed legend appearance.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPElevationPlotPlugin.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPElevationPlotPlugin.java
@@ -2,10 +2,7 @@ package jsky.app.ot.viewer;
 
 import edu.gemini.pot.client.SPDB;
 import edu.gemini.pot.sp.*;
-import edu.gemini.shared.util.immutable.ImOption;
-import edu.gemini.shared.util.immutable.None;
-import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.shared.util.immutable.Some;
+import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
@@ -232,10 +229,16 @@ public class SPElevationPlotPlugin implements ChangeListener, Storeable {
         }
 
         // Iterate over the selected observations.
-        final List<ISPObservation> obsList = Arrays.asList(_selectedObservations);
-        obsList.sort(comparator);
-        for (int obsIdx = 0; obsIdx < obsList.size(); ++obsIdx) {
-            final ISPObservation obs = obsList.get(obsIdx);
+        // Sort first to bring sanity to the legend items, but maintain index so we can assign to colors array properly.
+        final List<Pair<ISPObservation,Integer>> obsList = new ArrayList<>();
+        for (int obsIdx=0; obsIdx < _selectedObservations.length; ++obsIdx) {
+            obsList.add(new Pair<>(_selectedObservations[obsIdx], obsIdx));
+        }
+        obsList.sort((p1,p2) -> comparator.compare(p1._1(), p2._1()));
+
+        for (final Pair<ISPObservation,Integer> pair: obsList) {
+            final ISPObservation obs = pair._1();
+            final int obsIdx = pair._2();
             final Option<String> idOpt = extractor.apply(obs);
             final Paint p = idOpt.map(id -> paintMap.computeIfAbsent(id, s -> ColorManager.instance.nextColor())).getOrElse(Color.BLACK);
             colors[obsIdx] = p;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPElevationPlotPlugin.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPElevationPlotPlugin.java
@@ -290,7 +290,7 @@ public class SPElevationPlotPlugin implements ChangeListener, Storeable {
                             final SPProgramID id1 = o1.getProgramID();
                             final SPProgramID id2 = o2.getProgramID();
                             if (id1 == null) return (id2 == null) ? 0 : 1;
-                            return -1;
+                            return (id2 == null) ? -1 : id1.compareTo(id2);
                         },
                         obs -> ImOption.apply(obs.getProgramID()).map(SPProgramID::stringValue)
                 );

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPElevationPlotPlugin.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPElevationPlotPlugin.java
@@ -289,12 +289,7 @@ public class SPElevationPlotPlugin implements ChangeListener, Storeable {
 
             case _COLOR_CODE_PROG:
                 lic = createLegendItemsOpt(
-                        (o1,o2) -> {
-                            final SPProgramID id1 = o1.getProgramID();
-                            final SPProgramID id2 = o2.getProgramID();
-                            if (id1 == null) return (id2 == null) ? 0 : 1;
-                            return (id2 == null) ? -1 : id1.compareTo(id2);
-                        },
+                        Comparator.nullsFirst(Comparator.comparing(ISPObservation::getProgramID)),
                         obs -> ImOption.apply(obs.getProgramID()).map(SPProgramID::stringValue)
                 );
                 break;
@@ -328,12 +323,8 @@ public class SPElevationPlotPlugin implements ChangeListener, Storeable {
                         plic.add(new LegendItem(prioStr, p));
                     }
                     return plic;
-                }, (o1, o2) -> {
-                            final SPObservation.Priority p1 = ((SPObservation) o1.getDataObject()).getPriority();
-                            final SPObservation.Priority p2 = ((SPObservation) o2.getDataObject()).getPriority();
-                            return p1.compareTo(p2);
-                        },
-                    obs -> String.format("%s Priority", ((SPObservation) obs.getDataObject()).getPriority().displayValue())
+                }, Comparator.comparing(obs -> ((SPObservation) obs.getDataObject()).getPriority()),
+                   obs -> String.format("%s Priority", ((SPObservation) obs.getDataObject()).getPriority().displayValue())
                 );
                 break;
 

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
@@ -21,7 +21,6 @@ import org.jfree.data.time.TimeSeriesCollection;
 import org.jfree.data.xy.XYDataset;
 import org.jfree.ui.Layer;
 import org.jfree.ui.RectangleEdge;
-import org.jfree.ui.RectangleInsets;
 import org.jfree.ui.TextAnchor;
 
 import javax.print.attribute.standard.OrientationRequested;

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
@@ -21,6 +21,7 @@ import org.jfree.data.time.TimeSeriesCollection;
 import org.jfree.data.xy.XYDataset;
 import org.jfree.ui.Layer;
 import org.jfree.ui.RectangleEdge;
+import org.jfree.ui.RectangleInsets;
 import org.jfree.ui.TextAnchor;
 
 import javax.print.attribute.standard.OrientationRequested;
@@ -40,7 +41,7 @@ import static java.lang.Math.PI;
 /**
  * A panel for displaying an elevation plot for given target positions.
  */
-public class ElevationPanel extends JPanel implements PrintableWithDialog, SaveableWithDialog {
+public class ElevationPanel extends JPanel implements LegendTitleUser, PrintableWithDialog, SaveableWithDialog {
 
     // Used to access internationalized strings (see i18n/gui*.properties)
     private static final I18N _I18N = I18N.getInstance(ElevationPanel.class);
@@ -508,7 +509,7 @@ public class ElevationPanel extends JPanel implements PrintableWithDialog, Savea
 
         JFreeChart chart = new JFreeChart(title, JFreeChart.DEFAULT_TITLE_FONT, plot, false);
         if (_showLegend) {
-            chart.addSubtitle(new LegendTitle(chart.getPlot()));
+            useLegendTitle(chart);
         }
 
         return chart;

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
@@ -58,7 +58,10 @@ public class ElevationPlotModel {
     private Date[][] _xDate;
 
     // Used to format the dates in the table
-    private SimpleDateFormat _dateFormat = new SimpleDateFormat("HH:mm:ss");
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss");
+
+    // Used to format titles.
+    private static final SimpleDateFormat TITLE_FORMAT = new SimpleDateFormat("yyyy MMM d");
 
     // the Y values are elevation (angle between 0 and 90 degrees)
     private double[][] _yData;
@@ -131,11 +134,10 @@ public class ElevationPlotModel {
 
     /** Return a title based on the site and the date */
     public String getTitle() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy MMM d HH:mm");
         return _site.mountain + ": Night of "
-                + dateFormat.format(_sunRiseSet.nauticalTwilightStart)
+                + TITLE_FORMAT.format(_sunRiseSet.nauticalTwilightStart)
                 + " ---> "
-                + dateFormat.format(_sunRiseSet.nauticalTwilightEnd);
+                + TITLE_FORMAT.format(_sunRiseSet.nauticalTwilightEnd);
     }
 
 
@@ -235,7 +237,7 @@ public class ElevationPlotModel {
         if (! _timeZoneId.equals(LST) && ! _timeZoneId.equals(UT)) {
             _timeZone = _site.timezone();
         }
-        _dateFormat.setTimeZone(_timeZone);
+        DATE_FORMAT.setTimeZone(_timeZone);
     }
 
 
@@ -744,7 +746,7 @@ public class ElevationPlotModel {
                     if (_timeZoneId.equals(LST)) {
                          date = _plotUtil.getLst(date);
                     }
-                    return _dateFormat.format(date);
+                    return DATE_FORMAT.format(date);
                 case 1:
                     return _yData[_targetIndex][rowIndex];
                 case 2:

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotPanel.java
@@ -1,9 +1,3 @@
-// Copyright 2003
-// Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: ElevationPlotPanel.java 40560 2012-01-09 14:27:46Z swalker $
-
 package jsky.plot;
 
 import edu.gemini.spModel.core.Site;
@@ -16,6 +10,9 @@ import jsky.plot.util.gui.DateChooserDialog;
 import jsky.util.gui.DialogUtil;
 import jsky.util.gui.SwingUtil;
 import jsky.util.gui.GridBagUtil;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.title.LegendTitle;
+import org.jfree.ui.RectangleInsets;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -31,13 +28,10 @@ import javax.swing.event.ChangeListener;
 
 /**
  * A panel for displaying an elevation plot for given target positions.
- *
- * @version $Revision: 40560 $
- * @author Allan Brighton
  */
 public class ElevationPlotPanel extends JPanel implements ChangeListener {
 
-    // Used to access internationalized strings (see i18n/gui*.proprties)
+    // Used to access internationalized strings (see i18n/gui*.properties)
     private static final I18N _I18N = I18N.getInstance(ElevationPlotPanel.class);
 
     // Available time zone ids

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotPanel.java
@@ -10,9 +10,6 @@ import jsky.plot.util.gui.DateChooserDialog;
 import jsky.util.gui.DialogUtil;
 import jsky.util.gui.SwingUtil;
 import jsky.util.gui.GridBagUtil;
-import org.jfree.chart.JFreeChart;
-import org.jfree.chart.title.LegendTitle;
-import org.jfree.ui.RectangleInsets;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/LegendTitleUser.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/LegendTitleUser.java
@@ -1,0 +1,15 @@
+package jsky.plot;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.title.LegendTitle;
+import org.jfree.ui.RectangleInsets;
+
+public interface LegendTitleUser {
+    // Used to properly space out legend titles in panels used in this class.
+    RectangleInsets TITLE_INSETS = new RectangleInsets(2, 2, 2, 15);
+    default void useLegendTitle(final JFreeChart chart) {
+        final LegendTitle title = new LegendTitle(chart.getPlot());
+        title.setItemLabelPadding(TITLE_INSETS);
+        chart.addSubtitle(title);
+    }
+}

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ObservationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ObservationPanel.java
@@ -39,9 +39,9 @@ import java.text.SimpleDateFormat;
  * @version $Revision: 42349 $
  * @author Allan Brighton
  */
-public class ObservationPanel extends JPanel implements PrintableWithDialog, SaveableWithDialog {
+public class ObservationPanel extends JPanel implements LegendTitleUser, PrintableWithDialog, SaveableWithDialog {
 
-    // Used to access internationalized strings (see i18n/gui*.proprties)
+    // Used to access internationalized strings (see i18n/gui*.properties)
     private static final I18N _I18N = I18N.getInstance(ObservationPanel.class);
 
     // Tabbed pane containing the charts for the different categories
@@ -335,7 +335,7 @@ public class ObservationPanel extends JPanel implements PrintableWithDialog, Sav
         plot.setOrientation(PlotOrientation.HORIZONTAL);
         JFreeChart chart = new JFreeChart(title, JFreeChart.DEFAULT_TITLE_FONT, plot, false);
         if (_showLegend) {
-            chart.addSubtitle(new LegendTitle(chart.getPlot()));
+            useLegendTitle(chart);
         }
 
         return chart;


### PR DESCRIPTION
This PR does two things:

1. Removes the times from the titles of the elevation plot and the observation chart as per my conversation with @andrewwstephens. (This information is now displayed directly in the plot, and thus is no longer useful in the title.)

2. Fixes the previously used hideous legends by adding spacing between legend items in the legend.

@cquiroz, I tried to switch from `java.util` to `java.time` classes, but there was just way too much conversion that needed to be done back and forth, and `JFreeChart` uses the `java.util` classes, so it just became way too cumbersome.

Here is a before and after demonstrating the title and legend difference:
![before](https://user-images.githubusercontent.com/8795653/32858069-e91a9404-ca28-11e7-9428-417731cf760a.png)

![after](https://user-images.githubusercontent.com/8795653/32858075-eecf64ba-ca28-11e7-9de5-7b110c391beb.png)
