### PR TITLE
REL-1485: Restored title dates to start and end dates instead of twilights.

### DIFF
--- a/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
+++ b/bundle/jsky.elevation.plot/src/main/java/jsky/plot/ElevationPlotModel.java
@@ -135,9 +135,9 @@ public class ElevationPlotModel {
     /** Return a title based on the site and the date */
     public String getTitle() {
         return _site.mountain + ": Night of "
-                + TITLE_FORMAT.format(_sunRiseSet.nauticalTwilightStart)
+                + TITLE_FORMAT.format(_startDate)
                 + " ⟶ "
-                + TITLE_FORMAT.format(_sunRiseSet.nauticalTwilightEnd);
+                + TITLE_FORMAT.format(_endDate);
     }
 
 


### PR DESCRIPTION
Since we removed twilight times from the elevation plot and observation chart titles, the dates are now sometimes wrong, so we are reverting back to start and end date to have the appropriate dates appear.