### PR TITLE
REL-3187, take 3

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/Phase1FolderFactory.scala
@@ -125,11 +125,12 @@ trait Partitioner {
 object GnirsSpectroscopyPartitioner extends Partitioner {
   import edu.gemini.spModel.core.MagnitudeBand.H
   def bucket(t:SPTarget):Int = t.getMagnitude(H).map(_.value).map { H =>
-    if (H < 11.5) 1
-    else if (H < 16) 2
-    else if (H < 20) 3
-    else 4
-  }.getOrElse(5)
+         if (H <  7.0) 1
+    else if (H < 11.5) 2
+    else if (H < 16.0) 3
+    else if (H < 20.0) 4
+    else 5
+  }.getOrElse(6)
 }
 
 // TARGET BRIGHTNESS = TB

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsSpectroscopy.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsSpectroscopy.scala
@@ -54,7 +54,7 @@ case class GnirsSpectroscopy(blueprint:SpGnirsBlueprintSpectroscopy, exampleTarg
   // #           SET FILTER (== central wavelength) FROM PI #12B not possible to be set automatically.
   // #           IF FILTER FROM PI == L or M (central wavelength > 2.5um) SET Well depth == Deep
 
-  include(5, 6, 12, 13, 14, 23) in TargetGroup
+  include(5, 6, 12, 13, 14) in TargetGroup
 
   forObs(12, 6, 14)(
     setPixelScale(pixelScale),
@@ -139,7 +139,7 @@ case class GnirsSpectroscopy(blueprint:SpGnirsBlueprintSpectroscopy, exampleTarg
   // #           SET FILTER (== central wavelength) FROM PI #12B not possible to be set automatically.
   // #           IF FILTER FROM PI == L or M (central wavelength > 2.5um) SET Well depth == Deep
 
-  val acq = Seq(5) ++ otherAcq ++ Seq(13, 23)
+  val acq = Seq(5) ++ otherAcq ++ Seq(13)
 
   forObs(acq:_*)(
 


### PR DESCRIPTION
Two more bug fixes for GNIRS template creation.

1) Existing bug on H-mag partitioning that lumped the <7 and <11.5 buckets together
2) Stop always including library observation 23 (reacquisition) even when not needed