### PR TITLE
REL-3310: Added line to allow sysadm to do a chkconfig add.

### DIFF
--- a/app/spdb/scripts/spdb
+++ b/app/spdb/scripts/spdb
@@ -1,5 +1,7 @@
 #!/bin/bash
-# 
+#
+# chkconfig: 345 99 01
+#
 # This script manages the startup / shutdown of the ODB.
 
 # RETVALS:


### PR DESCRIPTION
Added a line to help the ITS staff by enabling them to do a `chkconfig --add spdb`.