### PR TITLE
REL-3310: Fixing script to run spdb as software instead of root.

### DIFF
--- a/app/spdb/scripts/spdb
+++ b/app/spdb/scripts/spdb
@@ -159,7 +159,7 @@ start ()
 
 	    # Attempt to start.
 	    printf "Starting ODB ${SPDB_VERSION_STR}"
-	    "${SPDB_EXEC}" 2>&1 > "${SPDB_DIR}/sysout.txt" &
+	    /sbin/runuser software -s /bin/bash -c "nohup ${SPDB_EXEC} 2>&1 > ${SPDB_DIR}/sysout.txt &"
 	    sleep_dots
 	    printf "\n"
 


### PR DESCRIPTION
The original `spdb` `init.d` script accidentally started the `spdb` as `root` when it should have been started as `software`. This should fix that according to my research.

(Note: I cannot test this directly because `/sbin/runuser` is only executable as `root`.)