### PR TITLE
REL-3317: don't clobber ToO 'override rapid'

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/too/Too.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/too/Too.java
@@ -50,30 +50,12 @@ public final class Too {
     /**
      * Sets the ToO type of the program and all of its observations to match.
      */
-    public static boolean set(ISPProgram prog, TooType newType) {
+    public static void set(ISPProgram prog, TooType newType) {
         // REL-538 Move TooType to SPProgram
-        SPProgram spProgram = (SPProgram) prog.getDataObject();
-        spProgram.setTooType(newType);
-        prog.setDataObject(spProgram);
-
-        updateObservations(prog);
-
-        ISPTemplateFolder f = prog.getTemplateFolder();
-        if (f != null) {
-            for (ISPTemplateGroup grp : f.getTemplateGroups()) {
-                updateObservations(grp);
-            }
-        }
-        return true;
-    }
-
-    private static void updateObservations(ISPObservationContainer c) {
-        for (ISPObservation obs : c.getAllObservations()) {
-            final SPObservation dataObj = (SPObservation) obs.getDataObject();
-            if (dataObj.isOverrideRapidToo()) {
-                dataObj.setOverrideRapidToo(false);
-                obs.setDataObject(dataObj);
-            }
+        final SPProgram spProgram = (SPProgram) prog.getDataObject();
+        if (newType != spProgram.getTooType()) {
+            spProgram.setTooType(newType);
+            prog.setDataObject(spProgram);
         }
     }
 }


### PR DESCRIPTION
This PR addresses a bug in which all standard ToO observations are reset to rapid ToO in a rapid ToO program if the program admin dialog is opened and the "OK" button is clicked.

Determining the ToO status of an observation involves consulting the ToO designation of the program as a whole and the value of a "override rapid too" flag in the observation itself.  The combination of these values determines the ToO status of the observation.  It is probably most concisely described in code:

```java
    public static TooType get(ISPObservation obs) {
        final TooType progType = get(obs.getProgram());
        if (progType == TooType.rapid) {
            final boolean override = ((SPObservation) obs.getDataObject()).isOverrideRapidToo();
            return override ? TooType.standard : TooType.rapid;
        } else {
            return progType;
        }
    }
```

This PR avoids attempting to update the ToO status of the program unless it has actually changed, and removes code that would reset the override flag in every observation to `false` every time regardless.  This means that now when a program toggles from `TooType.rapid` to either `standard` or `none` and then back to `rapid`, observations that were previously set to `standard` remain `standard`.