### PR TITLE
REL-1485: Change to unicode arrow in date range titles.

### DIFF
--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
@@ -136,7 +136,7 @@ public class ElevationPlotModel {
     public String getTitle() {
         return _site.mountain + ": Night of "
                 + TITLE_FORMAT.format(_sunRiseSet.nauticalTwilightStart)
-                + " ---> "
+                + " ⟶ "
                 + TITLE_FORMAT.format(_sunRiseSet.nauticalTwilightEnd);
     }
 

--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ObservationPanel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ObservationPanel.java
@@ -94,17 +94,6 @@ public class ObservationPanel extends JPanel implements LegendTitleUser, Printab
     // Controls the visibility of the graph legend
     private boolean _showLegend = true;
 
-//    // This is used for the tooltips on the bars
-//    private IntervalCategoryToolTipGenerator _tooltipGenerator = new IntervalCategoryToolTipGenerator() {
-//            public String generateToolTip(CategoryDataset data, int series, int category) {
-//                TargetDesc[] targets = _model.getTargets();
-//                if (category < targets.length) {
-//                    return targets[category].getDescription();
-//                }
-//                return "";
-//            }
-//        };
-
     // Use a custom chart renderer that uses the priority to determine the bar color
     // and marks the dark time as a darker grey area
     private GanttRenderer _renderer = new GanttRenderer() {


### PR DESCRIPTION
As per Andy's comment on REL-1485, the elevation panel and observation chart would formerly use titles of the form:
"Night of 2017 Nov 16 ---> 2017 Nov 17"

This makeshift arrow looked ugly, especially in certain cases, so I have changed it to a proper unicode long arrow:
"Night of 2017 Nov 16 ⟶ 2017 Nov 17"

<img width="987" alt="screen shot 2017-11-20 at 8 04 14 am" src="https://user-images.githubusercontent.com/8795653/33015428-77d05136-cdc9-11e7-9754-729533c8b3de.png">

