### PR TITLE
REL-3341: Added CWFS window marker geometry and drawing.

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsMagnitudeTable.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsMagnitudeTable.scala
@@ -105,6 +105,7 @@ object GemsMagnitudeTable extends MagnitudeTable {
   lazy val CanopusWfsMagnitudeLimitsCalculator = new CanopusWfsCalculator {
     // The values provided by science are assumed to be at SB ANY, CC50, and IQ70.
     // Since SB ANY results in an adjustment of -0.5 mag, we add 0.5 mag to account for this.
+    // Note that the adjustments for conditions are done in the api file of edu.gemini.catalog.
     private val FaintLimit  = 17.5
     private val BrightLimit = 11.0
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
@@ -14,6 +14,7 @@ import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 
+import java.awt.*;
 import java.awt.geom.*;
 import java.util.*;
 
@@ -30,6 +31,15 @@ public enum CanopusWfs implements GuideProbe, ValidatableGuideProbe, OffsetValid
     static {
         final Ellipse2D AO_PORT = new Ellipse2D.Double(-RADIUS_ARCSEC, -RADIUS_ARCSEC, RADIUS_ARCSEC * 2, RADIUS_ARCSEC * 2);
         patrolField = new PatrolField(AO_PORT);
+    }
+
+    // According to NGS2, guide stars should be centered in 2" or 4" windows. We select 4".
+    private static final double GS_WINDOW_SIZE_ARCSEC = 4.0;
+    private static final Area   GS_WINDOW;
+
+    static {
+        final Shape GS_WINDOW_SHAPE = new Rectangle2D.Double(-GS_WINDOW_SIZE_ARCSEC / 2.0, -GS_WINDOW_SIZE_ARCSEC / 2.0, GS_WINDOW_SIZE_ARCSEC, GS_WINDOW_SIZE_ARCSEC);
+        GS_WINDOW = new Area(GS_WINDOW_SHAPE);
     }
 
     @Override
@@ -115,6 +125,10 @@ public enum CanopusWfs implements GuideProbe, ValidatableGuideProbe, OffsetValid
     @Override
     public Option<PatrolField> getCorrectedPatrolField(final ObsContext ctx) {
         return ctx.getAOComponent().filter(ado -> ado instanceof Gems).map(a -> patrolField);
+    }
+
+    public static Area getGuideStarWindow() {
+        return GS_WINDOW;
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
@@ -128,7 +128,7 @@ public enum CanopusWfs implements GuideProbe, ValidatableGuideProbe, OffsetValid
     }
 
     public static Area getGuideStarWindow() {
-        return GS_WINDOW;
+        return (Area) GS_WINDOW.clone();
     }
 
     @Override


### PR DESCRIPTION
This PR aims to satisfy the remaining parts of REQ-OT-002 in the NGS2 OT document, i.e. for CWFS guide stars, mark them with a fixed 2" or 4" square or circle.

I am very iffy about this PR, given that the requirements are still not entirely clear, but I've designed it so that we can change size, shape, and color of the CWFS markers easily enough.

Here is an image of some "dummy stars" for M6 to show that the translation for the markers works properly and to show what a star that is out of range for Canopus looks like. I am not very happy with the way that this looks, and think it appears quite awkward in the TPE.

It is still unknown if these markers have any physical significance with regards to NGS2 or if they are simply there to mark the stars now that the probe arms have been removed: to finalize this requirement, once clear, we may need to:
1. Filter out asterisms where the markers overlap (which will be done in MASCOT); and
2. Filter out guide stars that do not fall completely within the CWFS patrol field (which will be done in `CanopusWfs` when validating a guide star).

Any feedback would be much appreciated.
![screen shot 2017-12-22 at 11 17 19 am](https://user-images.githubusercontent.com/8795653/34301331-e49c5eb8-e70a-11e7-8428-7081f78b89a5.png)
