### PR TITLE
REL-3323: Fix QPT NPE after deleting a variant

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/CandidateObsComparator.java
@@ -33,6 +33,12 @@ public class CandidateObsComparator extends MouseAdapter implements GComparator<
 			int ret = (int) Math.signum(variant.getScore(o1) - variant.getScore(o2));
 			return direction * ((ret != 0) ? ret : -o1.compareTo(o2));
 		}
+
+        // If we don't have a variant, then we don't have a middle point.
+        // This will happen when we've just deleted a variant, for example.
+        // In this case, consider all Obs equal since we will have nothing to compare.
+        if (variant == null)
+            return 0;
 		
 		return direction * attr.getComparator(variant.getSchedule().getMiddlePoint()).compare(o1, o2);
 	}


### PR DESCRIPTION
In recent changes, when a variant in the QPT is deleted, the `CandidateObsComparator` causes a `NullPointerException` due to the fact that the selected `Variant` is then `null` and it tries to retrieve a comparator from it.

This change just instead uses a dummy comparison, since there are no `Obs` to be compared when there is no selected `Variant`.