### PR TITLE
REL-3273: Add OVI and OVIC filters for GMOS-N and GMOS-S to PIT.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -130,9 +130,9 @@ package object immutable {
       Ha_G0310,
       HaC_G0311,
       SII_G0317,
-      DS920_G0312,
       OVI_G0345,
       OVIC_G0346,
+      DS920_G0312,
       USER_SUPPLIED
     )
     val ALTAIR_IMAGING = List(

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -131,6 +131,8 @@ package object immutable {
       HaC_G0311,
       SII_G0317,
       DS920_G0312,
+      OVI_G0345,
+      OVIC_G0346,
       USER_SUPPLIED
     )
     val ALTAIR_IMAGING = List(
@@ -198,6 +200,8 @@ package object immutable {
       Ha_G0336,
       HaC_G0337,
       SII_G0335,
+      OVI_G0347,
+      OVIC_G0348,
       USER_SUPPLIED
     )
   }

--- a/bundle/edu.gemini.model.p1/src/main/xjb/GmosN.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/GmosN.xjb
@@ -98,6 +98,12 @@
             <jxb:bindings node="./xsd:enumeration[@value='DS920 (920 nm)']">
                 <jxb:typesafeEnumMember name="DS920_G0312"/>
             </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='OVI (684 nm)']">
+                <jxb:typesafeEnumMember name="OVI_G0345"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='OVIC (678 nm)']">
+                <jxb:typesafeEnumMember name="OVIC_G0346"/>
+            </jxb:bindings>
         </jxb:bindings>
 
         <!-- GmosNFpu => GmosNorthType.FPUnitNorth -->

--- a/bundle/edu.gemini.model.p1/src/main/xjb/GmosN.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/GmosN.xjb
@@ -95,14 +95,14 @@
             <jxb:bindings node="./xsd:enumeration[@value='SII (672 nm)']">
                 <jxb:typesafeEnumMember name="SII_G0317"/>
             </jxb:bindings>
-            <jxb:bindings node="./xsd:enumeration[@value='DS920 (920 nm)']">
-                <jxb:typesafeEnumMember name="DS920_G0312"/>
-            </jxb:bindings>
             <jxb:bindings node="./xsd:enumeration[@value='OVI (684 nm)']">
                 <jxb:typesafeEnumMember name="OVI_G0345"/>
             </jxb:bindings>
             <jxb:bindings node="./xsd:enumeration[@value='OVIC (678 nm)']">
                 <jxb:typesafeEnumMember name="OVIC_G0346"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='DS920 (920 nm)']">
+                <jxb:typesafeEnumMember name="DS920_G0312"/>
             </jxb:bindings>
         </jxb:bindings>
 

--- a/bundle/edu.gemini.model.p1/src/main/xjb/GmosS.xjb
+++ b/bundle/edu.gemini.model.p1/src/main/xjb/GmosS.xjb
@@ -104,6 +104,12 @@
             <jxb:bindings node="./xsd:enumeration[@value='SII (672 nm)']">
                 <jxb:typesafeEnumMember name="SII_G0335"/>
             </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='OVI (684 nm)']">
+                <jxb:typesafeEnumMember name="OVI_G0347"/>
+            </jxb:bindings>
+            <jxb:bindings node="./xsd:enumeration[@value='OVIC (678 nm)']">
+                <jxb:typesafeEnumMember name="OVIC_G0348"/>
+            </jxb:bindings>
         </jxb:bindings>
 
         <!-- GmosSFpu => GmosSouthType.FPUnitSouth -->

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -1,6 +1,11 @@
 Gemini Phase I Schema Changes
 
-# Version 2018.1.1 - 2018B
+# Version 2018.2.1 - 2018B
+##########################
+
+* Added OVI and OVIC filters for GMOS-N and GMOS-S. (REL-3273)
+
+# Version 2018.1.1 - 2018A
 ##########################
 
 * Hidden filter Y and J-lo for Flamingos2

--- a/bundle/edu.gemini.model.p1/src/main/xsd/GmosN.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/GmosN.xsd
@@ -166,9 +166,9 @@
             <xsd:enumeration value="Ha (656 nm)"/>
             <xsd:enumeration value="HaC (662 nm)"/>
             <xsd:enumeration value="SII (672 nm)"/>
-            <xsd:enumeration value="DS920 (920 nm)"/>
             <xsd:enumeration value="OVI (684 nm)"/>
             <xsd:enumeration value="OVIC (678 nm)"/>
+            <xsd:enumeration value="DS920 (920 nm)"/>
             <xsd:enumeration value="User-supplied"/>
         </xsd:restriction>
     </xsd:simpleType>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/GmosN.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/GmosN.xsd
@@ -167,6 +167,8 @@
             <xsd:enumeration value="HaC (662 nm)"/>
             <xsd:enumeration value="SII (672 nm)"/>
             <xsd:enumeration value="DS920 (920 nm)"/>
+            <xsd:enumeration value="OVI (684 nm)"/>
+            <xsd:enumeration value="OVIC (678 nm)"/>
             <xsd:enumeration value="User-supplied"/>
         </xsd:restriction>
     </xsd:simpleType>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/GmosS.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/GmosS.xsd
@@ -178,6 +178,8 @@
             <xsd:enumeration value="Ha (656 nm)"/>
             <xsd:enumeration value="HaC (662 nm)"/>
             <xsd:enumeration value="SII (672 nm)"/>
+            <xsd:enumeration value="OVI (684 nm)"/>
+            <xsd:enumeration value="OVIC (678 nm)"/>
             <xsd:enumeration value="User-supplied"/>
         </xsd:restriction>
     </xsd:simpleType>


### PR DESCRIPTION
This mirrors task REL-3272, i.e. adding the OVI and OVIC filters for GMOS-N and GMOS-S to the OT, which has already been done.

The PIT must support these new filters for 2018B. This adds the filters and their internal names to the XJB and XSD files, as well as to the immutable classes.

I think we will also need to modify the template creation process, e.g. `GmosNImaging.defaultExposures`:
https://github.com/gemini-hlsw/ocs/blob/f6e26b07e05f7ba3c69b4850534f3303cfe56153/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNImaging.scala#L40