### PR TITLE
REL-3341: Implement 4 arcsec squares around active guide probe targets for CWFS

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsMagnitudeTable.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsMagnitudeTable.scala
@@ -105,6 +105,7 @@ object GemsMagnitudeTable extends MagnitudeTable {
   lazy val CanopusWfsMagnitudeLimitsCalculator = new CanopusWfsCalculator {
     // The values provided by science are assumed to be at SB ANY, CC50, and IQ70.
     // Since SB ANY results in an adjustment of -0.5 mag, we add 0.5 mag to account for this.
+    // Note that the adjustments for conditions are done in the api file of edu.gemini.catalog.
     private val FaintLimit  = 17.5
     private val BrightLimit = 11.0
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -263,18 +263,21 @@ object GemsResultsAnalyzer {
 
   // Returns the given targets list with any objects removed that are not valid in the
   // given position angle.
-  private def filter(obsContext: ObsContext, targetsList: List[SiderealTarget], group: GemsGuideProbeGroup, posAngle: Angle): List[SiderealTarget] =
-    targetsList.filter(isTargetValidInGroup(obsContext, _, group, posAngle))
+  private def filter(obsContext: ObsContext, targetsList: List[SiderealTarget], group: GemsGuideProbeGroup, posAngle: Angle): List[SiderealTarget] = {
+    val ctx = obsContext.withPositionAngle(posAngle)
+    targetsList.filter(isTargetValidInGroup(ctx, _, group))
+  }
 
   // Returns true if all the stars in the given target list are valid for the given group
-  private def areAllTargetsValidInGroup(obsContext: ObsContext, targetList: List[SiderealTarget], group: GemsGuideProbeGroup, posAngle: Angle): Boolean =
-    targetList.forall(isTargetValidInGroup(obsContext, _, group, posAngle))
+  private def areAllTargetsValidInGroup(obsContext: ObsContext, targetList: List[SiderealTarget], group: GemsGuideProbeGroup, posAngle: Angle): Boolean = {
+    val ctx = obsContext.withPositionAngle(posAngle)
+    group.asterismFilter(ctx, targetList.asImList) && targetList.forall(isTargetValidInGroup(ctx, _, group))
+  }
 
   // Returns true if the given target is valid for the given group
-  private def isTargetValidInGroup(obsContext: ObsContext, target: SiderealTarget, group: GemsGuideProbeGroup, posAngle: Angle): Boolean = {
-    val ctx = obsContext.withPositionAngle(posAngle)
+  private def isTargetValidInGroup(obsContext: ObsContext, target: SiderealTarget, group: GemsGuideProbeGroup): Boolean = {
     val st = toSPTarget(target)
-    group.getMembers.asScala.exists(_.validate(st, ctx) == GuideStarValidation.VALID)
+    group.getMembers.asScala.exists(_.validate(st, obsContext) == GuideStarValidation.VALID)
   }
 
   // Returns the first valid guide probe for the given target in the given guide probe group at the given

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
@@ -7,10 +7,7 @@ import edu.gemini.p2checker.api.P2Problems;
 import edu.gemini.p2checker.util.PositionOffsetChecker;
 import edu.gemini.pot.sp.ISPProgramNode;
 import edu.gemini.pot.sp.SPComponentType;
-import edu.gemini.shared.util.immutable.DefaultImList;
-import edu.gemini.shared.util.immutable.ImList;
-import edu.gemini.shared.util.immutable.ImOption;
-import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2OiwfsGuideProbe;
@@ -29,18 +26,19 @@ import edu.gemini.spModel.target.env.GuideGroup;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A rule for checking GeMS guide star positions.
  */
 public final class GemsGuideStarRule implements IRule {
     private static final String PREFIX = "GemsGuideStarRule_";
-    private static final String ODGW = "The ODGW%d guide star falls out of the range of the detector";
-    private static final String CWFS = "The CWFS%d guide star falls out of the range of the guide probe";
-    private static final String ConfigError = "Configuration not supported. Please select 3 CWFS + 1 ODGW or 1 CWFS + 3 ODGW";
-    private static final String MagnitudeDifference = "CWFS guide star magnitudes must differ by at most %.1f mag in the R band";
+    private static final String ODGW = "The ODGW%d guide star falls out of the range of the detector.";
+    private static final String CWFS = "The CWFS%d guide star falls out of the range of the guide probe.";
+    private static final String ConfigError = "Configuration not supported. Please select 3 CWFS + 1 ODGW or 1 CWFS + 3 ODGW.";
+    private static final String WindowOverlap = "The guide windows for %s and %s overlap.";
+    private static final String MagnitudeDifference = "CWFS guide star magnitudes must differ by at most %.1f mag in the R band.";
     private static final String TipTilt = "Less than 3 GeMS guide stars of the same origin. Tip-tilt correction will not be optimal.";
     private static final String SlowFocus = "Missing Slow-focus Sensor star. Slow Focus correction will be not be applied.";
 // TODO: REL-2941   private static final String Flexure = "Missing flexure guide star. Flexure will not be compensated.";
@@ -109,20 +107,30 @@ public final class GemsGuideStarRule implements IRule {
 
             // Extract the CWFS targets and count them.
             GuideGroup primaryGuideGroup = env.getPrimaryGuideGroup();
-            final List<SiderealTarget> cwfsTargets = new ArrayList<>();
+            //final List<SiderealTarget> cwfsTargets = new ArrayList<>();
+            final Map<SiderealTarget,CanopusWfs> cwfsTargets = new HashMap<>();
             int cwfs = 0;
             for (final CanopusWfs canwfs : CanopusWfs.values()) {
-                Option<GuideProbeTargets> gpt = primaryGuideGroup.get(canwfs);
+                final Option<GuideProbeTargets> gpt = primaryGuideGroup.get(canwfs);
                 if (!gpt.isEmpty() && !gpt.getValue().getPrimary().isEmpty()) {
-                    gpt.getValue().getPrimary().foreach(t -> ImOption.fromScalaOpt(t.getSiderealTarget()).foreach(cwfsTargets::add));
+                    gpt.getValue().getPrimary().foreach(t -> ImOption.fromScalaOpt(t.getSiderealTarget()).foreach(st -> cwfsTargets.put(st, canwfs)));
                     cwfs++;
                 }
             }
+            final ImList<SiderealTarget> cwfsTargetsImList = DefaultImList.create(cwfsTargets.keySet());
+
+            // Check for overlapping guide windows.
+            CanopusWfs.Group.findOverlappingGuideWindows(ctx, cwfsTargetsImList).foreach(p -> {
+                final SiderealTarget t1 = p._1();
+                final SiderealTarget t2 = p._2();
+                final CanopusWfs c1 = cwfsTargets.get(t1);
+                final CanopusWfs c2 = cwfsTargets.get(t2);
+                problems.addError(PREFIX + "GuideWindowOverlapError", String.format(WindowOverlap, c1.getKey(), c2.getKey()), targetNode);
+            });
 
             // Check for magnitude violations.
-            final ImList<SiderealTarget> cwfsTargetsImList = DefaultImList.create(cwfsTargets);
-            final ImList<Double> cwfsMagnitudes = CanopusWfs.Group.instance.extractRMagnitudes(cwfsTargetsImList);
-            if (!cwfsTargets.isEmpty() && !cwfsMagnitudes.isEmpty() && !CanopusWfs.Group.instance.checkAsterismMagnitude(DefaultImList.create(cwfsTargets)))
+            final ImList<Double> cwfsMagnitudes = CanopusWfs.Group.extractRMagnitudes(cwfsTargetsImList);
+            if (!cwfsTargets.isEmpty() && !cwfsMagnitudes.isEmpty() && !CanopusWfs.Group.checkAsterismMagnitude(cwfsTargetsImList))
                 problems.addError(PREFIX + "MagnitudeDifferenceLimitError", String.format(MagnitudeDifference, CanopusWfs.Group.MAGNITUDE_DIFFERENCE_LIMIT), targetNode);
 
             if (Gsaoi.SP_TYPE.equals(elements.getInstrument().getType())) {

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
@@ -107,7 +107,6 @@ public final class GemsGuideStarRule implements IRule {
 
             // Extract the CWFS targets and count them.
             GuideGroup primaryGuideGroup = env.getPrimaryGuideGroup();
-            //final List<SiderealTarget> cwfsTargets = new ArrayList<>();
             final Map<SiderealTarget,CanopusWfs> cwfsTargets = new HashMap<>();
             int cwfs = 0;
             for (final CanopusWfs canwfs : CanopusWfs.values()) {

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/gems/GemsGuideStarRule.java
@@ -28,6 +28,7 @@ import edu.gemini.spModel.target.env.TargetEnvironment;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A rule for checking GeMS guide star positions.
@@ -124,7 +125,18 @@ public final class GemsGuideStarRule implements IRule {
                 final SiderealTarget t2 = p._2();
                 final CanopusWfs c1 = cwfsTargets.get(t1);
                 final CanopusWfs c2 = cwfsTargets.get(t2);
-                problems.addError(PREFIX + "GuideWindowOverlapError", String.format(WindowOverlap, c1.getKey(), c2.getKey()), targetNode);
+
+                // Sort the probe names as they might be out of order since maps can only be sorted on keys.
+                final CanopusWfs sc1;
+                final CanopusWfs sc2;
+                if (c1.getKey().compareTo(c2.getKey()) < 0) {
+                    sc1 = c1;
+                    sc2 = c2;
+                } else {
+                    sc1 = c2;
+                    sc2 = c1;
+                }
+                problems.addError(PREFIX + "GuideWindowOverlapError", String.format(WindowOverlap, sc1.getKey(), sc2.getKey()), targetNode);
             });
 
             // Check for magnitude violations.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
@@ -12,6 +12,7 @@ import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 
+import java.awt.*;
 import java.awt.geom.*;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -29,6 +30,15 @@ public enum CanopusWfs implements GuideProbe, ValidatableGuideProbe, OffsetValid
     static {
         final Ellipse2D AO_PORT = new Ellipse2D.Double(-RADIUS_ARCSEC, -RADIUS_ARCSEC, RADIUS_ARCSEC * 2, RADIUS_ARCSEC * 2);
         patrolField = new PatrolField(AO_PORT);
+    }
+
+    // According to NGS2, guide stars should be centered in 2" or 4" windows. We select 4".
+    private static final double GS_WINDOW_SIZE_ARCSEC = 4.0;
+    private static final Area   GS_WINDOW;
+
+    static {
+        final Shape GS_WINDOW_SHAPE = new Rectangle2D.Double(-GS_WINDOW_SIZE_ARCSEC / 2.0, -GS_WINDOW_SIZE_ARCSEC / 2.0, GS_WINDOW_SIZE_ARCSEC, GS_WINDOW_SIZE_ARCSEC);
+        GS_WINDOW = new Area(GS_WINDOW_SHAPE);
     }
 
     @Override
@@ -141,6 +151,10 @@ public enum CanopusWfs implements GuideProbe, ValidatableGuideProbe, OffsetValid
     @Override
     public Option<PatrolField> getCorrectedPatrolField(final ObsContext ctx) {
         return ctx.getAOComponent().filter(ado -> ado instanceof Gems).map(a -> patrolField);
+    }
+
+    public static Area getGuideStarWindow() {
+        return GS_WINDOW;
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
@@ -106,15 +106,11 @@ public enum CanopusWfs implements GuideProbe, ValidatableGuideProbe, OffsetValid
                     final SiderealTarget t2 = targets.get(j);
                     final Area a2 = windowFromCoordinates(posAngle, t2.coordinates());
 
-                    // To check overlap, take a1 xor a2 and compare to a1 union a2.
-                    // If they are not equal, they overlap.
-                    final Area xorArea = (Area) a1.clone();
-                    xorArea.exclusiveOr(a2);
-
-                    final Area combinedArea = (Area) a1.clone();
-                    combinedArea.add(a2);
-
-                    if (!xorArea.equals(combinedArea))
+                    // To check overlap, take the intersection of a1 and a2.
+                    // If it is not empty, there is an overlap.
+                    final Area intArea = (Area) a1.clone();
+                    intArea.intersect(a2);
+                    if (!intArea.isEmpty())
                         overlappingGuideWindows.add(new Pair<>(t1, t2));
                 }
             }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gems/CanopusWfs.java
@@ -154,7 +154,7 @@ public enum CanopusWfs implements GuideProbe, ValidatableGuideProbe, OffsetValid
     }
 
     public static Area getGuideStarWindow() {
-        return GS_WINDOW;
+        return (Area) GS_WINDOW.clone();
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gems/GemsGuideProbeGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gems/GemsGuideProbeGroup.java
@@ -4,7 +4,7 @@ import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.spModel.core.SiderealTarget;
 import edu.gemini.spModel.guide.GuideProbeGroup;
-import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.obs.context.ObsContext;
 
 /**
  * Defines key aspects of the catalog search.
@@ -14,7 +14,13 @@ import edu.gemini.spModel.target.SPTarget;
 public interface GemsGuideProbeGroup extends GuideProbeGroup {
     Angle getRadiusLimits();
 
+    // Filtering that can be done on asterisms prior to Strehl calculations.
     default boolean asterismPreFilter(final ImList<SiderealTarget> targets) {
+        return true;
+    }
+
+    // Filtering that can be done on asterisms when settings like posAngle are known.
+    default boolean asterismFilter(final ObsContext ctx, final ImList<SiderealTarget> targets) {
         return true;
     }
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/CanopusFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gems/CanopusFeature.java
@@ -35,7 +35,7 @@ public final class CanopusFeature extends TpeImageFeature implements PropertyWat
     private static final Color AO_FOV_COLOR = Color.RED;
 
     // Color for windows drawn around CWFS primary guide stars.
-    private static final Color GS_WINDOW_COLOR = Color.YELLOW;
+    private static final Color GS_WINDOW_COLOR = Color.MAGENTA;
 
     /**
      * Construct the feature with its name and description.


### PR DESCRIPTION
This code is an extension of my earlier PR that I released for NGS2 regarding OT_REQ_002, which requests squares of 4 arcsecs drawn around targets. Discussions from Thursday revealed that science staff is stating that these squares are not just for display in the TPE and have physical significance, i.e. they must fall completely in the Canopus patrol field and cannot overlap.

This PR extends on my earlier work to implement the code for target validation, asterism filtering, and Phase-2 checks to take these physical constraints into account.

Unfortunately, to determine if two squares overlap, we need the position angle, as two squares next to each other may intersect when rotated at certain angles, and not intersect otherwise, so I had to change how the position angle was handled a bit in the way it was passed around in MASCOT, but this was fairly minor.

Here is a screenshot of some manual guide stars, showing:
1. CWFS1's window falls outside of the Canopus patrol field; and
2. The guiding window for CWFS2 and CWFS3 overlap slightly, generating a P2 error.

![screen shot 2018-01-05 at 5 38 25 pm](https://user-images.githubusercontent.com/8795653/34627502-81dc16ca-f23f-11e7-9d43-3c027a459c3e.png)
