### PR TITLE
REL-3557: Change p1monitor to use the old style for DD proposals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization in Global := "edu.gemini.ocs"
 
 ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2018A", false, 1, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2018A", false, 1, 1, 1)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2018A.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2018A.xml
@@ -13,11 +13,13 @@
     <type name="DirectorTime">
         <dir>/home/software/proposals/directors_time/proposals/2018A</dir>
         <to>pitdd@gemini.edu</to>
+        <template>dt</template>
     </type>
 
     <type name="PoorWeather">
         <dir>/home/software/proposals/poor_weather/proposals/2018A</dir>
         <to>pitpw@gemini.edu</to>
+        <template>pw</template>
     </type>
 
     <type name="DemoScience">

--- a/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/config/P1MonitorConfig.scala
+++ b/bundle/edu.gemini.p1monitor/src/main/scala/edu/gemini/p1monitor/config/P1MonitorConfig.scala
@@ -103,6 +103,7 @@ class P1MonitorConfig(ctx: BundleContext) {
   private def toTemplate(s: String): P1PDF.Template = s match {
     case "ar" | "br" | "kr" | "uh" => P1PDF.GeminiDefault
     case "cfh" | "subaru" | "keck" => P1PDF.GeminiDefault
+    case "dt" | "pw"               => P1PDF.GeminiDefault
     case "au"                      => P1PDF.AU
     case "cl"                      => P1PDF.CL
     case "us"                      => P1PDF.NOAOListAtTheEnd


### PR DESCRIPTION
This PR changes the template used for DD and PW to include the full info unlike the current status where the pdf was formatted with the unbiased version