### PR TITLE
REL-1485: Added rounding for sunset / twilights / sunrise times.

### DIFF
--- a/bundle/edu.gemini.util.skycalc/src/main/java/edu/gemini/skycalc/TwilightBoundedNight.java
+++ b/bundle/edu.gemini.util.skycalc/src/main/java/edu/gemini/skycalc/TwilightBoundedNight.java
@@ -1,7 +1,3 @@
-//
-// $Id: TwilightBoundedNight.java 21291 2009-07-29 16:23:21Z swalker $
-//
-
 package edu.gemini.skycalc;
 
 import edu.gemini.spModel.core.Site;
@@ -9,7 +5,6 @@ import java.util.logging.Logger;
 import java.util.logging.Level;
 
 import java.util.Calendar;
-import java.util.Date;
 
 /**
  * The start and end of a particular night, bounded by twilight as defined by
@@ -253,23 +248,5 @@ public final class TwilightBoundedNight implements Night {
 
     public TwilightBoundedNight next() {
         return TwilightBoundedNight.forObservingNight(_type, getObservingNight().next());
-    }
-
-    public static void main(String[] args) {
-
-        Calendar cal = Calendar.getInstance();
-
-        TwilightBoundedNight today;
-        today = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, cal.getTimeInMillis(), Site.GS);
-
-        cal.add(Calendar.DAY_OF_YEAR, -1);
-
-        TwilightBoundedNight yesterday;
-        yesterday = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, cal.getTimeInMillis(), Site.GS);
-
-        System.out.println("yesterday: " + (new Date(yesterday.getStartTime())) + " --> " +
-                                           (new Date(yesterday.getEndTime())));
-        System.out.println("today....: " + (new Date(today.getStartTime())) + " --> " +
-                                           (new Date(today.getEndTime())));
     }
 }

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
@@ -1,5 +1,6 @@
 package jsky.plot;
 
+import jsky.util.DateUtil;
 import jsky.util.I18N;
 import jsky.util.PrintableWithDialog;
 import jsky.util.SaveableWithDialog;
@@ -570,33 +571,38 @@ public class ElevationPanel extends JPanel implements LegendTitleUser, Printable
         _itemColors = colors;
     }
 
-
-    // Add a marker to the given plot, showing the area of darkness
+    // Add a marker to the given plot, showing the area of darkness.
+    // We round dates to the nearest minute.
     private void addDomainMarker(final XYPlot xyPlot,
                                  final Date startDate, final String startDateName,
                                  final Date endDate,   final String endDateName,
                                  float alpha, Color color) {
         final DateFormat df = ((DateAxis)xyPlot.getDomainAxis()).getDateFormatOverride();
-        double start = startDate.getTime();
-        double end = endDate.getTime();
+        final Date startDateRounded = DateUtil.roundToNearestMinute(startDate, _model.getTimeZone());
+        final Date endDateRounded   = DateUtil.roundToNearestMinute(endDate,   _model.getTimeZone());
 
-        if (start < end) {
-            IntervalMarker m = new IntervalMarker(start, end, color, DARKNESS_STROKE,
+        final double startRounded = startDate.getTime();
+        final double endRounded   = endDate.getTime();
+        final SimpleDateFormat sdf = new SimpleDateFormat("hh:mm:ss.SS");
+        System.out.println(String.format("\n\n%s start: %s, startRounded: %s", startDateName, sdf.format(startDate), sdf.format(startDateRounded)));
+        System.out.println(String.format("%s  end: %s,   endRounded: %s\n\n", endDateName, sdf.format(endDate), sdf.format(endDateRounded)));
+        if (startRounded < endRounded) {
+            final IntervalMarker m = new IntervalMarker(startRounded, endRounded, color, DARKNESS_STROKE,
                     color, DARKNESS_STROKE, alpha);
             xyPlot.addDomainMarker(m, Layer.BACKGROUND);
-            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", startDateName, df.format(startDate)), start));
-            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", endDateName, df.format(endDate)), end));
+            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", startDateName, df.format(startDateRounded)), startRounded));
+            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", endDateName, df.format(endDateRounded)), endRounded));
         } else {
-            double first = _model.getDateForHour(0.0).getTime();
-            double last = _model.getDateForHour(24.0).getTime();
-            IntervalMarker m1 = new IntervalMarker(start, last, color, DARKNESS_STROKE,
+            final double first = _model.getDateForHour(0.0).getTime();
+            final double last = _model.getDateForHour(24.0).getTime();
+            final IntervalMarker m1 = new IntervalMarker(startRounded, last, color, DARKNESS_STROKE,
                     color, DARKNESS_STROKE, alpha);
             xyPlot.addDomainMarker(m1, Layer.BACKGROUND);
-            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", startDateName, df.format(startDate)), start));
-            IntervalMarker m2 = new IntervalMarker(first, end, color, DARKNESS_STROKE,
+            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", startDateName, df.format(startDateRounded)), startRounded));
+            final IntervalMarker m2 = new IntervalMarker(first, endRounded, color, DARKNESS_STROKE,
                     color, DARKNESS_STROKE, alpha);
             xyPlot.addDomainMarker(m2, Layer.BACKGROUND);
-            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", endDateName, df.format(endDate)), first));
+            xyPlot.addAnnotation(createAnnotation(String.format("%s: %s", endDateName, df.format(endDateRounded)), endRounded));
         }
     }
 

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPanel.java
@@ -583,9 +583,7 @@ public class ElevationPanel extends JPanel implements LegendTitleUser, Printable
 
         final double startRounded = startDate.getTime();
         final double endRounded   = endDate.getTime();
-        final SimpleDateFormat sdf = new SimpleDateFormat("hh:mm:ss.SS");
-        System.out.println(String.format("\n\n%s start: %s, startRounded: %s", startDateName, sdf.format(startDate), sdf.format(startDateRounded)));
-        System.out.println(String.format("%s  end: %s,   endRounded: %s\n\n", endDateName, sdf.format(endDate), sdf.format(endDateRounded)));
+
         if (startRounded < endRounded) {
             final IntervalMarker m = new IntervalMarker(startRounded, endRounded, color, DARKNESS_STROKE,
                     color, DARKNESS_STROKE, alpha);

--- a/bundle/jsky.util/src/main/java/jsky/util/DateUtil.java
+++ b/bundle/jsky.util/src/main/java/jsky/util/DateUtil.java
@@ -1,12 +1,7 @@
-// Copyright 2002 Association for Universities for Research in Astronomy, Inc.,
-// Observatory Control System, Gemini Telescopes Project.
-//
-// $Id: DateUtil.java 4414 2004-02-03 16:21:36Z brighton $
-//
-
 package jsky.util;
 
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -14,7 +9,10 @@ import java.util.TimeZone;
 /**
  * Time/Date related static utility methods
  */
-public class DateUtil {
+public final class DateUtil {
+    // Static access only.
+    private DateUtil() {
+    }
 
     /**
      * Return a string with the UTC time in the format yyyy-MMM-dd hh:mm:ss,
@@ -37,6 +35,18 @@ public class DateUtil {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         return dateFormat.format(date);
+    }
+
+    /**
+     * Algorithm to round a time to the nearest minute: add 30 seconds and then truncate seconds and milliseconds.
+     */
+    public static Date roundToNearestMinute(final Date date, final TimeZone zone) {
+        final Calendar c = Calendar.getInstance(zone);
+        c.setTime(date);
+        c.add(Calendar.SECOND, 30);
+        c.set(Calendar.SECOND, 0);
+        c.set(Calendar.MILLISECOND, 0);
+        return c.getTime();
     }
 }
 


### PR DESCRIPTION
As per Andy's comments on REL-1485, on the new labels on the elevation plot for sunrise, twilights, and sunsets, we were truncating times to minute precision, when we should have been rounding to the nearest minute.

This change handles that, with some code I largely yoinked off stackoverflow.