### PR TITLE
REL-3323: Fix QPT NPE after deleting a variant (for 2018A)

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
@@ -34,7 +34,7 @@ public class CandidateObsComparator extends MouseAdapter implements GComparator<
 			return direction * ((ret != 0) ? ret : -o1.compareTo(o2));
 		}
 
-		// If we don't have a variant, then we don't have a middle point.
+        // If we don't have a variant, then we don't have a middle point.
         // This will happen when we've just deleted a variant, for example.
         // In this case, consider all Obs equal since we will have nothing to compare.
         if (variant == null)

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
@@ -11,7 +11,6 @@ import javax.swing.table.JTableHeader;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.Variant;
 import edu.gemini.qpt.shared.sp.Obs;
-import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GComparator;
 import edu.gemini.ui.gface.GTableViewer;
 import edu.gemini.ui.gface.GViewer;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
@@ -11,6 +11,7 @@ import javax.swing.table.JTableHeader;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.Variant;
 import edu.gemini.qpt.shared.sp.Obs;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GComparator;
 import edu.gemini.ui.gface.GTableViewer;
 import edu.gemini.ui.gface.GViewer;
@@ -33,7 +34,13 @@ public class CandidateObsComparator extends MouseAdapter implements GComparator<
 			int ret = (int) Math.signum(variant.getScore(o1) - variant.getScore(o2));
 			return direction * ((ret != 0) ? ret : -o1.compareTo(o2));
 		}
-		
+
+		// If we don't have a variant, then we don't have a middle point.
+        // This will happen when we've just deleted a variant, for example.
+        // In this case, consider all Obs equal since we will have nothing to compare.
+        if (variant == null)
+            return 0;
+
 		return direction * attr.getComparator(variant.getSchedule().getMiddlePoint()).compare(o1, o2);
 	}
 

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -579,7 +579,10 @@ public final class Obs implements Serializable, Comparable<Obs> {
     }
 
 	public double getRa(Long when) {
-        return (targetEnvironment != null ? targetEnvironment.getAsterism().getRaDegrees(new Some<>(when)).getOrElse(0.0) : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getAsterism().
+
+
+        (new Some<>(when)).getOrElse(0.0) : 0.0);
 	}
 
 	public double getDec(Long when) {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -579,10 +579,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
     }
 
 	public double getRa(Long when) {
-        return (targetEnvironment != null ? targetEnvironment.getAsterism().
-
-
-        (new Some<>(when)).getOrElse(0.0) : 0.0);
+        return (targetEnvironment != null ? targetEnvironment.getAsterism().getRaDegrees(new Some<>(when)).getOrElse(0.0) : 0.0);
 	}
 
 	public double getDec(Long when) {


### PR DESCRIPTION
In recent changes, when a variant in the QPT is deleted, the `CandidateObsComparator` causes a `NullPointerException` due to the fact that the selected `Variant` is then `null` and it tries to retrieve a comparator from it.

This change just instead uses a dummy comparison, since there are no `Obs` to be compared when there is no selected `Variant`.