### PR TITLE
REL-2784: Fixing exceptions arising from not setting ZoneIds.

### DIFF
--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/DBNightlyPlanInfo.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/DBNightlyPlanInfo.java
@@ -2,12 +2,8 @@ package edu.gemini.obslog.obslog;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-
-//
-// Gemini Observatory/AURA
-// $Id: DBNightlyPlanInfo.java,v 1.2 2005/04/19 19:52:28 gillies Exp $
-//
 
 public class DBNightlyPlanInfo implements Serializable, Comparable<DBNightlyPlanInfo> {
 
@@ -22,7 +18,8 @@ public class DBNightlyPlanInfo implements Serializable, Comparable<DBNightlyPlan
     // last modified timestamp
     private long _timestamp;
 
-    private static DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:hh:ss");
+    private static DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss")
+            .withZone(ZoneId.of("UTC"));
 
     private String _lastModified;
 

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/functor/OlListPlanFunctor.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/functor/OlListPlanFunctor.java
@@ -13,10 +13,6 @@ import java.util.*;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
-//
-// Gemini Observatory/AURA
-// $Id: OlListPlanFunctor.java,v 1.2 2006/10/17 21:37:11 shane Exp $
-//
 
 public class OlListPlanFunctor extends DBAbstractQueryFunctor implements IDBParallelFunctor {
 
@@ -25,7 +21,7 @@ public class OlListPlanFunctor extends DBAbstractQueryFunctor implements IDBPara
 
     List<DBNightlyPlanInfo> getPlans() {
         if (_result == null) {
-            _result = new ArrayList<DBNightlyPlanInfo>();
+            _result = new ArrayList<>();
         }
         return _result;
     }

--- a/bundle/edu.gemini.obslog/src/main/resources/openLog.jsp
+++ b/bundle/edu.gemini.obslog/src/main/resources/openLog.jsp
@@ -38,7 +38,7 @@
                 </a>
             </display:column>
 
-            <display:column title="Last Modified" property="lastmodified" sortable="true"/>
+            <display:column title="Last Modified (UTC)" property="lastmodified" sortable="true"/>
 
         </display:table>
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Block.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Block.java
@@ -8,6 +8,7 @@ import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 /**
@@ -16,7 +17,8 @@ import java.time.format.DateTimeFormatter;
  */
 public final class Block implements Comparable<Block>, IntervalType<Block>, PioSerializable {
 
-    private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm");
+    private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
+            .withZone(ZoneId.of("UTC"));
     private static final String PROP_START = "start";
     private static final String PROP_END = "end";
 

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ObservationState.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ObservationState.java
@@ -173,7 +173,8 @@ public final class ObservationState implements Serializable {
         final StringBuilder buf = new StringBuilder();
         buf.append(startDay).append("/").append(endDay).append(" ");
 
-        final DateTimeFormatter f = DateTimeFormatter.ofPattern("MMM yyyy").withZone(ZoneId.of("UTC"));
+        // Do not need to explicitly set a ZoneId since we are only accessing MMM and yyyy.
+        final DateTimeFormatter f = DateTimeFormatter.ofPattern("MMM yyyy");
         buf.append(f.format(end));
 
         return buf.toString();

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ObservationState.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/odbState/ObservationState.java
@@ -1,6 +1,3 @@
-//
-// $Id: ObservationState.java 46768 2012-07-16 18:58:53Z rnorris $
-//
 package edu.gemini.dbTools.odbState;
 
 import edu.gemini.pot.sp.ISPObservation;
@@ -15,10 +12,12 @@ import org.dom4j.DocumentFactory;
 import org.dom4j.Element;
 
 import java.io.Serializable;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 
 public final class ObservationState implements Serializable {
     private static final long serialVersionUID = 2;
@@ -144,42 +143,38 @@ public final class ObservationState implements Serializable {
     }
 
     /**
-     * Gets a formated string that indicates the night during which the
+     * Gets a formatted string that indicates the night during which the
      * observation took place.
      * @param time utc time of the last observation event message
      * @return formatted string indicating the night during which the
      * observation took place.
      */
     private static String _getNight(final long time) {
-        final Calendar cal = GregorianCalendar.getInstance();
-        cal.setTimeInMillis(time);
+        // Determine when, in the local time zone, the time started:
+        // If the time is before noon, then the night started on the previous day.
+        // If the time is after noon, then the night ends on the next day.
+        // Note: AM is 0, PM is 1 by documentation for ChronoField.
+        final LocalDateTime dt = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneId.systemDefault());
+        final int ampm = dt.get(ChronoField.AMPM_OF_DAY);
 
-        // The calendar is in the local time zone.  If the time is before
-        // noon, then the night started on the previous day.  If the time
-        // is after noon, then the night ends on the next day.
-        final int ampm = cal.get(Calendar.AM_PM);
-
-        final Calendar endCal;
-
-        final int startDay;
-        final int endDay;
-        if (ampm == Calendar.AM) {
-            endCal = (Calendar) cal.clone();
-            endDay = cal.get(Calendar.DAY_OF_MONTH);
-            cal.add(Calendar.DAY_OF_MONTH, -1);
-            startDay = cal.get(Calendar.DAY_OF_MONTH);
+        final LocalDateTime start;
+        final LocalDateTime end;
+        if (ampm == 0) {
+            start = dt.minus(1, ChronoUnit.DAYS);
+            end   = dt;
         } else {
-            startDay = cal.get(Calendar.DAY_OF_MONTH);
-            cal.add(Calendar.DAY_OF_MONTH, 1);
-            endCal = cal;
-            endDay = cal.get(Calendar.DAY_OF_MONTH);
+            start = dt;
+            end   = dt.plus(1, ChronoUnit.DAYS);
         }
+
+        final int startDay = start.get(ChronoField.DAY_OF_MONTH);
+        final int endDay   = end.get(ChronoField.DAY_OF_MONTH);
 
         final StringBuilder buf = new StringBuilder();
         buf.append(startDay).append("/").append(endDay).append(" ");
 
-        final DateFormat f = new SimpleDateFormat("MMM yyyy");
-        buf.append(f.format(endCal.getTime()));
+        final DateTimeFormatter f = DateTimeFormatter.ofPattern("MMM yyyy").withZone(ZoneId.of("UTC"));
+        buf.append(f.format(end));
 
         return buf.toString();
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/sitequality/SiteQualityPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/sitequality/SiteQualityPanel.java
@@ -8,6 +8,7 @@ import jsky.util.gui.Resources;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableRowSorter;
 import javax.swing.text.DefaultFormatter;
 import java.awt.*;
 import java.beans.PropertyChangeEvent;
@@ -15,8 +16,10 @@ import java.beans.PropertyChangeListener;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 final class SiteQualityPanel extends JPanel {
@@ -155,7 +158,9 @@ final class SiteQualityPanel extends JPanel {
             final JTable table = new JTable(model) {{
                 getColumnModel().getColumn(0).setMinWidth(175);
                 owner.addPropertyChangeListener(e -> model.setSiteQuality(owner.getDataObject()));
-                setAutoCreateRowSorter(true);
+                setRowSorter(new TableRowSorter<TimingWindowTableModel>(model) {{
+                    setComparator(0, TimingWindowTableModel.START_DATE_COMPARATOR);
+                }});
             }};
 
             add(new JLabel("Timing Windows"), new GBC(0, 7));
@@ -296,7 +301,9 @@ class TimingWindowTableModel extends DefaultTableModel implements PropertyChange
     private static final long MS_PER_MINUTE = MS_PER_SECOND * 60;
     private static final long MS_PER_HOUR = MS_PER_MINUTE * 60;
 
-    private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z").withZone(ZoneId.of("UTC"));
+    private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss z")
+            .withZone(ZoneId.of("UTC"));
+    public static final Comparator<String> START_DATE_COMPARATOR = Comparator.comparingLong(s -> ZonedDateTime.parse(s, dateFormat).toEpochSecond());
 
     private SPSiteQuality sq;
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/sitequality/SiteQualityPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/sitequality/SiteQualityPanel.java
@@ -4,6 +4,7 @@ import edu.gemini.shared.gui.ButtonFlattener;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.*;
 import jsky.app.ot.editor.type.SpTypeUIUtil;
+import jsky.util.DateUtil;
 import jsky.util.gui.Resources;
 
 import javax.swing.*;
@@ -159,7 +160,7 @@ final class SiteQualityPanel extends JPanel {
                 getColumnModel().getColumn(0).setMinWidth(175);
                 owner.addPropertyChangeListener(e -> model.setSiteQuality(owner.getDataObject()));
                 setRowSorter(new TableRowSorter<TimingWindowTableModel>(model) {{
-                    setComparator(0, TimingWindowTableModel.START_DATE_COMPARATOR);
+                    setComparator(0, DateUtil.createComparator(DateUtil.TIMING_WINDOW_START));
                 }});
             }};
 
@@ -301,10 +302,6 @@ class TimingWindowTableModel extends DefaultTableModel implements PropertyChange
     private static final long MS_PER_MINUTE = MS_PER_SECOND * 60;
     private static final long MS_PER_HOUR = MS_PER_MINUTE * 60;
 
-    private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss z")
-            .withZone(ZoneId.of("UTC"));
-    public static final Comparator<String> START_DATE_COMPARATOR = Comparator.comparingLong(s -> ZonedDateTime.parse(s, dateFormat).toEpochSecond());
-
     private SPSiteQuality sq;
 
     void setSiteQuality(final SPSiteQuality siteQuality) {
@@ -384,6 +381,6 @@ class TimingWindowTableModel extends DefaultTableModel implements PropertyChange
     }
 
     private static String formatWindow(final TimingWindow tw) {
-        return dateFormat.format(Instant.ofEpochMilli(tw.getStart()));
+        return DateUtil.TIMING_WINDOW_START.format(Instant.ofEpochMilli(tw.getStart()));
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/too/TooAlertPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/too/TooAlertPanel.java
@@ -17,7 +17,7 @@ import java.util.TimeZone;
  */
 public final class TooAlertPanel extends JPanel {
     private static final String TIME_ONLY_PATTERN = "HH:mm:ss";
-    private static final String TIME_DATE_PATTERN = "YYYY-MMM-dd HH:mm:ss";
+    private static final String TIME_DATE_PATTERN = "yyyy-MMM-dd HH:mm:ss";
     private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     private static String formatTimeOnly(long time) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/too/TooAlertPanel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/too/TooAlertPanel.java
@@ -1,7 +1,3 @@
-//
-// $Id$
-//
-
 package jsky.app.ot.too;
 
 import edu.gemini.skycalc.TwilightBoundedNight;
@@ -12,17 +8,16 @@ import edu.gemini.spModel.obs.ObsSchedulingReport;
 
 import javax.swing.*;
 import java.awt.*;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
-import java.util.Date;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 /**
  * A panel that displays a TOO alert according to the spec in SCT-233.
  */
 public final class TooAlertPanel extends JPanel {
     private static final String TIME_ONLY_PATTERN = "HH:mm:ss";
-    private static final String TIME_DATE_PATTERN = "yyyy/MM/dd HH:mm:ss";
+    private static final String TIME_DATE_PATTERN = "YYYY-MMM-dd HH:mm:ss";
     private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     private static String formatTimeOnly(long time) {
@@ -34,9 +29,8 @@ public final class TooAlertPanel extends JPanel {
     }
 
     private static String format(long time, TimeZone zone, String pattern) {
-        DateFormat f = new SimpleDateFormat(pattern);
-        f.setTimeZone(zone);
-        return f.format(new Date(time));
+        final DateTimeFormatter f = DateTimeFormatter.ofPattern(pattern).withZone(zone.toZoneId());
+        return f.format(Instant.ofEpochMilli(time));
     }
 
     public TooAlertPanel(ObsSchedulingReport report) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
@@ -17,6 +17,7 @@ import javax.print.PrintServiceLookup;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.swing.JComponent;
 
+import jsky.app.ot.util.TimeZonePreference;
 import jsky.coords.WorldCoordinateConverter;
 import jsky.coords.WorldCoords;
 import jsky.util.I18N;
@@ -32,7 +33,7 @@ import jsky.util.gui.ProgressPanel;
  */
 public class ImagePrintDialog implements Printable, ActionListener {
 
-    // Used to access internationalized strings (see i18n/gui*.proprties)
+    // Used to access internationalized strings (see i18n/gui*.properties)
     private static final I18N _I18N = I18N.getInstance(ImagePrintDialog.class);
 
     // Base name of file used to store printer settings (under ~/.jsky)
@@ -56,7 +57,8 @@ public class ImagePrintDialog implements Printable, ActionListener {
     private boolean _newPrint;
     private double _printOffsetX;
     private double _printOffsetY;
-    private final DateTimeFormatter _dateFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss");
+    private final DateTimeFormatter _dateFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss")
+            .withZone(TimeZonePreference.getZoneId());
 
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImagePrintDialog.java
@@ -10,6 +10,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.print.*;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import javax.print.PrintService;
@@ -58,7 +59,7 @@ public class ImagePrintDialog implements Printable, ActionListener {
     private double _printOffsetX;
     private double _printOffsetY;
     private final DateTimeFormatter _dateFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss")
-            .withZone(TimeZonePreference.getZoneId());
+            .withZone(ZoneId.systemDefault());
 
 
     /**

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/util/TimeZonePreference.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/util/TimeZonePreference.scala
@@ -1,5 +1,6 @@
 package jsky.app.ot.util
 
+import java.time.ZoneId
 import java.util.TimeZone
 import java.util.prefs.Preferences
 
@@ -8,9 +9,13 @@ import java.util.prefs.Preferences
  * of timezone.
  */
 object TimeZonePreference {
-  val pref = Preferences.userNodeForPackage(TimeZonePreference.getClass)
+  val pref: Preferences = Preferences.userNodeForPackage(TimeZonePreference.getClass)
 
   def get: TimeZone = TimeZone.getTimeZone(pref.get("TimeZone", "UTC"))
 
   def set(tz: TimeZone): Unit = pref.put("TimeZone", tz.getID)
+
+  def getZoneId: ZoneId = get.toZoneId
+
+  def setZoneId(zi: ZoneId): Unit = pref.put("TimeZone", TimeZone.getTimeZone(zi).getID)
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/util/TimeZonePreference.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/util/TimeZonePreference.scala
@@ -17,5 +17,5 @@ object TimeZonePreference {
 
   def getZoneId: ZoneId = get.toZoneId
 
-  def setZoneId(zi: ZoneId): Unit = pref.put("TimeZone", TimeZone.getTimeZone(zi).getID)
+  def setZoneId(zi: ZoneId): Unit = set(TimeZone.getTimeZone(zi))
 }

--- a/bundle/jsky.util/src/main/java/jsky/util/DateUtil.java
+++ b/bundle/jsky.util/src/main/java/jsky/util/DateUtil.java
@@ -1,7 +1,11 @@
 package jsky.util;
 
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -12,6 +16,14 @@ import java.util.TimeZone;
 public final class DateUtil {
     // Static access only.
     private DateUtil() {
+    }
+
+    // Used for timing window formatting.
+    public static DateTimeFormatter TIMING_WINDOW_START = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss z").withZone(ZoneId.of("UTC"));
+
+    // Create a Comparator<String> from a DateTimeFormatter.
+    public static Comparator<String> createComparator(final DateTimeFormatter df) {
+        return Comparator.comparingLong(s -> ZonedDateTime.parse(s, df).toEpochSecond());
     }
 
     /**


### PR DESCRIPTION
The obslog was generating exceptions from the update from `SimpleDateFormat` to `DateTimeFormatter`, because `DateTimeFormatter` needs a specified `ZoneId` to be able to extract certain fields from an `Instant` or other `TemporalAccessor`.

I also modernized `ObservationState` to use new `java.time` constructs instead of the old `java.util.Calendar`. See below in comments for more notes on this.