### PR TITLE
REL-1438: add a bit of space after the image download spinner

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/ImageCatalogPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/ImageCatalogPanel.scala
@@ -114,7 +114,7 @@ final class ImageCatalogPanel(imageDisplay: CatalogImageDisplay) {
 
   private def row(l: Component, r: Component): Component =
     new BoxPanel(Orientation.Horizontal) {
-      contents ++= List(l, Swing.HGlue, r)
+      contents ++= List(l, Swing.HGlue, r, Swing.HStrut(5))
     }
 
   lazy val panel: Component =


### PR DESCRIPTION
This PR addresses a comment in JIRA:

> It's a minor issue, but in the Position Editor "Image Catalog" section at the bottom of the left-hand panel, the busy spinner icon that appears when images are being downloaded overlaps the radio button.

The spinner icon brushes the side of the radio button to the right, so this update adds a bit of space to separate them.