### PR TITLE
REL-3342: Restored magnitude property settings to GpiCB.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
@@ -74,7 +74,7 @@ public class GpiCB extends AbstractObsComponentCB {
                     final ImList<Magnitude> magnitudes = base.getMagnitudesJava();
                     MAG_PROPERTIES.forEach((band, propName) ->
                         magnitudes.find(m -> m.band().equals(band)).
-                                foreach(mag -> config.putParameter(systemName, DefaultParameter.getInstance(propName, mag))));
+                                foreach(mag -> config.putParameter(systemName, DefaultParameter.getInstance(propName, mag.value()))));
                 });
             }
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/GpiCB.java
@@ -1,8 +1,6 @@
 package edu.gemini.spModel.gemini.gpi;
 
 import edu.gemini.pot.sp.ISPObsComponent;
-import edu.gemini.shared.util.immutable.ApplyOp;
-import edu.gemini.shared.util.immutable.Function1;
 import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.spModel.config.AbstractObsComponentCB;
 import edu.gemini.spModel.core.Magnitude;
@@ -17,6 +15,7 @@ import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.util.SPTreeUtil;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -30,6 +29,7 @@ public class GpiCB extends AbstractObsComponentCB {
         super(obsComp);
     }
 
+    @Override
     public Object clone() {
         GpiCB result = (GpiCB) super.clone();
         result._sysConfig = null;
@@ -44,50 +44,46 @@ public class GpiCB extends AbstractObsComponentCB {
         _sysConfig = dataObj.getSysConfig();
     }
 
+    @Override
     protected boolean thisHasConfiguration() {
         if (_sysConfig == null)
             return false;
         return (_sysConfig.getParameterCount() > 0);
     }
 
-    protected void thisApplyNext(final IConfig config, IConfig prevFull) {
+    @Override
+    protected void thisApplyNext(final IConfig config, final IConfig prevFull) {
         final String systemName = _sysConfig.getSystemName();
-        Collection<IParameter> sysConfig = _sysConfig.getParameters();
+        final Collection<IParameter> sysConfig = _sysConfig.getParameters();
 
-        final class MagnitudeFilter implements Function1<Magnitude, Boolean> {
-            private final MagnitudeBand band;
-
-            private MagnitudeFilter(MagnitudeBand band) {
-                this.band = band;
-            }
-
-            @Override
-            public Boolean apply(Magnitude magnitude) {
-                return magnitude.band().equals(band);
-            }
-        }
-
-        final class MagnitudeSetter implements ApplyOp<Magnitude> {
-            private final String magProp;
-
-            private MagnitudeSetter(String magHProp) {
-                this.magProp = magHProp;
-            }
-
-            @Override
-            public void apply(Magnitude magnitude) {
-                config.putParameter(systemName,
-                            DefaultParameter.getInstance(magProp,
-                                magnitude.value()));
-            }
-        }
-        for (IParameter param : sysConfig) {
+        for (final IParameter param : sysConfig) {
             config.putParameter(systemName,
                     DefaultParameter.getInstance(param.getName(), param.getValue()));
         }
         config.putParameter(systemName,
-                            StringParameter.getInstance(InstConstants.INSTRUMENT_NAME_PROP,
-                                    Gpi.INSTRUMENT_NAME_PROP));
+                StringParameter.getInstance(InstConstants.INSTRUMENT_NAME_PROP,
+                        Gpi.INSTRUMENT_NAME_PROP));
+
+        // Set the magnitude properties.
+        final ISPObsComponent targetcomp = SPTreeUtil.findTargetEnvNode(getObsComponent().getContextObservation());
+        if (targetcomp != null) {
+            final TargetObsComp toc = (TargetObsComp) targetcomp.getDataObject();
+            if (toc != null) {
+                // The Asterism here should be Single(base), so we only need to concern ourselves with the head target.
+                toc.getAsterism().allSpTargetsJava().headOption().foreach(base -> {
+                    final ImList<Magnitude> magnitudes = base.getMagnitudesJava();
+                    MAG_PROPERTIES.forEach((band, propName) ->
+                        magnitudes.find(m -> m.band().equals(band)).
+                                foreach(mag -> config.putParameter(systemName, DefaultParameter.getInstance(propName, mag))));
+                });
+            }
+        }
     }
 
+    // The magnitude bands of interest and their property names in the configuration.
+    private static final Map<MagnitudeBand, String> MAG_PROPERTIES = new HashMap<>();
+    static {
+        MAG_PROPERTIES.put(MagnitudeBand.H$.MODULE$, Gpi.MAG_H_PROP);
+        MAG_PROPERTIES.put(MagnitudeBand.I$.MODULE$, Gpi.MAG_I_PROP);
+    }
 }


### PR DESCRIPTION
This restores the accidentally removed setting of magnitudes for H and I band in `GpiCB.java`, and has been rewritten to make it clear that these properties are being set instead of relying on unusual uses of `ApplyOp`.